### PR TITLE
fix(publish): 2FA OTP 입력 가능하도록 stdio inherit

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import chalk from 'chalk'
 import inquirer from 'inquirer'
 import ora from 'ora'
-import { safeExecFile } from '../lib/exec.js'
+import { safeExecFile, safeExecFileStream } from '../lib/exec.js'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 
@@ -106,11 +106,13 @@ export async function publish(): Promise<void> {
     return
   }
 
-  // npm publish
-  const pubSpinner = ora(t('publish.publishing')).start()
-  const pubResult = safeExecFile('npm', ['publish', '--access', 'public'])
+  // npm publish — 2FA OTP 입력 등 대화형 프롬프트 지원을 위해 stdio inherit 사용.
+  // spinner는 stdin 점유 충돌 회피 위해 사용 안 함.
+  console.log(chalk.cyan(`\n📤 ${t('publish.publishing')}`))
+  console.log(chalk.gray('   (2FA 활성화된 계정이면 OTP 입력 프롬프트가 표시됩니다)'))
+  const pubResult = safeExecFileStream('npm', ['publish', '--access', 'public'])
   if (!pubResult.ok) {
-    pubSpinner.fail(t('publish.publishFailed'))
+    console.log(chalk.red(`\n✖ ${t('publish.publishFailed')}`))
     console.log(chalk.red(pubResult.err.slice(0, 500)))
     // 버전 롤백 (publish 실패 시 package.json 원래대로)
     pkg.version = currentVersion
@@ -118,7 +120,7 @@ export async function publish(): Promise<void> {
     console.log(chalk.gray(`📦 package.json 버전을 v${currentVersion}로 복구했습니다.`))
     return
   }
-  pubSpinner.succeed(t('publish.publishSuccess'))
+  console.log(chalk.green(`\n✔ ${t('publish.publishSuccess')}`))
 
   // git tag (옵션 — 실패해도 publish는 성공)
   const addResult = safeExecFile('git', ['add', 'package.json'])

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -106,10 +106,10 @@ export async function publish(): Promise<void> {
     return
   }
 
-  // npm publish — 2FA OTP 입력 등 대화형 프롬프트 지원을 위해 stdio inherit 사용.
-  // spinner는 stdin 점유 충돌 회피 위해 사용 안 함.
+  // npm publish — 2FA 인증(OTP 입력 또는 웹 기반 URL 클릭) 지원을 위해 stdio inherit 사용.
+  // spinner는 stdin/stdout 점유 충돌 회피 위해 사용 안 함.
   console.log(chalk.cyan(`\n📤 ${t('publish.publishing')}`))
-  console.log(chalk.gray('   (2FA 활성화된 계정이면 OTP 입력 프롬프트가 표시됩니다)'))
+  console.log(chalk.gray('   2FA 활성화 시: OTP 6자리 입력 또는 브라우저 인증 URL 클릭 (Windows Hello / PIN 지원)'))
   const pubResult = safeExecFileStream('npm', ['publish', '--access', 'public'])
   if (!pubResult.ok) {
     console.log(chalk.red(`\n✖ ${t('publish.publishFailed')}`))


### PR DESCRIPTION
## Summary

PR #7 + #8 머지 후 \`vhk publish\` 재시도 시 npm publish 단계에서 OTP 입력 못 해 실패.

## Repro

\`\`\`powershell
vhk publish
# patch → 0.8.1 → 빌드 OK → 테스트 OK → "Yes" 확인
# ✖ npm 배포 실패
#   Command failed: cmd.exe /d /s /c npm.cmd publish --access public
#   npm notice 📦  @byh3071/vhk@0.8.1
#   npm notice Tarball Contents
#   ... (Tarball De... 절단)
# 📦 package.json 버전을 v0.8.0로 복구했습니다.
\`\`\`

## 원인

\`src/commands/publish.ts\`의 npm publish 호출이 \`safeExecFile\` (stdio: pipe) 사용 → npm이 OTP 프롬프트를 사용자에게 표시 못 함. 2FA 계정에서 사일런트 실패.

## Fix

- \`safeExecFile\` → \`safeExecFileStream\` (stdio: inherit) 전환
- ora spinner 제거 — stdin 점유로 OTP 입력 충돌 회피
- 사용자 안내 메시지 추가: \"2FA 활성화된 계정이면 OTP 입력 프롬프트가 표시됩니다\"
- build/test 단계는 인터랙티브 아니므로 \`safeExecFile\` 유지

## Test plan

- [x] \`pnpm test --run\` — 169/169 passing
- [x] \`pnpm build\` 성공
- [ ] \`vhk publish\` 재시도 (사용자 직접) — OTP 입력 프롬프트 보이면 OK