### PR TITLE
feat(v1.0.0): GA — context/memory/brief + API 안정성 약속

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ---
 
+## [1.0.0] — 2026-05-24 — GA 🎉
+
+### Added
+- `vhk context` — 프로젝트 디렉토리 트리(3-depth) + 기술 스택 자동 감지(Next/Nuxt/React/Vue/Svelte/TS/Tailwind/tsup/Vite/webpack/vitest/jest/commander/inquirer + pnpm/yarn/npm) + VHK 명령어 목록을 `.vhk/context.md` 마크다운으로 자동 생성. AI 어시스턴트의 프로젝트 맥락 파악용
+- `vhk context-show` — 현재 컨텍스트 파일 내용 출력
+- `vhk memory add|list|remove` — `.vhk/memory.json` 기반 결정사항 기억 관리. `--tags` 옵션으로 태그 지원. NL은 list만 (add/remove는 인자 필수 → commander 전용)
+- `vhk brief` — 프로젝트 정보 + git 상태(브랜치·마지막 커밋·미커밋 변경) + 최근 결정사항 5건 + 레퍼런스 3건 통합 보고서 `.vhk/brief.md` 생성 + 콘솔 출력. `safeExecFile` 기반 (Windows .cmd shim 안전)
+- 자연어 라우터에 context/context-show/memory(list)/brief 키워드 추가 — `"맥락 만들어줘"`, `"컨텍스트 보여줘"`, `"기억 목록"`, `"프로젝트 브리핑 만들어줘"`, `"상태 요약 보여줘"` 등 9건
+- README에 v1.0 GA 정책 섹션 + 전체 30+ 명령어 한국어 별칭 표
+
+### Changed
+- 버전: 0.9.1 → 1.0.0 (GA)
+- `nlp-router` init 룰에 v1.0 신규 키워드 negation guard 추가 (`브리핑|brief|컨텍스트|context|맥락|기억|memory`) — `"프로젝트 브리핑 만들어줘"`가 init에 잘못 매칭되던 문제 차단
+
+### Stability — v1.0 GA 공개 API 약속
+- 명령어 이름, CLI 인자, `.vhk/` 파일 포맷은 v2.0까지 breaking change 없음
+- 신규 명령 추가는 마이너 버전(1.x.0)으로 진행
+- deprecation은 제거 전 1개 마이너 버전에서 경고
+- i18n 키(`ko.ts`)는 누적만, 기존 키 미제거
+- MCP 도구 8개 인터페이스 안정
+
+---
+
 ## [0.9.0] — 2026-05-24
 
 ### Added
@@ -151,7 +174,8 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 - **`vhk gate`** — 아이디어 검증 (퀵 5문항 / 풀 13문항 / 스킵)
 - **`vhk init`** — 프로젝트 시작. 하네스 파일 생성 (`CLAUDE.md`, `.cursorrules`, `docs/PRD.md`, `docs/ARCHITECTURE.md`, ADR/log 폴더)
 
-[Unreleased]: https://github.com/byh3071-cpu/vhk/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/byh3071-cpu/vhk/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/byh3071-cpu/vhk/compare/v0.9.1...v1.0.0
 [0.9.0]: https://github.com/byh3071-cpu/vhk/compare/v0.8.1...v0.9.0
 [0.8.0]: https://github.com/byh3071-cpu/vhk/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/byh3071-cpu/vhk/compare/v0.7.0...v0.7.1

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 ---
 id: vhk-readme
 date: 2026-05-24
-tags: [vhk, cli, readme, v0.9.0]
+tags: [vhk, cli, readme, v1.0.0, ga]
 ---
 
 # 🔧 VHK — Vibe Harness Kit
 
-> AI 코딩 에이전트를 부리는 사람을 위한 **한국어 풀사이클 CLI** (v0.9.0)
+> 🎉 **v1.0.0 GA** — 바이브코더의 올인원 CLI. 공개 API 안정성 보장.
+>
+> AI 코딩 에이전트를 부리는 사람을 위한 **한국어 풀사이클 CLI** (v1.0.0)
 >
 > 🍽️ **VHK는 VHK로 부트스트랩됨** — 이 레포의 `docs/`, `CLAUDE.md`, `.cursorrules`도 `vhk init`이 만들었습니다.
 
@@ -100,9 +102,13 @@ vhk 기획 끝났고 바로 시작
 | `vhk theme` | `테마` | 다크/라이트 모드 CSS + 토글 유틸리티 생성 |
 | `vhk ref` | `레퍼런스` | 레퍼런스 URL 관리 (`add` / `list` / `open`) |
 | `vhk harness` | `하네스` | 통합 품질 점검 (lint + type-check + test + build 순차 실행 + 리포트) |
-| `vhk audit` | `감사` | npm 보안 취약점 감사 (`--fix`로 자동 수정) |
+| `vhk audit` | `감사` | npm/pnpm/yarn 보안 취약점 감사 (`--fix`로 자동 수정, npm만) |
 | `vhk migrate [target]` | `전환` | 패키지 매니저 전환 (`npm` / `yarn` / `pnpm`, lockfile + node_modules 재구성) |
 | `vhk update` | `업데이트` | VHK CLI 최신 버전으로 셀프 업데이트 |
+| `vhk context` | `맥락` | 프로젝트 트리·스택·CLI 명령 목록을 `.vhk/context.md`로 자동 생성 (AI 어시스턴트용) |
+| `vhk context-show` | `맥락보기` | 현재 컨텍스트 파일 내용 출력 |
+| `vhk memory` | `기억` | 결정사항 기억 관리 (`add` / `list` / `remove`, `.vhk/memory.json` 기반, 태그 지원) |
+| `vhk brief` | `브리핑` | 프로젝트 정보 + git 상태 + 결정사항 + 레퍼런스 통합 보고서 `.vhk/brief.md` |
 
 ### init 옵션
 
@@ -136,6 +142,45 @@ MCP 서버를 수동으로 띄우려면:
 ```powershell
 vhk mcp                # stdio 서버 시작 (Cursor가 자동으로 호출)
 ```
