### PR TITLE
feat: v0.7.0 — deploy + env + publish + safeExecFile 공유

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ---
 
+## [0.7.0] — 2026-05-24
+
+### Added
+- `vhk deploy` — Vercel / Netlify / Cloudflare Workers 자동 감지 + 프로덕션 배포
+- `vhk env` — `.env` 키만 추출해 `.env.example` 생성, `.gitignore`에 `.env` 자동 추가
+- `vhk env-check` — `.env.example` 기준 누락 환경변수 검사
+- `vhk publish` — semver 범프(patch/minor/major) + 빌드 + 테스트 + `npm publish` + git tag
+- `src/lib/exec.ts` — `safeExecFile` 공유 헬퍼 분리 (MCP 서버 + v0.7 신규 명령 재사용)
+- 자연어 라우팅: `'환경변수 점검'`, `'vercel 배포'`, `'npm 출시'` 등 신규 패턴
+
+### Changed
+- `ship` 별칭: `'배포'` → `'출하'` (`deploy`와 의미 분리)
+- `ship` NLP 룰: `'배포 체크/준비/점검'` 또는 `'출하'` 단독으로만 매칭. `'배포'` 단독은 `deploy`로 양보
+- 버전: 0.6.0 → 0.7.0
+
+---
+
 ## [0.6.0] — 2026-05-24
 
 ### Added
@@ -90,7 +107,8 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 - **`vhk gate`** — 아이디어 검증 (퀵 5문항 / 풀 13문항 / 스킵)
 - **`vhk init`** — 프로젝트 시작. 하네스 파일 생성 (`CLAUDE.md`, `.cursorrules`, `docs/PRD.md`, `docs/ARCHITECTURE.md`, ADR/log 폴더)
 
-[Unreleased]: https://github.com/byh3071-cpu/vhk/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/byh3071-cpu/vhk/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/byh3071-cpu/vhk/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/byh3071-cpu/vhk/compare/v0.5.3...v0.6.0
 [0.5.3]: https://github.com/byh3071-cpu/vhk/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/byh3071-cpu/vhk/compare/v0.5.1...v0.5.2

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ vhk 기획 끝났고 바로 시작
 | `vhk mcp` | — | MCP 서버 시작 (Cursor 등 MCP 클라이언트용, stdio) |
 | `vhk mcp-init` | `mcp설정` | Cursor `.cursor/mcp.json` 자동 생성 |
 | `vhk deploy` | `배포` | 프로덕션 배포 (Vercel / Netlify / Cloudflare 자동 감지) |
-| `vhk env` | — | `.env` → `.env.example` 동기화 + `.gitignore`에 `.env` 자동 추가 |
+| `vhk env` | `환경변수` | `.env` → `.env.example` 동기화 + `.gitignore`에 `.env` 자동 추가 |
 | `vhk env-check` | `환경변수점검` | `.env.example` 기준 누락 환경변수 검사 |
 | `vhk publish` | `출시` | npm 배포 자동화 (버전 범프 → 빌드 → 테스트 → publish → git tag) |
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ vhk 기획 끝났고 바로 시작
 | `vhk sync` | `규칙`, `맞추기` | RULES.md → `.cursorrules` + CLAUDE.md |
 | `vhk check` | `점검`, `린트` | RULES.md 규칙 위반 검사 |
 | `vhk secure` | `보안` | 시크릿·키 유출 스캔 (`scan` / `스캔` 동일). **CRITICAL/HIGH 발견 시 exit code 1** (CI용) |
-| `vhk ship` | `출하`, `릴리즈` | 배포 체크리스트 + 회고 + 빌드 로그 |
+| `vhk ship` | `출하` | 배포 체크리스트 + 회고 + 빌드 로그 |
 | `vhk doctor` | `환경`, `진단` | Node / npm / pnpm / Git 환경 점검 |
 | `vhk save` | `저장`, `커밋` | git add · commit · push 한 번에 |
 | `vhk undo` | `되돌리기`, `취소` | 최근 커밋 soft reset (변경은 staged 유지) |

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ vhk 기획 끝났고 바로 시작
 | `vhk sync` | `규칙`, `맞추기` | RULES.md → `.cursorrules` + CLAUDE.md |
 | `vhk check` | `점검`, `린트` | RULES.md 규칙 위반 검사 |
 | `vhk secure` | `보안` | 시크릿·키 유출 스캔 (`scan` / `스캔` 동일). **CRITICAL/HIGH 발견 시 exit code 1** (CI용) |
-| `vhk ship` | `배포`, `릴리즈` | 배포 체크리스트 + 회고 + 빌드 로그 |
+| `vhk ship` | `출하`, `릴리즈` | 배포 체크리스트 + 회고 + 빌드 로그 |
 | `vhk doctor` | `환경`, `진단` | Node / npm / pnpm / Git 환경 점검 |
 | `vhk save` | `저장`, `커밋` | git add · commit · push 한 번에 |
 | `vhk undo` | `되돌리기`, `취소` | 최근 커밋 soft reset (변경은 staged 유지) |
@@ -91,6 +91,10 @@ vhk 기획 끝났고 바로 시작
 | `vhk status` | `상태`, `현황` | 브랜치·변경·커밋·원격·버전 대시보드 |
 | `vhk mcp` | — | MCP 서버 시작 (Cursor 등 MCP 클라이언트용, stdio) |
 | `vhk mcp-init` | `mcp설정` | Cursor `.cursor/mcp.json` 자동 생성 |
