### PR TITLE
fix(nlp): v0.8.0 post-merge NL 라우터 모호 발화 가드

### DIFF
--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -77,7 +77,8 @@ const RULES: NlpRule[] = [
     explanation: '프로젝트 시작 (vhk 시작)',
     confidence: 'high',
     test: t =>
-      /프로젝트.*(만들|시작)|폴더.*만들|만들고\s*싶|하네스|초기화/.test(t) || /^시작$/.test(t),
+      (/프로젝트.*(만들|시작)|폴더.*만들|만들고\s*싶|하네스|초기화/.test(t) || /^시작$/.test(t)) &&
+      !/디자인|design|팔레트|palette|테마|theme|레퍼런스|reference|다크\s*모드|라이트\s*모드|색상\s*모드/.test(t),
   },
   {
     command: 'mcp-init',

--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -98,14 +98,16 @@ const RULES: NlpRule[] = [
     explanation: '디자인 토큰 생성 (vhk design)',
     confidence: 'high',
     test: t =>
-      /디자인\s*(토큰|시스템|만들|생성|셋업|설정)|design\s*(token|system|setup)|토큰\s*만들|css\s*변수.*만들|tailwind\s*(컬러|설정)/.test(t),
+      (/디자인\s*(토큰|시스템|만들|생성|셋업|설정)|design\s*(token|system|setup)|토큰\s*만들|css\s*변수.*만들|tailwind\s*(컬러|설정)/.test(t)) &&
+      !/배포|deploy|vercel|netlify|cloudflare|wrangler|출시|publish|npm/.test(t),
   },
   {
     command: 'theme',
     explanation: '다크/라이트 테마 적용 (vhk theme)',
     confidence: 'high',
     test: t =>
-      /테마(?!\s*(파일|이름))|theme|다크\s*모드|라이트\s*모드|dark\s*mode|light\s*mode|색상\s*모드|모드\s*전환/.test(t),
+      (/테마(?!\s*(파일|이름))|theme|다크\s*모드|라이트\s*모드|dark\s*mode|light\s*mode|색상\s*모드|모드\s*전환/.test(t)) &&
+      !/보안|시크릿|비밀|키\s*유출|secure|scan|스캔|배포|deploy/.test(t),
   },
   {
     command: 'ref',

--- a/tests/nlp-router.test.ts
+++ b/tests/nlp-router.test.ts
@@ -104,4 +104,21 @@ describe('자연어 라우팅', () => {
   it('"테마 만들고 싶어" → theme (init 가로채기 방지)', () => {
     expect(routeNaturalLanguage('테마 만들고 싶어')?.command).toBe('theme')
   })
+
+  it('"다크 모드 보안 검사" → secure (theme 가드: 보안 키워드 우선)', () => {
+    expect(routeNaturalLanguage('다크 모드 보안 검사')?.command).toBe('secure')
+  })
+
+  it('"디자인 시스템 배포" → null (design 가드 + 모호 발화 → 메뉴 안내)', () => {
+    // design 가드로 design 차단, deploy 룰은 `^배포$` 단독만 인정 → 안전한 null
+    expect(routeNaturalLanguage('디자인 시스템 배포')).toBeNull()
+  })
+
+  it('"테마 시크릿 확인" → secure (theme 가드)', () => {
+    expect(routeNaturalLanguage('테마 시크릿 확인')?.command).toBe('secure')
+  })
+
+  it('"디자인 토큰 npm 출시" → publish (design 가드)', () => {
+    expect(routeNaturalLanguage('디자인 토큰 npm 출시')?.command).toBe('publish')
+  })
 })

--- a/tests/nlp-router.test.ts
+++ b/tests/nlp-router.test.ts
@@ -92,4 +92,16 @@ describe('자연어 라우팅', () => {
   it('"레퍼런스 추가해줘" → null (NL에서 의도적으로 배제)', () => {
     expect(routeNaturalLanguage('레퍼런스 추가해줘')).toBeNull()
   })
+
+  it('"팔레트 만들고 싶어" → design-palette (init 룰의 \'만들고 싶\' 가로채기 방지)', () => {
+    expect(routeNaturalLanguage('팔레트 만들고 싶어')?.command).toBe('design-palette')
+  })
+
+  it('"디자인 시스템 만들고 싶어" → design (init 가로채기 방지)', () => {
+    expect(routeNaturalLanguage('디자인 시스템 만들고 싶어')?.command).toBe('design')
+  })
+
+  it('"테마 만들고 싶어" → theme (init 가로채기 방지)', () => {
+    expect(routeNaturalLanguage('테마 만들고 싶어')?.command).toBe('theme')
+  })
 })


### PR DESCRIPTION
## Summary

v0.8.0 머지 후 실전 검증으로 발견된 NL 라우터 모호 케이스 4건 fix.

## Found via real-world validation

| 입력 | 이전 | 수정 | 근거 |
|------|------|------|------|
| `팔레트 만들고 싶어` | init | **design-palette** | init 룰의 `만들고\s*싶` 가로채기 방지 |
| `디자인 시스템 만들고 싶어` | init | **design** | 동일 |
| `테마 만들고 싶어` | init | **theme** | 동일 |
| `다크 모드 보안 검사` | theme | **secure** | `보안` 키워드 우선 (destructive 의도 명확) |
| `테마 시크릿 확인` | theme | **secure** | 동일 |
| `디자인 토큰 npm 출시` | design | **publish** | `npm 출시` 키워드 우선 |
| `디자인 시스템 배포` | design | **null + 안내** | deploy 룰은 `^배포$` 단독만 인정 → 모호 발화는 메뉴 안내가 안전 |

## Changes

- `src/lib/nlp-router.ts`: init/design/theme 룰에 신규/기존 키워드 가드 추가
- `tests/nlp-router.test.ts`: 7 case 신규 (회귀 + fix 검증)

## Test plan

- [x] `pnpm test --run tests/nlp-router.test.ts` — 26/26 passing
- [x] `pnpm test --run` — 168/168 passing (직전 164 + 4 신규)
- [x] 실전 smoke: 8개 발화 라우팅 직접 검증
- [x] 회귀 없음: `프로젝트 만들고 싶어` → init, `디자인 토큰 만들어줘` → design, `다크 모드 적용` → theme, `보안 검사` → secure, `배포해줘` → deploy

## Cherry-picked from

원본 feat/v0.8.0-design-theme-ref (PR #5 머지 후 추가된 fix 2 커밋):
- 9edfe8b → 7ce3810
- b5c6897 → d8d3d56