+
+## v1.0.0 GA 하이라이트 🎉
+
+> **공개 API 안정성 약속**. 명령어 이름, CLI 인자, `.vhk/` 파일 포맷은 v2.0까지 breaking change 없음.
+
+| 기능 | 설명 |
+|------|------|
+| **context** | 프로젝트 디렉토리 트리(3-depth) + 기술 스택(Next/Nuxt/Vue/Svelte/TS/Tailwind/tsup/Vite/...) 자동 감지 + 29개+ VHK 명령어 목록을 `.vhk/context.md` 마크다운으로 생성. AI 어시스턴트가 프로젝트 맥락을 즉시 파악 |
+| **memory** | `.vhk/memory.json` 결정사항 기억 관리. `add <content> --tags X,Y` / `list` / `remove <번호>`. NL은 list만 (add/remove는 인자 필수 → commander 전용) |
+| **brief** | 프로젝트 정보 + git 상태(브랜치·마지막 커밋·미커밋 변경) + 최근 결정사항 + 레퍼런스를 한 화면에 + `.vhk/brief.md` 저장. `safeExecFile` 기반 (Windows .cmd shim 안전) |
+| **자연어 확장** | `"맥락 만들어줘"` → context · `"컨텍스트 보여줘"` → context-show · `"기억 목록"` → memory · `"프로젝트 브리핑 만들어줘"` / `"상태 요약"` → brief |
+
+```powershell
+vhk context             # .vhk/context.md (트리 + 스택 + 명령 목록)
+vhk memory add "API는 tRPC 사용" --tags decision,arch
+vhk memory list
+vhk brief               # 콘솔 출력 + .vhk/brief.md
+```
+
+### Cursor 권장 시퀀스 (v1.0 GA)
+
+```text
+vhk init                # 프로젝트 셋업
+vhk design + theme      # 디자인 시스템
+vhk context             # AI 맥락 파일 생성
+... 개발 ...
+vhk memory add "<결정>"  # 결정 누적
+vhk brief               # 세션 종료 시 상태 보고서
+다음 세션 시작: "컨텍스트 보여줘" → 어제 맥락 복원
+```
+
+### v1.0.0 GA 정책
+
+- **공개 API 안정성**: 명령어 이름, CLI 인자, `.vhk/` 파일 포맷은 v2.0까지 breaking change 없음
+- **deprecation 절차**: 명령어/옵션 제거 전 1개 마이너 버전(1.x.0)에서 deprecation 경고
+- **i18n 키**: `ko.ts`의 `t()` 키 이름은 안정. 신규 키 누적, 기존 키 미제거
+- **MCP 서버 도구**: 8개 도구(save/undo/status/diff/ship/doctor/check/recap) 인터페이스 안정
+
+> **`vhk memory` vs Claude Code `auto memory`** — `vhk memory`는 **프로젝트 단위** 결정사항(`.vhk/memory.json`, 팀 공유). Claude Code의 `auto memory`는 **사용자 단위** (`~/.claude/projects/.../memory/`, 개인 컨텍스트). 둘은 별개.
 
 ## v0.9.0 하이라이트
 
@@ -250,6 +295,10 @@ vhk ref open 1          # 1번 레퍼런스를 브라우저로 열기
 | 보안 감사 해줘 / 취약점 확인 | `vhk audit` |
 | 패키지 매니저 전환 | `vhk migrate` |
 | vhk 업데이트 해줘 | `vhk update` |
+| 맥락 만들어줘 / 컨텍스트 생성 | `vhk context` |
+| 컨텍스트 보여줘 / 맥락 보여줘 | `vhk context-show` |
+| 기억 목록 / 결정사항 확인 | `vhk memory` (list) |
+| 프로젝트 브리핑 / 상태 요약 | `vhk brief` |
 
 ## 특징
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "Vibe Harness Kit — 바이브코딩 풀사이클 CLI",
   "bin": {
     "vhk": "dist/index.js",

--- a/src/commands/brief.ts
+++ b/src/commands/brief.ts
@@ -107,15 +107,15 @@ export async function brief(): Promise<void> {
     }
   }
 
-  // 5. 다음 단계 제안
+  // 5. 다음 단계 제안 — 동적 번호 매기기 (uncommitted 유무에 따라 1~4단계)
   lines.push('## 다음 단계 제안')
   lines.push('')
-  if (uncommitted) {
-    lines.push('1. 미커밋 변경 사항을 커밋하세요: `vhk save`')
-  }
-  lines.push('1. 품질 점검 실행: `vhk harness`')
-  lines.push('2. 보안 감사: `vhk audit`')
-  lines.push('3. 컨텍스트 갱신: `vhk context`')
+  const steps: string[] = []
+  if (uncommitted) steps.push('미커밋 변경 사항을 커밋하세요: `vhk save`')
+  steps.push('품질 점검 실행: `vhk harness`')
+  steps.push('보안 감사: `vhk audit`')
+  steps.push('컨텍스트 갱신: `vhk context`')
+  steps.forEach((s, i) => lines.push(`${i + 1}. ${s}`))
   lines.push('')
 
   lines.push('---')

--- a/src/commands/brief.ts
+++ b/src/commands/brief.ts
@@ -1,8 +1,9 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { safeExecFile } from '../lib/exec.js'
+import { readJsonFile } from '../lib/read-json.js'
 
 const BRIEF_PATH = '.vhk/brief.md'
 