+| `vhk deploy` | `배포` | 프로덕션 배포 (Vercel / Netlify / Cloudflare 자동 감지) |
+| `vhk env` | — | `.env` → `.env.example` 동기화 + `.gitignore`에 `.env` 자동 추가 |
+| `vhk env-check` | `환경변수점검` | `.env.example` 기준 누락 환경변수 검사 |
+| `vhk publish` | `출시` | npm 배포 자동화 (버전 범프 → 빌드 → 테스트 → publish → git tag) |
 
 ### init 옵션
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Vibe Harness Kit — 바이브코딩 풀사이클 CLI",
   "bin": {
     "vhk": "dist/index.js",

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,0 +1,120 @@
+import { existsSync } from 'node:fs'
+import chalk from 'chalk'
+import inquirer from 'inquirer'
+import ora from 'ora'
+import { safeExecFile } from '../lib/exec.js'
+import { t } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+
+export type Platform = 'vercel' | 'netlify' | 'cloudflare'
+
+interface PlatformConfig {
+  name: string
+  detectFiles: string[]
+  command: string
+  commandArgs: string[]
+  checkArgs: string[]
+  installHint: string
+}
+
+const PLATFORMS: Record<Platform, PlatformConfig> = {
+  vercel: {
+    name: 'Vercel',
+    detectFiles: ['vercel.json', '.vercel'],
+    command: 'vercel',
+    commandArgs: ['--prod'],
+    checkArgs: ['--version'],
+    installHint: 'npm i -g vercel',
+  },
+  netlify: {
+    name: 'Netlify',
+    detectFiles: ['netlify.toml', '.netlify'],
+    command: 'netlify',
+    commandArgs: ['deploy', '--prod'],
+    checkArgs: ['--version'],
+    installHint: 'npm i -g netlify-cli',
+  },
+  cloudflare: {
+    name: 'Cloudflare Workers',
+    detectFiles: ['wrangler.toml'],
+    command: 'wrangler',
+    commandArgs: ['deploy'],
+    checkArgs: ['--version'],
+    installHint: 'npm i -g wrangler',
+  },
+}
+
+export function detectPlatform(): Platform | null {
+  for (const [key, config] of Object.entries(PLATFORMS) as [Platform, PlatformConfig][]) {
+    for (const file of config.detectFiles) {
+      if (existsSync(file)) return key
+    }
+  }
+  return null
+}
+
+function isCLIAvailable(cmd: string, checkArgs: string[]): boolean {
+  return safeExecFile(cmd, checkArgs).ok
+}
+
+export async function deploy(): Promise<void> {
+  console.log(chalk.bold('\n🚀 ' + t('deploy.title')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  let platform: Platform | null = detectPlatform()
+
+  if (platform) {
+    console.log(chalk.cyan(`\n🔍 감지된 플랫폼: ${PLATFORMS[platform].name}`))
+  } else {
+    const { selected } = await inquirer.prompt<{ selected: Platform }>([
+      {
+        type: 'list',
+        name: 'selected',
+        message: t('deploy.selectPlatform'),
+        choices: [
+          { name: '▲ Vercel', value: 'vercel' as Platform },
+          { name: '◆ Netlify', value: 'netlify' as Platform },
+          { name: '☁ Cloudflare Workers', value: 'cloudflare' as Platform },
+        ],
+      },
+    ])
+    platform = selected
+  }
+
+  const config = PLATFORMS[platform]
+
+  if (!isCLIAvailable(config.command, config.checkArgs)) {
+    console.log(chalk.red(`\n❌ ${config.name} CLI가 설치되어 있지 않습니다.`))
+    console.log(chalk.yellow(`   → ${config.installHint}`))
+    return
+  }
+
+  const { confirm } = await inquirer.prompt<{ confirm: boolean }>([
+    {
+      type: 'confirm',
+      name: 'confirm',
+      message: `${config.name}에 프로덕션 배포할까요?`,
+      default: true,
+    },
+  ])
+
+  if (!confirm) {
+    console.log(chalk.gray('취소됨'))
+    return
+  }
+
+  const spinner = ora(t('deploy.deploying')).start()
+  const result = safeExecFile(config.command, config.commandArgs)
+
+  if (result.ok) {
+    spinner.succeed(t('deploy.success'))
+    printNextStep({
+      message: '배포 완료! 사이트를 확인하세요.',
+      command: 'vhk status',
+      cursorHint: '상태 확인해줘',
+    })
+  } else {
+    spinner.fail(t('deploy.failed'))
+    console.log(chalk.red(result.err))
+  }
+}

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,8 +1,7 @@
 import { existsSync } from 'node:fs'
 import chalk from 'chalk'
 import inquirer from 'inquirer'
-import ora from 'ora'
-import { safeExecFile } from '../lib/exec.js'
+import { safeExecFile, safeExecFileStream } from '../lib/exec.js'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 
@@ -103,18 +102,20 @@ export async function deploy(): Promise<void> {
     return
   }
 
-  const spinner = ora(t('deploy.deploying')).start()
-  const result = safeExecFile(config.command, config.commandArgs)
+  // 배포는 시간이 걸리는 작업 — 실시간 로그를 사용자가 볼 수 있도록 stream 모드 사용.
+  // ora 스피너는 자식 프로세스 stdout과 충돌하므로 사용 안 함.
+  console.log(chalk.cyan(`\n${t('deploy.deploying')}\n`))
+  const result = safeExecFileStream(config.command, config.commandArgs)
 
   if (result.ok) {
-    spinner.succeed(t('deploy.success'))
+    console.log(chalk.green(`\n✅ ${t('deploy.success')}`))
     printNextStep({
       message: '배포 완료! 사이트를 확인하세요.',
       command: 'vhk status',
       cursorHint: '상태 확인해줘',
     })
   } else {
-    spinner.fail(t('deploy.failed'))
+    console.log(chalk.red(`\n❌ ${t('deploy.failed')}`))
     console.log(chalk.red(result.err))
   }
 }

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -1,0 +1,93 @@
+import { existsSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs'
+import chalk from 'chalk'
+import { t } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+
+export function parseEnvKeys(content: string): string[] {
+  return content
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'))
+    .map((line) => line.split('=')[0].trim())
+    .filter(Boolean)
+}
+
+function ensureGitignore(): void {
+  const gitignorePath = '.gitignore'
+  if (existsSync(gitignorePath)) {
+    const content = readFileSync(gitignorePath, 'utf-8')
+    if (!content.split('\n').some((l) => l.trim() === '.env')) {
+      appendFileSync(gitignorePath, '\n.env\n')
+      console.log(chalk.green('\n🔒 .gitignore에 .env 추가됨'))
+    }
+  } else {
+    writeFileSync(gitignorePath, '.env\nnode_modules/\ndist/\n')
+    console.log(chalk.green('\n🔒 .gitignore 생성 (.env 포함)'))
+  }
+}
+
+export async function env(): Promise<void> {
+  console.log(chalk.bold('\n🔐 ' + t('env.title')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  if (!existsSync('.env')) {
+    console.log(chalk.yellow('\n⚠️  .env 파일이 없습니다.'))
+    console.log(chalk.gray('   .env 파일을 먼저 만들어주세요.'))
+    return
+  }
+
+  const envContent = readFileSync('.env', 'utf-8')
+  const keys = parseEnvKeys(envContent)
+
+  if (keys.length === 0) {
+    console.log(chalk.yellow('\n📭 .env에 환경변수가 없습니다.'))
+    return
+  }
+
+  const exampleContent = keys.map((k) => `${k}=`).join('\n') + '\n'
+  writeFileSync('.env.example', exampleContent, 'utf-8')
+  console.log(chalk.green(`\n✅ .env.example 생성 (${keys.length}개 키)`))
+  keys.forEach((k) => console.log(chalk.gray(`   ${k}`)))
+
+  ensureGitignore()
+
+  printNextStep({
+    message: '.env.example 생성 완료!',
+    command: 'vhk env-check',
+    cursorHint: '환경변수 점검해줘',
+  })
+}
+
+export async function envCheck(): Promise<void> {
+  console.log(chalk.bold('\n🔍 ' + t('env.checkTitle')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  if (!existsSync('.env.example')) {
+    console.log(chalk.yellow('\n⚠️  .env.example이 없습니다. 먼저 vhk env를 실행하세요.'))
+    return
+  }
+
+  const requiredKeys = parseEnvKeys(readFileSync('.env.example', 'utf-8'))
+  const currentKeys = existsSync('.env')
+    ? parseEnvKeys(readFileSync('.env', 'utf-8'))
+    : []
+
+  const missing = requiredKeys.filter((k) => !currentKeys.includes(k))
+  const extra = currentKeys.filter((k) => !requiredKeys.includes(k))
+
+  console.log(chalk.cyan(`\n📋 필수 환경변수: ${requiredKeys.length}개`))
+
+  if (missing.length === 0) {
+    console.log(chalk.green('\n✅ 모든 필수 환경변수가 설정되어 있습니다!'))
+  } else {
+    console.log(chalk.red(`\n❌ 누락된 환경변수 (${missing.length}개):`))
+    missing.forEach((k) => console.log(chalk.red(`   • ${k}`)))
+  }
+
+  if (extra.length > 0) {
+    console.log(chalk.yellow(`\n💡 .env.example에 없는 추가 변수 (${extra.length}개):`))
+    extra.forEach((k) => console.log(chalk.yellow(`   • ${k}`)))
+  }
+
+  ensureGitignore()
+}

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,0 +1,141 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import chalk from 'chalk'
+import inquirer from 'inquirer'
+import ora from 'ora'
+import { safeExecFile } from '../lib/exec.js'
+import { t } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+
+export type BumpType = 'patch' | 'minor' | 'major'
+
+export function bumpVersion(current: string, type: BumpType): string {
+  const [major, minor, patch] = current.split('.').map((n) => parseInt(n, 10) || 0)
+  switch (type) {
+    case 'major':
+      return `${major + 1}.0.0`
+    case 'minor':
+      return `${major}.${minor + 1}.0`
+    case 'patch':
+      return `${major}.${minor}.${patch + 1}`
+  }
+}
+
+interface Pkg {
+  version?: string
+  [key: string]: unknown
+}
+
+export async function publish(): Promise<void> {
+  console.log(chalk.bold('\n📦 ' + t('publish.title')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  if (!existsSync('package.json')) {
+    console.log(chalk.red('❌ package.json을 찾을 수 없습니다.'))
+    return
+  }
+
+  let pkg: Pkg
+  try {
+    pkg = JSON.parse(readFileSync('package.json', 'utf-8'))
+  } catch {
+    console.log(chalk.red('❌ package.json 파싱 실패'))
+    return
+  }
+
+  const currentVersion = pkg.version || '0.0.0'
+  console.log(chalk.cyan(`\n📌 현재 버전: v${currentVersion}`))
+
+  const { bumpType } = await inquirer.prompt<{ bumpType: BumpType }>([
+    {
+      type: 'list',
+      name: 'bumpType',
+      message: t('publish.selectBump'),
+      choices: [
+        { name: `🔧 patch (${bumpVersion(currentVersion, 'patch')}) — 버그 수정`, value: 'patch' },
+        { name: `✨ minor (${bumpVersion(currentVersion, 'minor')}) — 새 기능`, value: 'minor' },
+        { name: `💥 major (${bumpVersion(currentVersion, 'major')}) — 호환성 변경`, value: 'major' },
+      ],
+    },
+  ])
+
+  const newVersion = bumpVersion(currentVersion, bumpType)
+  console.log(chalk.cyan(`\n🆕 새 버전: v${newVersion}`))
+
+  pkg.version = newVersion
+  writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n', 'utf-8')
+  console.log(chalk.green('✅ package.json 버전 업데이트'))
+
+  // 빌드
+  const buildSpinner = ora(t('publish.building')).start()
+  const buildResult = safeExecFile('pnpm', ['build'])
+  if (!buildResult.ok) {
+    buildSpinner.fail(t('publish.buildFailed'))
+    console.log(chalk.red(buildResult.err.slice(0, 500)))
+    pkg.version = currentVersion
+    writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n', 'utf-8')
+    return
+  }
+  buildSpinner.succeed(t('publish.buildSuccess'))
+
+  // 테스트
+  const testSpinner = ora(t('publish.testing')).start()
+  const testResult = safeExecFile('pnpm', ['test', '--run'])
+  if (!testResult.ok) {
+    testSpinner.fail(t('publish.testFailed'))
+    console.log(chalk.red(testResult.err.slice(0, 500)))
+    pkg.version = currentVersion
+    writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n', 'utf-8')
+    return
+  }
+  testSpinner.succeed(t('publish.testSuccess'))
+
+  // 최종 확인
+  const { confirm } = await inquirer.prompt<{ confirm: boolean }>([
+    {
+      type: 'confirm',
+      name: 'confirm',
+      message: `v${newVersion}을 npm에 배포할까요?`,
+      default: true,
+    },
+  ])
+
+  if (!confirm) {
+    pkg.version = currentVersion
+    writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n', 'utf-8')
+    console.log(chalk.gray('취소됨. 버전이 원래대로 복구됩니다.'))
+    return
+  }
+
+  // npm publish
+  const pubSpinner = ora(t('publish.publishing')).start()
+  const pubResult = safeExecFile('npm', ['publish', '--access', 'public'])
+  if (!pubResult.ok) {
+    pubSpinner.fail(t('publish.publishFailed'))
+    console.log(chalk.red(pubResult.err.slice(0, 500)))
+    return
+  }
+  pubSpinner.succeed(t('publish.publishSuccess'))
+
+  // git tag (옵션 — 실패해도 publish는 성공)
+  const addResult = safeExecFile('git', ['add', 'package.json'])
+  if (addResult.ok) {
+    safeExecFile('git', ['commit', '-m', `chore: release v${newVersion}`])
+    const tagResult = safeExecFile('git', ['tag', `v${newVersion}`])
+    if (tagResult.ok) {
+      const pushResult = safeExecFile('git', ['push'])
+      const pushTagsResult = safeExecFile('git', ['push', '--tags'])
+      if (pushResult.ok && pushTagsResult.ok) {
+        console.log(chalk.green(`\n🏷️  git tag v${newVersion} 생성 + push 완료`))
+      } else {
+        console.log(chalk.yellow(`\n🏷️  git tag v${newVersion} 생성됨 (push는 수동으로)`))
+      }
+    }
+  }
+
+  console.log(chalk.green.bold(`\n🎉 v${newVersion} 배포 완료!`))
+  printNextStep({
+    message: 'npm 배포 완료!',
+    command: 'vhk status',
+    cursorHint: '상태 확인해줘',
+  })
+}

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -112,6 +112,10 @@ export async function publish(): Promise<void> {
   if (!pubResult.ok) {
     pubSpinner.fail(t('publish.publishFailed'))
     console.log(chalk.red(pubResult.err.slice(0, 500)))
+    // 버전 롤백 (publish 실패 시 package.json 원래대로)
+    pkg.version = currentVersion
+    writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n', 'utf-8')
+    console.log(chalk.gray(`📦 package.json 버전을 v${currentVersion}로 복구했습니다.`))
     return
   }
   pubSpinner.succeed(t('publish.publishSuccess'))

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -253,6 +253,30 @@ export const ko = {
     initTitle: 'Cursor MCP 연동 설정',
     serverStarted: 'VHK MCP 서버 시작됨',
   },
+  deploy: {
+    title: '배포하기',
+    selectPlatform: '어떤 플랫폼에 배포할까요?',
+    deploying: '배포 중...',
+    success: '배포 성공!',
+    failed: '배포 실패',
+  },
+  env: {
+    title: '환경변수 관리',
+    checkTitle: '환경변수 점검',
+  },
+  publish: {
+    title: 'npm 배포',
+    selectBump: '버전을 어떻게 올릴까요?',
+    building: '빌드 중...',
+    buildSuccess: '빌드 성공',
+    buildFailed: '빌드 실패',
+    testing: '테스트 중...',
+    testSuccess: '테스트 통과',
+    testFailed: '테스트 실패',
+    publishing: 'npm 배포 중...',
+    publishSuccess: 'npm 배포 성공!',
+    publishFailed: 'npm 배포 실패',
+  },
 } as const
 
 type KoValue = string | ((...args: never[]) => string)

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,9 @@ import { diff } from './commands/diff.js'
 import { status } from './commands/status.js'
 import { startMcpServer } from './mcp/server.js'
 import { mcpInit } from './commands/mcp-init.js'
+import { deploy } from './commands/deploy.js'
+import { env, envCheck } from './commands/env.js'
+import { publish } from './commands/publish.js'
 
 const program = new Command()
 const defaultHelp = new Help()
@@ -29,12 +32,16 @@ const KO_ALIASES: Record<string, string> = {
   sync: '규칙',
   check: '점검',
   secure: '보안',
-  ship: '배포',
+  ship: '출하',
   doctor: '환경',
   save: '저장',
   undo: '되돌리기',
   status: '상태',
   diff: '변경',
+  deploy: '배포',
+  env: '환경변수',
+  'env-check': '환경변수점검',
+  publish: '출시',
 }
 
 program
@@ -129,8 +136,7 @@ secureCmd
 
 program
   .command('ship')
-  .alias('배포')
-  .alias('릴리즈')
+  .alias('출하')
   .description('배포 체크리스트 + 회고 + 빌드 로그 생성')
   .action(ship)
 
@@ -180,6 +186,30 @@ program
   .action(async () => {
     await mcpInit()
   })
+
+program
+  .command('deploy')
+  .alias('배포')
+  .description('프로덕션 배포 (Vercel/Netlify/Cloudflare 자동 감지)')
+  .action(async () => { await deploy() })
+
+program
+  .command('env')
+  .alias('환경변수')
+  .description('.env → .env.example 동기화 + .gitignore 자동 추가')
+  .action(async () => { await env() })
+
+program
+  .command('env-check')
+  .alias('환경변수점검')
+  .description('필수 환경변수 누락 검사')
+  .action(async () => { await envCheck() })
+
+program
+  .command('publish')
+  .alias('출시')
+  .description('npm 배포 (버전 범프 → 빌드 → 테스트 → publish)')
+  .action(async () => { await publish() })
 
 program.on('command:*', async (operands: string[]) => {
   const unknown = operands[0] ?? ''

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ const KO_ALIASES: Record<string, string> = {
 program
   .name('vhk')
   .description('VHK — 바이브코딩 프로젝트 코치 (한국어로 안내합니다)')
-  .version('0.6.0')
+  .version('0.7.0')
 
 program.configureHelp({
   formatHelp(cmd, helper) {

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -8,7 +8,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'sync', '맞추기', '규칙',
   'check', '점검', '린트',
   'secure', '보안', 'scan', '스캔',
-  'ship', '배포', '릴리즈',
+  'ship',
   'doctor', '환경', '진단',
   'save', '저장',
   'undo', '되돌리기',
@@ -16,6 +16,11 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'diff', '변경', '차이',
   'mcp',
   'mcp-init', 'mcp설정',
+  'deploy', '배포',
+  'env', '환경변수',
+  'env-check', '환경변수점검',
+  'publish', '출시',
+  '출하',
   'help',
 ])
 

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -24,3 +24,21 @@ export function safeExecFile(cmd: string, args: string[]): ExecResult {
     return { ok: false, err: msg }
   }
 }
+
+export type StreamResult = { ok: true } | { ok: false; err: string }
+
+// 자식 프로세스의 stdin/stdout/stderr를 현재 터미널에 그대로 연결한다.
+// 장시간 작업(vercel deploy, netlify deploy, pnpm build 등)의 실시간 로그가 사용자에게 보임.
+// 반환값에 out 필드는 없음 — 출력은 이미 터미널에 흘러감.
+export function safeExecFileStream(cmd: string, args: string[]): StreamResult {
+  try {
+    execFileSync(platformCmd(cmd), args, {
+      encoding: 'utf-8',
+      stdio: 'inherit',
+    })
+    return { ok: true }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return { ok: false, err: msg }
+  }
+}

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -1,0 +1,26 @@
+import { execFileSync } from 'node:child_process'
+
+// Windows에서 pnpm/npm/npx/yarn은 .cmd shim. execFileSync는 native 바이너리만 찾으므로 .cmd 확장자 부여.
+const SHIM_BINARIES = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+
+export function platformCmd(cmd: string): string {
+  if (process.platform === 'win32' && SHIM_BINARIES.has(cmd)) {
+    return `${cmd}.cmd`
+  }
+  return cmd
+}
+
+export type ExecResult = { ok: true; out: string } | { ok: false; err: string }
+
+export function safeExecFile(cmd: string, args: string[]): ExecResult {
+  try {
+    const out = execFileSync(platformCmd(cmd), args, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).toString()
+    return { ok: true, out: out.trim() }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return { ok: false, err: msg }
+  }
+}

--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -12,6 +12,10 @@ export type NlpCommand =
   | 'diff'
   | 'status'
   | 'mcp-init'
+  | 'deploy'
+  | 'env'
+  | 'env-check'
+  | 'publish'
 
 export type NlpConfidence = 'high' | 'low'
 
@@ -148,9 +152,39 @@ const RULES: NlpRule[] = [
   },
   {
     command: 'ship',
-    explanation: '배포 체크 + 회고 (vhk ship)',
+    explanation: '배포 체크리스트 + 회고 (vhk 출하)',
     confidence: 'high',
-    test: t => /배포|출시|릴리스|ship|빌드\s*전/.test(t),
+    test: t => /^출하$|^ship$|빌드\s*전|(배포|출하)\s*(체크|준비|점검)/.test(t),
+  },
+  {
+    command: 'deploy',
+    explanation: '프로덕션 배포 (vhk deploy)',
+    confidence: 'high',
+    test: t =>
+      /^배포$|배포\s*해|배포하|배포해줘|^deploy$|디플로이|vercel|netlify|cloudflare|wrangler|프로덕션|올려줘/.test(t) &&
+      !/체크|준비|점검|출하|회고|빌드\s*전/.test(t),
+  },
+  {
+    command: 'env-check',
+    explanation: '환경변수 누락 검사 (vhk env-check)',
+    confidence: 'high',
+    test: t => /환경변수\s*(점검|확인|누락)|env\s*(체크|확인|check)|키\s*(확인|누락)/.test(t),
+  },
+  {
+    command: 'env',
+    explanation: '환경변수 관리 (vhk env)',
+    confidence: 'high',
+    test: t =>
+      /환경변수|\.env|env\s*example|env\s*동기화|시크릿\s*정리|키\s*설정/.test(t) &&
+      !/점검|확인|누락|체크|check/.test(t),
+  },
+  {
+    command: 'publish',
+    explanation: 'npm 배포 (vhk publish)',
+    confidence: 'high',
+    test: t =>
+      /^출시$|출시\s*해|^publish$|퍼블리시|npm\s*(배포|출시)|버전\s*올|^릴리즈$|^release$/.test(t) &&
+      !/체크|준비|회고/.test(t),
   },
 ]
 

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -15,6 +15,9 @@ import { undo } from '../commands/undo.js'
 import { status } from '../commands/status.js'
 import { diff } from '../commands/diff.js'
 import { mcpInit } from '../commands/mcp-init.js'
+import { deploy } from '../commands/deploy.js'
+import { env, envCheck } from '../commands/env.js'
+import { publish } from '../commands/publish.js'
 
 export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<void> {
   switch (route.command) {
@@ -49,6 +52,14 @@ export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<
       return diff()
     case 'mcp-init':
       return mcpInit()
+    case 'deploy':
+      return deploy()
+    case 'env':
+      return env()
+    case 'env-check':
+      return envCheck()
+    case 'publish':
+      return publish()
   }
 }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import { existsSync, readFileSync } from 'node:fs'
 import { safeExecFile } from '../lib/exec.js'
 
-const SERVER_VERSION = '0.6.0'
+const SERVER_VERSION = '0.7.0'
 
 function isGitRepo(): boolean {
   return safeExecFile('git', ['rev-parse', '--is-inside-work-tree']).ok

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,35 +1,10 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod'
-import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
+import { safeExecFile } from '../lib/exec.js'
 
 const SERVER_VERSION = '0.6.0'
-
-// Windows에서 pnpm/npm/npx/yarn은 .cmd shim. execFileSync는 native 바이너리만 찾으므로 .cmd 확장자 부여.
-const SHIM_BINARIES = new Set(['pnpm', 'npm', 'npx', 'yarn'])
-function platformCmd(cmd: string): string {
-  if (process.platform === 'win32' && SHIM_BINARIES.has(cmd)) {
-    return `${cmd}.cmd`
-  }
-  return cmd
-}
-
-function safeExecFile(
-  cmd: string,
-  args: string[]
-): { ok: true; out: string } | { ok: false; err: string } {
-  try {
-    const out = execFileSync(platformCmd(cmd), args, {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).toString()
-    return { ok: true, out: out.trim() }
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return { ok: false, err: msg }
-  }
-}
 
 function isGitRepo(): boolean {
   return safeExecFile('git', ['rev-parse', '--is-inside-work-tree']).ok

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockExistsSync = vi.fn()
+
+vi.mock('node:fs', () => ({
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
+}))
+
+vi.mock('inquirer', () => ({
+  default: { prompt: vi.fn() },
+}))
+
+vi.mock('ora', () => ({
+  default: () => ({
+    start: () => ({ succeed: vi.fn(), fail: vi.fn() }),
+  }),
+}))
+
+vi.mock('../src/lib/exec.js', () => ({
+  safeExecFile: vi.fn(() => ({ ok: true, out: '' })),
+}))
+
+describe('deploy', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('모듈을 import 할 수 있다', async () => {
+    const mod = await import('../src/commands/deploy.js')
+    expect(mod.deploy).toBeDefined()
+    expect(mod.detectPlatform).toBeDefined()
+  })
+
+  it('detectPlatform: vercel.json 있으면 vercel 반환', async () => {
+    const { detectPlatform } = await import('../src/commands/deploy.js')
+    mockExistsSync.mockImplementation((p: unknown) => String(p) === 'vercel.json')
+    expect(detectPlatform()).toBe('vercel')
+  })
+
+  it('detectPlatform: netlify.toml 있으면 netlify 반환', async () => {
+    const { detectPlatform } = await import('../src/commands/deploy.js')
+    mockExistsSync.mockImplementation((p: unknown) => String(p) === 'netlify.toml')
+    expect(detectPlatform()).toBe('netlify')
+  })
+
+  it('detectPlatform: wrangler.toml 있으면 cloudflare 반환', async () => {
+    const { detectPlatform } = await import('../src/commands/deploy.js')
+    mockExistsSync.mockImplementation((p: unknown) => String(p) === 'wrangler.toml')
+    expect(detectPlatform()).toBe('cloudflare')
+  })
+
+  it('detectPlatform: 아무것도 없으면 null', async () => {
+    const { detectPlatform } = await import('../src/commands/deploy.js')
+    mockExistsSync.mockReturnValue(false)
+    expect(detectPlatform()).toBeNull()
+  })
+})

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockExistsSync = vi.fn()
+const mockReadFileSync = vi.fn()
+const mockWriteFileSync = vi.fn()
+const mockAppendFileSync = vi.fn()
+
+vi.mock('node:fs', () => ({
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
+  readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
+  writeFileSync: (...a: unknown[]) => mockWriteFileSync(...a),
+  appendFileSync: (...a: unknown[]) => mockAppendFileSync(...a),
+}))
+
+describe('env', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('parseEnvKeys: 일반 키 추출', async () => {
+    const { parseEnvKeys } = await import('../src/commands/env.js')
+    const result = parseEnvKeys('API_KEY=abc\nDB_URL=postgres://...\nSECRET=xyz')
+    expect(result).toEqual(['API_KEY', 'DB_URL', 'SECRET'])
+  })
+
+  it('parseEnvKeys: 빈 줄/주석 무시', async () => {
+    const { parseEnvKeys } = await import('../src/commands/env.js')
+    const result = parseEnvKeys('# comment\n\nAPI_KEY=abc\n# another comment\nDB_URL=xyz\n')
+    expect(result).toEqual(['API_KEY', 'DB_URL'])
+  })
+
+  it('parseEnvKeys: 공백/빈 값 처리', async () => {
+    const { parseEnvKeys } = await import('../src/commands/env.js')
+    const result = parseEnvKeys('  API_KEY  =  value  \nDB_URL=\n  ')
+    expect(result).toEqual(['API_KEY', 'DB_URL'])
+  })
+
+  it('env: .env 없으면 경고 후 종료', async () => {
+    mockExistsSync.mockReturnValue(false)
+    const { env } = await import('../src/commands/env.js')
+    await env()
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
+  })
+
+  it('env: .env 있으면 .env.example 생성 (값 비움)', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p) === '.env')
+    mockReadFileSync.mockReturnValue('API_KEY=secret\nDB_URL=postgres')
+    const { env } = await import('../src/commands/env.js')
+    await env()
+    // .env.example 쓰기 호출 확인
+    const exampleCall = mockWriteFileSync.mock.calls.find(
+      (c) => String(c[0]) === '.env.example'
+    )
+    expect(exampleCall).toBeDefined()
+    expect(String(exampleCall![1])).toContain('API_KEY=')
+    expect(String(exampleCall![1])).toContain('DB_URL=')
+    // 값은 비어 있어야 함
+    expect(String(exampleCall![1])).not.toContain('secret')
+    expect(String(exampleCall![1])).not.toContain('postgres')
+  })
+
+  it('envCheck: .env.example 없으면 경고', async () => {
+    mockExistsSync.mockReturnValue(false)
+    const { envCheck } = await import('../src/commands/env.js')
+    await envCheck()
+    // 어떤 파일도 쓰지 않음
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
+  })
+
+  it('envCheck: 누락 키가 있으면 console.log에 누락 표시', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const s = String(p)
+      return s === '.env.example' || s === '.env' || s === '.gitignore'
+    })
+    mockReadFileSync.mockImplementation((p: unknown) => {
+      const s = String(p)
+      if (s === '.env.example') return 'API_KEY=\nDB_URL=\nMISSING_KEY='
+      if (s === '.env') return 'API_KEY=value\nDB_URL=value'
+      if (s === '.gitignore') return '.env\nnode_modules/\n'
+      return ''
+    })
+    const logSpy = vi.spyOn(console, 'log')
+    const { envCheck } = await import('../src/commands/env.js')
+    await envCheck()
+    const allLogs = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+    expect(allLogs).toContain('MISSING_KEY')
+  })
+})

--- a/tests/exec.test.ts
+++ b/tests/exec.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+
+describe('lib/exec', () => {
+  it('platformCmd: Windows에서 pnpm은 pnpm.cmd로 변환', async () => {
+    const { platformCmd } = await import('../src/lib/exec.js')
+    // process.platform이 win32일 때 .cmd 부착
+    const original = process.platform
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    expect(platformCmd('pnpm')).toBe('pnpm.cmd')
+    expect(platformCmd('npm')).toBe('npm.cmd')
+    expect(platformCmd('npx')).toBe('npx.cmd')
+    expect(platformCmd('yarn')).toBe('yarn.cmd')
+    expect(platformCmd('git')).toBe('git')
+    expect(platformCmd('node')).toBe('node')
+    Object.defineProperty(process, 'platform', { value: original })
+  })
+
+  it('platformCmd: 비 Windows에서는 그대로 반환', async () => {
+    const { platformCmd } = await import('../src/lib/exec.js')
+    const original = process.platform
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    expect(platformCmd('pnpm')).toBe('pnpm')
+    expect(platformCmd('git')).toBe('git')
+    Object.defineProperty(process, 'platform', { value: original })
+  })
+
+  it('safeExecFile: 성공 시 ok=true와 trim된 out 반환', async () => {
+    const { safeExecFile } = await import('../src/lib/exec.js')
+    const result = safeExecFile('node', ['--version'])
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.out).toMatch(/^v\d+\.\d+\.\d+/)
+    }
+  })
+
+  it('safeExecFile: 실패 시 ok=false와 err 메시지 반환', async () => {
+    const { safeExecFile } = await import('../src/lib/exec.js')
+    const result = safeExecFile('this-binary-does-not-exist-vhk-xyz', [])
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.err).toBeTruthy()
+    }
+  })
+})

--- a/tests/exec.test.ts
+++ b/tests/exec.test.ts
@@ -5,23 +5,29 @@ describe('lib/exec', () => {
     const { platformCmd } = await import('../src/lib/exec.js')
     // process.platform이 win32일 때 .cmd 부착
     const original = process.platform
-    Object.defineProperty(process, 'platform', { value: 'win32' })
-    expect(platformCmd('pnpm')).toBe('pnpm.cmd')
-    expect(platformCmd('npm')).toBe('npm.cmd')
-    expect(platformCmd('npx')).toBe('npx.cmd')
-    expect(platformCmd('yarn')).toBe('yarn.cmd')
-    expect(platformCmd('git')).toBe('git')
-    expect(platformCmd('node')).toBe('node')
-    Object.defineProperty(process, 'platform', { value: original })
+    try {
+      Object.defineProperty(process, 'platform', { value: 'win32' })
+      expect(platformCmd('pnpm')).toBe('pnpm.cmd')
+      expect(platformCmd('npm')).toBe('npm.cmd')
+      expect(platformCmd('npx')).toBe('npx.cmd')
+      expect(platformCmd('yarn')).toBe('yarn.cmd')
+      expect(platformCmd('git')).toBe('git')
+      expect(platformCmd('node')).toBe('node')
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original })
+    }
   })
 
   it('platformCmd: 비 Windows에서는 그대로 반환', async () => {
     const { platformCmd } = await import('../src/lib/exec.js')
     const original = process.platform
-    Object.defineProperty(process, 'platform', { value: 'linux' })
-    expect(platformCmd('pnpm')).toBe('pnpm')
-    expect(platformCmd('git')).toBe('git')
-    Object.defineProperty(process, 'platform', { value: original })
+    try {
+      Object.defineProperty(process, 'platform', { value: 'linux' })
+      expect(platformCmd('pnpm')).toBe('pnpm')
+      expect(platformCmd('git')).toBe('git')
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original })
+    }
   })
 
   it('safeExecFile: 성공 시 ok=true와 trim된 out 반환', async () => {

--- a/tests/nlp-router.test.ts
+++ b/tests/nlp-router.test.ts
@@ -31,9 +31,9 @@ describe('자연어 라우팅', () => {
     expect(result?.command).toBe('secure')
   })
 
-  it('"배포하고 싶어" → ship', () => {
+  it('"배포하고 싶어" → deploy', () => {
     const result = routeNaturalLanguage('배포하고 싶어')
-    expect(result?.command).toBe('ship')
+    expect(result?.command).toBe('deploy')
   })
 
   it('키워드 맵 — save', () => {

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockExistsSync = vi.fn()
+const mockReadFileSync = vi.fn()
+const mockWriteFileSync = vi.fn()
+
+vi.mock('node:fs', () => ({
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
+  readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
+  writeFileSync: (...a: unknown[]) => mockWriteFileSync(...a),
+}))
+
+vi.mock('inquirer', () => ({
+  default: { prompt: vi.fn() },
+}))
+
+vi.mock('ora', () => ({
+  default: () => ({
+    start: () => ({ succeed: vi.fn(), fail: vi.fn() }),
+  }),
+}))
+
+vi.mock('../src/lib/exec.js', () => ({
+  safeExecFile: vi.fn(() => ({ ok: true, out: '' })),
+}))
+
+describe('publish', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('bumpVersion: patch 0.6.0 → 0.6.1', async () => {
+    const { bumpVersion } = await import('../src/commands/publish.js')
+    expect(bumpVersion('0.6.0', 'patch')).toBe('0.6.1')
+  })
+
+  it('bumpVersion: minor 0.6.5 → 0.7.0', async () => {
+    const { bumpVersion } = await import('../src/commands/publish.js')
+    expect(bumpVersion('0.6.5', 'minor')).toBe('0.7.0')
+  })
+
+  it('bumpVersion: major 0.6.5 → 1.0.0', async () => {
+    const { bumpVersion } = await import('../src/commands/publish.js')
+    expect(bumpVersion('0.6.5', 'major')).toBe('1.0.0')
+  })
+
+  it('bumpVersion: 1.2.3 patch → 1.2.4', async () => {
+    const { bumpVersion } = await import('../src/commands/publish.js')
+    expect(bumpVersion('1.2.3', 'patch')).toBe('1.2.4')
+  })
+
+  it('모듈을 import 할 수 있다', async () => {
+    const mod = await import('../src/commands/publish.js')
+    expect(mod.publish).toBeDefined()
+    expect(mod.bumpVersion).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary

VHK CLI v0.7.0 — 바이브코더가 **프로덕션 배포·환경변수 동기화·npm 출시**를 CLI 한 줄로 끝낼 수 있게 한다.

- **`vhk deploy`** (`배포`): Vercel/Netlify/Cloudflare Workers 자동 감지 + 프로덕션 배포
- **`vhk env`** (`환경변수`): `.env` → `.env.example` 동기화 + `.gitignore`에 `.env` 자동 추가
- **`vhk env-check`** (`환경변수점검`): `.env.example` 기준 누락 환경변수 검사
- **`vhk publish`** (`출시`): semver 범프(patch/minor/major) + 빌드 + 테스트 + `npm publish` + git tag
- **`src/lib/exec.ts`**: `safeExecFile` 공유 헬퍼 분리 — v0.6 MCP 서버 + v0.7 신규 명령 공통 사용
- **NLP 라우팅**: `'vercel 배포'`, `'환경변수 점검'`, `'npm 출시'` 등 신규 패턴
- **alias 충돌 해소**: `ship.alias('배포')` → `'출하'` (deploy에 `'배포'` 양보)
- **버전**: 0.6.0 → 0.7.0

## Plan

[docs/superpowers/plans/2026-05-24-v0.7.0-deploy-env-publish.md](docs/superpowers/plans/2026-05-24-v0.7.0-deploy-env-publish.md) — 11 task TDD plan, subagent-driven 실행, task당 spec + code-quality 2단계 리뷰.

## 변경 파일

- **신규**: `src/lib/exec.ts`, `src/commands/deploy.ts`, `src/commands/env.ts`, `src/commands/publish.ts`, `tests/exec.test.ts`, `tests/deploy.test.ts`, `tests/env.test.ts`, `tests/publish.test.ts`
- **수정**: `src/mcp/server.ts` (safeExecFile import), `src/index.ts` (명령 등록 + ship alias 변경 + 버전 0.7.0), `src/i18n/ko.ts` (deploy/env/publish 섹션), `src/lib/nlp-router.ts` (NlpCommand 확장 + RULES + ship 룰 좁힘), `src/lib/nlp-run.ts` (dispatcher), `src/lib/cli-args.ts` (KNOWN_COMMAND_TOKENS), `tests/nlp-router.test.ts` (배포 → deploy 라우팅 테스트 remap), `package.json` (version), `README.md` (4 신규 명령 + ship alias 정정), `CHANGELOG.md` ([0.7.0] 추가)

## 신규 의존성

없음. 기존 commander/inquirer/ora/chalk/vitest만 사용.

## Final review 발견 + 즉시 fix

- `src/mcp/server.ts` `SERVER_VERSION` 0.6.0 → 0.7.0 동기화 (commit `a384182`)
- README env 행 alias 누락 → `환경변수` 추가 (commit `a384182`)
- README ship 행 alias `릴리즈` 제거 (Task 6에서 .alias 제거됨, 일관성 — commit `bfdaec8`)

## Test plan

- [x] `pnpm test --run` — 133/133 pass (29 files). 신규 21건 (exec 4 + deploy 5 + env 7 + publish 5)
- [x] `pnpm build` — clean (`dist/index.js` + `dist/mcp/index.js` 둘 다 shebang 포함)
- [x] `npx tsc --noEmit` — 3 pre-existing errors만 (src/lib/git.ts × 2, src/lib/notion-import.ts × 1), 신규 0
- [x] 직접 호출 smoke (4개 명령 모두 정상 진입):
  - `vhk env` → `.env 파일이 없습니다` 경고
  - `vhk env-check` → `.env.example이 없습니다` 경고
  - `vhk deploy` → 플랫폼 감지 + inquirer 프롬프트
  - `vhk publish` → 현재 버전 + 범프 프롬프트
- [x] NLP smoke (4개 라우팅 모두 정확):
  - `"환경변수 점검"` → `vhk env-check`
  - `"vercel에 배포"` → `vhk deploy` (ship 아님)
  - `"출하 준비"` → `vhk 출하` (ship, deploy 아님)
  - `"npm 출시"` → `vhk publish`
- [x] MCP 서버 regression — `node dist/mcp/index.js` 정상 stdio 대기, stderr 없음
- [x] `vhk --version` → `0.7.0`
- [ ] (수동 검증) Cursor 재시작 후 MCP 도구 8개 + 신규 명령 NL 호출 동작 확인
- [ ] (배포 후) `npm i -g @byh3071/vhk@0.7.0` → `vhk-mcp` 글로벌 실행

## 보안 / Best practice

- **모든 exec via `safeExecFile`** (shell 인터폴레이션 0). spec 예제의 `git push && git push --tags` 등 shell-chained 패턴은 의도적으로 모두 argv 형태로 분리.
- **Windows shim 대응**: `platformCmd` 헬퍼가 pnpm/npm/npx/yarn에 `.cmd` 확장자 자동 부착.
- **버전 롤백 안전망**: `publish` 명령이 build/test 실패 시 package.json 버전을 원래대로 복구.

## 알려진 latent issue (follow-up)

- NLP `'npm 배포해줘'` → 현재 array 우선순위로 `deploy` 라우팅. 의도가 `publish`였다면 publish 룰을 deploy 앞으로 이동 또는 deploy 부정 lookahead에 `npm` 추가 필요. 실사용자 보고 시 처리.
- `tests/exec.test.ts`의 `process.platform` mutation try/finally 미적용. 격리 worker로 영향 제한적이지만 follow-up 정리 권장.
- `ship` 도구 동기 블로킹 TODO 주석 유지 (v0.6.1로 표시, execa 전환 미수행).

🤖 Generated with [Claude Code](https://claude.com/claude-code)