### PR TITLE
fix(version): runtime read from package.json — publish 자동 bump 호환

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 import { Command, Help } from 'commander'
 import chalk from 'chalk'
 import inquirer from 'inquirer'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { detectNaturalLanguageInput } from './lib/cli-args.js'
 import { runNaturalLanguageRoute } from './lib/nlp-run.js'
 import { ko } from './i18n/ko.js'
@@ -24,6 +27,24 @@ import { publish } from './commands/publish.js'
 import { design, designPalette } from './commands/design.js'
 import { theme } from './commands/theme.js'
 import { refAdd, refList, refOpen } from './commands/ref.js'
+
+// 런타임에 package.json에서 버전 읽기 — src와 dist 둘 다 동작.
+// dist/index.js: ../package.json (npm 글로벌 + 로컬 빌드 동일)
+// src/index.ts (dev): ../package.json (repo root)
+function getVersion(): string {
+  const dir = path.dirname(fileURLToPath(import.meta.url))
+  for (const pkgPath of [path.join(dir, '../package.json'), path.join(dir, '../../package.json')]) {
+    try {
+      if (fs.existsSync(pkgPath)) {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as { version?: string }
+        if (pkg.version) return pkg.version
+      }
+    } catch {
+      continue
+    }
+  }
+  return '0.0.0'
+}
 
 const program = new Command()
 const defaultHelp = new Help()
@@ -54,7 +75,7 @@ const KO_ALIASES: Record<string, string> = {
 program
   .name('vhk')
   .description('VHK — 바이브코딩 프로젝트 코치 (한국어로 안내합니다)')
-  .version('0.8.0')
+  .version(getVersion())
 
 program.configureHelp({
   formatHelp(cmd, helper) {


### PR DESCRIPTION
## Summary

PR #7 머지 직후 \`vhk publish\` 재시도 시 발견된 추가 차단 버그.

## Repro

\`\`\`powershell
vhk publish
# patch 선택
# ✔ 빌드 성공
# ✖ 테스트 실패
#   AssertionError: expected '0.8.0' to be '0.8.1'
#   FAIL  tests/cli-args.test.ts > cli NL e2e > vhk --version
\`\`\`

## 원인

\`src/index.ts\`에 \`.version('0.8.0')\` 리터럴 하드코딩 → dist/index.js에 인라인.
\`vhk publish\`가 package.json만 bump (0.8.0 → 0.8.1) 하고 빌드 → dist는 여전히 0.8.0 출력.
\`tests/cli-args.test.ts\`의 \`vhk --version\` 테스트가 package.json의 값(0.8.1)과 비교 → fail.

## Fix

src/index.ts에서 런타임에 package.json 읽어 \`.version()\` 동적 설정. \`src/commands/doctor.ts\`의 \`getVhkVersion()\` 패턴 재사용.

\`\`\`ts
function getVersion(): string {
  const dir = path.dirname(fileURLToPath(import.meta.url))
  for (const pkgPath of [path.join(dir, '../package.json'), path.join(dir, '../../package.json')]) {
    try {
      if (fs.existsSync(pkgPath)) {
        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as { version?: string }
        if (pkg.version) return pkg.version
      }
    } catch { continue }
  }
  return '0.0.0'
}
\`\`\`

## Test plan

- [x] \`pnpm test --run tests/cli-args.test.ts\` — 12/12 passing
- [x] \`pnpm build\` 성공
- [x] fake bump 시뮬레이션: package.json 9.9.9 → \`node dist/index.js --version\` → 9.9.9 출력 (런타임 read 검증)
- [ ] \`vhk publish\` 재시도 (사용자 직접) — patch bump → 빌드 → 테스트 pass → npm publish (OTP)

## Note

원래 PR #7에 같이 들어갔어야 했으나 push 타이밍 차이로 누락. 별도 patch PR로 복구.