@@ -21,15 +22,15 @@ export async function brief(): Promise<void> {
   lines.push(`> 생성: ${new Date().toLocaleString('ko-KR')}`)
   lines.push('')
 
-  // 1. 프로젝트 정보
+  // 1. 프로젝트 정보 — readJsonFile로 BOM 안전 처리
   try {
-    const pkg = JSON.parse(readFileSync('package.json', 'utf-8')) as {
+    const pkg = readJsonFile<{
       name?: string
       version?: string
       description?: string
       dependencies?: Record<string, string>
       devDependencies?: Record<string, string>
-    }
+    }>('package.json')
     lines.push('## 프로젝트 정보')
     lines.push('')
     lines.push(`- **이름**: ${pkg.name ?? '미정'}`)
@@ -67,9 +68,7 @@ export async function brief(): Promise<void> {
   // 3. 결정사항
   if (existsSync('.vhk/memory.json')) {
     try {
-      const memories = JSON.parse(readFileSync('.vhk/memory.json', 'utf-8')) as Array<{
-        content: string
-      }>
+      const memories = readJsonFile<Array<{ content: string }>>('.vhk/memory.json')
       if (Array.isArray(memories) && memories.length > 0) {
         lines.push(`## 저장된 결정사항 (${memories.length}개)`)
         lines.push('')
@@ -89,10 +88,7 @@ export async function brief(): Promise<void> {
   // 4. 레퍼런스
   if (existsSync('.vhk/refs.json')) {
     try {
-      const refs = JSON.parse(readFileSync('.vhk/refs.json', 'utf-8')) as Array<{
-        url: string
-        memo?: string
-      }>
+      const refs = readJsonFile<Array<{ url: string; memo?: string }>>('.vhk/refs.json')
       if (Array.isArray(refs) && refs.length > 0) {
         lines.push(`## 레퍼런스 (${refs.length}개)`)
         lines.push('')

--- a/src/commands/brief.ts
+++ b/src/commands/brief.ts
@@ -1,0 +1,137 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import chalk from 'chalk'
+import { t } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+import { safeExecFile } from '../lib/exec.js'
+
+const BRIEF_PATH = '.vhk/brief.md'
+
+function git(args: string[]): string {
+  const result = safeExecFile('git', args)
+  return result.ok ? result.out : ''
+}
+
+export async function brief(): Promise<void> {
+  console.log(chalk.bold('\n📋 ' + t('brief.title')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  const lines: string[] = []
+  lines.push('# 프로젝트 브리핑')
+  lines.push('')
+  lines.push(`> 생성: ${new Date().toLocaleString('ko-KR')}`)
+  lines.push('')
+
+  // 1. 프로젝트 정보
+  try {
+    const pkg = JSON.parse(readFileSync('package.json', 'utf-8')) as {
+      name?: string
+      version?: string
+      description?: string
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+    }
+    lines.push('## 프로젝트 정보')
+    lines.push('')
+    lines.push(`- **이름**: ${pkg.name ?? '미정'}`)
+    lines.push(`- **버전**: ${pkg.version ?? '미정'}`)
+    lines.push(`- **설명**: ${pkg.description ?? '없음'}`)
+    const deps = Object.keys(pkg.dependencies ?? {}).length
+    const devDeps = Object.keys(pkg.devDependencies ?? {}).length
+    lines.push(`- **의존성**: ${deps}개 (dev: ${devDeps}개)`)
+    lines.push('')
+  } catch {
+    lines.push('## 프로젝트 정보')
+    lines.push('')
+    lines.push('⚠️ package.json을 찾을 수 없습니다.')
+    lines.push('')
+  }
+
+  // 2. Git 상태 — safeExecFile로 .cmd shim 안전 호출
+  const branch = git(['branch', '--show-current'])
+  const lastCommit = git(['log', '-1', '--pretty=format:%h %s (%cr)'])
+  const uncommitted = git(['status', '--porcelain'])
+  const totalCommits = git(['rev-list', '--count', 'HEAD'])
+
+  lines.push('## Git 상태')
+  lines.push('')
+  lines.push(`- **현재 브랜치**: ${branch || '알 수 없음'}`)
+  lines.push(`- **마지막 커밋**: ${lastCommit || '없음'}`)
+  lines.push(`- **총 커밋 수**: ${totalCommits || '알 수 없음'}`)
+  lines.push(
+    `- **미커밋 변경**: ${
+      uncommitted ? `${uncommitted.split('\n').length}개 파일` : '없음 ✅'
+    }`
+  )
+  lines.push('')
+
+  // 3. 결정사항
+  if (existsSync('.vhk/memory.json')) {
+    try {
+      const memories = JSON.parse(readFileSync('.vhk/memory.json', 'utf-8')) as Array<{
+        content: string
+      }>
+      if (Array.isArray(memories) && memories.length > 0) {
+        lines.push(`## 저장된 결정사항 (${memories.length}개)`)
+        lines.push('')
+        for (const m of memories.slice(-5)) {
+          lines.push(`- ${m.content}`)
+        }
+        if (memories.length > 5) {
+          lines.push(`- ... 외 ${memories.length - 5}개`)
+        }
+        lines.push('')
+      }
+    } catch {
+      // 무시
+    }
+  }
+
+  // 4. 레퍼런스
+  if (existsSync('.vhk/refs.json')) {
+    try {
+      const refs = JSON.parse(readFileSync('.vhk/refs.json', 'utf-8')) as Array<{
+        url: string
+        memo?: string
+      }>
+      if (Array.isArray(refs) && refs.length > 0) {
+        lines.push(`## 레퍼런스 (${refs.length}개)`)
+        lines.push('')
+        for (const r of refs.slice(-3)) {
+          const label = r.memo && r.memo.length > 0 ? r.memo : r.url
+          lines.push(`- [${label}](${r.url})`)
+        }
+        lines.push('')
+      }
+    } catch {
+      // 무시
+    }
+  }
+
+  // 5. 다음 단계 제안
+  lines.push('## 다음 단계 제안')
+  lines.push('')
+  if (uncommitted) {
+    lines.push('1. 미커밋 변경 사항을 커밋하세요: `vhk save`')
+  }
+  lines.push('1. 품질 점검 실행: `vhk harness`')
+  lines.push('2. 보안 감사: `vhk audit`')
+  lines.push('3. 컨텍스트 갱신: `vhk context`')
+  lines.push('')
+
+  lines.push('---')
+  lines.push('')
+  lines.push('_VHK CLI 브리핑_')
+  lines.push('')
+
+  mkdirSync('.vhk', { recursive: true })
+  writeFileSync(BRIEF_PATH, lines.join('\n'), 'utf-8')
+
+  console.log('\n' + lines.join('\n'))
+  console.log(chalk.green(`\n✅ ${BRIEF_PATH} 저장 완료`))
+
+  printNextStep({
+    message: '브리핑 생성 완료!',
+    command: 'vhk context',
+    cursorHint: '컨텍스트 업데이트해줘',
+  })
+}

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -10,6 +10,7 @@ import { join } from 'node:path'
 import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
+import { readJsonFile } from '../lib/read-json.js'
 
 const CONTEXT_PATH = '.vhk/context.md'
 
@@ -58,12 +59,13 @@ type DepMap = Record<string, string>
 function extractTechStack(): Record<string, string> {
   const stack: Record<string, string> = {}
   try {
-    const pkg = JSON.parse(readFileSync('package.json', 'utf-8')) as {
+    // PowerShell `Out-File -Encoding utf8`로 만든 package.json은 BOM 포함 → readJsonFile로 stripBom.
+    const pkg = readJsonFile<{
       name?: string
       version?: string
       dependencies?: DepMap
       devDependencies?: DepMap
-    }
+    }>('package.json')
     const all: DepMap = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) }
 
     if (all.next) stack['프레임워크'] = `Next.js ${all.next}`
@@ -169,10 +171,9 @@ export async function context(): Promise<void> {
 
   if (existsSync('.vhk/memory.json')) {
     try {
-      const memories = JSON.parse(readFileSync('.vhk/memory.json', 'utf-8')) as Array<{
-        content: string
-        addedAt: string
-      }>
+      const memories = readJsonFile<Array<{ content: string; addedAt: string }>>(
+        '.vhk/memory.json'
+      )
       if (Array.isArray(memories) && memories.length > 0) {
         lines.push('## 저장된 결정사항')
         lines.push('')

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -1,0 +1,221 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import { join } from 'node:path'
+import chalk from 'chalk'
+import { t } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+
+const CONTEXT_PATH = '.vhk/context.md'
+
+const IGNORE_DIRS = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  '.next',
+  '.nuxt',
+  '.output',
+  'coverage',
+  '.cache',
+  '.turbo',
+  '.vhk',
+])
+
+function buildTree(dir: string, prefix = '', maxDepth = 3, depth = 0): string[] {
+  if (depth >= maxDepth) return []
+  const lines: string[] = []
+  try {
+    const entries = readdirSync(dir) as string[]
+    const filtered = entries.filter(
+      (e) => (!e.startsWith('.') || e === '.env.example') && !IGNORE_DIRS.has(e)
+    )
+
+    filtered.forEach((entry, index) => {
+      const isLast = index === filtered.length - 1
+      const connector = isLast ? '└── ' : '├── '
+      const fullPath = join(dir, entry)
+      const stat = statSync(fullPath)
+      const isDir = stat.isDirectory()
+      lines.push(`${prefix}${connector}${entry}${isDir ? '/' : ''}`)
+      if (isDir) {
+        const nextPrefix = prefix + (isLast ? '    ' : '│   ')
+        lines.push(...buildTree(fullPath, nextPrefix, maxDepth, depth + 1))
+      }
+    })
+  } catch {
+    // dir 없음 또는 권한 X
+  }
+  return lines
+}
+
+type DepMap = Record<string, string>
+
+function extractTechStack(): Record<string, string> {
+  const stack: Record<string, string> = {}
+  try {
+    const pkg = JSON.parse(readFileSync('package.json', 'utf-8')) as {
+      name?: string
+      version?: string
+      dependencies?: DepMap
+      devDependencies?: DepMap
+    }
+    const all: DepMap = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) }
+
+    if (all.next) stack['프레임워크'] = `Next.js ${all.next}`
+    else if (all.nuxt) stack['프레임워크'] = `Nuxt ${all.nuxt}`
+    else if (all.react) stack['프레임워크'] = `React ${all.react}`
+    else if (all.vue) stack['프레임워크'] = `Vue ${all.vue}`
+    else if (all.svelte) stack['프레임워크'] = `Svelte ${all.svelte}`
+
+    if (all.typescript) stack['언어'] = `TypeScript ${all.typescript}`
+    if (all.tailwindcss) stack['스타일'] = `Tailwind CSS ${all.tailwindcss}`
+
+    if (all.tsup) stack['빌드'] = 'tsup'
+    else if (all.vite) stack['빌드'] = `Vite ${all.vite}`
+    else if (all.webpack) stack['빌드'] = 'webpack'
+
+    if (all.vitest) stack['테스트'] = 'vitest'
+    else if (all.jest) stack['테스트'] = 'jest'
+
+    if (all.commander) stack['CLI'] = 'commander'
+    if (all.inquirer) stack['인터랙티브'] = 'inquirer'
+
+    if (existsSync('pnpm-lock.yaml')) stack['패키지 매니저'] = 'pnpm'
+    else if (existsSync('yarn.lock')) stack['패키지 매니저'] = 'yarn'
+    else stack['패키지 매니저'] = 'npm'
+
+    if (pkg.name) stack['패키지 이름'] = pkg.name
+    if (pkg.version) stack['버전'] = pkg.version
+  } catch {
+    // package.json 없음
+  }
+  return stack
+}
+
+function getVhkCommands(): string[] {
+  return [
+    'gate — 아이디어 검증',
+    'init — 프로젝트 초기화',
+    'recap — 세션 요약 저장',
+    'sync — 규칙 파일 동기화',
+    'check — 규칙 점검',
+    'secure — 보안 스캔',
+    'ship — 배포 체크 + 회고',
+    'doctor — 환경 진단',
+    'save — git 저장 (add+commit+push)',
+    'undo — 최근 커밋 되돌리기',
+    'status — git 상태 확인',
+    'diff — git 변경 사항 요약',
+    'deploy — 프로덕션 배포',
+    'env — 환경변수 관리',
+    'publish — npm 배포 자동화',
+    'design — 디자인 토큰 생성',
+    'design-palette — 컬러 팔레트 선택',
+    'theme — 다크/라이트 모드',
+    'ref add|list|open — 레퍼런스 URL 관리',
+    'harness — 통합 품질 점검',
+    'audit — 보안 취약점 감사',
+    'migrate — 패키지 매니저 전환',
+    'update — VHK CLI 셀프 업데이트',
+    'context — 프로젝트 맥락 생성',
+    'context-show — 맥락 파일 보기',
+    'memory add|list|remove — 결정사항 기억',
+    'brief — 프로젝트 요약 보고서',
+    'mcp — MCP 서버 시작',
+    'mcp-init — Cursor MCP 설정',
+  ]
+}
+
+export async function context(): Promise<void> {
+  console.log(chalk.bold('\n🧠 ' + t('context.title')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  const stack = extractTechStack()
+  const tree = buildTree('.').join('\n')
+  const commands = getVhkCommands()
+
+  const lines: string[] = []
+  lines.push('# 프로젝트 컨텍스트')
+  lines.push('')
+  lines.push('> 이 파일은 `vhk context`로 자동 생성되었습니다.')
+  lines.push('> AI 어시스턴트에게 프로젝트 맥락을 제공합니다.')
+  lines.push('')
+
+  lines.push('## 기술 스택')
+  lines.push('')
+  for (const [key, value] of Object.entries(stack)) {
+    lines.push(`- **${key}**: ${value}`)
+  }
+  lines.push('')
+
+  lines.push('## 디렉토리 구조')
+  lines.push('')
+  lines.push('```')
+  lines.push(tree)
+  lines.push('```')
+  lines.push('')
+
+  lines.push('## VHK CLI 명령어')
+  lines.push('')
+  for (const cmd of commands) {
+    lines.push(`- \`vhk ${cmd}\``)
+  }
+  lines.push('')
+
+  if (existsSync('.vhk/memory.json')) {
+    try {
+      const memories = JSON.parse(readFileSync('.vhk/memory.json', 'utf-8')) as Array<{
+        content: string
+        addedAt: string
+      }>
+      if (Array.isArray(memories) && memories.length > 0) {
+        lines.push('## 저장된 결정사항')
+        lines.push('')
+        for (const m of memories) {
+          const date = new Date(m.addedAt).toLocaleDateString('ko-KR')
+          lines.push(`- ${m.content} _(${date})_`)
+        }
+        lines.push('')
+      }
+    } catch {
+      // memory.json 파싱 실패 → 무시
+    }
+  }
+
+  lines.push('---')
+  lines.push('')
+  lines.push(`_생성: ${new Date().toLocaleString('ko-KR')}_`)
+  lines.push('')
+
+  mkdirSync('.vhk', { recursive: true })
+  writeFileSync(CONTEXT_PATH, lines.join('\n'), 'utf-8')
+
+  console.log(chalk.green(`\n✅ ${CONTEXT_PATH} 생성 완료!`))
+  console.log(chalk.gray(`   기술 스택 ${Object.keys(stack).length}개 감지`))
+  console.log(chalk.gray('   AI 어시스턴트에게 이 파일을 참조하게 하세요.'))
+
+  printNextStep({
+    message: '컨텍스트 파일 생성 완료!',
+    command: 'vhk context-show',
+    cursorHint: '컨텍스트 보여줘',
+  })
+}
+
+export async function contextShow(): Promise<void> {
+  console.log(chalk.bold('\n📄 ' + t('context.showTitle')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  if (!existsSync(CONTEXT_PATH)) {
+    console.log(chalk.yellow('\n⚠️  컨텍스트 파일이 없습니다.'))
+    console.log(chalk.gray('   vhk context를 먼저 실행하세요.'))
+    return
+  }
+
+  const content = readFileSync(CONTEXT_PATH, 'utf-8')
+  console.log('\n' + content)
+}

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -1,0 +1,95 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import chalk from 'chalk'
+import { t } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+
+interface MemoryEntry {
+  content: string
+  addedAt: string
+  tags?: string[]
+}
+
+const MEMORY_PATH = '.vhk/memory.json'
+
+function loadMemories(): MemoryEntry[] {
+  if (!existsSync(MEMORY_PATH)) return []
+  try {
+    const raw = readFileSync(MEMORY_PATH, 'utf-8')
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? (parsed as MemoryEntry[]) : []
+  } catch {
+    return []
+  }
+}
+
+function saveMemories(memories: MemoryEntry[]): void {
+  mkdirSync('.vhk', { recursive: true })
+  writeFileSync(MEMORY_PATH, JSON.stringify(memories, null, 2) + '\n', 'utf-8')
+}
+
+export async function memoryAdd(content: string, tags?: string[]): Promise<void> {
+  console.log(chalk.bold('\n🧠 ' + t('memory.addTitle')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  if (!content) {
+    console.log(chalk.red('❌ 기억할 내용을 입력해주세요.'))
+    console.log(chalk.gray('   예: vhk memory add "API는 tRPC 사용하기로 결정"'))
+    return
+  }
+
+  const memories = loadMemories()
+  memories.push({
+    content,
+    addedAt: new Date().toISOString(),
+    tags: tags && tags.length > 0 ? tags : [],
+  })
+  saveMemories(memories)
+
+  console.log(chalk.green(`\n✅ 기억 저장됨 (#${memories.length})`))
+  console.log(chalk.cyan(`   📝 ${content}`))
+
+  printNextStep({
+    message: '기억 저장 완료!',
+    command: 'vhk memory list',
+    cursorHint: '기억 목록 보여줘',
+  })
+}
+
+export async function memoryList(): Promise<void> {
+  console.log(chalk.bold('\n🧠 ' + t('memory.listTitle')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  const memories = loadMemories()
+  if (memories.length === 0) {
+    console.log(chalk.yellow('\n📭 저장된 기억이 없습니다.'))
+    console.log(chalk.gray('   vhk memory add "내용"으로 추가하세요.'))
+    return
+  }
+
+  console.log(chalk.cyan(`\n총 ${memories.length}개의 기억:\n`))
+  memories.forEach((m, index) => {
+    const date = new Date(m.addedAt).toLocaleDateString('ko-KR')
+    console.log(chalk.white(`  [${index + 1}] ${m.content}`))
+    if (m.tags && m.tags.length > 0) {
+      console.log(chalk.blue(`      🏷️  ${m.tags.join(', ')}`))
+    }
+    console.log(chalk.gray(`      📅 ${date}`))
+    console.log('')
+  })
+}
+
+export async function memoryRemove(indexStr: string): Promise<void> {
+  const memories = loadMemories()
+  const idx = parseInt(indexStr, 10) - 1
+
+  if (Number.isNaN(idx) || idx < 0 || idx >= memories.length) {
+    console.log(chalk.red(`❌ 유효하지 않은 번호입니다. (1~${memories.length || 0})`))
+    return
+  }
+
+  const removed = memories.splice(idx, 1)[0]
+  saveMemories(memories)
+
+  console.log(chalk.green('\n✅ 기억 삭제됨:'))
+  console.log(chalk.gray(`   ${removed.content}`))
+}

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -1,7 +1,8 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
+import { readJsonFile } from '../lib/read-json.js'
 
 interface MemoryEntry {
   content: string
@@ -14,8 +15,7 @@ const MEMORY_PATH = '.vhk/memory.json'
 function loadMemories(): MemoryEntry[] {
   if (!existsSync(MEMORY_PATH)) return []
   try {
-    const raw = readFileSync(MEMORY_PATH, 'utf-8')
-    const parsed = JSON.parse(raw)
+    const parsed = readJsonFile<unknown>(MEMORY_PATH)
     return Array.isArray(parsed) ? (parsed as MemoryEntry[]) : []
   } catch {
     return []

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -260,6 +260,10 @@ export const ko = {
     addTitle: '레퍼런스 추가',
     listTitle: '레퍼런스 목록',
   },
+  memory: {
+    addTitle: '기억 추가',
+    listTitle: '기억 목록',
+  },
   mcp: {
     initTitle: 'Cursor MCP 연동 설정',
     serverStarted: 'VHK MCP 서버 시작됨',

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -305,6 +305,13 @@ export const ko = {
   update: {
     title: 'VHK CLI 업데이트',
   },
+  context: {
+    title: '프로젝트 컨텍스트 생성',
+    showTitle: '컨텍스트 파일',
+  },
+  brief: {
+    title: '프로젝트 브리핑',
+  },
 } as const
 
 type KoValue = string | ((...args: never[]) => string)

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,9 @@ import { harness } from './commands/harness.js'
 import { audit } from './commands/audit.js'
 import { migrate } from './commands/migrate.js'
 import { update } from './commands/update.js'
+import { context, contextShow } from './commands/context.js'
+import { memoryAdd, memoryList, memoryRemove } from './commands/memory.js'
+import { brief } from './commands/brief.js'
 
 // 런타임에 package.json에서 버전 읽기 — src와 dist 둘 다 동작.
 // dist/index.js: ../package.json (npm 글로벌 + 로컬 빌드 동일)
@@ -78,6 +81,10 @@ const KO_ALIASES: Record<string, string> = {
   audit: '감사',
   migrate: '전환',
   update: '업데이트',
+  context: '맥락',
+  'context-show': '맥락보기',
+  memory: '기억',
+  brief: '브리핑',
 }
 
 program
@@ -315,6 +322,51 @@ program
   .alias('업데이트')
   .description('VHK CLI 최신 버전 업데이트')
   .action(async () => { await update() })
+
+program
+  .command('context')
+  .alias('맥락')
+  .description('프로젝트 맥락 파일 생성 (.vhk/context.md)')
+  .action(async () => { await context() })
+
+program
+  .command('context-show')
+  .alias('맥락보기')
+  .description('현재 컨텍스트 파일 내용 출력')
+  .action(async () => { await contextShow() })
+
+const memoryCmd = program
+  .command('memory')
+  .alias('기억')
+  .description('결정사항 기억 관리 (add / list / remove)')
+  .action(async () => { await memoryList() })
+
+memoryCmd
+  .command('add <content>')
+  .option('--tags <tags>', '태그 (쉼표 구분)')
+  .description('결정사항 기억 저장')
+  .action(async (content: string, opts: { tags?: string }) => {
+    const tags = opts.tags ? opts.tags.split(',').map((s) => s.trim()) : undefined
+    await memoryAdd(content, tags)
+  })
+
+memoryCmd
+  .command('list')
+  .alias('목록')
+  .description('저장된 기억 목록')
+  .action(async () => { await memoryList() })
+
+memoryCmd
+  .command('remove <index>')
+  .alias('삭제')
+  .description('기억 삭제 (1부터 시작하는 번호)')
+  .action(async (index: string) => { await memoryRemove(index) })
+
+program
+  .command('brief')
+  .alias('브리핑')
+  .description('프로젝트 상태 요약 보고서 생성 (.vhk/brief.md)')
+  .action(async () => { await brief() })
 
 program.on('command:*', async (operands: string[]) => {
   const unknown = operands[0] ?? ''

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -29,6 +29,10 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'audit', '감사',
   'migrate', '전환',
   'update', '업데이트',
+  'context', '맥락',
+  'context-show', '맥락보기',
+  'memory', '기억',
+  'brief', '브리핑',
   'help',
 ])
 

--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -24,6 +24,10 @@ export type NlpCommand =
   | 'audit'
   | 'migrate'
   | 'update'
+  | 'context'
+  | 'context-show'
+  | 'memory'
+  | 'brief'
 
 export type NlpConfidence = 'high' | 'low'
 
@@ -82,7 +86,7 @@ const RULES: NlpRule[] = [
     confidence: 'high',
     test: t =>
       (/프로젝트.*(만들|시작)|폴더.*만들|만들고\s*싶|하네스|초기화/.test(t) || /^시작$/.test(t)) &&
-      !/디자인|design|팔레트|palette|테마|theme|레퍼런스|reference|다크\s*모드|라이트\s*모드|색상\s*모드/.test(t),
+      !/디자인|design|팔레트|palette|테마|theme|레퍼런스|reference|다크\s*모드|라이트\s*모드|색상\s*모드|브리핑|brief|컨텍스트|context|맥락|기억|memory/.test(t),
   },
   {
     command: 'mcp-init',
@@ -148,6 +152,36 @@ const RULES: NlpRule[] = [
     confidence: 'high',
     test: t =>
       /업데이트|update|버전\s*업|최신\s*버전|셀프\s*업데이트|vhk.*최신|vhk.*업데이트/.test(t),
+  },
+  {
+    command: 'context-show',
+    explanation: '컨텍스트 파일 보기 (vhk context-show)',
+    confidence: 'high',
+    test: t =>
+      /맥락\s*(보|확인|보여)|컨텍스트\s*(보|확인|보여)|context\s*show/.test(t),
+  },
+  {
+    command: 'context',
+    explanation: '프로젝트 맥락 생성 (vhk context)',
+    confidence: 'high',
+    test: t =>
+      /(^맥락$|^컨텍스트$|^context$|맥락\s*(만들|생성|갱신|업데이트)|컨텍스트\s*(만들|생성|갱신|업데이트)|프로젝트\s*맥락|프로젝트\s*정보\s*생성)/.test(t)
+      && !/보|확인|보여|show/.test(t),
+  },
+  {
+    command: 'memory',
+    explanation: '기억 목록 조회 (vhk memory list)',
+    confidence: 'high',
+    test: t =>
+      (/^기억$|기억\s*(목록|보|확인|뭐)|memory.*list|결정사항\s*(목록|확인|보여)/.test(t))
+      && !/(추가|add|삭제|remove|저장|기록해)/.test(t),
+  },
+  {
+    command: 'brief',
+    explanation: '프로젝트 상태 요약 (vhk brief)',
+    confidence: 'high',
+    test: t =>
+      /브리핑|brief|상태\s*요약|프로젝트\s*요약|요약\s*(보고|리포트|보여|만들)|보고서\s*(만들|생성|보여)/.test(t),
   },
   {
     command: 'secure',

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -25,6 +25,9 @@ import { harness } from '../commands/harness.js'
 import { audit } from '../commands/audit.js'
 import { migrate } from '../commands/migrate.js'
 import { update } from '../commands/update.js'
+import { context, contextShow } from '../commands/context.js'
+import { memoryList } from '../commands/memory.js'
+import { brief } from '../commands/brief.js'
 
 export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<void> {
   switch (route.command) {
@@ -83,6 +86,14 @@ export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<
       return migrate()
     case 'update':
       return update()
+    case 'context':
+      return context()
+    case 'context-show':
+      return contextShow()
+    case 'memory':
+      return memoryList()
+    case 'brief':
+      return brief()
   }
 }
 

--- a/src/lib/read-json.ts
+++ b/src/lib/read-json.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs'
+import { readFileSync } from 'node:fs'
 
 /** UTF-8 BOM 제거 (PowerShell Set-Content -Encoding utf8 등) */
 export function stripBom(text: string): string {
@@ -6,6 +6,6 @@ export function stripBom(text: string): string {
 }
 
 export function readJsonFile<T>(filePath: string): T {
-  const raw = stripBom(fs.readFileSync(filePath, 'utf-8'))
+  const raw = stripBom(readFileSync(filePath, 'utf-8'))
   return JSON.parse(raw) as T
 }

--- a/tests/brief.test.ts
+++ b/tests/brief.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockSafeExecFile = vi.fn()
+const mockExistsSync = vi.fn()
+const mockReadFileSync = vi.fn()
+const mockWriteFileSync = vi.fn()
+const mockMkdirSync = vi.fn()
+
+vi.mock('../src/lib/exec.js', () => ({
+  safeExecFile: (...a: unknown[]) => mockSafeExecFile(...a),
+}))
+
+vi.mock('node:fs', () => ({
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
+  readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
+  writeFileSync: (...a: unknown[]) => mockWriteFileSync(...a),
+  mkdirSync: (...a: unknown[]) => mockMkdirSync(...a),
+}))
+
+describe('brief', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('모듈을 import 할 수 있다', async () => {
+    const mod = await import('../src/commands/brief.js')
+    expect(mod.brief).toBeDefined()
+  })
+
+  it('.vhk/brief.md를 생성한다', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p) === 'package.json')
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        name: 'p',
+        version: '1.0.0',
+        description: 'd',
+        dependencies: { a: '1' },
+        devDependencies: { b: '2', c: '3' },
+      })
+    )
+    mockSafeExecFile.mockReturnValue({ ok: true, out: '' })
+    const { brief } = await import('../src/commands/brief.js')
+    await brief()
+
+    expect(mockMkdirSync).toHaveBeenCalledWith('.vhk', { recursive: true })
+    const call = mockWriteFileSync.mock.calls.find((c) =>
+      String(c[0]).includes('brief.md')
+    )
+    expect(call).toBeDefined()
+  })
+
+  it('git 정보가 마크다운에 포함된다', async () => {
+    mockExistsSync.mockReturnValue(false)
+    mockReadFileSync.mockReturnValue(JSON.stringify({}))
+    mockSafeExecFile.mockImplementation((bin: string, args: string[]) => {
+      const argv = args.join(' ')
+      if (argv.includes('branch --show-current')) return { ok: true, out: 'main' }
+      if (argv.includes('log -1')) return { ok: true, out: 'abc123 commit msg (5분 전)' }
+      if (argv.includes('rev-list')) return { ok: true, out: '42' }
+      if (argv.includes('status --porcelain')) return { ok: true, out: 'M file.ts' }
+      return { ok: true, out: '' }
+    })
+    const { brief } = await import('../src/commands/brief.js')
+    await brief()
+
+    const call = mockWriteFileSync.mock.calls.find((c) =>
+      String(c[0]).includes('brief.md')
+    )
+    const md = String(call![1])
+    expect(md).toContain('main')
+    expect(md).toContain('abc123')
+    expect(md).toContain('42')
+  })
+
+  it('미커밋 변경 없으면 "없음 ✅" 표시', async () => {
+    mockExistsSync.mockReturnValue(false)
+    mockReadFileSync.mockReturnValue(JSON.stringify({}))
+    mockSafeExecFile.mockImplementation((bin: string, args: string[]) => {
+      const argv = args.join(' ')
+      if (argv.includes('status --porcelain')) return { ok: true, out: '' }
+      return { ok: true, out: 'main' }
+    })
+    const { brief } = await import('../src/commands/brief.js')
+    await brief()
+
+    const md = String(mockWriteFileSync.mock.calls[0][1])
+    expect(md).toContain('없음 ✅')
+  })
+
+  it('memory.json 있으면 결정사항 섹션 포함', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p).includes('memory.json'))
+    mockReadFileSync.mockImplementation((p: unknown) => {
+      if (String(p).includes('memory.json'))
+        return JSON.stringify([{ content: '결정-1', addedAt: '2026-01-01' }])
+      return '{}'
+    })
+    mockSafeExecFile.mockReturnValue({ ok: true, out: '' })
+    const { brief } = await import('../src/commands/brief.js')
+    await brief()
+
+    const md = String(mockWriteFileSync.mock.calls[0][1])
+    expect(md).toContain('저장된 결정사항')
+    expect(md).toContain('결정-1')
+  })
+})

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockExistsSync = vi.fn()
+const mockReadFileSync = vi.fn()
+const mockWriteFileSync = vi.fn()
+const mockMkdirSync = vi.fn()
+const mockReaddirSync = vi.fn()
+const mockStatSync = vi.fn()
+
+vi.mock('node:fs', () => ({
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
+  readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
+  writeFileSync: (...a: unknown[]) => mockWriteFileSync(...a),
+  mkdirSync: (...a: unknown[]) => mockMkdirSync(...a),
+  readdirSync: (...a: unknown[]) => mockReaddirSync(...a),
+  statSync: (...a: unknown[]) => mockStatSync(...a),
+}))
+
+describe('context', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('모듈을 import 할 수 있다', async () => {
+    const mod = await import('../src/commands/context.js')
+    expect(mod.context).toBeDefined()
+    expect(mod.contextShow).toBeDefined()
+  })
+
+  it('context — .vhk/context.md를 생성한다', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p).includes('package.json'))
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        name: 'test-pkg',
+        version: '1.2.3',
+        dependencies: { next: '15.0.0', typescript: '5.5.0' },
+        devDependencies: { vitest: '2.0.0' },
+      })
+    )
+    mockReaddirSync.mockReturnValue([])
+    mockStatSync.mockReturnValue({ isDirectory: () => false })
+
+    const { context } = await import('../src/commands/context.js')
+    await context()
+
+    expect(mockMkdirSync).toHaveBeenCalledWith('.vhk', { recursive: true })
+    const call = mockWriteFileSync.mock.calls.find((c) =>
+      String(c[0]).includes('context.md')
+    )
+    expect(call).toBeDefined()
+    const md = String(call![1])
+    expect(md).toContain('# 프로젝트 컨텍스트')
+    expect(md).toContain('Next.js')
+    expect(md).toContain('TypeScript')
+    expect(md).toContain('vitest')
+    expect(md).toContain('test-pkg')
+    expect(md).toContain('1.2.3')
+    expect(md).toContain('vhk context')
+  })
+
+  it('context — node_modules / .git 등은 트리에서 제외', async () => {
+    mockExistsSync.mockReturnValue(false)
+    mockReadFileSync.mockReturnValue('{}')
+    mockReaddirSync.mockImplementation((dir: unknown) => {
+      if (dir === '.') return ['src', 'node_modules', '.git', 'package.json']
+      return []
+    })
+    mockStatSync.mockImplementation((p: unknown) => ({
+      isDirectory: () => String(p) === 'src' || String(p).endsWith('node_modules') || String(p).endsWith('.git'),
+    }))
+
+    const { context } = await import('../src/commands/context.js')
+    await context()
+
+    const call = mockWriteFileSync.mock.calls.find((c) =>
+      String(c[0]).includes('context.md')
+    )
+    const md = String(call![1])
+    expect(md).toContain('src')
+    expect(md).not.toContain('node_modules/')
+    expect(md).not.toContain('.git/')
+  })
+
+  it('contextShow — 파일 없으면 안내만, readFileSync 호출 X', async () => {
+    mockExistsSync.mockReturnValue(false)
+    const { contextShow } = await import('../src/commands/context.js')
+    await contextShow()
+    expect(mockReadFileSync).not.toHaveBeenCalled()
+  })
+
+  it('contextShow — 파일 있으면 내용을 출력한다', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue('# 컨텍스트\n\n내용')
+    const logSpy = vi.spyOn(console, 'log')
+    const { contextShow } = await import('../src/commands/context.js')
+    await contextShow()
+    const joined = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+    expect(joined).toContain('# 컨텍스트')
+  })
+})

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockExistsSync = vi.fn()
+const mockReadFileSync = vi.fn()
+const mockWriteFileSync = vi.fn()
+const mockMkdirSync = vi.fn()
+
+vi.mock('node:fs', () => ({
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
+  readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
+  writeFileSync: (...a: unknown[]) => mockWriteFileSync(...a),
+  mkdirSync: (...a: unknown[]) => mockMkdirSync(...a),
+}))
+
+describe('memory', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('모듈을 import 할 수 있다', async () => {
+    const mod = await import('../src/commands/memory.js')
+    expect(mod.memoryAdd).toBeDefined()
+    expect(mod.memoryList).toBeDefined()
+    expect(mod.memoryRemove).toBeDefined()
+  })
+
+  it('memoryAdd — 빈 content면 쓰지 않음', async () => {
+    const { memoryAdd } = await import('../src/commands/memory.js')
+    await memoryAdd('')
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
+  })
+
+  it('memoryAdd — 새 content면 .vhk/memory.json에 추가', async () => {
+    mockExistsSync.mockReturnValue(false)
+    const { memoryAdd } = await import('../src/commands/memory.js')
+    await memoryAdd('API는 tRPC 사용', ['decision', 'arch'])
+
+    expect(mockMkdirSync).toHaveBeenCalledWith('.vhk', { recursive: true })
+    const call = mockWriteFileSync.mock.calls[0]
+    expect(String(call[0])).toContain('memory.json')
+    const data = JSON.parse(String(call[1]))
+    expect(data).toHaveLength(1)
+    expect(data[0].content).toBe('API는 tRPC 사용')
+    expect(data[0].tags).toEqual(['decision', 'arch'])
+    expect(data[0].addedAt).toBeDefined()
+  })
+
+  it('memoryAdd — 기존 항목에 append', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify([{ content: '기존', addedAt: '2026-01-01', tags: [] }])
+    )
+    const { memoryAdd } = await import('../src/commands/memory.js')
+    await memoryAdd('새 결정')
+
+    const data = JSON.parse(String(mockWriteFileSync.mock.calls[0][1]))
+    expect(data).toHaveLength(2)
+    expect(data[0].content).toBe('기존')
+    expect(data[1].content).toBe('새 결정')
+  })
+
+  it('memoryList — 항목 0이면 안내만, read 호출 X', async () => {
+    mockExistsSync.mockReturnValue(false)
+    const { memoryList } = await import('../src/commands/memory.js')
+    await memoryList()
+    expect(mockReadFileSync).not.toHaveBeenCalled()
+  })
+
+  it('memoryList — 항목 출력', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify([
+        { content: 'A', addedAt: '2026-01-01T00:00:00.000Z', tags: [] },
+        { content: 'B', addedAt: '2026-02-01T00:00:00.000Z', tags: ['db'] },
+      ])
+    )
+    const logSpy = vi.spyOn(console, 'log')
+    const { memoryList } = await import('../src/commands/memory.js')
+    await memoryList()
+    const joined = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+    expect(joined).toContain('A')
+    expect(joined).toContain('B')
+    expect(joined).toContain('db')
+  })
+
+  it('memoryRemove — 유효하지 않은 인덱스면 쓰지 않음', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify([{ content: 'A', addedAt: '2026-01-01', tags: [] }])
+    )
+    const { memoryRemove } = await import('../src/commands/memory.js')
+    await memoryRemove('99')
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
+  })
+
+  it('memoryRemove — 유효한 인덱스면 삭제 후 저장', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify([
+        { content: 'A', addedAt: '2026-01-01', tags: [] },
+        { content: 'B', addedAt: '2026-02-01', tags: [] },
+      ])
+    )
+    const { memoryRemove } = await import('../src/commands/memory.js')
+    await memoryRemove('1')
+
+    const data = JSON.parse(String(mockWriteFileSync.mock.calls[0][1]))
+    expect(data).toHaveLength(1)
+    expect(data[0].content).toBe('B')
+  })
+})

