### PR TITLE
feat: v0.6.0 — MCP 서버 (8 tools) + vhk mcp-init Cursor 연동

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ## [Unreleased]
 
+---
+
+## [0.6.0] — 2026-05-24
+
+### Added
+- **MCP 서버 (`vhk mcp`)** — 8개 도구(save/undo/status/diff/ship/doctor/check/recap) stdio 노출. Cursor 등 MCP 클라이언트에서 자연어로 호출
+- **`vhk mcp-init`** — Cursor `.cursor/mcp.json` 자동 생성. 재시작 한 번으로 연동 완료
+- 자연어 라우팅에 `mcp설정` → `mcp-init` 키워드 추가
+- `package.json` `bin`에 `vhk-mcp` 별도 엔트리 추가
+- v0.5.x → v0.6.0 버전 업
+
+### Security
+- MCP `save` 도구의 shell injection 취약점 차단 — 모든 git 호출에 `execFileSync` 사용 ([aed5b47](https://github.com/byh3071-cpu/vhk/commit/aed5b47))
+
+---
+
+## [0.5.3] — 2026-05-23
+
 ### Added
 - `CHANGELOG.md` 신설 — 릴리즈마다 자동 갱신
 - `doctor` 명령에 npm 최신 버전 비교 — 새 버전 안내 한 줄
@@ -72,7 +90,9 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 - **`vhk gate`** — 아이디어 검증 (퀵 5문항 / 풀 13문항 / 스킵)
 - **`vhk init`** — 프로젝트 시작. 하네스 파일 생성 (`CLAUDE.md`, `.cursorrules`, `docs/PRD.md`, `docs/ARCHITECTURE.md`, ADR/log 폴더)
 
-[Unreleased]: https://github.com/byh3071-cpu/vhk/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/byh3071-cpu/vhk/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/byh3071-cpu/vhk/compare/v0.5.3...v0.6.0
+[0.5.3]: https://github.com/byh3071-cpu/vhk/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/byh3071-cpu/vhk/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/byh3071-cpu/vhk/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/byh3071-cpu/vhk/compare/v0.4.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ---
 id: vhk-readme
-date: 2026-05-23
-tags: [vhk, cli, readme, v0.5.3]
+date: 2026-05-24
+tags: [vhk, cli, readme, v0.6.0]
 ---
 
 # 🔧 VHK — Vibe Harness Kit
 
-> AI 코딩 에이전트를 부리는 사람을 위한 **한국어 풀사이클 CLI** (v0.5.3)
+> AI 코딩 에이전트를 부리는 사람을 위한 **한국어 풀사이클 CLI** (v0.6.0)
 >
 > 🍽️ **VHK는 VHK로 부트스트랩됨** — 이 레포의 `docs/`, `CLAUDE.md`, `.cursorrules`도 `vhk init`이 만들었습니다.
 
@@ -89,6 +89,8 @@ vhk 기획 끝났고 바로 시작
 | `vhk undo` | `되돌리기`, `취소` | 최근 커밋 soft reset (변경은 staged 유지) |
 | `vhk diff` | `변경`, `차이` | staged / unstaged / 새 파일 요약 (줄 수 합계는 tracked·HEAD 기준) |
 | `vhk status` | `상태`, `현황` | 브랜치·변경·커밋·원격·버전 대시보드 |
+| `vhk mcp` | — | MCP 서버 시작 (Cursor 등 MCP 클라이언트용, stdio) |
+| `vhk mcp-init` | `mcp설정` | Cursor `.cursor/mcp.json` 자동 생성 |
 
 ### init 옵션
 
@@ -104,6 +106,33 @@ vhk 기획 끝났고 바로 시작
 | 옵션 | 설명 |
 |------|------|
 | `--since YYYY-MM-DD` | 분석 시작일 (기본: 오늘) |
+
+## Cursor와 MCP로 연동하기
+
+`v0.6.0`부터 vhk는 [Model Context Protocol](https://modelcontextprotocol.io) 서버를 내장합니다. Cursor 채팅에서 자연어로 vhk 도구를 호출할 수 있습니다.
+
+```powershell
+vhk mcp-init           # .cursor/mcp.json 자동 생성
+# → Cursor 재시작 후 채팅에서 자연어로 vhk 도구 호출 가능
+# 예: "상태 알려줘" → Cursor가 vhk status 도구 호출
+```
+
+노출되는 MCP 도구 8개: `save`, `undo`, `status`, `diff`, `ship`, `doctor`, `check`, `recap`.
+
+MCP 서버를 수동으로 띄우려면:
+
+```powershell
+vhk mcp                # stdio 서버 시작 (Cursor가 자동으로 호출)
+```
+
+## v0.6.0 하이라이트
+
+| 기능 | 설명 |
+|------|------|
+| **MCP 서버** | `vhk mcp` — 8개 도구(save/undo/status/diff/ship/doctor/check/recap)를 stdio로 노출. Cursor 등 MCP 클라이언트에서 자연어로 호출 |
+| **mcp-init** | `vhk mcp-init` — Cursor `.cursor/mcp.json` 자동 생성. 재시작 한 번으로 연동 완료 |
+| **자연어 라우팅 확장** | `vhk mcp설정` → `vhk mcp-init` 별칭 |
+| **보안** | MCP save 도구의 shell injection 차단 — 모든 git 호출에 `execFileSync` 사용 |
 
 ## v0.5.3 하이라이트
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@byh3071/vhk",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Vibe Harness Kit — 바이브코딩 풀사이클 CLI",
   "bin": {
-    "vhk": "dist/index.js"
+    "vhk": "dist/index.js",
+    "vhk-mcp": "dist/mcp/index.js"
   },
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -42,13 +42,15 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@notionhq/client": "^5.22.0",
     "chalk": "^5.6.2",
     "commander": "^14.0.3",
     "handlebars": "^4.7.9",
     "inquirer": "^9.3.8",
     "ora": "^9.4.0",
-    "simple-git": "^3.36.0"
+    "simple-git": "^3.36.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/inquirer": "^9.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
 
   .:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@notionhq/client':
         specifier: ^5.22.0
         version: 5.22.0
@@ -231,6 +234,9 @@ importers:
       simple-git:
         specifier: ^3.36.0
         version: 3.36.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/inquirer':
         specifier: ^9.0.9
@@ -577,6 +583,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
@@ -608,6 +620,16 @@ packages:
 
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -920,10 +942,25 @@ packages:
   '@vitest/utils@4.1.7':
     resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -954,6 +991,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
@@ -963,9 +1004,21 @@ packages:
     peerDependencies:
       esbuild: '>=0.18'
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1032,8 +1085,36 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1047,15 +1128,42 @@ packages:
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -1067,12 +1175,43 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1083,17 +1222,44 @@ packages:
       picomatch:
         optional: true
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
@@ -1103,6 +1269,22 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.22:
+    resolution: {integrity: sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -1122,6 +1304,14 @@ packages:
     resolution: {integrity: sha512-pFGGdaHrmRKMh4WoDDSowddgjT1Vkl90atobmTeSmcPGdYiwikch/m/Ef5wRaiamHejtw0cUUMMerzDUXCci2w==}
     engines: {node: '>=18'}
 
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -1134,6 +1324,9 @@ packages:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
@@ -1142,9 +1335,21 @@ packages:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1242,6 +1447,26 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -1271,6 +1496,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -1278,8 +1507,19 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -1297,6 +1537,17 @@ packages:
     resolution: {integrity: sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==}
     engines: {node: '>=20'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -1310,6 +1561,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -1336,6 +1591,22 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -1343,6 +1614,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -1366,6 +1641,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-async@3.0.0:
     resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
     engines: {node: '>=0.12.0'}
@@ -1378,6 +1657,41 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1406,6 +1720,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
@@ -1467,6 +1785,10 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
@@ -1505,6 +1827,10 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -1521,8 +1847,16 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@8.0.14:
     resolution: {integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==}
@@ -1611,6 +1945,11 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -1623,6 +1962,9 @@ packages:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
@@ -1630,6 +1972,14 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -1805,6 +2155,10 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
+  '@hono/node-server@1.19.14(hono@4.12.22)':
+    dependencies:
+      hono: 4.12.22
+
   '@inquirer/external-editor@1.0.3(@types/node@25.9.1)':
     dependencies:
       chardet: 2.1.1
@@ -1835,6 +2189,28 @@ snapshots:
       - supports-color
 
   '@kwsites/promise-deferred@1.1.1': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.22)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.22
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -2051,7 +2427,23 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn@8.16.0: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-escapes@4.3.2:
     dependencies:
@@ -2077,6 +2469,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
@@ -2087,7 +2493,19 @@ snapshots:
       esbuild: 0.27.7
       load-tsconfig: 0.2.5
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   chai@6.2.2: {}
 
@@ -2134,7 +2552,28 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   debug@4.4.3:
     dependencies:
@@ -2144,11 +2583,31 @@ snapshots:
     dependencies:
       clone: 1.0.4
 
+  depd@2.0.0: {}
+
   detect-libc@2.1.2: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
 
   emoji-regex@8.0.0: {}
 
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.1.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -2208,15 +2667,78 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
 
+  escape-html@1.0.3: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
@@ -2224,10 +2746,36 @@ snapshots:
       mlly: 1.8.2
       rollup: 4.60.4
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   get-east-asian-width@1.6.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  gopd@1.2.0: {}
 
   handlebars@4.7.9:
     dependencies:
@@ -2239,6 +2787,22 @@ snapshots:
       uglify-js: 3.19.3
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.22: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   iconv-lite@0.7.2:
     dependencies:
@@ -2267,17 +2831,31 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-interactive@1.0.0: {}
 
   is-interactive@2.0.0: {}
 
+  is-promise@4.0.0: {}
+
   is-unicode-supported@0.1.0: {}
 
   is-unicode-supported@2.1.0: {}
 
+  isexe@2.0.0: {}
+
+  jose@6.2.3: {}
+
   joycon@3.1.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -2348,6 +2926,18 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mimic-fn@2.1.0: {}
 
   mimic-function@5.0.1: {}
@@ -2373,11 +2963,23 @@ snapshots:
 
   nanoid@3.3.12: {}
 
+  negotiator@1.0.0: {}
+
   neo-async@2.6.2: {}
 
   object-assign@4.1.1: {}
 
+  object-inspect@1.13.4: {}
+
   obug@2.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@5.1.2:
     dependencies:
@@ -2410,6 +3012,12 @@ snapshots:
       stdin-discarder: 0.3.2
       string-width: 8.2.1
 
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -2417,6 +3025,8 @@ snapshots:
   picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -2437,6 +3047,24 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
@@ -2444,6 +3072,8 @@ snapshots:
       util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-from@5.0.0: {}
 
@@ -2509,6 +3139,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-async@3.0.0: {}
 
   rxjs@7.8.2:
@@ -2518,6 +3158,67 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -2542,6 +3243,8 @@ snapshots:
   source-map@0.7.6: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.1.0: {}
 
@@ -2605,6 +3308,8 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  toidentifier@1.0.1: {}
+
   tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
@@ -2647,6 +3352,12 @@ snapshots:
 
   type-fest@0.21.3: {}
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@6.0.3: {}
 
   ufo@1.6.4: {}
@@ -2656,7 +3367,11 @@ snapshots:
 
   undici-types@7.24.6: {}
 
+  unpipe@1.0.0: {}
+
   util-deprecate@1.0.2: {}
+
+  vary@1.1.2: {}
 
   vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3):
     dependencies:
@@ -2702,6 +3417,10 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -2715,6 +3434,14 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrappy@1.0.2: {}
+
   yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}

--- a/src/commands/mcp-init.ts
+++ b/src/commands/mcp-init.ts
@@ -1,0 +1,63 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import chalk from 'chalk'
+import { t } from '../i18n/ko.js'
+
+type McpEntry = { command: string; args: string[] }
+type McpConfig = { mcpServers: Record<string, McpEntry> }
+
+function resolveVhkMcpPath(): string {
+  try {
+    // 글로벌 설치 (npm i -g) 환경: import.meta.resolve로 패키지 경로를 찾는다.
+    // 반환값은 file:// URL이므로 fileURLToPath로 OS 네이티브 경로로 변환 (Windows 대응).
+    const url = import.meta.resolve?.('@byh3071/vhk/dist/mcp/index.js')
+    if (typeof url === 'string') return fileURLToPath(url)
+  } catch {
+    // ignore
+  }
+  // 로컬 fallback: node_modules 안의 경로 추정.
+  return join(process.cwd(), 'node_modules', '@byh3071', 'vhk', 'dist', 'mcp', 'index.js')
+}
+
+export async function mcpInit(): Promise<void> {
+  console.log(chalk.bold('\n🔌 ' + t('mcp.initTitle')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  const cursorDir = join(process.cwd(), '.cursor')
+  if (!existsSync(cursorDir)) {
+    mkdirSync(cursorDir, { recursive: true })
+  }
+
+  const configPath = join(cursorDir, 'mcp.json')
+  const vhkEntry: McpEntry = {
+    command: 'node',
+    args: [resolveVhkMcpPath()],
+  }
+
+  let config: McpConfig
+  if (existsSync(configPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(configPath, 'utf-8')) as Partial<McpConfig>
+      config = {
+        mcpServers: { ...(parsed.mcpServers ?? {}), vhk: vhkEntry },
+      }
+    } catch {
+      // 손상된 JSON: 새 설정으로 덮어쓰기 전에 사용자에게 알린다.
+      console.log(chalk.yellow('⚠️  기존 .cursor/mcp.json 파싱 실패 — 새 파일로 덮어씁니다.'))
+      config = { mcpServers: { vhk: vhkEntry } }
+    }
+  } else {
+    config = { mcpServers: { vhk: vhkEntry } }
+  }
+
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8')
+
+  console.log(chalk.green('\n✅ Cursor MCP 설정 완료!'))
+  console.log(chalk.cyan('📁 생성된 파일:'))
+  console.log(`   ${configPath}`)
+  console.log(chalk.cyan('\n🔄 다음 단계:'))
+  console.log('   1. Cursor를 재시작하세요')
+  console.log('   2. Cursor 채팅에서 vhk 도구를 사용할 수 있습니다')
+  console.log(chalk.gray('\n💡 예: "프로젝트 상태 알려줘" → Cursor가 vhk status 호출'))
+}

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -249,6 +249,10 @@ export const ko = {
     changelogMissing:
       'CHANGELOG.md가 없어요. 만들면 ship이 자동으로 [Unreleased] → 버전 섹션으로 옮겨줍니다.',
   },
+  mcp: {
+    initTitle: 'Cursor MCP 연동 설정',
+    serverStarted: 'VHK MCP 서버 시작됨',
+  },
 } as const
 
 type KoValue = string | ((...args: never[]) => string)

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { undo } from './commands/undo.js'
 import { diff } from './commands/diff.js'
 import { status } from './commands/status.js'
 import { startMcpServer } from './mcp/server.js'
+import { mcpInit } from './commands/mcp-init.js'
 
 const program = new Command()
 const defaultHelp = new Help()
@@ -170,6 +171,14 @@ program
   .description('MCP 서버 시작 (Cursor 등 MCP 클라이언트용)')
   .action(async () => {
     await startMcpServer()
+  })
+
+program
+  .command('mcp-init')
+  .alias('mcp설정')
+  .description('Cursor MCP 연동 설정 자동 생성 (.cursor/mcp.json)')
+  .action(async () => {
+    await mcpInit()
   })
 
 program.on('command:*', async (operands: string[]) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ const KO_ALIASES: Record<string, string> = {
 program
   .name('vhk')
   .description('VHK — 바이브코딩 프로젝트 코치 (한국어로 안내합니다)')
-  .version('0.5.3')
+  .version('0.6.0')
 
 program.configureHelp({
   formatHelp(cmd, helper) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { save } from './commands/save.js'
 import { undo } from './commands/undo.js'
 import { diff } from './commands/diff.js'
 import { status } from './commands/status.js'
+import { startMcpServer } from './mcp/server.js'
 
 const program = new Command()
 const defaultHelp = new Help()
@@ -47,7 +48,10 @@ program.configureHelp({
     }
 
     const subs = helper.visibleCommands(cmd).filter((c) => c.name() !== 'help')
-    const terms = subs.map((c) => `${c.name()} (${KO_ALIASES[c.name()]})`)
+    const terms = subs.map((c) => {
+      const alias = KO_ALIASES[c.name()]
+      return alias ? `${c.name()} (${alias})` : c.name()
+    })
     const termWidth = Math.max(...terms.map((t) => t.length), 0)
 
     const lines = [
@@ -160,6 +164,13 @@ program
   .alias('차이')
   .description('Git 변경사항 한국어 요약 (staged / unstaged / 새 파일)')
   .action(diff)
+
+program
+  .command('mcp')
+  .description('MCP 서버 시작 (Cursor 등 MCP 클라이언트용)')
+  .action(async () => {
+    await startMcpServer()
+  })
 
 program.on('command:*', async (operands: string[]) => {
   const unknown = operands[0] ?? ''

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -15,6 +15,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'status', '상태', '현황',
   'diff', '변경', '차이',
   'mcp',
+  'mcp-init', 'mcp설정',
   'help',
 ])
 

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -14,6 +14,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'undo', '되돌리기',
   'status', '상태', '현황',
   'diff', '변경', '차이',
+  'mcp',
   'help',
 ])
 

--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -11,6 +11,7 @@ export type NlpCommand =
   | 'undo'
   | 'diff'
   | 'status'
+  | 'mcp-init'
 
 export type NlpConfidence = 'high' | 'low'
 
@@ -69,6 +70,12 @@ const RULES: NlpRule[] = [
     confidence: 'high',
     test: t =>
       /프로젝트.*(만들|시작)|폴더.*만들|만들고\s*싶|하네스|초기화/.test(t) || /^시작$/.test(t),
+  },
+  {
+    command: 'mcp-init',
+    explanation: 'Cursor MCP 연동 설정 (vhk mcp-init)',
+    confidence: 'high',
+    test: t => /mcp.*(설정|연동|초기|init)|커서.*(연동|설정|mcp)|cursor.*mcp/.test(t),
   },
   {
     command: 'secure',

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -14,6 +14,7 @@ import { save } from '../commands/save.js'
 import { undo } from '../commands/undo.js'
 import { status } from '../commands/status.js'
 import { diff } from '../commands/diff.js'
+import { mcpInit } from '../commands/mcp-init.js'
 
 export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<void> {
   switch (route.command) {
@@ -46,6 +47,8 @@ export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<
       return status()
     case 'diff':
       return diff()
+    case 'mcp-init':
+      return mcpInit()
   }
 }
 

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,0 +1,7 @@
+import { startMcpServer } from './server.js'
+
+startMcpServer().catch((err) => {
+  // stderr로 에러를 흘려보내고 비정상 종료. MCP 클라이언트가 재시작 판단.
+  console.error('VHK MCP 서버 시작 실패:', err)
+  process.exit(1)
+})

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -277,7 +277,7 @@ export function createVhkMcpServer(): McpServer {
   // ─── recap ──────────────────────────────────────────────
   server.tool(
     'recap',
-    '최근 작업 요약 (커밋 히스토리 기반)',
+    '최근 작업 요약 (커밋 히스토리 기반, 날짜 포함)',
     {
       count: z.number().optional().describe('표시할 커밋 수 (기본: 10)'),
     },
@@ -286,7 +286,7 @@ export function createVhkMcpServer(): McpServer {
         return { content: [{ type: 'text', text: '❌ git 저장소가 아닙니다.' }] }
       }
       const n = count && count > 0 ? Math.floor(count) : 10
-      const log = safeExecFile('git', ['log', '--oneline', `-${n}`])
+      const log = safeExecFile('git', ['log', '--format=%h %ad %s', '--date=short', `-${n}`])
       if (!log.ok) {
         return { content: [{ type: 'text', text: `❌ git log 실패: ${log.err}` }] }
       }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -42,11 +42,13 @@ export function createVhkMcpServer(): McpServer {
   })
 
   // ─── save ───────────────────────────────────────────────
-  server.tool(
+  server.registerTool(
     'save',
-    '변경사항 저장 (git add → commit → push)',
     {
-      message: z.string().optional().describe('커밋 메시지 (비우면 자동 생성)'),
+      description: '변경사항 저장 (git add → commit → push)',
+      inputSchema: {
+        message: z.string().optional().describe('커밋 메시지 (비우면 자동 생성)'),
+      },
     },
     async ({ message }) => {
       if (!isGitRepo()) {
@@ -90,7 +92,7 @@ export function createVhkMcpServer(): McpServer {
   )
 
   // ─── undo ───────────────────────────────────────────────
-  server.tool('undo', '최근 커밋 되돌리기 (soft reset, 변경사항은 유지)', {}, async () => {
+  server.registerTool('undo', { description: '최근 커밋 되돌리기 (soft reset, 변경사항은 유지)' }, async () => {
     if (!isGitRepo()) {
       return { content: [{ type: 'text', text: '❌ git 저장소가 아닙니다.' }] }
     }
@@ -116,7 +118,7 @@ export function createVhkMcpServer(): McpServer {
   })
 
   // ─── status ─────────────────────────────────────────────
-  server.tool('status', '프로젝트 상태 대시보드 (브랜치/변경사항/최근 커밋)', {}, async () => {
+  server.registerTool('status', { description: '프로젝트 상태 대시보드 (브랜치/변경사항/최근 커밋)' }, async () => {
     const lines: string[] = []
 
     if (existsSync('package.json')) {
@@ -163,7 +165,7 @@ export function createVhkMcpServer(): McpServer {
   })
 
   // ─── diff ───────────────────────────────────────────────
-  server.tool('diff', '변경사항 확인 (staged/unstaged/새파일 + 총 변경 요약)', {}, async () => {
+  server.registerTool('diff', { description: '변경사항 확인 (staged/unstaged/새파일 + 총 변경 요약)' }, async () => {
     if (!isGitRepo()) {
       return { content: [{ type: 'text', text: '❌ git 저장소가 아닙니다.' }] }
     }
@@ -214,7 +216,7 @@ export function createVhkMcpServer(): McpServer {
 
   // ─── ship ───────────────────────────────────────────────
   // TODO(v0.6.1): execa로 비동기 전환 — ship 장시간 블로킹 방지
-  server.tool('ship', '배포 체크리스트 실행 (빌드 + 테스트 + 버전 + git 상태)', {}, async () => {
+  server.registerTool('ship', { description: '배포 체크리스트 실행 (빌드 + 테스트 + 버전 + git 상태)' }, async () => {
     const checks: string[] = []
 
     const build = safeExecFile('pnpm', ['build'])
@@ -247,7 +249,7 @@ export function createVhkMcpServer(): McpServer {
   })
 
   // ─── doctor ─────────────────────────────────────────────
-  server.tool('doctor', '개발 환경 점검 (Node/Git/npm/pnpm/TypeScript)', {}, async () => {
+  server.registerTool('doctor', { description: '개발 환경 점검 (Node/Git/npm/pnpm/TypeScript)' }, async () => {
     const checks: string[] = []
 
     const node = safeExecFile('node', ['--version'])
@@ -269,7 +271,7 @@ export function createVhkMcpServer(): McpServer {
   })
 
   // ─── check ──────────────────────────────────────────────
-  server.tool('check', '프로젝트 구조 점검 (필수 파일 + VHK 하네스 파일)', {}, async () => {
+  server.registerTool('check', { description: '프로젝트 구조 점검 (필수 파일 + VHK 하네스 파일)' }, async () => {
     const required = ['package.json', 'tsconfig.json', 'README.md', '.gitignore']
     const recommended = ['CLAUDE.md', '.cursorrules', 'docs/PRD.md', 'docs/ARCHITECTURE.md']
 
@@ -286,11 +288,13 @@ export function createVhkMcpServer(): McpServer {
   })
 
   // ─── recap ──────────────────────────────────────────────
-  server.tool(
+  server.registerTool(
     'recap',
-    '최근 작업 요약 (커밋 히스토리 기반, 날짜 포함)',
     {
-      count: z.number().optional().describe('표시할 커밋 수 (기본: 10)'),
+      description: '최근 작업 요약 (커밋 히스토리 기반, 날짜 포함)',
+      inputSchema: {
+        count: z.number().optional().describe('표시할 커밋 수 (기본: 10)'),
+      },
     },
     async ({ count }) => {
       if (!isGitRepo()) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -213,6 +213,7 @@ export function createVhkMcpServer(): McpServer {
   })
 
   // ─── ship ───────────────────────────────────────────────
+  // TODO(v0.6.1): execa로 비동기 전환 — ship 장시간 블로킹 방지
   server.tool('ship', '배포 체크리스트 실행 (빌드 + 테스트 + 버전 + git 상태)', {}, async () => {
     const checks: string[] = []
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod'
-import { execSync } from 'node:child_process'
+import { execSync, execFileSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 
 const SERVER_VERSION = '0.6.0'
@@ -9,6 +9,22 @@ const SERVER_VERSION = '0.6.0'
 function safeExec(cmd: string): { ok: true; out: string } | { ok: false; err: string } {
   try {
     const out = execSync(cmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).toString()
+    return { ok: true, out: out.trim() }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return { ok: false, err: msg }
+  }
+}
+
+function safeExecFile(
+  cmd: string,
+  args: string[]
+): { ok: true; out: string } | { ok: false; err: string } {
+  try {
+    const out = execFileSync(cmd, args, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).toString()
     return { ok: true, out: out.trim() }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
@@ -50,13 +66,12 @@ export function createVhkMcpServer(): McpServer {
       const now = new Date()
       const ts = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')} ${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`
       const commitMsg = message?.trim() || `✨ vhk save: ${ts}`
-      const escaped = commitMsg.replace(/"/g, '\\"')
 
       const add = safeExec('git add .')
       if (!add.ok) {
         return { content: [{ type: 'text', text: `❌ git add 실패: ${add.err}` }] }
       }
-      const commit = safeExec(`git commit -m "${escaped}"`)
+      const commit = safeExecFile('git', ['commit', '-m', commitMsg])
       if (!commit.ok) {
         return { content: [{ type: 'text', text: `❌ commit 실패: ${commit.err}` }] }
       }
@@ -272,7 +287,7 @@ export function createVhkMcpServer(): McpServer {
         return { content: [{ type: 'text', text: '❌ git 저장소가 아닙니다.' }] }
       }
       const n = count && count > 0 ? Math.floor(count) : 10
-      const log = safeExec(`git log --oneline -${n}`)
+      const log = safeExecFile('git', ['log', '--oneline', `-${n}`])
       if (!log.ok) {
         return { content: [{ type: 'text', text: `❌ git log 실패: ${log.err}` }] }
       }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -268,10 +268,20 @@ export function createVhkMcpServer(): McpServer {
   })
 
   // ─── check ──────────────────────────────────────────────
-  server.tool('check', '프로젝트 구조 점검 (필수 파일 존재 여부)', {}, async () => {
+  server.tool('check', '프로젝트 구조 점검 (필수 파일 + VHK 하네스 파일)', {}, async () => {
     const required = ['package.json', 'tsconfig.json', 'README.md', '.gitignore']
-    const results = required.map((f) => `${existsSync(f) ? '✅' : '❌'} ${f}`)
-    return { content: [{ type: 'text', text: '🔍 프로젝트 점검\n' + results.join('\n') }] }
+    const recommended = ['CLAUDE.md', '.cursorrules', 'docs/PRD.md', 'docs/ARCHITECTURE.md']
+
+    const lines: string[] = ['🔍 프로젝트 점검', '', '필수:']
+    required.forEach((f) => {
+      lines.push(`  ${existsSync(f) ? '✅' : '❌'} ${f}`)
+    })
+    lines.push('', '권장 (VHK 하네스):')
+    recommended.forEach((f) => {
+      lines.push(`  ${existsSync(f) ? '✅' : '⚠️'} ${f}`)
+    })
+
+    return { content: [{ type: 'text', text: lines.join('\n') }] }
   })
 
   // ─── recap ──────────────────────────────────────────────

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,19 +1,18 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod'
-import { execSync, execFileSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 
 const SERVER_VERSION = '0.6.0'
 
-function safeExec(cmd: string): { ok: true; out: string } | { ok: false; err: string } {
-  try {
-    const out = execSync(cmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).toString()
-    return { ok: true, out: out.trim() }
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return { ok: false, err: msg }
+// Windows에서 pnpm/npm/npx/yarn은 .cmd shim. execFileSync는 native 바이너리만 찾으므로 .cmd 확장자 부여.
+const SHIM_BINARIES = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function platformCmd(cmd: string): string {
+  if (process.platform === 'win32' && SHIM_BINARIES.has(cmd)) {
+    return `${cmd}.cmd`
   }
+  return cmd
 }
 
 function safeExecFile(
@@ -21,7 +20,7 @@ function safeExecFile(
   args: string[]
 ): { ok: true; out: string } | { ok: false; err: string } {
   try {
-    const out = execFileSync(cmd, args, {
+    const out = execFileSync(platformCmd(cmd), args, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     }).toString()
@@ -33,7 +32,7 @@ function safeExecFile(
 }
 
 function isGitRepo(): boolean {
-  return safeExec('git rev-parse --is-inside-work-tree').ok
+  return safeExecFile('git', ['rev-parse', '--is-inside-work-tree']).ok
 }
 
 export function createVhkMcpServer(): McpServer {
@@ -54,7 +53,7 @@ export function createVhkMcpServer(): McpServer {
         return { content: [{ type: 'text', text: '❌ git 저장소가 아닙니다.' }] }
       }
 
-      const status = safeExec('git status --porcelain')
+      const status = safeExecFile('git', ['status', '--porcelain'])
       if (!status.ok) {
         return { content: [{ type: 'text', text: `❌ git status 실패: ${status.err}` }] }
       }
@@ -67,7 +66,7 @@ export function createVhkMcpServer(): McpServer {
       const ts = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')} ${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`
       const commitMsg = message?.trim() || `✨ vhk save: ${ts}`
 
-      const add = safeExec('git add .')
+      const add = safeExecFile('git', ['add', '.'])
       if (!add.ok) {
         return { content: [{ type: 'text', text: `❌ git add 실패: ${add.err}` }] }
       }
@@ -76,7 +75,7 @@ export function createVhkMcpServer(): McpServer {
         return { content: [{ type: 'text', text: `❌ commit 실패: ${commit.err}` }] }
       }
 
-      const push = safeExec('git push')
+      const push = safeExecFile('git', ['push'])
       const pushResult = push.ok ? '+ 원격 업로드 완료' : '(원격 저장소 없거나 push 실패 → 스킵)'
 
       return {
@@ -96,12 +95,12 @@ export function createVhkMcpServer(): McpServer {
       return { content: [{ type: 'text', text: '❌ git 저장소가 아닙니다.' }] }
     }
 
-    const last = safeExec('git log --oneline -1')
+    const last = safeExecFile('git', ['log', '--oneline', '-1'])
     if (!last.ok || !last.out) {
       return { content: [{ type: 'text', text: '📭 되돌릴 커밋이 없습니다.' }] }
     }
 
-    const reset = safeExec('git reset --soft HEAD~1')
+    const reset = safeExecFile('git', ['reset', '--soft', 'HEAD~1'])
     if (!reset.ok) {
       return { content: [{ type: 'text', text: `❌ reset 실패: ${reset.err}` }] }
     }
@@ -134,10 +133,10 @@ export function createVhkMcpServer(): McpServer {
       return { content: [{ type: 'text', text: lines.join('\n') }] }
     }
 
-    const branch = safeExec('git branch --show-current')
+    const branch = safeExecFile('git', ['branch', '--show-current'])
     if (branch.ok) lines.push(`🌿 브랜치: ${branch.out || '(detached)'}`)
 
-    const status = safeExec('git status --porcelain')
+    const status = safeExecFile('git', ['status', '--porcelain'])
     if (status.ok) {
       if (!status.out) {
         lines.push('📝 변경사항: ✅ 깨끗함')
@@ -154,7 +153,7 @@ export function createVhkMcpServer(): McpServer {
       }
     }
 
-    const log = safeExec('git log --oneline -3')
+    const log = safeExecFile('git', ['log', '--oneline', '-3'])
     if (log.ok && log.out) {
       lines.push('📜 최근 커밋:')
       log.out.split('\n').forEach((l) => lines.push(`   ${l}`))
@@ -169,9 +168,9 @@ export function createVhkMcpServer(): McpServer {
       return { content: [{ type: 'text', text: '❌ git 저장소가 아닙니다.' }] }
     }
 
-    const unstaged = safeExec('git diff --stat')
-    const staged = safeExec('git diff --cached --stat')
-    const untracked = safeExec('git ls-files --others --exclude-standard')
+    const unstaged = safeExecFile('git', ['diff', '--stat'])
+    const staged = safeExecFile('git', ['diff', '--cached', '--stat'])
+    const untracked = safeExecFile('git', ['ls-files', '--others', '--exclude-standard'])
 
     const unstagedOut = unstaged.ok ? unstaged.out : ''
     const stagedOut = staged.ok ? staged.out : ''
@@ -196,7 +195,7 @@ export function createVhkMcpServer(): McpServer {
       files.forEach((f) => lines.push(`   + ${f}`))
     }
 
-    const numstat = safeExec('git diff --numstat HEAD')
+    const numstat = safeExecFile('git', ['diff', '--numstat', 'HEAD'])
     if (numstat.ok && numstat.out) {
       let totalAdd = 0
       let totalDel = 0
@@ -217,10 +216,10 @@ export function createVhkMcpServer(): McpServer {
   server.tool('ship', '배포 체크리스트 실행 (빌드 + 테스트 + 버전 + git 상태)', {}, async () => {
     const checks: string[] = []
 
-    const build = safeExec('pnpm build')
+    const build = safeExecFile('pnpm', ['build'])
     checks.push(build.ok ? '✅ 빌드 성공' : '❌ 빌드 실패')
 
-    const test = safeExec('pnpm test --run')
+    const test = safeExecFile('pnpm', ['test', '--run'])
     checks.push(test.ok ? '✅ 테스트 통과' : '❌ 테스트 실패')
 
     if (existsSync('package.json')) {
@@ -233,7 +232,7 @@ export function createVhkMcpServer(): McpServer {
     }
 
     if (isGitRepo()) {
-      const status = safeExec('git status --porcelain')
+      const status = safeExecFile('git', ['status', '--porcelain'])
       if (status.ok) {
         if (status.out) {
           checks.push(`⚠️ 커밋되지 않은 변경사항 ${status.out.split('\n').length}개`)
@@ -250,19 +249,19 @@ export function createVhkMcpServer(): McpServer {
   server.tool('doctor', '개발 환경 점검 (Node/Git/npm/pnpm/TypeScript)', {}, async () => {
     const checks: string[] = []
 
-    const node = safeExec('node --version')
+    const node = safeExecFile('node', ['--version'])
     checks.push(node.ok ? `✅ Node.js: ${node.out}` : '❌ Node.js: 설치 안 됨')
 
-    const git = safeExec('git --version')
+    const git = safeExecFile('git', ['--version'])
     checks.push(git.ok ? `✅ Git: ${git.out}` : '❌ Git: 설치 안 됨')
 
-    const pnpm = safeExec('pnpm --version')
+    const pnpm = safeExecFile('pnpm', ['--version'])
     checks.push(pnpm.ok ? `✅ pnpm: v${pnpm.out}` : '⚠️ pnpm: 설치 안 됨')
 
-    const npm = safeExec('npm --version')
+    const npm = safeExecFile('npm', ['--version'])
     checks.push(npm.ok ? `✅ npm: v${npm.out}` : '❌ npm: 설치 안 됨')
 
-    const tsc = safeExec('npx tsc --version')
+    const tsc = safeExecFile('npx', ['tsc', '--version'])
     checks.push(tsc.ok ? `✅ TypeScript: ${tsc.out}` : '⚠️ TypeScript: 프로젝트에 없음')
 
     return { content: [{ type: 'text', text: '🩺 환경 점검 결과\n' + checks.join('\n') }] }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,293 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { z } from 'zod'
+import { execSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SERVER_VERSION = '0.6.0'
+
+function safeExec(cmd: string): { ok: true; out: string } | { ok: false; err: string } {
+  try {
+    const out = execSync(cmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).toString()
+    return { ok: true, out: out.trim() }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return { ok: false, err: msg }
+  }
+}
+
+function isGitRepo(): boolean {
+  return safeExec('git rev-parse --is-inside-work-tree').ok
+}
+
+export function createVhkMcpServer(): McpServer {
+  const server = new McpServer({
+    name: 'vhk',
+    version: SERVER_VERSION,
+  })
+
+  // ─── save ───────────────────────────────────────────────
+  server.tool(
+    'save',
+    '변경사항 저장 (git add → commit → push)',
+    {
+      message: z.string().optional().describe('커밋 메시지 (비우면 자동 생성)'),
+    },
+    async ({ message }) => {
+      if (!isGitRepo()) {
+        return { content: [{ type: 'text', text: '❌ git 저장소가 아닙니다.' }] }
+      }
+
+      const status = safeExec('git status --porcelain')
+      if (!status.ok) {
+        return { content: [{ type: 'text', text: `❌ git status 실패: ${status.err}` }] }
+      }
+      if (!status.out) {
+        return { content: [{ type: 'text', text: '📭 저장할 변경사항이 없습니다.' }] }
+      }
+
+      const files = status.out.split('\n')
+      const now = new Date()
+      const ts = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')} ${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`
+      const commitMsg = message?.trim() || `✨ vhk save: ${ts}`
+      const escaped = commitMsg.replace(/"/g, '\\"')
+
+      const add = safeExec('git add .')
+      if (!add.ok) {
+        return { content: [{ type: 'text', text: `❌ git add 실패: ${add.err}` }] }
+      }
+      const commit = safeExec(`git commit -m "${escaped}"`)
+      if (!commit.ok) {
+        return { content: [{ type: 'text', text: `❌ commit 실패: ${commit.err}` }] }
+      }
+
+      const push = safeExec('git push')
+      const pushResult = push.ok ? '+ 원격 업로드 완료' : '(원격 저장소 없거나 push 실패 → 스킵)'
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `✅ ${files.length}개 파일 저장 완료! ${pushResult}\n커밋: ${commitMsg}`,
+          },
+        ],
+      }
+    }
+  )
+
+  // ─── undo ───────────────────────────────────────────────
+  server.tool('undo', '최근 커밋 되돌리기 (soft reset, 변경사항은 유지)', {}, async () => {
+    if (!isGitRepo()) {
+      return { content: [{ type: 'text', text: '❌ git 저장소가 아닙니다.' }] }
+    }
+
+    const last = safeExec('git log --oneline -1')
+    if (!last.ok || !last.out) {
+      return { content: [{ type: 'text', text: '📭 되돌릴 커밋이 없습니다.' }] }
+    }
+
+    const reset = safeExec('git reset --soft HEAD~1')
+    if (!reset.ok) {
+      return { content: [{ type: 'text', text: `❌ reset 실패: ${reset.err}` }] }
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `✅ 되돌리기 완료!\n취소된 커밋: ${last.out}\n💡 변경사항은 스테이징 영역에 남아있습니다.`,
+        },
+      ],
+    }
+  })
+
+  // ─── status ─────────────────────────────────────────────
+  server.tool('status', '프로젝트 상태 대시보드 (브랜치/변경사항/최근 커밋)', {}, async () => {
+    const lines: string[] = []
+
+    if (existsSync('package.json')) {
+      try {
+        const pkg = JSON.parse(readFileSync('package.json', 'utf-8'))
+        lines.push(`📦 프로젝트: ${pkg.name ?? '(이름 없음)'} v${pkg.version ?? '?'}`)
+      } catch {
+        // skip
+      }
+    }
+
+    if (!isGitRepo()) {
+      lines.push('⚠️  git 저장소가 아닙니다')
+      return { content: [{ type: 'text', text: lines.join('\n') }] }
+    }
+
+    const branch = safeExec('git branch --show-current')
+    if (branch.ok) lines.push(`🌿 브랜치: ${branch.out || '(detached)'}`)
+
+    const status = safeExec('git status --porcelain')
+    if (status.ok) {
+      if (!status.out) {
+        lines.push('📝 변경사항: ✅ 깨끗함')
+      } else {
+        const fileLines = status.out.split('\n')
+        const staged = fileLines.filter((l) => l[0] !== ' ' && l[0] !== '?').length
+        const unstaged = fileLines.filter((l) => l[1] === 'M' || l[1] === 'D').length
+        const untracked = fileLines.filter((l) => l.startsWith('??')).length
+        const parts: string[] = []
+        if (staged) parts.push(`스테이징 ${staged}개`)
+        if (unstaged) parts.push(`수정 ${unstaged}개`)
+        if (untracked) parts.push(`새파일 ${untracked}개`)
+        lines.push(`📝 변경사항: ${parts.join(', ')}`)
+      }
+    }
+
+    const log = safeExec('git log --oneline -3')
+    if (log.ok && log.out) {
+      lines.push('📜 최근 커밋:')
+      log.out.split('\n').forEach((l) => lines.push(`   ${l}`))
+    }
+
+    return { content: [{ type: 'text', text: lines.join('\n') }] }
+  })
+
+  // ─── diff ───────────────────────────────────────────────
+  server.tool('diff', '변경사항 확인 (staged/unstaged/새파일 + 총 변경 요약)', {}, async () => {
+    if (!isGitRepo()) {
+      return { content: [{ type: 'text', text: '❌ git 저장소가 아닙니다.' }] }
+    }
+
+    const unstaged = safeExec('git diff --stat')
+    const staged = safeExec('git diff --cached --stat')
+    const untracked = safeExec('git ls-files --others --exclude-standard')
+
+    const unstagedOut = unstaged.ok ? unstaged.out : ''
+    const stagedOut = staged.ok ? staged.out : ''
+    const untrackedOut = untracked.ok ? untracked.out : ''
+
+    if (!unstagedOut && !stagedOut && !untrackedOut) {
+      return { content: [{ type: 'text', text: '✅ 변경사항 없음! 깨끗합니다.' }] }
+    }
+
+    const lines: string[] = []
+    if (stagedOut) {
+      lines.push('📦 커밋 대기 (staged):')
+      lines.push(stagedOut)
+    }
+    if (unstagedOut) {
+      lines.push('✏️ 수정됨 (unstaged):')
+      lines.push(unstagedOut)
+    }
+    if (untrackedOut) {
+      const files = untrackedOut.split('\n')
+      lines.push(`➕ 새 파일 (${files.length}개):`)
+      files.forEach((f) => lines.push(`   + ${f}`))
+    }
+
+    const numstat = safeExec('git diff --numstat HEAD')
+    if (numstat.ok && numstat.out) {
+      let totalAdd = 0
+      let totalDel = 0
+      let fileCount = 0
+      numstat.out.split('\n').forEach((line) => {
+        const [add, del] = line.split('\t')
+        totalAdd += parseInt(add, 10) || 0
+        totalDel += parseInt(del, 10) || 0
+        fileCount += 1
+      })
+      lines.push(`\n📊 총 변경: ${fileCount}개 파일, +${totalAdd}줄 -${totalDel}줄`)
+    }
+
+    return { content: [{ type: 'text', text: lines.join('\n') }] }
+  })
+
+  // ─── ship ───────────────────────────────────────────────
+  server.tool('ship', '배포 체크리스트 실행 (빌드 + 테스트 + 버전 + git 상태)', {}, async () => {
+    const checks: string[] = []
+
+    const build = safeExec('pnpm build')
+    checks.push(build.ok ? '✅ 빌드 성공' : '❌ 빌드 실패')
+
+    const test = safeExec('pnpm test --run')
+    checks.push(test.ok ? '✅ 테스트 통과' : '❌ 테스트 실패')
+
+    if (existsSync('package.json')) {
+      try {
+        const pkg = JSON.parse(readFileSync('package.json', 'utf-8'))
+        checks.push(`📦 버전: ${pkg.version}`)
+      } catch {
+        // skip
+      }
+    }
+
+    if (isGitRepo()) {
+      const status = safeExec('git status --porcelain')
+      if (status.ok) {
+        if (status.out) {
+          checks.push(`⚠️ 커밋되지 않은 변경사항 ${status.out.split('\n').length}개`)
+        } else {
+          checks.push('✅ 워킹 디렉토리 깨끗함')
+        }
+      }
+    }
+
+    return { content: [{ type: 'text', text: '🚀 배포 체크리스트\n' + checks.join('\n') }] }
+  })
+
+  // ─── doctor ─────────────────────────────────────────────
+  server.tool('doctor', '개발 환경 점검 (Node/Git/npm/pnpm/TypeScript)', {}, async () => {
+    const checks: string[] = []
+
+    const node = safeExec('node --version')
+    checks.push(node.ok ? `✅ Node.js: ${node.out}` : '❌ Node.js: 설치 안 됨')
+
+    const git = safeExec('git --version')
+    checks.push(git.ok ? `✅ Git: ${git.out}` : '❌ Git: 설치 안 됨')
+
+    const pnpm = safeExec('pnpm --version')
+    checks.push(pnpm.ok ? `✅ pnpm: v${pnpm.out}` : '⚠️ pnpm: 설치 안 됨')
+
+    const npm = safeExec('npm --version')
+    checks.push(npm.ok ? `✅ npm: v${npm.out}` : '❌ npm: 설치 안 됨')
+
+    const tsc = safeExec('npx tsc --version')
+    checks.push(tsc.ok ? `✅ TypeScript: ${tsc.out}` : '⚠️ TypeScript: 프로젝트에 없음')
+
+    return { content: [{ type: 'text', text: '🩺 환경 점검 결과\n' + checks.join('\n') }] }
+  })
+
+  // ─── check ──────────────────────────────────────────────
+  server.tool('check', '프로젝트 구조 점검 (필수 파일 존재 여부)', {}, async () => {
+    const required = ['package.json', 'tsconfig.json', 'README.md', '.gitignore']
+    const results = required.map((f) => `${existsSync(f) ? '✅' : '❌'} ${f}`)
+    return { content: [{ type: 'text', text: '🔍 프로젝트 점검\n' + results.join('\n') }] }
+  })
+
+  // ─── recap ──────────────────────────────────────────────
+  server.tool(
+    'recap',
+    '최근 작업 요약 (커밋 히스토리 기반)',
+    {
+      count: z.number().optional().describe('표시할 커밋 수 (기본: 10)'),
+    },
+    async ({ count }) => {
+      if (!isGitRepo()) {
+        return { content: [{ type: 'text', text: '❌ git 저장소가 아닙니다.' }] }
+      }
+      const n = count && count > 0 ? Math.floor(count) : 10
+      const log = safeExec(`git log --oneline -${n}`)
+      if (!log.ok) {
+        return { content: [{ type: 'text', text: `❌ git log 실패: ${log.err}` }] }
+      }
+      if (!log.out) {
+        return { content: [{ type: 'text', text: '📭 커밋 히스토리가 없습니다.' }] }
+      }
+      return { content: [{ type: 'text', text: `📋 최근 작업 (${n}개):\n${log.out}` }] }
+    }
+  )
+
+  return server
+}
+
+export async function startMcpServer(): Promise<void> {
+  const server = createVhkMcpServer()
+  const transport = new StdioServerTransport()
+  await server.connect(transport)
+}

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -82,6 +82,6 @@ describe('cli NL e2e', () => {
 
   it('vhk --version', () => {
     const r = spawnSync(process.execPath, [bin, '--version'], { encoding: 'utf-8' })
-    expect(r.stdout?.trim()).toMatch(/0\.5\./)
+    expect(r.stdout?.trim()).toMatch(/^\d+\.\d+\.\d+/)
   })
 })

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -82,6 +82,7 @@ describe('cli NL e2e', () => {
 
   it('vhk --version', () => {
     const r = spawnSync(process.execPath, [bin, '--version'], { encoding: 'utf-8' })
-    expect(r.stdout?.trim()).toMatch(/^\d+\.\d+\.\d+/)
+    const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8')) as { version: string }
+    expect(r.stdout?.trim()).toBe(pkg.version)
   })
 })

--- a/tests/mcp-init.test.ts
+++ b/tests/mcp-init.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockExistsSync = vi.fn()
+const mockMkdirSync = vi.fn()
+const mockReadFileSync = vi.fn()
+const mockWriteFileSync = vi.fn()
+
+vi.mock('node:fs', () => ({
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
+  mkdirSync: (...a: unknown[]) => mockMkdirSync(...a),
+  readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
+  writeFileSync: (...a: unknown[]) => mockWriteFileSync(...a),
+}))
+
+describe('mcp-init', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('모듈을 import 할 수 있다', async () => {
+    const mod = await import('../src/commands/mcp-init.js')
+    expect(mod.mcpInit).toBeDefined()
+  })
+
+  it('.cursor/mcp.json 이 없으면 새로 생성한다', async () => {
+    mockExistsSync.mockReturnValue(false)
+    const { mcpInit } = await import('../src/commands/mcp-init.js')
+    await mcpInit()
+    expect(mockMkdirSync).toHaveBeenCalled()
+    expect(mockWriteFileSync).toHaveBeenCalled()
+    const writeCall = mockWriteFileSync.mock.calls[0]
+    expect(String(writeCall[0])).toContain('mcp.json')
+    const content = JSON.parse(String(writeCall[1]))
+    expect(content.mcpServers.vhk).toBeDefined()
+    expect(content.mcpServers.vhk.command).toBe('node')
+  })
+
+  it('.cursor/mcp.json 이 이미 있으면 vhk 항목만 병합한다', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p).includes('mcp.json'))
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ mcpServers: { other: { command: 'foo', args: [] } } })
+    )
+    const { mcpInit } = await import('../src/commands/mcp-init.js')
+    await mcpInit()
+    const writeCall = mockWriteFileSync.mock.calls[0]
+    const content = JSON.parse(String(writeCall[1]))
+    expect(content.mcpServers.other).toBeDefined()
+    expect(content.mcpServers.vhk).toBeDefined()
+  })
+})

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('node:child_process')
+vi.mock('node:fs')
+
+describe('MCP Server', () => {
+  it('서버 인스턴스가 생성된다', async () => {
+    const { createVhkMcpServer } = await import('../src/mcp/server.js')
+    const server = createVhkMcpServer()
+    expect(server).toBeDefined()
+  })
+
+  it('서버 이름이 vhk이고 버전이 0.6.0이다', async () => {
+    const { createVhkMcpServer } = await import('../src/mcp/server.js')
+    const server = createVhkMcpServer()
+    // McpServer의 내부 메타데이터 노출 방식이 SDK 버전에 따라 다름.
+    // 최소한 객체가 생성되었는지 확인. 실제 도구 동작은 통합 테스트 영역.
+    expect(server).toBeDefined()
+  })
+})

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/mcp/index.ts'],
   format: ['esm'],
   tsconfig: 'tsconfig.build.json',
-  dts: true,
+  dts: { entry: ['src/index.ts'] },
   clean: true,
   banner: { js: '#!/usr/bin/env node' },
 });


### PR DESCRIPTION
## Summary

VHK CLI v0.6.0 — MCP(Model Context Protocol) 서버 지원 추가. Cursor/Claude Desktop 등 MCP 클라이언트가 vhk 명령을 직접 호출 가능.

- **MCP 서버** (`vhk mcp`, `vhk-mcp` bin): 8개 도구 stdio 노출 — save / undo / status / diff / ship / doctor / check / recap
- **`vhk mcp-init`** (별칭 `mcp설정`): `.cursor/mcp.json` 자동 생성 (기존 설정 병합 지원 + dogfooding 감지)
- **자연어 라우팅**: "mcp 설정해줘" → `mcp-init` 디스패치
- **i18n**: `ko.mcp` 섹션 추가
- **Security fix**: MCP `save` 도구 shell injection 차단 (`execFileSync` 전면 전환)
- **API 마이그레이션**: `server.tool` → `registerTool` (deprecation 해결)
- **버전**: 0.5.3 → 0.6.0

## Plan

[docs/superpowers/plans/2026-05-24-v0.6.0-mcp.md](docs/superpowers/plans/2026-05-24-v0.6.0-mcp.md) — 11 task TDD plan, subagent-driven 실행, task당 spec + code-quality 2단계 리뷰.

## 변경 파일

- **신규**: `src/mcp/server.ts`, `src/mcp/index.ts`, `src/commands/mcp-init.ts`, `tests/mcp-server.test.ts`, `tests/mcp-init.test.ts`
- **수정**: `package.json` (version + bin + deps), `src/index.ts` (명령 등록 + 헬프 포매터 null-safe), `src/lib/nlp-router.ts` (NlpCommand 확장 + RULES), `src/lib/nlp-run.ts` (dispatcher), `src/lib/cli-args.ts` (KNOWN_COMMAND_TOKENS), `src/i18n/ko.ts` (mcp 섹션), `tsup.config.ts` (MCP entry), `tests/cli-args.test.ts` (version 정확 매칭), `README.md`, `CHANGELOG.md`

## 의존성 추가

- `@modelcontextprotocol/sdk@^1.29.0`
- `zod@^4.4.3`

## Code review fixes (PR review 후 추가 commit)

- `aaf878a` fix: execFileSync 일관성 통일 — shell injection 전면 차단
- `4459261` fix: recap 도구 출력에 날짜 포함 (`%h %ad %s --date=short`)
- `cf94f1f` fix: check 도구에 VHK 표준 하네스 파일 추가 (필수/권장 구분)
- `2b10b9b` test: --version 테스트 강화 — package.json 정확 매칭
- `b35cede` fix: ship 도구에 비동기 전환 TODO 주석 추가 (v0.6.1)
- `3c012d0` refactor: server.tool → registerTool 마이그레이션 (deprecation 해결)
- `f400352` fix: mcp-init dogfooding 경로 감지 (cwd가 vhk-cli repo일 때 dist/mcp/index.js 사용)

## Test plan

- [x] `pnpm test --run` — 112/112 pass (mcp-server 2개 + mcp-init 3개 신규 추가 포함)
- [x] `pnpm build` — clean (`dist/index.js` + `dist/mcp/index.js` 둘 다 shebang 포함)
- [x] `npx tsc --noEmit` — 3 pre-existing errors만 (src/lib/git.ts, src/lib/notion-import.ts), 신규 0, deprecation hint 0
- [x] `node dist/mcp/index.js` — stdio 대기 (3초 alive)
- [x] `node dist/index.js mcp` — stdio 대기
- [x] `node dist/index.js mcp-init` → `.cursor/mcp.json` 생성, `mcpServers.vhk` 포함, dogfooding 경로 정확
- [x] `node dist/index.js "mcp 설정해줘"` → NL 라우팅 → mcp-init 실행
- [x] `node dist/index.js --version` → `0.6.0`
- [x] `node dist/index.js --help` → `mcp`, `mcp-init (mcp설정)` 표시
- [x] **(수동 검증) Cursor 재시작 후 채팅에서 vhk 도구 호출 동작 확인** ✅
- [ ] (배포 후) `npm i -g @byh3071/vhk@0.6.0` → `vhk-mcp` 글로벌 실행

## 알려진 사항

- v0.6.0 plan에서 도출된 v0.7~v1.0 스펙 버그(harness.ts 템플릿 리터럴, audit.ts Windows 호환, deploy/ship 별칭 충돌 등)는 부록 B에 기록.
- ship 도구는 동기 블로킹 (`pnpm build/test --run`). v0.6.1에서 execa 비동기 전환 예정 (TODO 주석 in-file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)