### PR TITLE
feat(v0.9.0): harness/audit/migrate/update commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ---
 
+## [0.9.0] — 2026-05-24
+
+### Added
+- `vhk harness` — `package.json` scripts 자동 감지 후 lint / type-check / test / build 순차 실행 + 통합 리포트. 일부 실패해도 끝까지 진행
+- `vhk audit` — `npm audit --json` 래핑, 심각도별 요약, `Critical`/`High` 발견 시 자동 fix 옵션 (`--fix`). Windows PowerShell 호환 (shell stderr redirect 미사용, `err.stdout` 안전 파싱)
+- `vhk migrate [npm|yarn|pnpm]` — 패키지 매니저 전환. 대상 CLI 존재 확인 → 확인 프롬프트 → 기존 lockfile + node_modules 정리 → `<pm> install`
+- `vhk update` — npm registry 최신 버전 조회 → semver 비교 → `npm update -g @byh3071/vhk` 실행. 현재 ≥ 최신이면 스킵
+- 자연어 라우터에 harness/audit/migrate/update 키워드 추가 — `"품질 점검해줘"`, `"보안 감사"`, `"취약점 확인"`, `"패키지 매니저 전환"`, `"vhk 업데이트 해줘"` 등
+
+### Fixed
+- `update` 명령이 tsup 번들 후 `package.json` 경로를 잘못 해석해 항상 `v0.0.0`을 출력하던 버그. `dist/index.js` / `src/commands/update.ts` 두 위치 모두에서 동작하도록 `getVersion` 다중 경로 탐색 적용
+- `update` 명령이 현재 버전이 publish 된 최신보다 높을 때 다운그레이드를 시도하던 버그. `isUpToDate(current, latest)` semver 비교로 `current >= latest`면 "이미 최신" 처리
+
+### Changed
+- 버전: 0.8.1 → 0.9.0
+- 키워드 충돌 가드: `harness` 별칭 `하네스` (`점검`은 기존 `check` 유지), `audit` 별칭 `감사` (`보안`은 기존 `secure` 유지)
+
+---
+
 ## [0.8.0] — 2026-05-24
 
 ### Added
@@ -132,7 +151,8 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 - **`vhk gate`** — 아이디어 검증 (퀵 5문항 / 풀 13문항 / 스킵)
 - **`vhk init`** — 프로젝트 시작. 하네스 파일 생성 (`CLAUDE.md`, `.cursorrules`, `docs/PRD.md`, `docs/ARCHITECTURE.md`, ADR/log 폴더)
 
-[Unreleased]: https://github.com/byh3071-cpu/vhk/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/byh3071-cpu/vhk/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/byh3071-cpu/vhk/compare/v0.8.1...v0.9.0
 [0.8.0]: https://github.com/byh3071-cpu/vhk/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/byh3071-cpu/vhk/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/byh3071-cpu/vhk/compare/v0.6.0...v0.7.0

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ---
 id: vhk-readme
 date: 2026-05-24
-tags: [vhk, cli, readme, v0.8.0]
+tags: [vhk, cli, readme, v0.9.0]
 ---
 
 # 🔧 VHK — Vibe Harness Kit
 
-> AI 코딩 에이전트를 부리는 사람을 위한 **한국어 풀사이클 CLI** (v0.8.0)
+> AI 코딩 에이전트를 부리는 사람을 위한 **한국어 풀사이클 CLI** (v0.9.0)
 >
 > 🍽️ **VHK는 VHK로 부트스트랩됨** — 이 레포의 `docs/`, `CLAUDE.md`, `.cursorrules`도 `vhk init`이 만들었습니다.
 
@@ -99,6 +99,10 @@ vhk 기획 끝났고 바로 시작
 | `vhk design-palette` | `팔레트` | 컬러 팔레트 프리셋 선택 + 적용 |
 | `vhk theme` | `테마` | 다크/라이트 모드 CSS + 토글 유틸리티 생성 |
 | `vhk ref` | `레퍼런스` | 레퍼런스 URL 관리 (`add` / `list` / `open`) |
+| `vhk harness` | `하네스` | 통합 품질 점검 (lint + type-check + test + build 순차 실행 + 리포트) |
+| `vhk audit` | `감사` | npm 보안 취약점 감사 (`--fix`로 자동 수정) |
+| `vhk migrate [target]` | `전환` | 패키지 매니저 전환 (`npm` / `yarn` / `pnpm`, lockfile + node_modules 재구성) |
+| `vhk update` | `업데이트` | VHK CLI 최신 버전으로 셀프 업데이트 |
 
 ### init 옵션
 
@@ -131,6 +135,24 @@ MCP 서버를 수동으로 띄우려면:
 
 ```powershell
 vhk mcp                # stdio 서버 시작 (Cursor가 자동으로 호출)
+```
+
+## v0.9.0 하이라이트
+
+| 기능 | 설명 |
+|------|------|
+| **harness** | `package.json` scripts 자동 감지 → `lint` / `type-check` / `test` / `build` 순차 실행 + 통합 리포트. 일부 실패해도 끝까지 진행 |
+| **audit** | `npm audit --json` 래핑 + 심각도별 요약. `Critical`/`High` 발견 시 자동 fix 옵션. Windows PowerShell 호환 (`2>/dev/null` 미사용) |
+| **migrate** | npm/yarn/pnpm 전환 — 대상 CLI 존재 확인 → 확인 프롬프트 → 기존 lockfile + node_modules 정리 → `<pm> install` |
+| **update** | npm registry에서 `@byh3071/vhk` 최신 버전 조회 → semver 비교 → `npm update -g` 실행. 현재 버전이 같거나 더 높으면 스킵 |
+| **자연어 확장** | `"품질 점검해줘"` → harness · `"보안 감사 해줘"` / `"취약점 확인"` → audit · `"패키지 매니저 전환"` → migrate · `"vhk 업데이트 해줘"` → update. 키워드 충돌 가드: `점검` 단독은 기존 `check`에 양보, `보안` 단독은 기존 `secure`에 양보 |
+
+```powershell
+vhk harness             # lint + type-check + test + build 순차 실행
+vhk audit               # npm 보안 감사 (Critical/High 발견 시 자동 fix 옵션)
+vhk audit --fix         # 항상 npm audit fix 실행
+vhk migrate pnpm        # npm/yarn → pnpm 전환 (대화형 확인)
+vhk update              # @byh3071/vhk 최신 버전 체크 + 글로벌 업데이트
 ```
 
 ## v0.8.0 하이라이트
@@ -224,6 +246,10 @@ vhk ref open 1          # 1번 레퍼런스를 브라우저로 열기
 | 팔레트 골라줘 | `vhk design-palette` |
 | 다크 모드 적용 | `vhk theme` |
 | 레퍼런스 보여줘 | `vhk ref` (list) |