--- a/tests/nlp-router.test.ts
+++ b/tests/nlp-router.test.ts
@@ -149,4 +149,36 @@ describe('자연어 라우팅', () => {
   it('"vhk 업데이트 해줘" → update', () => {
     expect(routeNaturalLanguage('vhk 업데이트 해줘')?.command).toBe('update')
   })
+
+  it('"맥락 만들어줘" → context', () => {
+    expect(routeNaturalLanguage('맥락 만들어줘')?.command).toBe('context')
+  })
+
+  it('"컨텍스트 보여줘" → context-show', () => {
+    expect(routeNaturalLanguage('컨텍스트 보여줘')?.command).toBe('context-show')
+  })
+
+  it('"맥락 보여줘" → context-show (context 아님)', () => {
+    expect(routeNaturalLanguage('맥락 보여줘')?.command).toBe('context-show')
+  })
+
+  it('"기억 목록" → memory', () => {
+    expect(routeNaturalLanguage('기억 목록')?.command).toBe('memory')
+  })
+
+  it('"기억 추가해줘" → null (NL 배제)', () => {
+    expect(routeNaturalLanguage('기억 추가해줘')).toBeNull()
+  })
+
+  it('"프로젝트 브리핑 만들어줘" → brief', () => {
+    expect(routeNaturalLanguage('프로젝트 브리핑 만들어줘')?.command).toBe('brief')
+  })
+
+  it('"상태 요약 보여줘" → brief', () => {
+    expect(routeNaturalLanguage('상태 요약 보여줘')?.command).toBe('brief')
+  })
+
+  it('"오늘 한 일 정리" → recap (brief 아님)', () => {
+    expect(routeNaturalLanguage('오늘 한 일 정리')?.command).toBe('recap')
+  })
 })


