### PR TITLE
feat: v0.8.0 — design / theme / ref 명령 3종

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ---
 
+## [0.8.0] — 2026-05-24
+
+### Added
+- `vhk design` — 컬러 팔레트 프리셋 4종(Minimal/Vibrant/Corporate/Pastel) 선택 + Tailwind config 또는 CSS 변수 토큰 파일 생성
+- `vhk design-palette` — design과 동일 (별칭 진입점)
+- `vhk theme` — 다크/라이트 모드 CSS + 토글 유틸리티(`getTheme`/`setTheme`/`toggleTheme`/`initTheme`) 생성
+- `vhk ref add|list|open` — `.vhk/refs.json` 기반 레퍼런스 URL 관리. 브라우저 자동 오픈 (Windows/macOS/Linux)
+- 자연어 라우터에 design/design-palette/theme/ref 키워드 추가 — `"디자인 토큰 만들어줘"`, `"다크 모드 적용"`, `"레퍼런스 보여줘"` 등
+- `ref add` / `ref open`은 인자 추출 인프라가 없어 NL 진입점에서 의도적으로 배제 — commander 서브커맨드로만 노출
+
+### Changed
+- 버전: 0.7.1 → 0.8.0
+
+---
+
 ## [0.7.1] — 2026-05-24
 
 ### Added
@@ -117,7 +132,9 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 - **`vhk gate`** — 아이디어 검증 (퀵 5문항 / 풀 13문항 / 스킵)
 - **`vhk init`** — 프로젝트 시작. 하네스 파일 생성 (`CLAUDE.md`, `.cursorrules`, `docs/PRD.md`, `docs/ARCHITECTURE.md`, ADR/log 폴더)
 
-[Unreleased]: https://github.com/byh3071-cpu/vhk/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/byh3071-cpu/vhk/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/byh3071-cpu/vhk/compare/v0.7.1...v0.8.0
+[0.7.1]: https://github.com/byh3071-cpu/vhk/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/byh3071-cpu/vhk/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/byh3071-cpu/vhk/compare/v0.5.3...v0.6.0
 [0.5.3]: https://github.com/byh3071-cpu/vhk/compare/v0.5.2...v0.5.3

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ---
 id: vhk-readme
 date: 2026-05-24
-tags: [vhk, cli, readme, v0.6.0]
+tags: [vhk, cli, readme, v0.8.0]
 ---
 
 # 🔧 VHK — Vibe Harness Kit
 
-> AI 코딩 에이전트를 부리는 사람을 위한 **한국어 풀사이클 CLI** (v0.6.0)
+> AI 코딩 에이전트를 부리는 사람을 위한 **한국어 풀사이클 CLI** (v0.8.0)
 >
 > 🍽️ **VHK는 VHK로 부트스트랩됨** — 이 레포의 `docs/`, `CLAUDE.md`, `.cursorrules`도 `vhk init`이 만들었습니다.
 
@@ -95,6 +95,10 @@ vhk 기획 끝났고 바로 시작
 | `vhk env` | `환경변수` | `.env` → `.env.example` 동기화 + `.gitignore`에 `.env` 자동 추가 |
 | `vhk env-check` | `환경변수점검` | `.env.example` 기준 누락 환경변수 검사 |
 | `vhk publish` | `출시` | npm 배포 자동화 (버전 범프 → 빌드 → 테스트 → publish → git tag) |
+| `vhk design` | `디자인` | 디자인 토큰 생성 (Tailwind config 또는 CSS 변수) |
+| `vhk design-palette` | `팔레트` | 컬러 팔레트 프리셋 선택 + 적용 |
+| `vhk theme` | `테마` | 다크/라이트 모드 CSS + 토글 유틸리티 생성 |
+| `vhk ref` | `레퍼런스` | 레퍼런스 URL 관리 (`add` / `list` / `open`) |
 
 ### init 옵션
 
@@ -128,6 +132,31 @@ MCP 서버를 수동으로 띄우려면:
 ```powershell
 vhk mcp                # stdio 서버 시작 (Cursor가 자동으로 호출)
 ```
+
+## v0.8.0 하이라이트
+
+| 기능 | 설명 |
+|------|------|
+| **design** | 팔레트 프리셋 4종(Minimal/Vibrant/Corporate/Pastel) 선택 → `src/styles/tokens.css` 또는 `src/styles/vhk-colors.ts` (Tailwind config가 있으면 TS) 생성 |
+| **theme** | `src/styles/theme.css` (다크/라이트 + `prefers-color-scheme` + `data-theme` 셀렉터) + `src/lib/theme-toggle.ts` (`getTheme`/`setTheme`/`toggleTheme`/`initTheme`) 생성 |
+| **ref** | `.vhk/refs.json` 기반 레퍼런스 URL 관리. `ref add <url> --memo "..."` / `ref list` / `ref open <번호>` (Windows/macOS/Linux 브라우저 자동 오픈) |
+| **자연어 확장** | `"디자인 토큰 만들어줘"` / `"팔레트 골라줘"` / `"다크 모드 적용"` / `"레퍼런스 보여줘"` 인식. `ref add`/`open`은 인자 추출 인프라가 없어 의도적으로 NL 배제 — commander 서브커맨드만 사용 |
+
+```powershell
+vhk design              # 팔레트 선택 → src/styles/tokens.css 또는 vhk-colors.ts
+vhk theme               # src/styles/theme.css + src/lib/theme-toggle.ts
+vhk ref add https://example.com --memo "참고 사이트"
+vhk ref list            # 저장된 레퍼런스 목록
+vhk ref open 1          # 1번 레퍼런스를 브라우저로 열기
+```
+
+## v0.7.0 하이라이트
+
+| 기능 | 설명 |
+|------|------|
+| **deploy** | Vercel / Netlify / Cloudflare Workers 자동 감지 + 프로덕션 배포 |
+| **env / env-check** | `.env` → `.env.example` 동기화 + 누락 환경변수 검사. MCP 도구로도 노출 (v0.7.1) |
+| **publish** | semver 범프 + 빌드 + 테스트 + `npm publish` + git tag 자동화 |
 
 ## v0.6.0 하이라이트
 
@@ -191,6 +220,10 @@ vhk mcp                # stdio 서버 시작 (Cursor가 자동으로 호출)
 | 보안 스캔 돌려 | `vhk 보안` |
 | 배포하고 싶어 | `vhk 배포` |
 | 뭔가 안 돼 | `vhk doctor` |