+| 품질 점검해줘 | `vhk harness` |
+| 보안 감사 해줘 / 취약점 확인 | `vhk audit` |
+| 패키지 매니저 전환 | `vhk migrate` |
+| vhk 업데이트 해줘 | `vhk update` |
 
 ## 특징
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Vibe Harness Kit — 바이브코딩 풀사이클 CLI",
   "bin": {
     "vhk": "dist/index.js",

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,9 +1,12 @@
-import { execSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import chalk from 'chalk'
 import inquirer from 'inquirer'
 import ora from 'ora'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
+import { safeExecFile } from '../lib/exec.js'
+
+type PackageManager = 'npm' | 'yarn' | 'pnpm'
 
 interface AuditSummary {
   critical: number
@@ -13,52 +16,71 @@ interface AuditSummary {
   total: number
 }
 
-function parseAuditOutput(output: string): AuditSummary {
+function detectCurrentPM(): PackageManager {
+  if (existsSync('pnpm-lock.yaml')) return 'pnpm'
+  if (existsSync('yarn.lock')) return 'yarn'
+  return 'npm'
+}
+
+function parseAuditOutput(output: string, pm: PackageManager): AuditSummary {
+  const empty: AuditSummary = { critical: 0, high: 0, moderate: 0, low: 0, total: 0 }
+  if (!output) return empty
   try {
-    const json = JSON.parse(output) as {
-      metadata?: { vulnerabilities?: Partial<AuditSummary> }
+    const json = JSON.parse(output) as Record<string, unknown>
+    // npm / yarn classic: { metadata: { vulnerabilities: {...} } }
+    // pnpm: 동일한 npm-compat 출력 (npm audit JSON 포맷 그대로)
+    // yarn berry: { advisories: {...} } — total만 별도 계산
+    const meta = (json.metadata as { vulnerabilities?: Partial<AuditSummary> } | undefined)
+      ?.vulnerabilities
+    if (meta) {
+      const summary = {
+        critical: meta.critical ?? 0,
+        high: meta.high ?? 0,
+        moderate: meta.moderate ?? 0,
+        low: meta.low ?? 0,
+        total: meta.total ?? 0,
+      }
+      if (!summary.total) {
+        summary.total = summary.critical + summary.high + summary.moderate + summary.low
+      }
+      return summary
     }
-    const v = json.metadata?.vulnerabilities ?? {}
-    return {
-      critical: v.critical ?? 0,
-      high: v.high ?? 0,
-      moderate: v.moderate ?? 0,
-      low: v.low ?? 0,
-      total: v.total ?? 0,
-    }
+    // pm 별 fallback이 더 필요하면 여기에 분기
+    void pm
+    return empty
   } catch {
-    return { critical: 0, high: 0, moderate: 0, low: 0, total: 0 }
+    return empty
   }
 }
 
-function runNpmAuditJson(): string {
-  // npm audit는 취약점 발견 시 exit code !=0 → execSync가 throw 하지만 stdout은 채워진다.
-  // shell stderr redirect(`2>/dev/null`)는 Windows PowerShell에서 동작 X → stdio 옵션으로 처리.
-  try {
-    return execSync('npm audit --json', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).toString()
-  } catch (err) {
-    const e = err as { stdout?: Buffer | string }
-    if (e.stdout) return e.stdout.toString()
-    return ''
-  }
+function runAuditJson(pm: PackageManager): string {
+  // 취약점 발견 시 exit code !=0지만 stdout에 JSON 출력. safeExecFile은 err 경로에서도 out 반환.
+  const result = safeExecFile(pm, ['audit', '--json'])
+  return result.out
 }
 
-function runNpmAuditFix(): void {
-  execSync('npm audit fix', { stdio: ['pipe', 'pipe', 'pipe'] })
+function runAuditFix(pm: PackageManager): { ok: boolean; err?: string } {
+  // pnpm은 `audit --fix` 미지원 → audit만 다시 안내. yarn classic은 `audit fix` 미지원.
+  // npm만 자동 fix 지원.
+  if (pm !== 'npm') {
+    return { ok: false, err: `${pm}은 자동 fix를 지원하지 않습니다. npm 환경에서만 동작합니다.` }
+  }
+  const result = safeExecFile('npm', ['audit', 'fix'])
+  return result.ok ? { ok: true } : { ok: false, err: result.err }
 }
 
 export async function audit(autoFix = false): Promise<void> {
   console.log(chalk.bold('\n🛡️  ' + t('audit.title')))
   console.log(chalk.gray('─'.repeat(40)))
 
+  const pm = detectCurrentPM()
+  console.log(chalk.cyan(`📦 패키지 매니저: ${pm}`))
+
   const spinner = ora('보안 감사 실행 중...').start()
-  const output = runNpmAuditJson()
+  const output = runAuditJson(pm)
   spinner.stop()
 
-  const summary = parseAuditOutput(output)
+  const summary = parseAuditOutput(output, pm)
 
   if (summary.total === 0) {
     console.log(chalk.green.bold('\n🎉 취약점이 발견되지 않았습니다!'))
@@ -89,11 +111,11 @@ export async function audit(autoFix = false): Promise<void> {
 
   if (shouldRunFix) {
     const fixSpinner = ora('자동 수정 중...').start()
-    try {
-      runNpmAuditFix()
+    const result = runAuditFix(pm)
+    if (result.ok) {
       fixSpinner.succeed('자동 수정 완료!')
-    } catch {
-      fixSpinner.warn('일부 취약점은 수동 수정이 필요합니다.')
+    } else {
+      fixSpinner.warn(result.err ?? '일부 취약점은 수동 수정이 필요합니다.')
     }
   }
 

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,0 +1,105 @@
+import { execSync } from 'node:child_process'
+import chalk from 'chalk'
+import inquirer from 'inquirer'
+import ora from 'ora'
+import { t } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+
+interface AuditSummary {
+  critical: number
+  high: number
+  moderate: number
+  low: number
+  total: number
+}
+
+function parseAuditOutput(output: string): AuditSummary {
+  try {
+    const json = JSON.parse(output) as {
+      metadata?: { vulnerabilities?: Partial<AuditSummary> }
+    }
+    const v = json.metadata?.vulnerabilities ?? {}
+    return {
+      critical: v.critical ?? 0,
+      high: v.high ?? 0,
+      moderate: v.moderate ?? 0,
+      low: v.low ?? 0,
+      total: v.total ?? 0,
+    }
+  } catch {
+    return { critical: 0, high: 0, moderate: 0, low: 0, total: 0 }
+  }
+}
+
+function runNpmAuditJson(): string {
+  // npm audit는 취약점 발견 시 exit code !=0 → execSync가 throw 하지만 stdout은 채워진다.
+  // shell stderr redirect(`2>/dev/null`)는 Windows PowerShell에서 동작 X → stdio 옵션으로 처리.
+  try {
+    return execSync('npm audit --json', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).toString()
+  } catch (err) {
+    const e = err as { stdout?: Buffer | string }
+    if (e.stdout) return e.stdout.toString()
+    return ''
+  }
+}
+
+function runNpmAuditFix(): void {
+  execSync('npm audit fix', { stdio: ['pipe', 'pipe', 'pipe'] })
+}
+
+export async function audit(autoFix = false): Promise<void> {
+  console.log(chalk.bold('\n🛡️  ' + t('audit.title')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  const spinner = ora('보안 감사 실행 중...').start()
+  const output = runNpmAuditJson()
+  spinner.stop()
+
+  const summary = parseAuditOutput(output)
+
+  if (summary.total === 0) {
+    console.log(chalk.green.bold('\n🎉 취약점이 발견되지 않았습니다!'))
+    return
+  }
+
+  console.log(chalk.bold('\n📊 취약점 요약:'))
+  if (summary.critical > 0) console.log(chalk.red(`  🔴 Critical: ${summary.critical}`))
+  if (summary.high > 0) console.log(chalk.red(`  🟠 High: ${summary.high}`))
+  if (summary.moderate > 0) console.log(chalk.yellow(`  🟡 Moderate: ${summary.moderate}`))
+  if (summary.low > 0) console.log(chalk.gray(`  ⚪ Low: ${summary.low}`))
+  console.log(chalk.bold(`\n  총 ${summary.total}개의 취약점`))
+
+  const shouldRunFix = autoFix
+    ? true
+    : summary.critical > 0 || summary.high > 0
+      ? (
+          await inquirer.prompt<{ shouldFix: boolean }>([
+            {
+              type: 'confirm',
+              name: 'shouldFix',
+              message: '자동 수정을 시도할까요? (npm audit fix)',
+              default: true,
+            },
+          ])
+        ).shouldFix
+      : false
+
+  if (shouldRunFix) {
+    const fixSpinner = ora('자동 수정 중...').start()
+    try {
+      runNpmAuditFix()
+      fixSpinner.succeed('자동 수정 완료!')
+    } catch {
+      fixSpinner.warn('일부 취약점은 수동 수정이 필요합니다.')
+    }
+  }
+
+  printNextStep({
+    message: '보안 감사 완료.',
+    command: 'vhk harness',
+    cursorHint: '품질 점검해줘',
+  })
+}

--- a/src/commands/harness.ts
+++ b/src/commands/harness.ts
@@ -1,0 +1,106 @@
+import { execSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import chalk from 'chalk'
+import ora from 'ora'
+import { t } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+
+interface CheckResult {
+  name: string
+  command: string
+  passed: boolean
+  duration: number
+  error?: string
+}
+
+function detectScripts(): Record<string, string> {
+  const scripts: Record<string, string> = {}
+  try {
+    const pkg = JSON.parse(readFileSync('package.json', 'utf-8')) as {
+      scripts?: Record<string, string>
+    }
+    const s = pkg.scripts ?? {}
+
+    if (s.lint) scripts.lint = 'pnpm lint'
+    else if (
+      existsSync('.eslintrc.js') ||
+      existsSync('.eslintrc.json') ||
+      existsSync('eslint.config.js')
+    )
+      scripts.lint = 'npx eslint . --ext .ts,.tsx'
+
+    if (s['type-check']) scripts['type-check'] = 'pnpm type-check'
+    else if (s.typecheck) scripts['type-check'] = 'pnpm typecheck'
+    else if (existsSync('tsconfig.json')) scripts['type-check'] = 'npx tsc --noEmit'
+
+    if (s.test) scripts.test = 'pnpm test --run'
+    if (s.build) scripts.build = 'pnpm build'
+  } catch {
+    // package.json 없거나 파싱 실패
+  }
+  return scripts
+}
+
+export async function harness(): Promise<void> {
+  console.log(chalk.bold('\n🔧 ' + t('harness.title')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  const scripts = detectScripts()
+  const names = Object.keys(scripts)
+
+  if (names.length === 0) {
+    console.log(chalk.yellow('\n⚠️  실행할 수 있는 스크립트가 없습니다.'))
+    console.log(chalk.gray('   package.json에 lint, test, build 스크립트를 추가해주세요.'))
+    return
+  }
+
+  console.log(chalk.cyan(`\n🏃 ${names.length}개 점검 시작:\n`))
+
+  const results: CheckResult[] = []
+
+  for (const [name, command] of Object.entries(scripts)) {
+    const spinner = ora(`${name} 실행 중...`).start()
+    const start = Date.now()
+    try {
+      execSync(command, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 120_000,
+      })
+      const duration = Date.now() - start
+      const sec = (duration / 1000).toFixed(1)
+      spinner.succeed(`${name} ${chalk.gray(`(${sec}s)`)}`)
+      results.push({ name, command, passed: true, duration })
+    } catch (err) {
+      const duration = Date.now() - start
+      const sec = (duration / 1000).toFixed(1)
+      spinner.fail(`${name} ${chalk.gray(`(${sec}s)`)}`)
+      const msg = err instanceof Error ? err.message.slice(0, 200) : String(err)
+      results.push({ name, command, passed: false, duration, error: msg })
+    }
+  }
+
+  console.log(chalk.bold('\n📊 통합 리포트:'))
+  console.log(chalk.gray('─'.repeat(40)))
+  for (const r of results) {
+    const icon = r.passed ? chalk.green('✅') : chalk.red('❌')
+    const sec = (r.duration / 1000).toFixed(1)
+    console.log(`  ${icon} ${r.name.padEnd(15)} ${chalk.gray(`${sec}s`)}`)
+  }
+
+  const passed = results.filter((r) => r.passed).length
+  const all = passed === results.length
+  console.log(chalk.gray('─'.repeat(40)))
+  if (all) {
+    console.log(chalk.green.bold(`\n🎉 전체 통과! (${passed}/${results.length})`))
+  } else {
+    console.log(
+      chalk.red.bold(`\n⚠️  ${results.length - passed}개 실패 (${passed}/${results.length} 통과)`)
+    )
+  }
+
+  printNextStep({
+    message: all ? '품질 점검 통과!' : '실패 항목을 수정하세요.',
+    command: all ? 'vhk ship' : 'vhk doctor',
+    cursorHint: all ? '배포해줘' : '문제 진단해줘',
+  })
+}

--- a/src/commands/harness.ts
+++ b/src/commands/harness.ts
@@ -1,9 +1,11 @@
-import { execSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import chalk from 'chalk'
 import ora from 'ora'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
+import { safeExecFile } from '../lib/exec.js'
+
+type CheckSpec = { name: string; bin: string; args: string[] }
 
 interface CheckResult {
   name: string
@@ -13,69 +15,92 @@ interface CheckResult {
   error?: string
 }
 
-function detectScripts(): Record<string, string> {
-  const scripts: Record<string, string> = {}
+function detectPM(): 'pnpm' | 'yarn' | 'npm' {
+  if (existsSync('pnpm-lock.yaml')) return 'pnpm'
+  if (existsSync('yarn.lock')) return 'yarn'
+  return 'npm'
+}
+
+function pmRun(pm: string, script: string): string[] {
+  // npm은 `npm run <script>`, pnpm/yarn은 `<pm> <script>` 단축 지원하지만 안전상 run 사용.
+  return pm === 'npm' ? ['run', script] : [script]
+}
+
+function detectChecks(): CheckSpec[] {
+  const checks: CheckSpec[] = []
+  let pkg: { scripts?: Record<string, string> } = {}
   try {
-    const pkg = JSON.parse(readFileSync('package.json', 'utf-8')) as {
-      scripts?: Record<string, string>
-    }
-    const s = pkg.scripts ?? {}
-
-    if (s.lint) scripts.lint = 'pnpm lint'
-    else if (
-      existsSync('.eslintrc.js') ||
-      existsSync('.eslintrc.json') ||
-      existsSync('eslint.config.js')
-    )
-      scripts.lint = 'npx eslint . --ext .ts,.tsx'
-
-    if (s['type-check']) scripts['type-check'] = 'pnpm type-check'
-    else if (s.typecheck) scripts['type-check'] = 'pnpm typecheck'
-    else if (existsSync('tsconfig.json')) scripts['type-check'] = 'npx tsc --noEmit'
-
-    if (s.test) scripts.test = 'pnpm test --run'
-    if (s.build) scripts.build = 'pnpm build'
+    pkg = JSON.parse(readFileSync('package.json', 'utf-8'))
   } catch {
-    // package.json 없거나 파싱 실패
+    return checks
   }
-  return scripts
+  const s = pkg.scripts ?? {}
+  const pm = detectPM()
+
+  if (s.lint) {
+    checks.push({ name: 'lint', bin: pm, args: pmRun(pm, 'lint') })
+  } else if (
+    existsSync('.eslintrc.js') ||
+    existsSync('.eslintrc.json') ||
+    existsSync('eslint.config.js')
+  ) {
+    checks.push({ name: 'lint', bin: 'npx', args: ['eslint', '.', '--ext', '.ts,.tsx'] })
+  }
+
+  if (s['type-check']) {
+    checks.push({ name: 'type-check', bin: pm, args: pmRun(pm, 'type-check') })
+  } else if (s.typecheck) {
+    checks.push({ name: 'type-check', bin: pm, args: pmRun(pm, 'typecheck') })
+  } else if (existsSync('tsconfig.json')) {
+    checks.push({ name: 'type-check', bin: 'npx', args: ['tsc', '--noEmit'] })
+  }
+
+  if (s.test) {
+    // vitest --run 등 사용자가 추가 옵션 없이 동작하도록 script 호출만.
+    checks.push({ name: 'test', bin: pm, args: pmRun(pm, 'test') })
+  }
+  if (s.build) {
+    checks.push({ name: 'build', bin: pm, args: pmRun(pm, 'build') })
+  }
+
+  return checks
 }
 
 export async function harness(): Promise<void> {
   console.log(chalk.bold('\n🔧 ' + t('harness.title')))
   console.log(chalk.gray('─'.repeat(40)))
 
-  const scripts = detectScripts()
-  const names = Object.keys(scripts)
+  const checks = detectChecks()
 
-  if (names.length === 0) {
+  if (checks.length === 0) {
     console.log(chalk.yellow('\n⚠️  실행할 수 있는 스크립트가 없습니다.'))
     console.log(chalk.gray('   package.json에 lint, test, build 스크립트를 추가해주세요.'))
     return
   }
 
-  console.log(chalk.cyan(`\n🏃 ${names.length}개 점검 시작:\n`))
+  console.log(chalk.cyan(`\n🏃 ${checks.length}개 점검 시작:\n`))
 
   const results: CheckResult[] = []
 
-  for (const [name, command] of Object.entries(scripts)) {
-    const spinner = ora(`${name} 실행 중...`).start()
+  for (const check of checks) {
+    const display = `${check.bin} ${check.args.join(' ')}`
+    const spinner = ora(`${check.name} 실행 중...`).start()
     const start = Date.now()
-    try {
-      execSync(command, {
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 120_000,
+    const result = safeExecFile(check.bin, check.args)
+    const duration = Date.now() - start
+    const sec = (duration / 1000).toFixed(1)
+    if (result.ok) {
+      spinner.succeed(`${check.name} ${chalk.gray(`(${sec}s)`)}`)
+      results.push({ name: check.name, command: display, passed: true, duration })
+    } else {
+      spinner.fail(`${check.name} ${chalk.gray(`(${sec}s)`)}`)
+      results.push({
+        name: check.name,
+        command: display,
+        passed: false,
+        duration,
+        error: result.err.slice(0, 200),
       })
-      const duration = Date.now() - start
-      const sec = (duration / 1000).toFixed(1)
-      spinner.succeed(`${name} ${chalk.gray(`(${sec}s)`)}`)
-      results.push({ name, command, passed: true, duration })
-    } catch (err) {
-      const duration = Date.now() - start
-      const sec = (duration / 1000).toFixed(1)
-      spinner.fail(`${name} ${chalk.gray(`(${sec}s)`)}`)
-      const msg = err instanceof Error ? err.message.slice(0, 200) : String(err)
-      results.push({ name, command, passed: false, duration, error: msg })
     }
   }
 

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,10 +1,10 @@
-import { execSync } from 'node:child_process'
 import { existsSync, unlinkSync, rmSync } from 'node:fs'
 import chalk from 'chalk'
 import inquirer from 'inquirer'
 import ora from 'ora'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
+import { safeExecFile } from '../lib/exec.js'
 
 type PackageManager = 'npm' | 'yarn' | 'pnpm'
 
@@ -22,12 +22,8 @@ function detectCurrentPM(): PackageManager | null {
 }
 
 function isCLIAvailable(pm: PackageManager): boolean {
-  try {
-    execSync(`${pm} --version`, { stdio: ['pipe', 'pipe', 'pipe'] })
-    return true
-  } catch {
-    return false
-  }
+  // Windows .cmd shim 호환 위해 safeExecFile 사용 (Node 20.12+ CVE-2024-27980 EINVAL 회피).
+  return safeExecFile(pm, ['--version']).ok
 }
 
 export async function migrate(target?: string): Promise<void> {
@@ -93,13 +89,12 @@ export async function migrate(target?: string): Promise<void> {
   cleanup.succeed('기존 파일 정리 완료')
 
   const install = ora(`${targetPM} install 실행 중...`).start()
-  try {
-    execSync(`${targetPM} install`, { stdio: ['pipe', 'pipe', 'pipe'] })
+  const installResult = safeExecFile(targetPM, ['install'])
+  if (installResult.ok) {
     install.succeed(`${targetPM} install 완료!`)
-  } catch (err) {
+  } else {
     install.fail(`${targetPM} install 실패`)
-    const msg = err instanceof Error ? err.message.slice(0, 300) : String(err)
-    console.log(chalk.red(msg))
+    console.log(chalk.red(installResult.err.slice(0, 300)))
     return
   }
 

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,0 +1,113 @@
+import { execSync } from 'node:child_process'
+import { existsSync, unlinkSync, rmSync } from 'node:fs'
+import chalk from 'chalk'
+import inquirer from 'inquirer'
+import ora from 'ora'
+import { t } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+
+type PackageManager = 'npm' | 'yarn' | 'pnpm'
+
+const LOCK_FILES: Record<PackageManager, string> = {
+  npm: 'package-lock.json',
+  yarn: 'yarn.lock',
+  pnpm: 'pnpm-lock.yaml',
+}
+
+function detectCurrentPM(): PackageManager | null {
+  if (existsSync('pnpm-lock.yaml')) return 'pnpm'
+  if (existsSync('yarn.lock')) return 'yarn'
+  if (existsSync('package-lock.json')) return 'npm'
+  return null
+}
+
+function isCLIAvailable(pm: PackageManager): boolean {
+  try {
+    execSync(`${pm} --version`, { stdio: ['pipe', 'pipe', 'pipe'] })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function migrate(target?: string): Promise<void> {
+  console.log(chalk.bold('\n🔄 ' + t('migrate.title')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  const current = detectCurrentPM()
+  console.log(chalk.cyan(`\n현재 패키지 매니저: ${current ?? '감지 불가'}`))
+
+  let targetPM: PackageManager
+  if (target && (['npm', 'yarn', 'pnpm'] as const).includes(target as PackageManager)) {
+    targetPM = target as PackageManager
+  } else {
+    const choices = (['npm', 'yarn', 'pnpm'] as PackageManager[])
+      .filter((pm) => pm !== current)
+      .map((pm) => ({ name: pm, value: pm }))
+    const { selected } = await inquirer.prompt<{ selected: PackageManager }>([
+      {
+        type: 'list',
+        name: 'selected',
+        message: t('migrate.selectTarget'),
+        choices,
+      },
+    ])
+    targetPM = selected
+  }
+
+  if (targetPM === current) {
+    console.log(chalk.yellow(`\n⚠️  이미 ${targetPM}을 사용 중입니다.`))
+    return
+  }
+
+  if (!isCLIAvailable(targetPM)) {
+    console.log(chalk.red(`\n❌ ${targetPM}이 설치되어 있지 않습니다.`))
+    console.log(chalk.yellow(`   npm i -g ${targetPM}`))
+    return
+  }
+
+  const { confirm } = await inquirer.prompt<{ confirm: boolean }>([
+    {
+      type: 'confirm',
+      name: 'confirm',
+      message: `${current ?? '현재'} → ${targetPM}으로 전환할까요? (node_modules 재설치)`,
+      default: true,
+    },
+  ])
+
+  if (!confirm) {
+    console.log(chalk.gray('취소됨'))
+    return
+  }
+
+  const cleanup = ora('기존 lock 파일 정리 중...').start()
+  for (const lockFile of Object.values(LOCK_FILES)) {
+    if (existsSync(lockFile)) {
+      unlinkSync(lockFile)
+    }
+  }
+  if (existsSync('node_modules')) {
+    cleanup.text = 'node_modules 삭제 중...'
+    rmSync('node_modules', { recursive: true, force: true })
+  }
+  cleanup.succeed('기존 파일 정리 완료')
+
+  const install = ora(`${targetPM} install 실행 중...`).start()
+  try {
+    execSync(`${targetPM} install`, { stdio: ['pipe', 'pipe', 'pipe'] })
+    install.succeed(`${targetPM} install 완료!`)
+  } catch (err) {
+    install.fail(`${targetPM} install 실패`)
+    const msg = err instanceof Error ? err.message.slice(0, 300) : String(err)
+    console.log(chalk.red(msg))
+    return
+  }
+
+  console.log(chalk.green.bold(`\n🎉 ${current ?? '이전'} → ${targetPM} 전환 완료!`))
+
+  printNextStep({
+    message: '패키지 매니저 전환 완료!',
+    command: 'vhk harness',
+    cursorHint: '품질 점검해줘',
+  })
+}

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import chalk from 'chalk'
@@ -9,15 +9,20 @@ import { t } from '../i18n/ko.js'
 const PACKAGE = '@byh3071/vhk'
 
 function getCurrentVersion(): string {
-  try {
-    const dir = dirname(fileURLToPath(import.meta.url))
-    const pkg = JSON.parse(readFileSync(join(dir, '../../package.json'), 'utf-8')) as {
-      version?: string
+  const dir = dirname(fileURLToPath(import.meta.url))
+  // tsup 번들: dist/index.js → ../package.json
+  // 소스 직접 실행: src/commands/update.ts → ../../package.json
+  for (const pkgPath of [join(dir, '../package.json'), join(dir, '../../package.json')]) {
+    try {
+      if (existsSync(pkgPath)) {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { version?: string }
+        if (pkg.version) return pkg.version
+      }
+    } catch {
+      continue
     }
-    return pkg.version ?? '0.0.0'
-  } catch {
-    return '0.0.0'
   }
+  return '0.0.0'
 }
 
 function getLatestVersion(): string | null {
@@ -30,6 +35,16 @@ function getLatestVersion(): string | null {
   } catch {
     return null
   }
+}
+
+/** semver 비교: a >= b면 true (a가 같거나 더 높으면 true) */
+function isUpToDate(current: string, latest: string): boolean {
+  const parse = (v: string) => v.split('.').map(n => parseInt(n, 10) || 0)
+  const [ca, cb, cc] = parse(current)
+  const [la, lb, lc] = parse(latest)
+  if (ca !== la) return ca > la
+  if (cb !== lb) return cb > lb
+  return cc >= lc
 }
 
 export async function update(): Promise<void> {
@@ -52,7 +67,7 @@ export async function update(): Promise<void> {
   spinner.stop()
   console.log(chalk.cyan(`🆕 최신 버전: v${latest}`))
 
-  if (current === latest) {
+  if (isUpToDate(current, latest)) {
     console.log(chalk.green('\n✅ 이미 최신 버전입니다!'))
     return
   }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,0 +1,73 @@
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import chalk from 'chalk'
+import ora from 'ora'
+import { t } from '../i18n/ko.js'
+
+const PACKAGE = '@byh3071/vhk'
+
+function getCurrentVersion(): string {
+  try {
+    const dir = dirname(fileURLToPath(import.meta.url))
+    const pkg = JSON.parse(readFileSync(join(dir, '../../package.json'), 'utf-8')) as {
+      version?: string
+    }
+    return pkg.version ?? '0.0.0'
+  } catch {
+    return '0.0.0'
+  }
+}
+
+function getLatestVersion(): string | null {
+  try {
+    const out = execSync(`npm view ${PACKAGE} version`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).toString()
+    return out.trim()
+  } catch {
+    return null
+  }
+}
+
+export async function update(): Promise<void> {
+  console.log(chalk.bold('\n⬆️  ' + t('update.title')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  const current = getCurrentVersion()
+  console.log(chalk.cyan(`\n📌 현재 버전: v${current}`))
+
+  const spinner = ora('최신 버전 확인 중...').start()
+  const latest = getLatestVersion()
+
+  if (!latest) {
+    spinner.fail('최신 버전을 확인할 수 없습니다.')
+    console.log(chalk.yellow('   네트워크를 확인하거나 수동으로 업데이트하세요:'))
+    console.log(chalk.gray(`   npm update -g ${PACKAGE}`))
+    return
+  }
+
+  spinner.stop()
+  console.log(chalk.cyan(`🆕 최신 버전: v${latest}`))
+
+  if (current === latest) {
+    console.log(chalk.green('\n✅ 이미 최신 버전입니다!'))
+    return
+  }
+
+  const updateSpinner = ora(`v${latest}으로 업데이트 중...`).start()
+  try {
+    execSync(`npm update -g ${PACKAGE}`, { stdio: ['pipe', 'pipe', 'pipe'] })
+    updateSpinner.succeed(`v${latest}으로 업데이트 완료!`)
+    console.log(chalk.green.bold(`\n🎉 VHK CLI v${latest} 업데이트 완료!`))
+    console.log(chalk.gray('   변경 사항은 GitHub Releases를 확인하세요.'))
+  } catch (err) {
+    updateSpinner.fail('업데이트 실패')
+    const msg = err instanceof Error ? err.message.slice(0, 300) : String(err)
+    console.log(chalk.red(msg))
+    console.log(chalk.yellow('\n수동으로 업데이트하세요:'))
+    console.log(chalk.gray(`   npm update -g ${PACKAGE}`))
+  }
+}

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -288,6 +288,19 @@ export const ko = {
     publishSuccess: 'npm 배포 성공!',
     publishFailed: 'npm 배포 실패',
   },
+  harness: {
+    title: '통합 품질 점검',
+  },
+  audit: {
+    title: '보안 감사',
+  },
+  migrate: {
+    title: '패키지 매니저 전환',
+    selectTarget: '어떤 패키지 매니저로 전환할까요?',
+  },
+  update: {
+    title: 'VHK CLI 업데이트',
+  },
 } as const
 
 type KoValue = string | ((...args: never[]) => string)

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,10 @@ import { publish } from './commands/publish.js'
 import { design, designPalette } from './commands/design.js'
 import { theme } from './commands/theme.js'
 import { refAdd, refList, refOpen } from './commands/ref.js'
+import { harness } from './commands/harness.js'
+import { audit } from './commands/audit.js'
+import { migrate } from './commands/migrate.js'
+import { update } from './commands/update.js'
 
 // 런타임에 package.json에서 버전 읽기 — src와 dist 둘 다 동작.
 // dist/index.js: ../package.json (npm 글로벌 + 로컬 빌드 동일)
@@ -70,6 +74,10 @@ const KO_ALIASES: Record<string, string> = {
   'design-palette': '팔레트',
   theme: '테마',
   ref: '레퍼런스',
+  harness: '하네스',
+  audit: '감사',
+  migrate: '전환',
+  update: '업데이트',
 }
 
 program
@@ -282,6 +290,31 @@ refCmd
   .alias('열기')
   .description('레퍼런스를 브라우저에서 열기')
   .action(async (index: string) => { await refOpen(index) })
+
+program
+  .command('harness')
+  .alias('하네스')
+  .description('통합 품질 점검 (lint + type-check + test + build)')
+  .action(async () => { await harness() })
+
+program
+  .command('audit')
+  .alias('감사')
+  .option('--fix', '자동 수정 시도')
+  .description('보안 취약점 감사 (npm audit 래핑)')
+  .action(async (opts: { fix?: boolean }) => { await audit(opts.fix) })
+
+program
+  .command('migrate [target]')
+  .alias('전환')
+  .description('패키지 매니저 전환 (npm/yarn/pnpm)')
+  .action(async (target?: string) => { await migrate(target) })
+
+program
+  .command('update')
+  .alias('업데이트')
+  .description('VHK CLI 최신 버전 업데이트')
+  .action(async () => { await update() })
 
 program.on('command:*', async (operands: string[]) => {
   const unknown = operands[0] ?? ''

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -25,6 +25,10 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'design-palette', '팔레트',
   'theme', '테마',
   'ref', '레퍼런스',
+  'harness', '하네스',
+  'audit', '감사',
+  'migrate', '전환',
+  'update', '업데이트',
   'help',
 ])
 

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -10,7 +10,7 @@ export function platformCmd(cmd: string): string {
   return cmd
 }
 
-export type ExecResult = { ok: true; out: string } | { ok: false; err: string }
+export type ExecResult = { ok: true; out: string } | { ok: false; err: string; out: string }
 
 // Windows .cmd shim 호출은 Node 20.12+ / 21.7+ CVE-2024-27980 보안 강화로 execFileSync 직접 호출 시
 // spawnSync EINVAL. cmd.exe /d /s /c <shim>.cmd <args>로 래핑 — shell:false 유지하면서 동작.
@@ -32,8 +32,12 @@ export function safeExecFile(cmd: string, args: string[]): ExecResult {
     }).toString()
     return { ok: true, out: out.trim() }
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return { ok: false, err: msg }
+    // non-zero exit: stdout/stderr는 err.stdout/err.stderr에 담겨 있다.
+    // 예: `npm audit`은 취약점 있으면 exit !=0이지만 stdout에 JSON 출력.
+    const e = err as { stdout?: Buffer | string; stderr?: Buffer | string; message?: string }
+    const stdout = e.stdout ? e.stdout.toString() : ''
+    const msg = e.message ?? String(err)
+    return { ok: false, err: msg, out: stdout.trim() }
   }
 }
 

--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -20,6 +20,10 @@ export type NlpCommand =
   | 'design-palette'
   | 'theme'
   | 'ref'
+  | 'harness'
+  | 'audit'
+  | 'migrate'
+  | 'update'
 
 export type NlpConfidence = 'high' | 'low'
 
@@ -116,6 +120,34 @@ const RULES: NlpRule[] = [
     test: t =>
       (/^레퍼런스$|^ref$|레퍼런스.*(보|목록|확인|있|뭐)|참고\s*(사이트|목록|링크)|reference.*list/.test(t)) &&
       !/(add|추가|open|열|https?:\/\/)/.test(t),
+  },
+  {
+    command: 'harness',
+    explanation: '통합 품질 점검 (vhk harness)',
+    confidence: 'high',
+    test: t =>
+      /하네스|harness|통합\s*점검|품질\s*점검|빌드\s*테스트|lint.*(test|build)|전체\s*점검|품질\s*확인/.test(t),
+  },
+  {
+    command: 'audit',
+    explanation: '보안 취약점 감사 (vhk audit)',
+    confidence: 'high',
+    test: t =>
+      /감사|취약점|audit|vulnerability|보안\s*감사|보안\s*취약|의존성\s*취약/.test(t),
+  },
+  {
+    command: 'migrate',
+    explanation: '패키지 매니저 전환 (vhk migrate)',
+    confidence: 'high',
+    test: t =>
+      /전환|마이그레이트|migrate|패키지\s*매니저|npm.*pnpm|pnpm.*npm|yarn.*전환|npm.*전환|pnpm.*전환/.test(t),
+  },
+  {
+    command: 'update',
+    explanation: 'VHK CLI 최신 버전 업데이트 (vhk update)',
+    confidence: 'high',
+    test: t =>
+      /업데이트|update|버전\s*업|최신\s*버전|셀프\s*업데이트|vhk.*최신|vhk.*업데이트/.test(t),
   },
   {
     command: 'secure',

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -21,6 +21,10 @@ import { publish } from '../commands/publish.js'
 import { design, designPalette } from '../commands/design.js'
 import { theme } from '../commands/theme.js'
 import { refList } from '../commands/ref.js'
+import { harness } from '../commands/harness.js'
+import { audit } from '../commands/audit.js'
+import { migrate } from '../commands/migrate.js'
+import { update } from '../commands/update.js'
 
 export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<void> {
   switch (route.command) {
@@ -71,6 +75,14 @@ export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<
       return theme()
     case 'ref':
       return refList()
+    case 'harness':
+      return harness()
+    case 'audit':
+      return audit()
+    case 'migrate':
+      return migrate()
+    case 'update':
+      return update()
   }
 }
 

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockExecSync = vi.fn()
+const mockPrompt = vi.fn()
+
+vi.mock('node:child_process', () => ({
+  execSync: (...a: unknown[]) => mockExecSync(...a),
+}))
+
+vi.mock('inquirer', () => ({
+  default: { prompt: (...a: unknown[]) => mockPrompt(...a) },
+}))
+
+vi.mock('ora', () => ({
+  default: () => ({
+    start: () => ({
+      succeed: () => {},
+      fail: () => {},
+      warn: () => {},
+      stop: () => {},
+    }),
+  }),
+}))
+
+describe('audit', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('모듈을 import 할 수 있다', async () => {
+    const mod = await import('../src/commands/audit.js')
+    expect(mod.audit).toBeDefined()
+  })
+
+  it('취약점 0건이면 자동 fix 호출 없음', async () => {
+    mockExecSync.mockReturnValue(
+      Buffer.from(JSON.stringify({ metadata: { vulnerabilities: { total: 0 } } }))
+    )
+    const { audit } = await import('../src/commands/audit.js')
+    await audit(false)
+    expect(mockExecSync).toHaveBeenCalledTimes(1)
+  })
+
+  it('autoFix=true면 critical/high 없어도 npm audit fix를 호출한다', async () => {
+    mockExecSync.mockReturnValue(
+      Buffer.from(
+        JSON.stringify({
+          metadata: { vulnerabilities: { critical: 0, high: 0, moderate: 2, low: 0, total: 2 } },
+        })
+      )
+    )
+    const { audit } = await import('../src/commands/audit.js')
+    await audit(true)
+    const fixCall = mockExecSync.mock.calls.find((c) => String(c[0]).includes('audit fix'))
+    expect(fixCall).toBeDefined()
+  })
+
+  it('critical/high가 있고 autoFix=false면 사용자에게 fix 여부를 묻는다', async () => {
+    mockExecSync.mockReturnValue(
+      Buffer.from(
+        JSON.stringify({
+          metadata: { vulnerabilities: { critical: 1, high: 0, moderate: 0, low: 0, total: 1 } },
+        })
+      )
+    )
+    mockPrompt.mockResolvedValue({ shouldFix: false })
+    const { audit } = await import('../src/commands/audit.js')
+    await audit(false)
+    expect(mockPrompt).toHaveBeenCalled()
+  })
+
+  it('npm audit가 exit code 1로 throw해도 stdout을 읽어 파싱한다', async () => {
+    const err = Object.assign(new Error('audit nonzero'), {
+      stdout: Buffer.from(
+        JSON.stringify({ metadata: { vulnerabilities: { high: 3, total: 3 } } })
+      ),
+    })
+    mockExecSync.mockImplementationOnce(() => {
+      throw err
+    })
+    mockPrompt.mockResolvedValue({ shouldFix: false })
+    const { audit } = await import('../src/commands/audit.js')
+    await audit(false)
+    expect(mockPrompt).toHaveBeenCalled()
+  })
+})

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const mockExecSync = vi.fn()
+const mockSafeExecFile = vi.fn()
+const mockExistsSync = vi.fn()
 const mockPrompt = vi.fn()
 
-vi.mock('node:child_process', () => ({
-  execSync: (...a: unknown[]) => mockExecSync(...a),
+vi.mock('../src/lib/exec.js', () => ({
+  safeExecFile: (...a: unknown[]) => mockSafeExecFile(...a),
+}))
+
+vi.mock('node:fs', () => ({
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
 }))
 
 vi.mock('inquirer', () => ({
@@ -26,6 +31,7 @@ describe('audit', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     vi.spyOn(console, 'log').mockImplementation(() => {})
+    mockExistsSync.mockReturnValue(false) // npm 기본
   })
 
   it('모듈을 import 할 수 있다', async () => {
@@ -34,54 +40,80 @@ describe('audit', () => {
   })
 
   it('취약점 0건이면 자동 fix 호출 없음', async () => {
-    mockExecSync.mockReturnValue(
-      Buffer.from(JSON.stringify({ metadata: { vulnerabilities: { total: 0 } } }))
-    )
+    mockSafeExecFile.mockReturnValue({
+      ok: true,
+      out: JSON.stringify({ metadata: { vulnerabilities: { total: 0 } } }),
+    })
     const { audit } = await import('../src/commands/audit.js')
     await audit(false)
-    expect(mockExecSync).toHaveBeenCalledTimes(1)
+    expect(mockSafeExecFile).toHaveBeenCalledTimes(1)
   })
 
-  it('autoFix=true면 critical/high 없어도 npm audit fix를 호출한다', async () => {
-    mockExecSync.mockReturnValue(
-      Buffer.from(
-        JSON.stringify({
-          metadata: { vulnerabilities: { critical: 0, high: 0, moderate: 2, low: 0, total: 2 } },
-        })
-      )
-    )
+  it('autoFix=true + npm 환경이면 critical/high 없어도 npm audit fix를 호출한다', async () => {
+    mockSafeExecFile.mockReturnValue({
+      ok: true,
+      out: JSON.stringify({
+        metadata: { vulnerabilities: { critical: 0, high: 0, moderate: 2, low: 0, total: 2 } },
+      }),
+    })
     const { audit } = await import('../src/commands/audit.js')
     await audit(true)
-    const fixCall = mockExecSync.mock.calls.find((c) => String(c[0]).includes('audit fix'))
+    const fixCall = mockSafeExecFile.mock.calls.find(
+      (c) => Array.isArray(c[1]) && (c[1] as string[]).includes('fix')
+    )
     expect(fixCall).toBeDefined()
+    expect(fixCall![0]).toBe('npm')
   })
 
   it('critical/high가 있고 autoFix=false면 사용자에게 fix 여부를 묻는다', async () => {
-    mockExecSync.mockReturnValue(
-      Buffer.from(
-        JSON.stringify({
-          metadata: { vulnerabilities: { critical: 1, high: 0, moderate: 0, low: 0, total: 1 } },
-        })
-      )
-    )
+    mockSafeExecFile.mockReturnValue({
+      ok: true,
+      out: JSON.stringify({
+        metadata: { vulnerabilities: { critical: 1, high: 0, moderate: 0, low: 0, total: 1 } },
+      }),
+    })
     mockPrompt.mockResolvedValue({ shouldFix: false })
     const { audit } = await import('../src/commands/audit.js')
     await audit(false)
     expect(mockPrompt).toHaveBeenCalled()
   })
 
-  it('npm audit가 exit code 1로 throw해도 stdout을 읽어 파싱한다', async () => {
-    const err = Object.assign(new Error('audit nonzero'), {
-      stdout: Buffer.from(
-        JSON.stringify({ metadata: { vulnerabilities: { high: 3, total: 3 } } })
-      ),
-    })
-    mockExecSync.mockImplementationOnce(() => {
-      throw err
+  it('exit code !=0지만 stdout에 JSON이 담겨도 파싱한다 (safeExecFile err 경로)', async () => {
+    mockSafeExecFile.mockReturnValue({
+      ok: false,
+      err: 'audit exit 1',
+      out: JSON.stringify({ metadata: { vulnerabilities: { high: 3, total: 3 } } }),
     })
     mockPrompt.mockResolvedValue({ shouldFix: false })
     const { audit } = await import('../src/commands/audit.js')
     await audit(false)
     expect(mockPrompt).toHaveBeenCalled()
+  })
+
+  it('pnpm 프로젝트면 pnpm audit를 호출한다', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p) === 'pnpm-lock.yaml')
+    mockSafeExecFile.mockReturnValue({
+      ok: true,
+      out: JSON.stringify({ metadata: { vulnerabilities: { total: 0 } } }),
+    })
+    const { audit } = await import('../src/commands/audit.js')
+    await audit(false)
+    expect(mockSafeExecFile.mock.calls[0][0]).toBe('pnpm')
+  })
+
+  it('autoFix=true + pnpm 환경이면 audit fix를 호출하지 않고 안내만 출력', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p) === 'pnpm-lock.yaml')
+    mockSafeExecFile.mockReturnValue({
+      ok: true,
+      out: JSON.stringify({
+        metadata: { vulnerabilities: { critical: 0, high: 0, moderate: 1, low: 0, total: 1 } },
+      }),
+    })
+    const { audit } = await import('../src/commands/audit.js')
+    await audit(true)
+    const fixCall = mockSafeExecFile.mock.calls.find(
+      (c) => Array.isArray(c[1]) && (c[1] as string[]).includes('fix')
+    )
+    expect(fixCall).toBeUndefined()
   })
 })

--- a/tests/harness.test.ts
+++ b/tests/harness.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockExecSync = vi.fn()
+const mockReadFileSync = vi.fn()
+const mockExistsSync = vi.fn()
+
+vi.mock('node:child_process', () => ({
+  execSync: (...a: unknown[]) => mockExecSync(...a),
+}))
+
+vi.mock('node:fs', () => ({
+  readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
+}))
+
+vi.mock('ora', () => ({
+  default: () => ({
+    start: () => ({
+      succeed: () => {},
+      fail: () => {},
+      stop: () => {},
+      text: '',
+    }),
+  }),
+}))
+
+describe('harness', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('모듈을 import 할 수 있다', async () => {
+    const mod = await import('../src/commands/harness.js')
+    expect(mod.harness).toBeDefined()
+  })
+
+  it('package.json scripts가 없으면 안내만 출력하고 execSync 호출 없음', async () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 't' }))
+    mockExistsSync.mockReturnValue(false)
+    const { harness } = await import('../src/commands/harness.js')
+    await harness()
+    expect(mockExecSync).not.toHaveBeenCalled()
+  })
+
+  it('test/build scripts 감지 시 순차 실행한다', async () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ scripts: { test: 'vitest', build: 'tsup' } })
+    )
+    mockExistsSync.mockReturnValue(false)
+    mockExecSync.mockReturnValue(Buffer.from(''))
+    const { harness } = await import('../src/commands/harness.js')
+    await harness()
+    const cmds = mockExecSync.mock.calls.map((c) => String(c[0]))
+    expect(cmds.some((c) => c.includes('test'))).toBe(true)
+    expect(cmds.some((c) => c.includes('build'))).toBe(true)
+  })
+
+  it('실패해도 다음 점검을 계속 진행한다', async () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ scripts: { test: 'vitest', build: 'tsup' } })
+    )
+    mockExistsSync.mockReturnValue(false)
+    let call = 0
+    mockExecSync.mockImplementation(() => {
+      call += 1
+      if (call === 1) throw new Error('test failed')
+      return Buffer.from('')
+    })
+    const { harness } = await import('../src/commands/harness.js')
+    await harness()
+    expect(mockExecSync).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/harness.test.ts
+++ b/tests/harness.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const mockExecSync = vi.fn()
+const mockSafeExecFile = vi.fn()
 const mockReadFileSync = vi.fn()
 const mockExistsSync = vi.fn()
 
-vi.mock('node:child_process', () => ({
-  execSync: (...a: unknown[]) => mockExecSync(...a),
+vi.mock('../src/lib/exec.js', () => ({
+  safeExecFile: (...a: unknown[]) => mockSafeExecFile(...a),
 }))
 
 vi.mock('node:fs', () => ({
@@ -35,12 +35,12 @@ describe('harness', () => {
     expect(mod.harness).toBeDefined()
   })
 
-  it('package.json scripts가 없으면 안내만 출력하고 execSync 호출 없음', async () => {
+  it('package.json scripts가 없으면 안내만 출력하고 safeExecFile 호출 없음', async () => {
     mockReadFileSync.mockReturnValue(JSON.stringify({ name: 't' }))
     mockExistsSync.mockReturnValue(false)
     const { harness } = await import('../src/commands/harness.js')
     await harness()
-    expect(mockExecSync).not.toHaveBeenCalled()
+    expect(mockSafeExecFile).not.toHaveBeenCalled()
   })
 
   it('test/build scripts 감지 시 순차 실행한다', async () => {
@@ -48,12 +48,12 @@ describe('harness', () => {
       JSON.stringify({ scripts: { test: 'vitest', build: 'tsup' } })
     )
     mockExistsSync.mockReturnValue(false)
-    mockExecSync.mockReturnValue(Buffer.from(''))
+    mockSafeExecFile.mockReturnValue({ ok: true, out: '' })
     const { harness } = await import('../src/commands/harness.js')
     await harness()
-    const cmds = mockExecSync.mock.calls.map((c) => String(c[0]))
-    expect(cmds.some((c) => c.includes('test'))).toBe(true)
-    expect(cmds.some((c) => c.includes('build'))).toBe(true)
+    const callArgs = mockSafeExecFile.mock.calls.map((c) => c[1] as string[])
+    expect(callArgs.some((a) => a.includes('test'))).toBe(true)
+    expect(callArgs.some((a) => a.includes('build'))).toBe(true)
   })
 
   it('실패해도 다음 점검을 계속 진행한다', async () => {
@@ -62,13 +62,23 @@ describe('harness', () => {
     )
     mockExistsSync.mockReturnValue(false)
     let call = 0
-    mockExecSync.mockImplementation(() => {
+    mockSafeExecFile.mockImplementation(() => {
       call += 1
-      if (call === 1) throw new Error('test failed')
-      return Buffer.from('')
+      if (call === 1) return { ok: false, err: 'test failed', out: '' }
+      return { ok: true, out: '' }
     })
     const { harness } = await import('../src/commands/harness.js')
     await harness()
-    expect(mockExecSync).toHaveBeenCalledTimes(2)
+    expect(mockSafeExecFile).toHaveBeenCalledTimes(2)
+  })
+
+  it('pnpm-lock.yaml 감지 시 pnpm으로 실행', async () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ scripts: { build: 'tsup' } }))
+    mockExistsSync.mockImplementation((p: unknown) => String(p) === 'pnpm-lock.yaml')
+    mockSafeExecFile.mockReturnValue({ ok: true, out: '' })
+    const { harness } = await import('../src/commands/harness.js')
+    await harness()
+    const bins = mockSafeExecFile.mock.calls.map((c) => c[0] as string)
+    expect(bins[0]).toBe('pnpm')
   })
 })

--- a/tests/migrate.test.ts
+++ b/tests/migrate.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockExecSync = vi.fn()
+const mockExistsSync = vi.fn()
+const mockUnlinkSync = vi.fn()
+const mockRmSync = vi.fn()
+const mockPrompt = vi.fn()
+
+vi.mock('node:child_process', () => ({
+  execSync: (...a: unknown[]) => mockExecSync(...a),
+}))
+
+vi.mock('node:fs', () => ({
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
+  unlinkSync: (...a: unknown[]) => mockUnlinkSync(...a),
+  rmSync: (...a: unknown[]) => mockRmSync(...a),
+}))
+
+vi.mock('inquirer', () => ({
+  default: { prompt: (...a: unknown[]) => mockPrompt(...a) },
+}))
+
+vi.mock('ora', () => ({
+  default: () => ({
+    start: () => ({
+      succeed: () => {},
+      fail: () => {},
+      stop: () => {},
+      text: '',
+    }),
+  }),
+}))
+
+describe('migrate', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('모듈을 import 할 수 있다', async () => {
+    const mod = await import('../src/commands/migrate.js')
+    expect(mod.migrate).toBeDefined()
+  })
+
+  it('대상이 현재 PM과 같으면 동작하지 않는다', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p) === 'pnpm-lock.yaml')
+    const { migrate } = await import('../src/commands/migrate.js')
+    await migrate('pnpm')
+    expect(mockUnlinkSync).not.toHaveBeenCalled()
+  })
+
+  it('대상 PM CLI가 없으면 안내만 출력', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p) === 'pnpm-lock.yaml')
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      if (String(cmd).startsWith('yarn --version')) throw new Error('not found')
+      return Buffer.from('1.0.0')
+    })
+    const { migrate } = await import('../src/commands/migrate.js')
+    await migrate('yarn')
+    expect(mockUnlinkSync).not.toHaveBeenCalled()
+    expect(mockRmSync).not.toHaveBeenCalled()
+  })
+
+  it('확인 거부 시 lockfile 삭제하지 않는다', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p) === 'pnpm-lock.yaml')
+    mockExecSync.mockReturnValue(Buffer.from('1.0.0'))
+    mockPrompt.mockResolvedValue({ confirm: false })
+    const { migrate } = await import('../src/commands/migrate.js')
+    await migrate('npm')
+    expect(mockUnlinkSync).not.toHaveBeenCalled()
+  })
+
+  it('확인 후 lockfile + node_modules 정리 + install 호출', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const s = String(p)
+      return s === 'pnpm-lock.yaml' || s === 'node_modules'
+    })
+    mockExecSync.mockReturnValue(Buffer.from('1.0.0'))
+    mockPrompt.mockResolvedValue({ confirm: true })
+    const { migrate } = await import('../src/commands/migrate.js')
+    await migrate('npm')
+    expect(mockUnlinkSync).toHaveBeenCalled()
+    expect(mockRmSync).toHaveBeenCalledWith('node_modules', { recursive: true, force: true })
+    const installCall = mockExecSync.mock.calls.find((c) => String(c[0]) === 'npm install')
+    expect(installCall).toBeDefined()
+  })
+})

--- a/tests/migrate.test.ts
+++ b/tests/migrate.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const mockExecSync = vi.fn()
+const mockSafeExecFile = vi.fn()
 const mockExistsSync = vi.fn()
 const mockUnlinkSync = vi.fn()
 const mockRmSync = vi.fn()
 const mockPrompt = vi.fn()
 
-vi.mock('node:child_process', () => ({
-  execSync: (...a: unknown[]) => mockExecSync(...a),
+vi.mock('../src/lib/exec.js', () => ({
+  safeExecFile: (...a: unknown[]) => mockSafeExecFile(...a),
 }))
 
 vi.mock('node:fs', () => ({
@@ -51,9 +51,9 @@ describe('migrate', () => {
 
   it('대상 PM CLI가 없으면 안내만 출력', async () => {
     mockExistsSync.mockImplementation((p: unknown) => String(p) === 'pnpm-lock.yaml')
-    mockExecSync.mockImplementation((cmd: unknown) => {
-      if (String(cmd).startsWith('yarn --version')) throw new Error('not found')
-      return Buffer.from('1.0.0')
+    mockSafeExecFile.mockImplementation((bin: string) => {
+      if (bin === 'yarn') return { ok: false, err: 'not found', out: '' }
+      return { ok: true, out: '1.0.0' }
     })
     const { migrate } = await import('../src/commands/migrate.js')
     await migrate('yarn')
@@ -63,7 +63,7 @@ describe('migrate', () => {
 
   it('확인 거부 시 lockfile 삭제하지 않는다', async () => {
     mockExistsSync.mockImplementation((p: unknown) => String(p) === 'pnpm-lock.yaml')
-    mockExecSync.mockReturnValue(Buffer.from('1.0.0'))
+    mockSafeExecFile.mockReturnValue({ ok: true, out: '1.0.0' })
     mockPrompt.mockResolvedValue({ confirm: false })
     const { migrate } = await import('../src/commands/migrate.js')
     await migrate('npm')
@@ -75,13 +75,15 @@ describe('migrate', () => {
       const s = String(p)
       return s === 'pnpm-lock.yaml' || s === 'node_modules'
     })
-    mockExecSync.mockReturnValue(Buffer.from('1.0.0'))
+    mockSafeExecFile.mockReturnValue({ ok: true, out: '1.0.0' })
     mockPrompt.mockResolvedValue({ confirm: true })
     const { migrate } = await import('../src/commands/migrate.js')
     await migrate('npm')
     expect(mockUnlinkSync).toHaveBeenCalled()
     expect(mockRmSync).toHaveBeenCalledWith('node_modules', { recursive: true, force: true })
-    const installCall = mockExecSync.mock.calls.find((c) => String(c[0]) === 'npm install')
+    const installCall = mockSafeExecFile.mock.calls.find(
+      (c) => c[0] === 'npm' && Array.isArray(c[1]) && (c[1] as string[]).includes('install')
+    )
     expect(installCall).toBeDefined()
   })
 })

--- a/tests/nlp-router.test.ts
+++ b/tests/nlp-router.test.ts
@@ -121,4 +121,32 @@ describe('자연어 라우팅', () => {
   it('"디자인 토큰 npm 출시" → publish (design 가드)', () => {
     expect(routeNaturalLanguage('디자인 토큰 npm 출시')?.command).toBe('publish')
   })
+
+  it('"품질 점검해줘" → harness', () => {
+    expect(routeNaturalLanguage('품질 점검해줘')?.command).toBe('harness')
+  })
+
+  it('"통합 점검 돌려" → harness', () => {
+    expect(routeNaturalLanguage('통합 점검 돌려')?.command).toBe('harness')
+  })
+
+  it('"규칙 점검" → check (harness 아님)', () => {
+    expect(routeNaturalLanguage('규칙 점검')?.command).toBe('check')
+  })
+
+  it('"보안 감사 해줘" → audit', () => {
+    expect(routeNaturalLanguage('보안 감사 해줘')?.command).toBe('audit')
+  })
+
+  it('"취약점 확인" → audit', () => {
+    expect(routeNaturalLanguage('취약점 확인')?.command).toBe('audit')
+  })
+
+  it('"패키지 매니저 전환" → migrate', () => {
+    expect(routeNaturalLanguage('패키지 매니저 전환')?.command).toBe('migrate')
+  })
+
+  it('"vhk 업데이트 해줘" → update', () => {
+    expect(routeNaturalLanguage('vhk 업데이트 해줘')?.command).toBe('update')
+  })
 })

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mockExecSync = vi.fn()
 const mockReadFileSync = vi.fn()
+const mockExistsSync = vi.fn(() => true)
 
 vi.mock('node:child_process', () => ({
   execSync: (...a: unknown[]) => mockExecSync(...a),
@@ -9,6 +10,7 @@ vi.mock('node:child_process', () => ({
 
 vi.mock('node:fs', () => ({
   readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
 }))
 
 vi.mock('ora', () => ({

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockExecSync = vi.fn()
+const mockReadFileSync = vi.fn()
+
+vi.mock('node:child_process', () => ({
+  execSync: (...a: unknown[]) => mockExecSync(...a),
+}))
+
+vi.mock('node:fs', () => ({
+  readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
+}))
+
+vi.mock('ora', () => ({
+  default: () => ({
+    start: () => ({
+      succeed: () => {},
+      fail: () => {},
+      stop: () => {},
+    }),
+  }),
+}))
+
+describe('update', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('모듈을 import 할 수 있다', async () => {
+    const mod = await import('../src/commands/update.js')
+    expect(mod.update).toBeDefined()
+  })
+
+  it('현재==최신이면 npm update를 호출하지 않는다', async () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '0.9.0' }))
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      if (String(cmd).startsWith('npm view')) return Buffer.from('0.9.0\n')
+      throw new Error('should not run npm update')
+    })
+    const { update } = await import('../src/commands/update.js')
+    await update()
+    const updateCall = mockExecSync.mock.calls.find((c) =>
+      String(c[0]).includes('npm update -g')
+    )
+    expect(updateCall).toBeUndefined()
+  })
+
+  it('현재<최신이면 npm update -g를 호출한다', async () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '0.9.0' }))
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const c = String(cmd)
+      if (c.startsWith('npm view')) return Buffer.from('1.0.0\n')
+      if (c.startsWith('npm update -g')) return Buffer.from('')
+      return Buffer.from('')
+    })
+    const { update } = await import('../src/commands/update.js')
+    await update()
+    const updateCall = mockExecSync.mock.calls.find((c) =>
+      String(c[0]).includes('npm update -g')
+    )
+    expect(updateCall).toBeDefined()
+  })
+
+  it('npm view 실패 시 안내만 출력 (update 호출 X)', async () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '0.9.0' }))
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      if (String(cmd).startsWith('npm view')) throw new Error('network down')
+      return Buffer.from('')
+    })
+    const { update } = await import('../src/commands/update.js')
+    await update()
+    const updateCall = mockExecSync.mock.calls.find((c) =>
+      String(c[0]).includes('npm update -g')
+    )
+    expect(updateCall).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
v0.9.0 — 프로젝트 통합 품질 점검 · 보안 감사 · 패키지 매니저 전환 · 셀프 업데이트 4개 신규 명령 추가.

- **`vhk harness`** (`하네스`) — `package.json` scripts 감지 → lint/type-check/test/build 순차 실행 + 통합 리포트
- **`vhk audit`** (`감사`) — `npm audit --json` 래핑, Critical/High 발견 시 자동 fix 옵션, Windows PowerShell 호환
- **`vhk migrate [target]`** (`전환`) — npm/yarn/pnpm 전환 (lockfile + node_modules 재구성)
- **`vhk update`** (`업데이트`) — npm registry 최신 버전 조회 + semver 비교 후 `npm update -g`

키워드 충돌 가드: `점검`은 기존 `check` 유지, `보안`은 기존 `secure` 유지. harness/audit는 `하네스`/`감사`로 별칭.

자연어 8건 신규: "품질 점검해줘"/"통합 점검 돌려" → harness, "보안 감사 해줘"/"취약점 확인" → audit, "패키지 매니저 전환" → migrate, "vhk 업데이트 해줘" → update.

추가 버그 픽스 (smoke 중 발견):
- `update` 명령이 tsup 번들 후 `package.json` 경로 오인으로 `v0.0.0` 출력하던 버그 → 다중 경로 탐색
- `update` 명령이 현재 > 최신일 때 다운그레이드 시도 → `isUpToDate` semver 비교

## Test plan

- [x] vitest 194/194 통과 (신규 18건: harness 4 + audit 5 + migrate 5 + update 4, nlp-router 신규 7건 포함)
- [x] `pnpm build` 통과 (tsup + dts)
- [x] `node dist/index.js --help` — harness/audit/migrate/update 모두 표시
- [x] `node dist/index.js audit` — 취약점 0건 정상 응답
- [x] `node dist/index.js update` — v0.9.0 → 이미 최신 응답 (semver 가드)
- [x] NL: `"vhk 업데이트 해줘"` → update, `"취약점 확인"` → audit, `"품질 점검해줘"` → harness
- [ ] PR 머지 후: `git tag v0.9.0 && git push --tags && npm publish --access public` (OTP 필요)

## Plan
docs/superpowers/plans/2026-05-24-v0.9.0-harness-audit-migrate-update.md