### PR DESCRIPTION
## Summary
v1.0.0 GA. AI 맥락 엔진 3 명령 추가 + 공개 API 안정성 약속.

### 신규 명령
- **`vhk context`** (`맥락`) — 트리(3-depth) + 기술 스택 자동 감지 + 29+ VHK 명령 목록 → `.vhk/context.md` 마크다운. AI 어시스턴트용
- **`vhk context-show`** (`맥락보기`) — 컨텍스트 파일 출력
- **`vhk memory add|list|remove`** (`기억`) — `.vhk/memory.json` 결정사항 + 태그. NL은 list만 (add/remove 인자 필수)
- **`vhk brief`** (`브리핑`) — 프로젝트 정보 + git 상태 + 결정사항 + 레퍼런스 통합 → `.vhk/brief.md`. `safeExecFile` 기반 (v0.9 review 피드백 반영)

자연어 9건 신규 + `nlp-router` init 룰에 v1.0 키워드 negation guard 추가.

### GA 약속 (v2.0까지)
- 명령어 이름, CLI 인자, `.vhk/` 파일 포맷 breaking change 없음
- deprecation 절차: 1개 마이너 버전에서 경고 → 다음 메이저에서 제거
- i18n 키 누적만, 기존 키 미제거
- MCP 8 도구 인터페이스 안정

### `vhk memory` vs Claude Code `auto memory` 구분
- `vhk memory` = 프로젝트 단위 (`.vhk/memory.json`, 팀 공유)
- `auto memory` = 사용자 단위 (`~/.claude/...`, 개인)

## Test plan

- [x] vitest 223/223 (이전 197 + 신규 26)
  - context 5 + memory 8 + brief 5 + nlp-router 8 신규
- [x] `pnpm build` 통과 (tsup + dts)
- [x] `node dist/index.js --help` 30 명령어 노출
- [x] `node dist/index.js context` — `.vhk/context.md` 생성 + 기술 스택 8개 감지
- [x] `node dist/index.js brief` — 보고서 출력
- [x] NL: `"맥락 만들어줘"` → context, `"컨텍스트 보여줘"` → context-show, `"기억 목록"` → memory, `"프로젝트 브리핑 만들어줘"` → brief
- [x] `"기억 추가해줘"` → null (NL 배제 가드)
- [ ] PR 머지 후 main: `pnpm run prepublishOnly && npm publish --access public` (OTP 필요) → `git tag v1.0.0 && git push --tags`

## Plan
docs/superpowers/plans/2026-05-24-v1.0.0-context-memory-brief-ga.md