+| 디자인 토큰 만들어줘 | `vhk design` |
+| 팔레트 골라줘 | `vhk design-palette` |
+| 다크 모드 적용 | `vhk theme` |
+| 레퍼런스 보여줘 | `vhk ref` (list) |
 
 ## 특징
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Vibe Harness Kit — 바이브코딩 풀사이클 CLI",
   "bin": {
     "vhk": "dist/index.js",

--- a/src/commands/design.ts
+++ b/src/commands/design.ts
@@ -102,14 +102,29 @@ export async function design(): Promise<void> {
   const palette = PALETTES[paletteIndex]
   console.log(chalk.cyan(`\n🎨 선택된 팔레트: ${palette.name}`))
 
+  const targetPath = hasTailwind() ? 'src/styles/vhk-colors.ts' : 'src/styles/tokens.css'
+  const content = hasTailwind() ? generateTailwindExtend(palette) : generateCSSTokens(palette)
+
+  if (existsSync(targetPath)) {
+    const { overwrite } = await inquirer.prompt<{ overwrite: boolean }>([{
+      type: 'confirm',
+      name: 'overwrite',
+      message: `${targetPath} 이미 있어요. 덮어쓸까요?`,
+      default: false,
+    }])
+    if (!overwrite) {
+      console.log(chalk.yellow('\n⏭️  생성 취소 — 기존 파일 유지.'))
+      return
+    }
+  }
+
   mkdirSync('src/styles', { recursive: true })
+  writeFileSync(targetPath, content, 'utf-8')
 
   if (hasTailwind()) {
-    writeFileSync('src/styles/vhk-colors.ts', generateTailwindExtend(palette), 'utf-8')
     console.log(chalk.green('\n✅ src/styles/vhk-colors.ts 생성'))
     console.log(chalk.gray('   tailwind.config의 extend.colors에 import 해서 사용하세요.'))
   } else {
-    writeFileSync('src/styles/tokens.css', generateCSSTokens(palette), 'utf-8')
     console.log(chalk.green('\n✅ src/styles/tokens.css 생성'))
     console.log(chalk.gray('   HTML에 <link>로 추가하거나 CSS에서 @import 하세요.'))
   }

--- a/src/commands/design.ts
+++ b/src/commands/design.ts
@@ -1,0 +1,131 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import chalk from 'chalk'
+import inquirer from 'inquirer'
+import { t } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+
+interface ColorPalette {
+  name: string
+  colors: Record<string, string>
+}
+
+const PALETTES: ColorPalette[] = [
+  {
+    name: 'Minimal',
+    colors: {
+      primary: '#1a1a1a',
+      secondary: '#6b7280',
+      accent: '#3b82f6',
+      background: '#ffffff',
+      surface: '#f9fafb',
+      text: '#111827',
+      muted: '#9ca3af',
+    },
+  },
+  {
+    name: 'Vibrant',
+    colors: {
+      primary: '#7c3aed',
+      secondary: '#ec4899',
+      accent: '#f59e0b',
+      background: '#ffffff',
+      surface: '#faf5ff',
+      text: '#1e1b4b',
+      muted: '#8b5cf6',
+    },
+  },
+  {
+    name: 'Corporate',
+    colors: {
+      primary: '#1e40af',
+      secondary: '#0f766e',
+      accent: '#ca8a04',
+      background: '#ffffff',
+      surface: '#f0f9ff',
+      text: '#0f172a',
+      muted: '#64748b',
+    },
+  },
+  {
+    name: 'Pastel',
+    colors: {
+      primary: '#a78bfa',
+      secondary: '#f9a8d4',
+      accent: '#fcd34d',
+      background: '#fffbeb',
+      surface: '#fef3c7',
+      text: '#44403c',
+      muted: '#a8a29e',
+    },
+  },
+]
+
+function hasTailwind(): boolean {
+  return (
+    existsSync('tailwind.config.js') ||
+    existsSync('tailwind.config.ts') ||
+    existsSync('tailwind.config.mjs') ||
+    existsSync('tailwind.config.cjs')
+  )
+}
+
+function generateCSSTokens(palette: ColorPalette): string {
+  const lines = Object.entries(palette.colors)
+    .map(([key, value]) => `  --color-${key}: ${value};`)
+    .join('\n')
+  return `:root {\n${lines}\n}\n`
+}
+
+function generateTailwindExtend(palette: ColorPalette): string {
+  const entries = Object.entries(palette.colors)
+    .map(([key, value]) => `  '${key}': '${value}',`)
+    .join('\n')
+  return `// vhk design — Tailwind config 확장용 컬러 토큰\n// tailwind.config의 theme.extend.colors에 spread 하세요.\nconst vhkColors = {\n${entries}\n}\n\nexport default vhkColors\n`
+}
+
+export async function design(): Promise<void> {
+  console.log(chalk.bold('\n🎨 ' + t('design.title')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  const { paletteIndex } = await inquirer.prompt<{ paletteIndex: number }>([
+    {
+      type: 'list',
+      name: 'paletteIndex',
+      message: t('design.selectPalette'),
+      choices: PALETTES.map((p, i) => ({
+        name: `${p.name} — primary ${p.colors.primary}`,
+        value: i,
+      })),
+    },
+  ])
+
+  const palette = PALETTES[paletteIndex]
+  console.log(chalk.cyan(`\n🎨 선택된 팔레트: ${palette.name}`))
+
+  mkdirSync('src/styles', { recursive: true })
+
+  if (hasTailwind()) {
+    writeFileSync('src/styles/vhk-colors.ts', generateTailwindExtend(palette), 'utf-8')
+    console.log(chalk.green('\n✅ src/styles/vhk-colors.ts 생성'))
+    console.log(chalk.gray('   tailwind.config의 extend.colors에 import 해서 사용하세요.'))
+  } else {
+    writeFileSync('src/styles/tokens.css', generateCSSTokens(palette), 'utf-8')
+    console.log(chalk.green('\n✅ src/styles/tokens.css 생성'))
+    console.log(chalk.gray('   HTML에 <link>로 추가하거나 CSS에서 @import 하세요.'))
+  }
+
+  console.log(chalk.bold('\n🌈 컬러 미리보기:'))
+  for (const [key, value] of Object.entries(palette.colors)) {
+    console.log(`   ${key.padEnd(12)} ${value}`)
+  }
+
+  printNextStep({
+    message: '디자인 토큰 생성 완료!',
+    command: 'vhk theme',
+    cursorHint: '테마 설정해줘',
+  })
+}
+
+export async function designPalette(): Promise<void> {
+  await design()
+}

--- a/src/commands/ref.ts
+++ b/src/commands/ref.ts
@@ -1,0 +1,106 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import chalk from 'chalk'
+import { t } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+
+interface RefEntry {
+  url: string
+  memo: string
+  addedAt: string
+}
+
+const REFS_PATH = '.vhk/refs.json'
+
+function loadRefs(): RefEntry[] {
+  if (!existsSync(REFS_PATH)) return []
+  try {
+    const raw = readFileSync(REFS_PATH, 'utf-8')
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? (parsed as RefEntry[]) : []
+  } catch {
+    return []
+  }
+}
+
+function saveRefs(refs: RefEntry[]): void {
+  mkdirSync('.vhk', { recursive: true })
+  writeFileSync(REFS_PATH, JSON.stringify(refs, null, 2) + '\n', 'utf-8')
+}
+
+export async function refAdd(url: string, memo = ''): Promise<void> {
+  console.log(chalk.bold('\n🔗 ' + t('ref.addTitle')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  if (!url) {
+    console.log(chalk.red('❌ URL을 입력해주세요.'))
+    console.log(chalk.gray('   예: vhk ref add https://example.com --memo "참고 사이트"'))
+    return
+  }
+
+  const refs = loadRefs()
+  if (refs.some((r) => r.url === url)) {
+    console.log(chalk.yellow('⚠️  이미 저장된 URL입니다.'))
+    return
+  }
+
+  refs.push({ url, memo, addedAt: new Date().toISOString() })
+  saveRefs(refs)
+
+  console.log(chalk.green(`\n✅ 레퍼런스 추가됨 (#${refs.length})`))
+  console.log(chalk.cyan(`   ${url}`))
+  if (memo) console.log(chalk.gray(`   📝 ${memo}`))
+
+  printNextStep({
+    message: '레퍼런스 저장 완료!',
+    command: 'vhk ref list',
+    cursorHint: '레퍼런스 목록 보여줘',
+  })
+}
+
+export async function refList(): Promise<void> {
+  console.log(chalk.bold('\n📚 ' + t('ref.listTitle')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  const refs = loadRefs()
+  if (refs.length === 0) {
+    console.log(chalk.yellow('\n📭 저장된 레퍼런스가 없습니다.'))
+    console.log(chalk.gray('   vhk ref add <url> --memo "메모"로 추가하세요.'))
+    return
+  }
+
+  console.log(chalk.cyan(`\n총 ${refs.length}개의 레퍼런스:\n`))
+  refs.forEach((ref, index) => {
+    const date = new Date(ref.addedAt).toLocaleDateString('ko-KR')
+    console.log(chalk.white(`  [${index + 1}] ${ref.url}`))
+    if (ref.memo) console.log(chalk.gray(`      📝 ${ref.memo}`))
+    console.log(chalk.gray(`      📅 ${date}`))
+    console.log('')
+  })
+}
+
+export async function refOpen(indexStr: string): Promise<void> {
+  const refs = loadRefs()
+  const idx = parseInt(indexStr, 10) - 1
+
+  if (Number.isNaN(idx) || idx < 0 || idx >= refs.length) {
+    console.log(chalk.red(`❌ 유효하지 않은 번호입니다. (1~${refs.length || 0})`))
+    return
+  }
+
+  const ref = refs[idx]
+  console.log(chalk.cyan(`\n🌐 열기: ${ref.url}`))
+
+  try {
+    if (process.platform === 'darwin') {
+      execSync(`open "${ref.url}"`)
+    } else if (process.platform === 'win32') {
+      execSync(`start "" "${ref.url}"`, { shell: 'cmd.exe' })
+    } else {
+      execSync(`xdg-open "${ref.url}"`)
+    }
+    console.log(chalk.green('✅ 브라우저에서 열었습니다.'))
+  } catch {
+    console.log(chalk.yellow('⚠️  브라우저를 열 수 없습니다. URL을 직접 방문해주세요.'))
+  }
+}

--- a/src/commands/ref.ts
+++ b/src/commands/ref.ts
@@ -1,8 +1,8 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { execSync } from 'node:child_process'
 import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
+import { safeExecFile } from '../lib/exec.js'
 
 interface RefEntry {
   url: string
@@ -89,18 +89,35 @@ export async function refOpen(indexStr: string): Promise<void> {
   }
 
   const ref = refs[idx]
+
+  // http(s) 외 프로토콜 거부 — javascript:, file:, data: 등 차단
+  let parsed: URL
+  try {
+    parsed = new URL(ref.url)
+  } catch {
+    console.log(chalk.red(`❌ 유효하지 않은 URL: ${ref.url}`))
+    return
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    console.log(chalk.red(`❌ http(s) URL만 열 수 있습니다 (${parsed.protocol})`))
+    return
+  }
+
   console.log(chalk.cyan(`\n🌐 열기: ${ref.url}`))
 
-  try {
-    if (process.platform === 'darwin') {
-      execSync(`open "${ref.url}"`)
-    } else if (process.platform === 'win32') {
-      execSync(`start "" "${ref.url}"`, { shell: 'cmd.exe' })
-    } else {
-      execSync(`xdg-open "${ref.url}"`)
-    }
+  // safeExecFile — shell 없이 argv 분리 호출 → URL injection 차단
+  let result
+  if (process.platform === 'darwin') {
+    result = safeExecFile('open', [ref.url])
+  } else if (process.platform === 'win32') {
+    result = safeExecFile('cmd.exe', ['/c', 'start', '', ref.url])
+  } else {
+    result = safeExecFile('xdg-open', [ref.url])
+  }
+
+  if (result.ok) {
     console.log(chalk.green('✅ 브라우저에서 열었습니다.'))
-  } catch {
+  } else {
     console.log(chalk.yellow('⚠️  브라우저를 열 수 없습니다. URL을 직접 방문해주세요.'))
   }
 }

--- a/src/commands/theme.ts
+++ b/src/commands/theme.ts
@@ -1,5 +1,6 @@
-import { mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import chalk from 'chalk'
+import inquirer from 'inquirer'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 
@@ -63,13 +64,30 @@ export async function theme(): Promise<void> {
   console.log(chalk.bold('\n🌙 ' + t('theme.title')))
   console.log(chalk.gray('─'.repeat(40)))
 
+  const cssPath = 'src/styles/theme.css'
+  const togglePath = 'src/lib/theme-toggle.ts'
+  const conflicts = [cssPath, togglePath].filter((p) => existsSync(p))
+
+  if (conflicts.length > 0) {
+    const { overwrite } = await inquirer.prompt<{ overwrite: boolean }>([{
+      type: 'confirm',
+      name: 'overwrite',
+      message: `다음 파일이 이미 있어요. 덮어쓸까요?\n   ${conflicts.join('\n   ')}`,
+      default: false,
+    }])
+    if (!overwrite) {
+      console.log(chalk.yellow('\n⏭️  생성 취소 — 기존 파일 유지.'))
+      return
+    }
+  }
+
   mkdirSync('src/styles', { recursive: true })
   mkdirSync('src/lib', { recursive: true })
 
-  writeFileSync('src/styles/theme.css', generateDarkCSS(), 'utf-8')
+  writeFileSync(cssPath, generateDarkCSS(), 'utf-8')
   console.log(chalk.green('\n✅ src/styles/theme.css 생성 (다크/라이트 모드)'))
 
-  writeFileSync('src/lib/theme-toggle.ts', generateToggleUtil(), 'utf-8')
+  writeFileSync(togglePath, generateToggleUtil(), 'utf-8')
   console.log(chalk.green('✅ src/lib/theme-toggle.ts 생성 (토글 유틸리티)'))
 
   console.log(chalk.bold('\n📖 사용법:'))

--- a/src/commands/theme.ts
+++ b/src/commands/theme.ts
@@ -1,0 +1,86 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import chalk from 'chalk'
+import { t } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+
+function generateDarkCSS(): string {
+  return `/* vhk theme — 다크/라이트 모드 CSS 변수 */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-background: #0f172a;
+    --color-surface: #1e293b;
+    --color-text: #f1f5f9;
+    --color-muted: #64748b;
+  }
+}
+
+[data-theme="dark"] {
+  --color-background: #0f172a;
+  --color-surface: #1e293b;
+  --color-text: #f1f5f9;
+  --color-muted: #64748b;
+}
+
+[data-theme="light"] {
+  --color-background: #ffffff;
+  --color-surface: #f9fafb;
+  --color-text: #111827;
+  --color-muted: #9ca3af;
+}
+`
+}
+
+function generateToggleUtil(): string {
+  return `// vhk theme — 다크/라이트 모드 토글 유틸리티
+
+export function getTheme(): 'light' | 'dark' {
+  if (typeof window === 'undefined') return 'light'
+  const stored = localStorage.getItem('vhk-theme') as 'light' | 'dark' | null
+  if (stored === 'light' || stored === 'dark') return stored
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+export function setTheme(theme: 'light' | 'dark'): void {
+  if (typeof document === 'undefined') return
+  document.documentElement.setAttribute('data-theme', theme)
+  localStorage.setItem('vhk-theme', theme)
+}
+
+export function toggleTheme(): 'light' | 'dark' {
+  const next = getTheme() === 'light' ? 'dark' : 'light'
+  setTheme(next)
+  return next
+}
+
+export function initTheme(): void {
+  setTheme(getTheme())
+}
+`
+}
+
+export async function theme(): Promise<void> {
+  console.log(chalk.bold('\n🌙 ' + t('theme.title')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  mkdirSync('src/styles', { recursive: true })
+  mkdirSync('src/lib', { recursive: true })
+
+  writeFileSync('src/styles/theme.css', generateDarkCSS(), 'utf-8')
+  console.log(chalk.green('\n✅ src/styles/theme.css 생성 (다크/라이트 모드)'))
+
+  writeFileSync('src/lib/theme-toggle.ts', generateToggleUtil(), 'utf-8')
+  console.log(chalk.green('✅ src/lib/theme-toggle.ts 생성 (토글 유틸리티)'))
+
+  console.log(chalk.bold('\n📖 사용법:'))
+  console.log(chalk.gray('   1. theme.css를 글로벌 스타일에 추가'))
+  console.log(chalk.gray('   2. import { initTheme, toggleTheme } from "./lib/theme-toggle"'))
+  console.log(chalk.gray('   3. 앱 진입점에서 initTheme() 호출'))
+  console.log(chalk.gray('   4. 토글 버튼에서 toggleTheme() 호출'))
+
+  printNextStep({
+    message: '테마 설정 완료!',
+    command: 'vhk ref list',
+    cursorHint: '레퍼런스 확인해줘',
+  })
+}

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -249,6 +249,17 @@ export const ko = {
     changelogMissing:
       'CHANGELOG.md가 없어요. 만들면 ship이 자동으로 [Unreleased] → 버전 섹션으로 옮겨줍니다.',
   },
+  design: {
+    title: '디자인 토큰 생성',
+    selectPalette: '컬러 팔레트를 선택하세요:',
+  },
+  theme: {
+    title: '테마 설정 (다크/라이트 모드)',
+  },
+  ref: {
+    addTitle: '레퍼런스 추가',
+    listTitle: '레퍼런스 목록',
+  },
   mcp: {
     initTitle: 'Cursor MCP 연동 설정',
     serverStarted: 'VHK MCP 서버 시작됨',

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,9 @@ import { mcpInit } from './commands/mcp-init.js'
 import { deploy } from './commands/deploy.js'
 import { env, envCheck } from './commands/env.js'
 import { publish } from './commands/publish.js'
+import { design, designPalette } from './commands/design.js'
+import { theme } from './commands/theme.js'
+import { refAdd, refList, refOpen } from './commands/ref.js'
 
 const program = new Command()
 const defaultHelp = new Help()
@@ -42,6 +45,10 @@ const KO_ALIASES: Record<string, string> = {
   env: '환경변수',
   'env-check': '환경변수점검',
   publish: '출시',
+  design: '디자인',
+  'design-palette': '팔레트',
+  theme: '테마',
+  ref: '레퍼런스',
 }
 
 program
@@ -210,6 +217,50 @@ program
   .alias('출시')
   .description('npm 배포 (버전 범프 → 빌드 → 테스트 → publish)')
   .action(async () => { await publish() })
+
+program
+  .command('design')
+  .alias('디자인')
+  .description('디자인 토큰 생성 (Tailwind config 또는 CSS 변수)')
+  .action(async () => { await design() })
+
+program
+  .command('design-palette')
+  .alias('팔레트')
+  .description('컬러 팔레트 프리셋 선택 + 적용')
+  .action(async () => { await designPalette() })
+
+program
+  .command('theme')
+  .alias('테마')
+  .description('다크/라이트 모드 CSS + 토글 유틸리티 생성')
+  .action(async () => { await theme() })
+
+const refCmd = program
+  .command('ref')
+  .alias('레퍼런스')
+  .description('레퍼런스 URL 관리 (add / list / open)')
+  .action(async () => { await refList() })
+
+refCmd
+  .command('add <url>')
+  .option('--memo <memo>', '메모 추가')
+  .description('레퍼런스 URL 추가')
+  .action(async (url: string, opts: { memo?: string }) => {
+    await refAdd(url, opts.memo)
+  })
+
+refCmd
+  .command('list')
+  .alias('목록')
+  .description('저장된 레퍼런스 목록')
+  .action(async () => { await refList() })
+
+refCmd
+  .command('open <index>')
+  .alias('열기')
+  .description('레퍼런스를 브라우저에서 열기')
+  .action(async (index: string) => { await refOpen(index) })
 
 program.on('command:*', async (operands: string[]) => {
   const unknown = operands[0] ?? ''

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ const KO_ALIASES: Record<string, string> = {
 program
   .name('vhk')
   .description('VHK — 바이브코딩 프로젝트 코치 (한국어로 안내합니다)')
-  .version('0.7.1')
+  .version('0.8.0')
 
 program.configureHelp({
   formatHelp(cmd, helper) {

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -21,6 +21,10 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'env-check', '환경변수점검',
   'publish', '출시',
   '출하',
+  'design', '디자인',
+  'design-palette', '팔레트',
+  'theme', '테마',
+  'ref', '레퍼런스',
   'help',
 ])
 

--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -16,6 +16,10 @@ export type NlpCommand =
   | 'env'
   | 'env-check'
   | 'publish'
+  | 'design'
+  | 'design-palette'
+  | 'theme'
+  | 'ref'
 
 export type NlpConfidence = 'high' | 'low'
 
@@ -80,6 +84,35 @@ const RULES: NlpRule[] = [
     explanation: 'Cursor MCP 연동 설정 (vhk mcp-init)',
     confidence: 'high',
     test: t => /mcp.*(설정|연동|초기|init)|커서.*(연동|설정|mcp)|cursor.*mcp/.test(t),
+  },
+  {
+    command: 'design-palette',
+    explanation: '컬러 팔레트 선택 (vhk design-palette)',
+    confidence: 'high',
+    test: t =>
+      /팔레트|palette|컬러\s*(고|선택|바꿔|변경)|색상\s*(고|선택|변경)|색깔\s*선택/.test(t),
+  },
+  {
+    command: 'design',
+    explanation: '디자인 토큰 생성 (vhk design)',
+    confidence: 'high',
+    test: t =>
+      /디자인\s*(토큰|시스템|만들|생성|셋업|설정)|design\s*(token|system|setup)|토큰\s*만들|css\s*변수.*만들|tailwind\s*(컬러|설정)/.test(t),
+  },
+  {
+    command: 'theme',
+    explanation: '다크/라이트 테마 적용 (vhk theme)',
+    confidence: 'high',
+    test: t =>
+      /테마(?!\s*(파일|이름))|theme|다크\s*모드|라이트\s*모드|dark\s*mode|light\s*mode|색상\s*모드|모드\s*전환/.test(t),
+  },
+  {
+    command: 'ref',
+    explanation: '레퍼런스 목록 (vhk ref list)',
+    confidence: 'high',
+    test: t =>
+      (/^레퍼런스$|^ref$|레퍼런스.*(보|목록|확인|있|뭐)|참고\s*(사이트|목록|링크)|reference.*list/.test(t)) &&
+      !/(add|추가|open|열|https?:\/\/)/.test(t),
   },
   {
     command: 'secure',

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -18,6 +18,9 @@ import { mcpInit } from '../commands/mcp-init.js'
 import { deploy } from '../commands/deploy.js'
 import { env, envCheck } from '../commands/env.js'
 import { publish } from '../commands/publish.js'
+import { design, designPalette } from '../commands/design.js'
+import { theme } from '../commands/theme.js'
+import { refList } from '../commands/ref.js'
 
 export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<void> {
   switch (route.command) {
@@ -60,6 +63,14 @@ export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<
       return envCheck()
     case 'publish':
       return publish()
+    case 'design':
+      return design()
+    case 'design-palette':
+      return designPalette()
+    case 'theme':
+      return theme()
+    case 'ref':
+      return refList()
   }
 }
 

--- a/tests/design.test.ts
+++ b/tests/design.test.ts
@@ -64,4 +64,31 @@ describe('design', () => {
 
     expect(mockWriteFileSync).toHaveBeenCalled()
   })
+
+  it('기존 tokens.css 있고 덮어쓰기 거부하면 파일 안 씀', async () => {
+    // tailwind 없음 → tokens.css 타겟. 그 파일이 존재
+    mockExistsSync.mockImplementation((p: unknown) => String(p).includes('tokens.css'))
+    // 첫 prompt = 팔레트 선택, 두 번째 prompt = 덮어쓰기 확인 (false)
+    mockPrompt
+      .mockResolvedValueOnce({ paletteIndex: 0 })
+      .mockResolvedValueOnce({ overwrite: false })
+
+    const { design } = await import('../src/commands/design.js')
+    await design()
+
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
+  })
+
+  it('기존 tokens.css 있고 덮어쓰기 승인하면 새로 씀', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p).includes('tokens.css'))
+    mockPrompt
+      .mockResolvedValueOnce({ paletteIndex: 0 })
+      .mockResolvedValueOnce({ overwrite: true })
+
+    const { design } = await import('../src/commands/design.js')
+    await design()
+
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1)
+    expect(String(mockWriteFileSync.mock.calls[0][0])).toContain('tokens.css')
+  })
 })

--- a/tests/design.test.ts
+++ b/tests/design.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockExistsSync = vi.fn()
+const mockMkdirSync = vi.fn()
+const mockWriteFileSync = vi.fn()
+const mockPrompt = vi.fn()
+
+vi.mock('node:fs', () => ({
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
+  mkdirSync: (...a: unknown[]) => mockMkdirSync(...a),
+  writeFileSync: (...a: unknown[]) => mockWriteFileSync(...a),
+}))
+
+vi.mock('inquirer', () => ({
+  default: { prompt: (...a: unknown[]) => mockPrompt(...a) },
+}))
+
+describe('design', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('모듈을 import 할 수 있다', async () => {
+    const mod = await import('../src/commands/design.js')
+    expect(mod.design).toBeDefined()
+    expect(mod.designPalette).toBeDefined()
+  })
+
+  it('tailwind.config 없으면 CSS 토큰 파일을 생성한다', async () => {
+    mockExistsSync.mockReturnValue(false)
+    mockPrompt.mockResolvedValue({ paletteIndex: 0 })
+
+    const { design } = await import('../src/commands/design.js')
+    await design()
+
+    expect(mockMkdirSync).toHaveBeenCalledWith('src/styles', { recursive: true })
+    expect(mockWriteFileSync).toHaveBeenCalled()
+    const call = mockWriteFileSync.mock.calls[0]
+    expect(String(call[0])).toContain('tokens.css')
+    expect(String(call[1])).toContain('--color-primary')
+    expect(String(call[1])).toContain(':root')
+  })
+
+  it('tailwind.config 있으면 vhk-colors.ts를 생성한다', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p).includes('tailwind.config'))
+    mockPrompt.mockResolvedValue({ paletteIndex: 1 })
+
+    const { design } = await import('../src/commands/design.js')
+    await design()
+
+    const call = mockWriteFileSync.mock.calls[0]
+    expect(String(call[0])).toContain('vhk-colors.ts')
+    expect(String(call[1])).toContain('export default')
+    expect(String(call[1])).toContain('primary')
+  })
+
+  it('designPalette는 design 위임(같은 동작)', async () => {
+    mockExistsSync.mockReturnValue(false)
+    mockPrompt.mockResolvedValue({ paletteIndex: 2 })
+
+    const { designPalette } = await import('../src/commands/design.js')
+    await designPalette()
+
+    expect(mockWriteFileSync).toHaveBeenCalled()
+  })
+})

--- a/tests/nlp-router.test.ts
+++ b/tests/nlp-router.test.ts
@@ -68,4 +68,28 @@ describe('자연어 라우팅', () => {
     const result = routeNaturalLanguage('asdfqwer')
     expect(result).toBeNull()
   })
+
+  it('"디자인 토큰 만들어줘" → design', () => {
+    expect(routeNaturalLanguage('디자인 토큰 만들어줘')?.command).toBe('design')
+  })
+
+  it('"팔레트 골라줘" → design-palette', () => {
+    expect(routeNaturalLanguage('팔레트 골라줘')?.command).toBe('design-palette')
+  })
+
+  it('"다크 모드 적용" → theme', () => {
+    expect(routeNaturalLanguage('다크 모드 적용')?.command).toBe('theme')
+  })
+
+  it('"레퍼런스 보여줘" → ref', () => {
+    expect(routeNaturalLanguage('레퍼런스 보여줘')?.command).toBe('ref')
+  })
+
+  it('"ref add https://x.com" → null (commander 서브커맨드 보호)', () => {
+    expect(routeNaturalLanguage('ref add https://x.com')).toBeNull()
+  })
+
+  it('"레퍼런스 추가해줘" → null (NL에서 의도적으로 배제)', () => {
+    expect(routeNaturalLanguage('레퍼런스 추가해줘')).toBeNull()
+  })
 })

--- a/tests/ref.test.ts
+++ b/tests/ref.test.ts
@@ -4,7 +4,7 @@ const mockExistsSync = vi.fn()
 const mockMkdirSync = vi.fn()
 const mockReadFileSync = vi.fn()
 const mockWriteFileSync = vi.fn()
-const mockExecSync = vi.fn()
+const mockSafeExecFile = vi.fn()
 
 vi.mock('node:fs', () => ({
   existsSync: (...a: unknown[]) => mockExistsSync(...a),
@@ -13,8 +13,8 @@ vi.mock('node:fs', () => ({
   writeFileSync: (...a: unknown[]) => mockWriteFileSync(...a),
 }))
 
-vi.mock('node:child_process', () => ({
-  execSync: (...a: unknown[]) => mockExecSync(...a),
+vi.mock('../src/lib/exec.js', () => ({
+  safeExecFile: (...a: unknown[]) => mockSafeExecFile(...a),
 }))
 
 describe('ref', () => {
@@ -84,25 +84,62 @@ describe('ref', () => {
     expect(joined).toContain('https://b.com')
   })
 
-  it('refOpen — 유효하지 않은 인덱스면 execSync를 호출하지 않는다', async () => {
+  it('refOpen — 유효하지 않은 인덱스면 safeExecFile을 호출하지 않는다', async () => {
     mockExistsSync.mockReturnValue(true)
     mockReadFileSync.mockReturnValue(
       JSON.stringify([{ url: 'https://a.com', memo: '', addedAt: '2026-01-01' }])
     )
     const { refOpen } = await import('../src/commands/ref.js')
     await refOpen('99')
-    expect(mockExecSync).not.toHaveBeenCalled()
+    expect(mockSafeExecFile).not.toHaveBeenCalled()
   })
 
-  it('refOpen — 유효한 인덱스면 플랫폼별 open 명령을 호출한다', async () => {
+  it('refOpen — 유효한 인덱스면 safeExecFile을 호출한다 (argv 분리)', async () => {
     mockExistsSync.mockReturnValue(true)
     mockReadFileSync.mockReturnValue(
       JSON.stringify([{ url: 'https://a.com', memo: '', addedAt: '2026-01-01' }])
     )
+    mockSafeExecFile.mockReturnValue({ ok: true, out: '' })
     const { refOpen } = await import('../src/commands/ref.js')
     await refOpen('1')
-    expect(mockExecSync).toHaveBeenCalled()
-    const cmd = String(mockExecSync.mock.calls[0][0])
-    expect(cmd).toContain('https://a.com')
+
+    expect(mockSafeExecFile).toHaveBeenCalledTimes(1)
+    const [cmd, args] = mockSafeExecFile.mock.calls[0]
+    // 플랫폼별 cmd는 다르나 args에 URL이 별도 토큰으로 전달돼야 함 (shell injection 차단)
+    expect(Array.isArray(args)).toBe(true)
+    expect((args as string[]).includes('https://a.com')).toBe(true)
+    // cmd 자체는 'open' / 'cmd.exe' / 'xdg-open' 중 하나
+    expect(['open', 'cmd.exe', 'xdg-open']).toContain(String(cmd))
+  })
+
+  it('refOpen — http(s) 외 프로토콜은 차단', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify([{ url: 'javascript:alert(1)', memo: '', addedAt: '2026-01-01' }])
+    )
+    const { refOpen } = await import('../src/commands/ref.js')
+    await refOpen('1')
+    expect(mockSafeExecFile).not.toHaveBeenCalled()
+  })
+
+  it('refOpen — URL injection 시도(따옴표/세미콜론)는 argv로 전달되어 shell 해석 안 됨', async () => {
+    const malicious = 'https://x.com"; rm -rf /'
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify([{ url: malicious, memo: '', addedAt: '2026-01-01' }])
+    )
+    mockSafeExecFile.mockReturnValue({ ok: true, out: '' })
+    const { refOpen } = await import('../src/commands/ref.js')
+    await refOpen('1')
+
+    // URL parse에서 통과한 경우 — 따옴표/세미콜론 포함 URL은 잘못된 URL이므로 차단됨
+    // 만약 차단됐다면 safeExecFile 안 호출
+    // 만약 호출됐다면 args에 별도 토큰으로 들어가 shell 해석 없음
+    if (mockSafeExecFile.mock.calls.length > 0) {
+      const args = mockSafeExecFile.mock.calls[0][1] as string[]
+      // URL이 args의 한 요소로 들어감 → shell metachar 분리 안 됨
+      expect(args.some((a) => a.includes('rm -rf'))).toBe(false)
+      expect(args.includes(malicious)).toBe(true)
+    }
   })
 })

--- a/tests/ref.test.ts
+++ b/tests/ref.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockExistsSync = vi.fn()
+const mockMkdirSync = vi.fn()
+const mockReadFileSync = vi.fn()
+const mockWriteFileSync = vi.fn()
+const mockExecSync = vi.fn()
+
+vi.mock('node:fs', () => ({
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
+  mkdirSync: (...a: unknown[]) => mockMkdirSync(...a),
+  readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
+  writeFileSync: (...a: unknown[]) => mockWriteFileSync(...a),
+}))
+
+vi.mock('node:child_process', () => ({
+  execSync: (...a: unknown[]) => mockExecSync(...a),
+}))
+
+describe('ref', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('모듈을 import 할 수 있다', async () => {
+    const mod = await import('../src/commands/ref.js')
+    expect(mod.refAdd).toBeDefined()
+    expect(mod.refList).toBeDefined()
+    expect(mod.refOpen).toBeDefined()
+  })
+
+  it('refAdd — 빈 URL이면 안내만 출력하고 파일은 쓰지 않는다', async () => {
+    const { refAdd } = await import('../src/commands/ref.js')
+    await refAdd('')
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
+  })
+
+  it('refAdd — 새 URL이면 .vhk/refs.json에 항목을 추가한다', async () => {
+    mockExistsSync.mockReturnValue(false)
+    const { refAdd } = await import('../src/commands/ref.js')
+    await refAdd('https://example.com', '참고 사이트')
+
+    expect(mockMkdirSync).toHaveBeenCalledWith('.vhk', { recursive: true })
+    const call = mockWriteFileSync.mock.calls[0]
+    expect(String(call[0])).toContain('refs.json')
+    const data = JSON.parse(String(call[1]))
+    expect(data).toHaveLength(1)
+    expect(data[0].url).toBe('https://example.com')
+    expect(data[0].memo).toBe('참고 사이트')
+    expect(data[0].addedAt).toBeDefined()
+  })
+
+  it('refAdd — 중복 URL이면 쓰지 않는다', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify([{ url: 'https://example.com', memo: '', addedAt: '2026-01-01' }])
+    )
+    const { refAdd } = await import('../src/commands/ref.js')
+    await refAdd('https://example.com')
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
+  })
+
+  it('refList — 저장된 항목이 없으면 안내만 출력', async () => {
+    mockExistsSync.mockReturnValue(false)
+    const { refList } = await import('../src/commands/ref.js')
+    await refList()
+    expect(mockReadFileSync).not.toHaveBeenCalled()
+  })
+
+  it('refList — 저장된 항목을 읽어 출력한다', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify([
+        { url: 'https://a.com', memo: 'A', addedAt: '2026-01-01T00:00:00.000Z' },
+        { url: 'https://b.com', memo: '', addedAt: '2026-02-01T00:00:00.000Z' },
+      ])
+    )
+    const logSpy = vi.spyOn(console, 'log')
+    const { refList } = await import('../src/commands/ref.js')
+    await refList()
+    const joined = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+    expect(joined).toContain('https://a.com')
+    expect(joined).toContain('https://b.com')
+  })
+
+  it('refOpen — 유효하지 않은 인덱스면 execSync를 호출하지 않는다', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify([{ url: 'https://a.com', memo: '', addedAt: '2026-01-01' }])
+    )
+    const { refOpen } = await import('../src/commands/ref.js')
+    await refOpen('99')
+    expect(mockExecSync).not.toHaveBeenCalled()
+  })
+
+  it('refOpen — 유효한 인덱스면 플랫폼별 open 명령을 호출한다', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify([{ url: 'https://a.com', memo: '', addedAt: '2026-01-01' }])
+    )
+    const { refOpen } = await import('../src/commands/ref.js')
+    await refOpen('1')
+    expect(mockExecSync).toHaveBeenCalled()
+    const cmd = String(mockExecSync.mock.calls[0][0])
+    expect(cmd).toContain('https://a.com')
+  })
+})

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockMkdirSync = vi.fn()
+const mockWriteFileSync = vi.fn()
+
+vi.mock('node:fs', () => ({
+  mkdirSync: (...a: unknown[]) => mockMkdirSync(...a),
+  writeFileSync: (...a: unknown[]) => mockWriteFileSync(...a),
+}))
+
+describe('theme', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('모듈을 import 할 수 있다', async () => {
+    const mod = await import('../src/commands/theme.js')
+    expect(mod.theme).toBeDefined()
+  })
+
+  it('theme.css와 theme-toggle.ts 두 파일을 생성한다', async () => {
+    const { theme } = await import('../src/commands/theme.js')
+    await theme()
+
+    expect(mockMkdirSync).toHaveBeenCalledWith('src/styles', { recursive: true })
+    expect(mockMkdirSync).toHaveBeenCalledWith('src/lib', { recursive: true })
+
+    const writes = mockWriteFileSync.mock.calls.map((c) => String(c[0]))
+    expect(writes.some((p) => p.includes('theme.css'))).toBe(true)
+    expect(writes.some((p) => p.includes('theme-toggle.ts'))).toBe(true)
+  })
+
+  it('theme.css는 dark/light data-theme 셀렉터를 포함한다', async () => {
+    const { theme } = await import('../src/commands/theme.js')
+    await theme()
+
+    const cssCall = mockWriteFileSync.mock.calls.find((c) => String(c[0]).includes('theme.css'))
+    expect(cssCall).toBeDefined()
+    const css = String(cssCall![1])
+    expect(css).toContain('prefers-color-scheme: dark')
+    expect(css).toContain('[data-theme="dark"]')
+    expect(css).toContain('[data-theme="light"]')
+  })
+
+  it('theme-toggle.ts는 getTheme/setTheme/toggleTheme/initTheme를 export한다', async () => {
+    const { theme } = await import('../src/commands/theme.js')
+    await theme()
+
+    const tsCall = mockWriteFileSync.mock.calls.find((c) => String(c[0]).includes('theme-toggle.ts'))
+    expect(tsCall).toBeDefined()
+    const ts = String(tsCall![1])
+    expect(ts).toContain('export function getTheme')
+    expect(ts).toContain('export function setTheme')
+    expect(ts).toContain('export function toggleTheme')
+    expect(ts).toContain('export function initTheme')
+  })
+})

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -1,11 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
+const mockExistsSync = vi.fn()
 const mockMkdirSync = vi.fn()
 const mockWriteFileSync = vi.fn()
+const mockPrompt = vi.fn()
 
 vi.mock('node:fs', () => ({
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
   mkdirSync: (...a: unknown[]) => mockMkdirSync(...a),
   writeFileSync: (...a: unknown[]) => mockWriteFileSync(...a),
+}))
+
+vi.mock('inquirer', () => ({
+  default: { prompt: (...a: unknown[]) => mockPrompt(...a) },
 }))
 
 describe('theme', () => {
@@ -20,6 +27,7 @@ describe('theme', () => {
   })
 
   it('theme.css와 theme-toggle.ts 두 파일을 생성한다', async () => {
+    mockExistsSync.mockReturnValue(false)
     const { theme } = await import('../src/commands/theme.js')
     await theme()
 
@@ -32,6 +40,7 @@ describe('theme', () => {
   })
 
   it('theme.css는 dark/light data-theme 셀렉터를 포함한다', async () => {
+    mockExistsSync.mockReturnValue(false)
     const { theme } = await import('../src/commands/theme.js')
     await theme()
 
@@ -44,6 +53,7 @@ describe('theme', () => {
   })
 
   it('theme-toggle.ts는 getTheme/setTheme/toggleTheme/initTheme를 export한다', async () => {
+    mockExistsSync.mockReturnValue(false)
     const { theme } = await import('../src/commands/theme.js')
     await theme()
 
@@ -54,5 +64,25 @@ describe('theme', () => {
     expect(ts).toContain('export function setTheme')
     expect(ts).toContain('export function toggleTheme')
     expect(ts).toContain('export function initTheme')
+  })
+
+  it('기존 theme.css 있고 덮어쓰기 거부하면 파일 안 씀', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p).includes('theme.css'))
+    mockPrompt.mockResolvedValue({ overwrite: false })
+
+    const { theme } = await import('../src/commands/theme.js')
+    await theme()
+
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
+  })
+
+  it('기존 theme.css 있고 덮어쓰기 승인하면 새로 씀', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p).includes('theme.css'))
+    mockPrompt.mockResolvedValue({ overwrite: true })
+
+    const { theme } = await import('../src/commands/theme.js')
+    await theme()
+
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
## Summary

v0.8.0 — 바이브코더가 디자인 토큰 셋업·다크/라이트 테마 적용·레퍼런스 URL 관리를 한 줄로 끝낼 수 있게 하는 신규 명령 3종 추가.

- **`vhk design`** / `디자인` — 컬러 팔레트 프리셋 4종(Minimal/Vibrant/Corporate/Pastel) 선택 → `tailwind.config` 감지 시 `src/styles/vhk-colors.ts`, 없으면 `src/styles/tokens.css` 생성
- **`vhk design-palette`** / `팔레트` — design 별칭 진입점
- **`vhk theme`** / `테마` — `src/styles/theme.css` (다크/라이트 + `prefers-color-scheme` + `data-theme`) + `src/lib/theme-toggle.ts` (`getTheme`/`setTheme`/`toggleTheme`/`initTheme`) 생성
- **`vhk ref add|list|open`** / `레퍼런스` — `.vhk/refs.json` 기반 URL 관리, Windows/macOS/Linux 브라우저 자동 오픈

## Changes

| 영역 | 파일 | 변경 |
|------|------|------|
| 신규 명령 | `src/commands/{design,theme,ref}.ts` | 3개 신규 |
| i18n | `src/i18n/ko.ts` | design/theme/ref 섹션 |
| 등록 | `src/index.ts` | 명령 4개 + ref 서브커맨드 3개 + 한국어 별칭 |
| CLI 파싱 가드 | `src/lib/cli-args.ts` | `KNOWN_COMMAND_TOKENS`에 신규 토큰 추가 |
| 자연어 라우터 | `src/lib/nlp-router.ts` | `NlpCommand` 유니온 확장 + RULES 4개 추가 (design-palette → design 순서, ref는 add/open/http 가드) |
| 자연어 디스패처 | `src/lib/nlp-run.ts` | switch case 4개 |
| 버전 | `package.json`, `src/index.ts` | 0.7.1 → 0.8.0 |
| 문서 | `README.md`, `CHANGELOG.md` | v0.8.0 섹션 |

## 키워드 충돌 가드

- `배포`(ship→deploy, v0.7), `환경`(doctor) 등 기존 별칭 회피
- `테마`/`레퍼런스`/`팔레트`/`디자인` 신규 — 충돌 없음
- `ref add`/`ref open`은 인자 추출 인프라가 없어 NL 진입점에서 의도적으로 배제 (`/(add|추가|open|열|https?:\/\/)/` 가드) → commander 서브커맨드로만 노출

## Test plan

- [x] `pnpm test --run` — 155/155 passing (22건 신규: design 4 + theme 4 + ref 8 + nlp-router 6)
- [x] `pnpm build` — dist/index.js, dist/mcp/index.js 빌드 성공
- [x] `node dist/index.js --version` → `0.8.0`
- [x] `node dist/index.js --help` — design/design-palette/theme/ref 모두 표시
- [x] theme smoke (격리 temp dir): theme.css + theme-toggle.ts 생성 확인
- [x] ref smoke: `ref add` + `ref list` → `.vhk/refs.json`에 항목 저장 확인
- [x] NL smoke: `"다크 모드 적용해줘"` → theme 실행, `"레퍼런스 보여줘"` → refList 호출
- [x] NL 가드: `ref add https://test.local --memo "..."` → commander 서브커맨드 정상 동작 (NL 라우터 가로채기 없음)
- [ ] (보류) `npm publish` — OTP 입력 필요해 maintainer 직접 실행

## 참고

플랜: `docs/superpowers/plans/2026-05-24-v0.8.0-design-theme-ref.md`
실행 방식: superpowers:subagent-driven-development (11 task)