### PR TITLE
fix(exec): Windows .cmd shim 호출 — vhk publish 빌드 실패 수정

### DIFF
--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -12,9 +12,21 @@ export function platformCmd(cmd: string): string {
 
 export type ExecResult = { ok: true; out: string } | { ok: false; err: string }
 
+// Windows .cmd shim 호출은 Node 20.12+ / 21.7+ CVE-2024-27980 보안 강화로 execFileSync 직접 호출 시
+// spawnSync EINVAL. cmd.exe /d /s /c <shim>.cmd <args>로 래핑 — shell:false 유지하면서 동작.
+// /d: AutoRun 무시, /s: 따옴표 처리 강화, /c: 명령 실행 후 종료.
+// shim args는 publish/deploy 등 코드 내부 리터럴만 → cmd.exe argv parsing 안전.
+function resolveCmd(cmd: string, args: string[]): { bin: string; argv: string[] } {
+  if (process.platform === 'win32' && SHIM_BINARIES.has(cmd)) {
+    return { bin: 'cmd.exe', argv: ['/d', '/s', '/c', `${cmd}.cmd`, ...args] }
+  }
+  return { bin: platformCmd(cmd), argv: args }
+}
+
 export function safeExecFile(cmd: string, args: string[]): ExecResult {
+  const { bin, argv } = resolveCmd(cmd, args)
   try {
-    const out = execFileSync(platformCmd(cmd), args, {
+    const out = execFileSync(bin, argv, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     }).toString()
@@ -31,8 +43,9 @@ export type StreamResult = { ok: true } | { ok: false; err: string }
 // 장시간 작업(vercel deploy, netlify deploy, pnpm build 등)의 실시간 로그가 사용자에게 보임.
 // 반환값에 out 필드는 없음 — 출력은 이미 터미널에 흘러감.
 export function safeExecFileStream(cmd: string, args: string[]): StreamResult {
+  const { bin, argv } = resolveCmd(cmd, args)
   try {
-    execFileSync(platformCmd(cmd), args, {
+    execFileSync(bin, argv, {
       encoding: 'utf-8',
       stdio: 'inherit',
     })

--- a/tests/exec.test.ts
+++ b/tests/exec.test.ts
@@ -47,4 +47,14 @@ describe('lib/exec', () => {
       expect(result.err).toBeTruthy()
     }
   })
+
+  it('safeExecFile: Windows .cmd shim 실행 (Node 20.12+ CVE-2024-27980 회귀 방지)', async () => {
+    // pnpm.cmd가 spawnSync EINVAL 없이 실행되어야 함
+    const { safeExecFile } = await import('../src/lib/exec.js')
+    const result = safeExecFile('pnpm', ['--version'])
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.out).toMatch(/^\d+\.\d+\.\d+/)
+    }
+  })
 })


### PR DESCRIPTION
## Summary

Windows에서 \`vhk publish\` 실행 시 \`pnpm build\` 단계에서 \`spawnSync pnpm.cmd EINVAL\` 발생. Node 20.12+ / 21.7+ CVE-2024-27980 보안 강화로 \`execFileSync\` 직접 호출이 .cmd 파일에 대해 거부됨.

## Repro

\`\`\`powershell
vhk publish
# patch 선택
# ✖ 빌드 실패
#   spawnSync pnpm.cmd EINVAL
\`\`\`

## Fix

\`src/lib/exec.ts\` — SHIM_BINARIES (pnpm/npm/npx/yarn)는 \`cmd.exe /d /s /c <shim>.cmd <args>\` 래핑으로 호출.

| 옵션 | 의미 |
|------|------|
| \`/d\` | AutoRun 무시 |
| \`/s\` | 따옴표 처리 강화 |
| \`/c\` | 명령 실행 후 종료 |

**왜 cmd.exe 래핑인가:**
- \`shell:true\` 대안은 Node DEP0190 경고 + injection 위험
- cmd.exe argv parsing이 각 arg를 별도 토큰으로 안전하게 전달
- shim 외 다른 cmd (git, vercel, cmd.exe 직접 호출 등)는 영향 없음
- safeExecFile injection 차단 원칙 보존

## Affected commands

이 버그로 Windows에서 동작 안 했던 명령:
- \`vhk publish\` — pnpm build/test 호출 단계
- \`vhk deploy\` — vercel/netlify CLI 호출 단계 (간접)
- \`vhk doctor\` — npm 최신 버전 확인 단계 (간접)

## Test plan

- [x] \`pnpm test --run tests/exec.test.ts\` — 5/5 (회귀 테스트 1건 신규: 'pnpm --version' 실제 호출)
- [x] \`pnpm test --run\` — 169/169 passing
- [x] \`pnpm build\` 성공
- [ ] \`vhk publish\` 재시도 (사용자 직접) — patch bump → 빌드 → 테스트 → npm publish (OTP 입력)

## Version

main이 v0.8.0이므로 이 fix는 v0.8.1 patch. publish 명령으로 자동 bump 예상.