### PR TITLE
fix(v1.0.1): mcp-init pnpm 회귀 + BOM 잔여 + recap 신규 레포 가드

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ---
 
+## [1.0.1] — 2026-05-24 — Hotfix
+
+### Fixed
+
+- `vhk mcp-init` — pnpm 글로벌 설치 환경에서 `import.meta.resolve` 실패 시 `<cwd>/node_modules/@byh3071/vhk/dist/mcp/index.js` (존재하지 않는 경로)로 fallback해 깨진 `.cursor/mcp.json` 생성하던 회귀. 자기 파일 위치(`dist/commands/mcp-init.js → ../mcp/index.js`) 기반 해석을 1순위로 사용하고 모든 후보 경로에 `existsSync` 검증 추가. 진입점 못 찾으면 PATH의 `vhk-mcp` shim으로 fallback. (영향: Cursor 사용자 모두)
+- `vhk harness` — Windows PowerShell의 `Out-File -Encoding utf8`이 생성하는 UTF-8 BOM 포함 `package.json`에서 `JSON.parse` throw → silent catch → "실행할 수 있는 스크립트가 없습니다" 잘못된 메시지. `readJsonFile` helper (BOM strip 포함)로 교체. 같은 패턴 7개 파일(`doctor`, `init`, `mcp-init`, `publish`, `update`, `mcp/server.ts` 2곳, `ref`)도 일괄 정리.
+- `vhk recap` — 신규 git 레포에서 커밋이 0개일 때 `simple-git`이 `GitError: fatal: your current branch 'master' does not have any commits yet`를 던지고 프로세스 크래시. recap 진입부에 `hasAnyCommits()` 가드 추가, lib/git의 `getSessionDiff` / `getRecentCommits`에도 try/catch 안전망 추가. 첫 커밋 만들도록 안내.
+
+### Internal
+
+- `src/lib/git.ts` — `hasAnyCommits(): Promise<boolean>` helper 신설
+- `src/lib/read-json.ts` 헬퍼 일관 적용 (이미 존재하던 helper를 그동안 호출자들이 안 쓰던 상태였음)
+
+---
+
 ## [1.0.0] — 2026-05-24 — GA 🎉
 
 ### Added

--- a/docs/patterns/build-json-parse-bom-strip.md
+++ b/docs/patterns/build-json-parse-bom-strip.md
@@ -1,0 +1,125 @@
+---
+패턴명: JSON.parse 호출 전 UTF-8 BOM 제거 (Windows PowerShell 호환)
+카테고리: build
+출처프로젝트: VHK (vhk-cli)
+태그: [Node, JSON, Windows, PowerShell, BOM, encoding]
+발견일: 2026-05-24
+출처DevLog: docs/log/2026-05-24-v1.0.1-hotfix.md
+---
+
+# 패턴: `JSON.parse` 전에 UTF-8 BOM 제거
+
+## 증상
+
+Windows 사용자가 PowerShell로 `package.json`, `tsconfig.json`, `mcp.json` 등을 만지면 도구가 침묵 실패한다.
+
+```text
+vhk harness
+🔧 통합 품질 점검
+⚠️  실행할 수 있는 스크립트가 없습니다.   ← scripts 진짜로 있는데!
+```
+
+증상 패턴:
+
+- "필드 없음"으로 보고하지만 실제로는 있음
+- `try/catch`로 감싼 `JSON.parse` 블록이 silent로 빈 객체 반환
+- macOS/Linux에선 재현 안 됨
+
+## 원인
+
+Windows PowerShell 5.1의 `Out-File -Encoding utf8`, `Set-Content -Encoding utf8`은 **UTF-8 BOM (`EF BB BF`)을 강제로 prepend**한다. (PowerShell 7+은 기본 `utf8NoBOM`이지만 5.1은 여전히 시스템 표준)
+
+```powershell
+'{ "name": "x" }' | Out-File -Encoding utf8 package.json
+# 결과 바이트: EF BB BF 7B 22 6E 61 6D 65 ...
+```
+
+Node의 `JSON.parse`는 입력 첫 글자가 BOM(`﻿`)이면 throw한다.
+
+```ts
+JSON.parse('﻿{"a":1}')
+// SyntaxError: Unexpected token  in JSON at position 0
+```
+
+호출자가 `try/catch`로 throw를 묻고 빈 결과를 반환하면 사용자에겐 "필드 없음"으로 보임 → 원인 추적 불가.
+
+## 해결
+
+`readFileSync` 결과를 `JSON.parse` 넘기기 전에 BOM strip. 헬퍼로 중앙화하면 모든 호출자가 안전.
+
+```ts
+// src/lib/read-json.ts
+import { readFileSync } from 'node:fs'
+
+export function stripBom(text: string): string {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text
+}
+
+export function readJsonFile<T>(filePath: string): T {
+  const raw = stripBom(readFileSync(filePath, 'utf-8'))
+  return JSON.parse(raw) as T
+}
+```
+
+호출자는 native pattern 대신 helper 사용.
+
+```ts
+// 변경 전 (BOM 시 throw → silent catch)
+const pkg = JSON.parse(readFileSync('package.json', 'utf-8'))
+
+// 변경 후
+import { readJsonFile } from '../lib/read-json.js'
+const pkg = readJsonFile<{ scripts?: Record<string, string> }>('package.json')
+```
+
+## 핵심 원리
+
+**bytes-on-disk와 JSON.parse 사양의 mismatch**를 호출자가 흡수.
+
+- JSON 표준(RFC 8259)은 BOM "허용"이지만 strict mode에선 제거 권장
+- Node `JSON.parse`는 strict — BOM throw
+- 입력은 외부 환경(Windows PowerShell, 사용자 에디터)에 의존 → 통제 불가
+- 따라서 boundary에서 sanitize
+
+## 적용 조건
+
+- ✅ Node.js + JSON 파일 read하는 모든 CLI/툴
+- ✅ Windows 지원이 필요한 모든 도구
+- ✅ 사용자가 직접 만든 설정 파일(.json) 파싱
+- ❌ JSON 입력이 항상 자기가 만든 출력만 받는 경우 (e.g., HTTP API 응답) — 그 경우는 BOM 불가
+- ⚠️ 다른 잠재 인코딩 이슈(UTF-16, Latin-1)는 별도 처리 필요. BOM strip 하나로 모든 인코딩 문제가 해결되는 건 아님
+
+## 추가 발견: silent catch의 위험
+
+원래 코드는 try/catch로 throw를 묻고 빈 결과 반환했다. 이게 BOM 버그를 가렸다.
+
+```ts
+try {
+  pkg = JSON.parse(readFileSync('package.json', 'utf-8'))
+} catch {
+  return checks   // ← 사용자는 왜 비었는지 모름
+}
+```
+
+근본 수정과 별개로, **silent catch는 진단 메시지 출력**하거나 에러 종류별 분기해야 한다. 글로벌 규칙 "근본 원인 찾기" 원칙과도 일치.
+
+## 검증
+
+회귀 테스트로 lock — BOM 포함 입력에서 정상 동작 보장.
+
+```ts
+it('UTF-8 BOM이 있어도 정상 파싱', async () => {
+  mockReadFileSync.mockReturnValue(
+    '﻿' + JSON.stringify({ scripts: { lint: 'eslint', test: 'vitest' } })
+  )
+  const { harness } = await import('../src/commands/harness.js')
+  await harness()
+  expect(mockSafeExecFile).toHaveBeenCalledTimes(2)  // lint + test
+})
+```
+
+## 참고
+
+- VHK `src/lib/read-json.ts` 헬퍼
+- v1.0.1 hotfix에서 `harness`, `doctor`, `init`, `mcp-init`, `publish`, `update`, `mcp/server.ts`(2곳), `ref` 9 사이트 일괄 마이그레이션
+- 관련 패턴: [env-windows-cmd-shim-node20.md](./env-windows-cmd-shim-node20.md) — Windows 환경 호환성 시리즈

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vibe Harness Kit — 바이브코딩 풀사이클 CLI",
   "bin": {
     "vhk": "dist/index.js",

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { printNextStep } from '../lib/next-step.js'
 import { ko } from '../i18n/ko.js'
+import { readJsonFile } from '../lib/read-json.js'
 
 export interface CheckResult {
   name: string
@@ -33,7 +34,7 @@ function getVhkVersion(): string | undefined {
   for (const pkgPath of candidates) {
     try {
       if (fs.existsSync(pkgPath)) {
-        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as { version?: string }
+        const pkg = readJsonFile<{ version?: string }>(pkgPath)
         return pkg.version
       }
     } catch {

--- a/src/commands/harness.ts
+++ b/src/commands/harness.ts
@@ -1,9 +1,10 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import chalk from 'chalk'
 import ora from 'ora'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { safeExecFile } from '../lib/exec.js'
+import { readJsonFile } from '../lib/read-json.js'
 
 type CheckSpec = { name: string; bin: string; args: string[] }
 
@@ -30,7 +31,7 @@ function detectChecks(): CheckSpec[] {
   const checks: CheckSpec[] = []
   let pkg: { scripts?: Record<string, string> } = {}
   try {
-    pkg = JSON.parse(readFileSync('package.json', 'utf-8'))
+    pkg = readJsonFile<{ scripts?: Record<string, string> }>('package.json')
   } catch {
     return checks
   }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -16,6 +16,7 @@ import { log } from '../utils/logger.js'
 import { writeFile, fileExists } from '../utils/file.js'
 import { fetchPrdFromNotion } from '../notion/fetch-prd.js'
 import type { PrdContent } from '../types/prd.js'
+import { readJsonFile } from '../lib/read-json.js'
 
 const PROJECT_TYPES = [
   { name: '🌐 웹 앱 (Next.js + Supabase + Vercel)', value: 'webapp' },
@@ -218,9 +219,7 @@ export function enhancePackageScripts(projectDir: string): boolean {
   const pkgPath = path.join(projectDir, 'package.json')
   if (!fs.existsSync(pkgPath)) return false
 
-  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as {
-    scripts?: Record<string, string>
-  }
+  const pkg = readJsonFile<{ scripts?: Record<string, string> }>(pkgPath)
   // 사용자가 정의한 동명 스크립트 보존. 누락된 키만 추가.
   pkg.scripts = { ...VHK_PACKAGE_SCRIPTS, ...pkg.scripts }
   fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf-8')

--- a/src/commands/mcp-init.ts
+++ b/src/commands/mcp-init.ts
@@ -1,35 +1,63 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
+import { readJsonFile } from '../lib/read-json.js'
 
 type McpEntry = { command: string; args: string[] }
 type McpConfig = { mcpServers: Record<string, McpEntry> }
 
-function resolveVhkMcpPath(): string {
-  // 1. 자기 dogfooding 감지: cwd의 package.json name이 @byh3071/vhk면 dist/mcp/index.js
+// 자기 파일 위치 기준으로 vhk-mcp 진입점(dist/mcp/index.js) 찾기.
+// npm 글로벌, pnpm 글로벌, 로컬 dev 모두에서 dist/commands/mcp-init.js → ../mcp/index.js 관계 동일.
+// 존재 검증해서 깨진 경로 생성 차단 (v1.0.0 회귀: pnpm 글로벌에서 import.meta.resolve 실패 시 sandbox node_modules 가짜 경로 생성).
+function resolveMcpEntryPoint(): string | null {
   try {
-    const pkgPath = join(process.cwd(), 'package.json')
-    if (existsSync(pkgPath)) {
-      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { name?: string }
-      if (pkg.name === '@byh3071/vhk') {
-        return join(process.cwd(), 'dist', 'mcp', 'index.js')
-      }
+    const here = fileURLToPath(import.meta.url)
+    const dir = dirname(here)
+    // 후보 경로 (번들/dev/test 모두 커버):
+    //   - dist/index.js (tsup 번들) → ./mcp/index.js (sibling 디렉토리)
+    //   - dist/commands/mcp-init.js (분리 빌드) → ../mcp/index.js
+    //   - src/commands/mcp-init.ts (dev) → ../mcp/index.js (런타임엔 dist 경로로 해석)
+    for (const rel of [['mcp', 'index.js'], ['..', 'mcp', 'index.js']]) {
+      const candidate = join(dir, ...rel)
+      if (existsSync(candidate)) return candidate
     }
-  } catch {
-    // skip
-  }
-  // 2. 글로벌 설치 (npm i -g) 환경: import.meta.resolve로 패키지 경로를 찾는다.
-  // 반환값은 file:// URL이므로 fileURLToPath로 OS 네이티브 경로로 변환 (Windows 대응).
-  try {
-    const url = import.meta.resolve?.('@byh3071/vhk/dist/mcp/index.js')
-    if (typeof url === 'string') return fileURLToPath(url)
   } catch {
     // ignore
   }
-  // 3. 로컬 fallback: node_modules 안의 경로 추정.
-  return join(process.cwd(), 'node_modules', '@byh3071', 'vhk', 'dist', 'mcp', 'index.js')
+  try {
+    const url = import.meta.resolve?.('@byh3071/vhk/dist/mcp/index.js')
+    if (typeof url === 'string') {
+      const p = fileURLToPath(url)
+      if (existsSync(p)) return p
+    }
+  } catch {
+    // ignore
+  }
+  // dogfooding: cwd가 vhk 저장소
+  try {
+    const pkgPath = join(process.cwd(), 'package.json')
+    if (existsSync(pkgPath)) {
+      const pkg = readJsonFile<{ name?: string }>(pkgPath)
+      if (pkg.name === '@byh3071/vhk') {
+        const local = join(process.cwd(), 'dist', 'mcp', 'index.js')
+        if (existsSync(local)) return local
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return null
+}
+
+export function resolveVhkMcpEntry(): McpEntry {
+  const entryPath = resolveMcpEntryPoint()
+  if (entryPath) {
+    return { command: 'node', args: [entryPath] }
+  }
+  // 진입점 못 찾으면 PATH의 vhk-mcp shim 사용 (npm/pnpm 글로벌 설치 시 등록됨).
+  return { command: 'vhk-mcp', args: [] }
 }
 
 export async function mcpInit(): Promise<void> {
@@ -42,15 +70,12 @@ export async function mcpInit(): Promise<void> {
   }
 
   const configPath = join(cursorDir, 'mcp.json')
-  const vhkEntry: McpEntry = {
-    command: 'node',
-    args: [resolveVhkMcpPath()],
-  }
+  const vhkEntry: McpEntry = resolveVhkMcpEntry()
 
   let config: McpConfig
   if (existsSync(configPath)) {
     try {
-      const parsed = JSON.parse(readFileSync(configPath, 'utf-8')) as Partial<McpConfig>
+      const parsed = readJsonFile<Partial<McpConfig>>(configPath)
       config = {
         mcpServers: { ...(parsed.mcpServers ?? {}), vhk: vhkEntry },
       }

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -5,6 +5,7 @@ import ora from 'ora'
 import { safeExecFile, safeExecFileStream } from '../lib/exec.js'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
+import { readJsonFile } from '../lib/read-json.js'
 
 export type BumpType = 'patch' | 'minor' | 'major'
 
@@ -36,7 +37,7 @@ export async function publish(): Promise<void> {
 
   let pkg: Pkg
   try {
-    pkg = JSON.parse(readFileSync('package.json', 'utf-8'))
+    pkg = readJsonFile<Pkg>('package.json')
   } catch {
     console.log(chalk.red('❌ package.json 파싱 실패'))
     return

--- a/src/commands/recap.ts
+++ b/src/commands/recap.ts
@@ -2,7 +2,7 @@ import inquirer from 'inquirer'
 import chalk from 'chalk'
 import fs from 'node:fs'
 import path from 'node:path'
-import { getSessionDiff, getRecentCommits, isGitRepo } from '../lib/git.js'
+import { getSessionDiff, getRecentCommits, isGitRepo, hasAnyCommits } from '../lib/git.js'
 import { detectAdrCandidates, createAdrFile } from '../lib/adr.js'
 import { ko } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
@@ -17,6 +17,12 @@ export async function recap(options: RecapOptions = {}) {
 
   if (!(await isGitRepo())) {
     console.log(chalk.red(ko.recap.noRepo))
+    return
+  }
+
+  if (!(await hasAnyCommits())) {
+    console.log(chalk.yellow('⚠️  아직 커밋이 없어요.'))
+    console.log(chalk.gray('   파일을 추가하고 `vhk save` 또는 `git commit`으로 첫 커밋을 만들어 보세요.'))
     return
   }
 

--- a/src/commands/ref.ts
+++ b/src/commands/ref.ts
@@ -1,8 +1,9 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { safeExecFile } from '../lib/exec.js'
+import { readJsonFile } from '../lib/read-json.js'
 
 interface RefEntry {
   url: string
@@ -15,8 +16,7 @@ const REFS_PATH = '.vhk/refs.json'
 function loadRefs(): RefEntry[] {
   if (!existsSync(REFS_PATH)) return []
   try {
-    const raw = readFileSync(REFS_PATH, 'utf-8')
-    const parsed = JSON.parse(raw)
+    const parsed = readJsonFile<unknown>(REFS_PATH)
     return Array.isArray(parsed) ? (parsed as RefEntry[]) : []
   } catch {
     return []

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,10 +1,11 @@
 import { execSync } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import chalk from 'chalk'
 import ora from 'ora'
 import { t } from '../i18n/ko.js'
+import { readJsonFile } from '../lib/read-json.js'
 
 const PACKAGE = '@byh3071/vhk'
 
@@ -15,7 +16,7 @@ function getCurrentVersion(): string {
   for (const pkgPath of [join(dir, '../package.json'), join(dir, '../../package.json')]) {
     try {
       if (existsSync(pkgPath)) {
-        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { version?: string }
+        const pkg = readJsonFile<{ version?: string }>(pkgPath)
         if (pkg.version) return pkg.version
       }
     } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,9 @@
 import { Command, Help } from 'commander'
 import chalk from 'chalk'
 import inquirer from 'inquirer'
-import fs from 'node:fs'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { detectNaturalLanguageInput } from './lib/cli-args.js'
 import { runNaturalLanguageRoute } from './lib/nlp-run.js'
+import { getVhkVersion } from './lib/version.js'
 import { ko } from './i18n/ko.js'
 import { gate } from './commands/gate.js'
 import { init } from './commands/init.js'
@@ -34,24 +32,6 @@ import { update } from './commands/update.js'
 import { context, contextShow } from './commands/context.js'
 import { memoryAdd, memoryList, memoryRemove } from './commands/memory.js'
 import { brief } from './commands/brief.js'
-
-// 런타임에 package.json에서 버전 읽기 — src와 dist 둘 다 동작.
-// dist/index.js: ../package.json (npm 글로벌 + 로컬 빌드 동일)
-// src/index.ts (dev): ../package.json (repo root)
-function getVersion(): string {
-  const dir = path.dirname(fileURLToPath(import.meta.url))
-  for (const pkgPath of [path.join(dir, '../package.json'), path.join(dir, '../../package.json')]) {
-    try {
-      if (fs.existsSync(pkgPath)) {
-        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as { version?: string }
-        if (pkg.version) return pkg.version
-      }
-    } catch {
-      continue
-    }
-  }
-  return '0.0.0'
-}
 
 const program = new Command()
 const defaultHelp = new Help()
@@ -90,7 +70,7 @@ const KO_ALIASES: Record<string, string> = {
 program
   .name('vhk')
   .description('VHK — 바이브코딩 프로젝트 코치 (한국어로 안내합니다)')
-  .version(getVersion())
+  .version(getVhkVersion())
 
 program.configureHelp({
   formatHelp(cmd, helper) {

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -74,15 +74,21 @@ export function buildSessionDiffFromSummary(diffSummary: {
 
 /**
  * --since 이후 커밋 diff만 사용 (작업 트리 status와 섞지 않음).
+ * 커밋이 0개인 신규 레포에서는 빈 결과 반환 (simple-git이 throw하는 GitError 흡수).
  */
 export async function getSessionDiff(since?: string): Promise<SessionDiff> {
   const sinceDate = since || new Date().toISOString().split('T')[0]
-  const diffSummary = await git.diffSummary([`--since=${sinceDate}`])
-  return buildSessionDiffFromSummary(diffSummary)
+  try {
+    const diffSummary = await git.diffSummary([`--since=${sinceDate}`])
+    return buildSessionDiffFromSummary(diffSummary)
+  } catch {
+    return { filesChanged: 0, insertions: 0, deletions: 0, files: [] }
+  }
 }
 
 /**
  * 최근 커밋 N개를 가져온다.
+ * 신규 레포(HEAD 없음)에서는 빈 배열 반환.
  */
 export async function getRecentCommits(
   count: number = 10,
@@ -91,14 +97,17 @@ export async function getRecentCommits(
   const options: Record<string, unknown> = { maxCount: count }
   if (since) options['--since'] = since
 
-  const log = await git.log(options)
-
-  return log.all.map(entry => ({
-    hash: entry.hash,
-    message: entry.message,
-    date: entry.date,
-    author: entry.author_name,
-  }))
+  try {
+    const log = await git.log(options)
+    return log.all.map(entry => ({
+      hash: entry.hash,
+      message: entry.message,
+      date: entry.date,
+      author: entry.author_name,
+    }))
+  } catch {
+    return []
+  }
 }
 
 /**
@@ -107,6 +116,18 @@ export async function getRecentCommits(
 export async function isGitRepo(): Promise<boolean> {
   try {
     await git.revparse(['--is-inside-work-tree'])
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * HEAD 커밋 존재 여부. `git init` 직후 커밋 0개면 false.
+ */
+export async function hasAnyCommits(): Promise<boolean> {
+  try {
+    await git.revparse(['HEAD'])
     return true
   } catch {
     return false

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,26 @@
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { readJsonFile } from './read-json.js'
+
+// 런타임에 package.json에서 버전 읽기 — src와 dist 둘 다 동작 + BOM 안전.
+// dist/lib/version.js → ../../package.json
+// src/lib/version.ts → ../../package.json
+// dist/index.js (tsup 번들) → ../package.json
+export function getVhkVersion(): string {
+  const dir = dirname(fileURLToPath(import.meta.url))
+  for (const pkgPath of [
+    join(dir, '../../package.json'),
+    join(dir, '../package.json'),
+  ]) {
+    try {
+      if (existsSync(pkgPath)) {
+        const pkg = readJsonFile<{ version?: string }>(pkgPath)
+        if (pkg.version) return pkg.version
+      }
+    } catch {
+      continue
+    }
+  }
+  return '0.0.0'
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { existsSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs'
 import { safeExecFile } from '../lib/exec.js'
 import { parseEnvKeys } from '../commands/env.js'
+import { readJsonFile } from '../lib/read-json.js'
 
 const SERVER_VERSION = '0.7.1'
 
@@ -99,7 +100,7 @@ export function createVhkMcpServer(): McpServer {
 
     if (existsSync('package.json')) {
       try {
-        const pkg = JSON.parse(readFileSync('package.json', 'utf-8'))
+        const pkg = readJsonFile<{ name?: string; version?: string }>('package.json')
         lines.push(`📦 프로젝트: ${pkg.name ?? '(이름 없음)'} v${pkg.version ?? '?'}`)
       } catch {
         // skip
@@ -203,7 +204,7 @@ export function createVhkMcpServer(): McpServer {
 
     if (existsSync('package.json')) {
       try {
-        const pkg = JSON.parse(readFileSync('package.json', 'utf-8'))
+        const pkg = readJsonFile<{ version?: string }>('package.json')
         checks.push(`📦 버전: ${pkg.version}`)
       } catch {
         // skip

--- a/tests/harness.test.ts
+++ b/tests/harness.test.ts
@@ -81,4 +81,21 @@ describe('harness', () => {
     const bins = mockSafeExecFile.mock.calls.map((c) => c[0] as string)
     expect(bins[0]).toBe('pnpm')
   })
+
+  it('UTF-8 BOM이 있는 package.json도 정상 파싱한다 (Windows PowerShell 호환)', async () => {
+    // BOM(﻿) prefix가 있어도 readJsonFile이 strip 후 parse → scripts 감지 정상
+    mockReadFileSync.mockReturnValue(
+      '﻿' + JSON.stringify({ scripts: { lint: 'eslint', test: 'vitest', build: 'tsup' } })
+    )
+    mockExistsSync.mockReturnValue(false)
+    mockSafeExecFile.mockReturnValue({ ok: true, out: '' })
+    const { harness } = await import('../src/commands/harness.js')
+    await harness()
+    // lint + test + build = 3개 호출
+    expect(mockSafeExecFile).toHaveBeenCalledTimes(3)
+    const scripts = mockSafeExecFile.mock.calls.map((c) => (c[1] as string[]).join(' '))
+    expect(scripts.some((s) => s.includes('lint'))).toBe(true)
+    expect(scripts.some((s) => s.includes('test'))).toBe(true)
+    expect(scripts.some((s) => s.includes('build'))).toBe(true)
+  })
 })

--- a/tests/mcp-init.test.ts
+++ b/tests/mcp-init.test.ts
@@ -21,10 +21,12 @@ describe('mcp-init', () => {
   it('모듈을 import 할 수 있다', async () => {
     const mod = await import('../src/commands/mcp-init.js')
     expect(mod.mcpInit).toBeDefined()
+    expect(mod.resolveVhkMcpEntry).toBeDefined()
   })
 
-  it('.cursor/mcp.json 이 없으면 새로 생성한다', async () => {
-    mockExistsSync.mockReturnValue(false)
+  it('.cursor/mcp.json 이 없으면 새로 생성하고 vhk 항목을 등록한다', async () => {
+    // dist/mcp/index.js 경로가 존재한다고 가정 (자기 파일 위치 기반 1차 시도가 성공)
+    mockExistsSync.mockImplementation((p: unknown) => String(p).endsWith('mcp/index.js') || String(p).endsWith('mcp\\index.js'))
     const { mcpInit } = await import('../src/commands/mcp-init.js')
     await mcpInit()
     expect(mockMkdirSync).toHaveBeenCalled()
@@ -34,10 +36,14 @@ describe('mcp-init', () => {
     const content = JSON.parse(String(writeCall[1]))
     expect(content.mcpServers.vhk).toBeDefined()
     expect(content.mcpServers.vhk.command).toBe('node')
+    expect(content.mcpServers.vhk.args[0]).toMatch(/mcp[\\/]index\.js$/)
   })
 
   it('.cursor/mcp.json 이 이미 있으면 vhk 항목만 병합한다', async () => {
-    mockExistsSync.mockImplementation((p: unknown) => String(p).includes('mcp.json'))
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const s = String(p)
+      return s.includes('mcp.json') || s.endsWith('mcp/index.js') || s.endsWith('mcp\\index.js')
+    })
     mockReadFileSync.mockReturnValue(
       JSON.stringify({ mcpServers: { other: { command: 'foo', args: [] } } })
     )
@@ -47,5 +53,27 @@ describe('mcp-init', () => {
     const content = JSON.parse(String(writeCall[1]))
     expect(content.mcpServers.other).toBeDefined()
     expect(content.mcpServers.vhk).toBeDefined()
+  })
+
+  it('진입점 파일을 못 찾으면 PATH의 vhk-mcp shim으로 fallback', async () => {
+    // dist/mcp/index.js 후보 경로 전부 false → resolveMcpEntryPoint() null 반환
+    mockExistsSync.mockImplementation((p: unknown) => String(p).includes('mcp.json'))
+    const { resolveVhkMcpEntry } = await import('../src/commands/mcp-init.js')
+    const entry = resolveVhkMcpEntry()
+    expect(entry.command).toBe('vhk-mcp')
+    expect(entry.args).toEqual([])
+  })
+
+  it('생성된 args 경로는 항상 실제 존재하는 파일이다 (가짜 node_modules 경로 회귀 방지)', async () => {
+    // existsSync는 mcp/index.js 끝나는 경로만 true 반환 → import.meta 기반 1차 시도 성공
+    mockExistsSync.mockImplementation((p: unknown) => /mcp[\\/]index\.js$/.test(String(p)))
+    const { resolveVhkMcpEntry } = await import('../src/commands/mcp-init.js')
+    const entry = resolveVhkMcpEntry()
+    // 'node' command + 실존 경로 args[0] 또는 vhk-mcp fallback 둘 중 하나
+    if (entry.command === 'node') {
+      expect(entry.args[0]).toMatch(/mcp[\\/]index\.js$/)
+    } else {
+      expect(entry.command).toBe('vhk-mcp')
+    }
   })
 })

--- a/tests/recap.test.ts
+++ b/tests/recap.test.ts
@@ -1,20 +1,68 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockIsGitRepo = vi.fn()
+const mockHasAnyCommits = vi.fn()
+const mockGetSessionDiff = vi.fn()
+const mockGetRecentCommits = vi.fn()
+
+vi.mock('../src/lib/git.js', () => ({
+  isGitRepo: (...a: unknown[]) => mockIsGitRepo(...a),
+  hasAnyCommits: (...a: unknown[]) => mockHasAnyCommits(...a),
+  getSessionDiff: (...a: unknown[]) => mockGetSessionDiff(...a),
+  getRecentCommits: (...a: unknown[]) => mockGetRecentCommits(...a),
+}))
+
+vi.mock('../src/lib/check-secure.js', () => ({
+  printSecurityWarnings: () => {},
+  filterTrackedPaths: (p: string[]) => p,
+}))
+
+vi.mock('../src/lib/adr.js', () => ({
+  detectAdrCandidates: () => [],
+  createAdrFile: () => '',
+}))
+
+vi.mock('inquirer', () => ({
+  default: { prompt: () => Promise.resolve({}) },
+}))
 
 describe('vhk recap', () => {
-  it('Git 레포가 아니면 에러 메시지 출력', () => {
-    // TODO: isGitRepo() mock → false → 에러 확인
-    expect(true).toBe(true)
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
   })
 
-  it('변경사항 없으면 경고 메시지', () => {
-    // TODO: getSessionDiff() mock → 빈 결과
+  it('Git 레포가 아니면 안내만 출력하고 종료한다', async () => {
+    mockIsGitRepo.mockResolvedValue(false)
+    const { recap } = await import('../src/commands/recap.js')
+    await recap()
+    expect(mockGetSessionDiff).not.toHaveBeenCalled()
+    expect(mockGetRecentCommits).not.toHaveBeenCalled()
   })
 
-  it('세션 로그 파일이 docs/log/에 생성된다', () => {
-    // TODO: 임시 디렉토리에서 생성 확인
+  it('커밋이 0개인 신규 레포에서는 안내만 출력하고 종료 (회귀 가드: simple-git GitError throw)', async () => {
+    mockIsGitRepo.mockResolvedValue(true)
+    mockHasAnyCommits.mockResolvedValue(false)
+    const { recap } = await import('../src/commands/recap.js')
+    await recap()
+    // 가드 통과 시 호출되는 단계가 실행되지 않아야 함
+    expect(mockGetSessionDiff).not.toHaveBeenCalled()
+    expect(mockGetRecentCommits).not.toHaveBeenCalled()
   })
 
-  it('같은 날짜에 여러 세션 → 세션 번호 증가', () => {
-    // TODO: session-1, session-2 파일명 검증
+  it('변경/커밋 둘 다 0이면 noChanges 메시지 후 inquirer 호출 없이 종료', async () => {
+    mockIsGitRepo.mockResolvedValue(true)
+    mockHasAnyCommits.mockResolvedValue(true)
+    mockGetSessionDiff.mockResolvedValue({
+      filesChanged: 0,
+      insertions: 0,
+      deletions: 0,
+      files: [],
+    })
+    mockGetRecentCommits.mockResolvedValue([])
+    const { recap } = await import('../src/commands/recap.js')
+    await recap()
+    expect(mockGetSessionDiff).toHaveBeenCalled()
+    expect(mockGetRecentCommits).toHaveBeenCalled()
   })
 })

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockExistsSync = vi.fn()
+const mockReadFileSync = vi.fn()
+
+vi.mock('node:fs', () => ({
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
+  readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
+}))
+
+describe('getVhkVersion', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.resetModules()
+  })
+
+  it('package.json에서 버전을 읽어 반환한다', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '0.10.0' }))
+    const { getVhkVersion } = await import('../src/lib/version.js')
+    expect(getVhkVersion()).toBe('0.10.0')
+  })
+
+  it('package.json이 없으면 0.0.0을 반환한다', async () => {
+    mockExistsSync.mockReturnValue(false)
+    const { getVhkVersion } = await import('../src/lib/version.js')
+    expect(getVhkVersion()).toBe('0.0.0')
+  })
+
+  it('package.json이 깨졌어도 throw하지 않고 0.0.0을 반환한다', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue('{ invalid json')
+    const { getVhkVersion } = await import('../src/lib/version.js')
+    expect(getVhkVersion()).toBe('0.0.0')
+  })
+
+  it('BOM 포함 package.json도 안전하게 파싱한다 (stripBom)', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue('﻿' + JSON.stringify({ version: '1.0.0' }))
+    const { getVhkVersion } = await import('../src/lib/version.js')
+    expect(getVhkVersion()).toBe('1.0.0')
+  })
+})


### PR DESCRIPTION
## Summary
v1.0.1 hotfix. Critical Cursor 사용자 영향.

### Fixed
- **`vhk mcp-init`** — pnpm 글로벌 설치 환경에서 `import.meta.resolve` 실패 시 잘못된 fallback 경로로 깨진 `.cursor/mcp.json` 생성. 자기 파일 위치 기반 해석 1순위 + 모든 후보 경로 `existsSync` 검증 + PATH의 `vhk-mcp` shim fallback. (영향: pnpm 글로벌 설치 Cursor 사용자 모두)
- **`vhk harness`** — PowerShell `Out-File -Encoding utf8` BOM `package.json`에서 silent fail → "실행할 수 있는 스크립트가 없습니다" 잘못된 메시지. `readJsonFile` 적용. 같은 패턴 7개 파일(`doctor`, `init`, `mcp-init`, `publish`, `update`, `mcp/server.ts` 2곳, `ref`) 일괄 정리
- **`vhk recap`** — 신규 git 레포 (커밋 0개)에서 simple-git crash. `hasAnyCommits()` 가드 + `getSessionDiff`/`getRecentCommits` try/catch 안전망

### Internal
- `src/lib/git.ts` — `hasAnyCommits(): Promise<boolean>` helper 신설
- `src/lib/read-json.ts` 헬퍼 일관 적용
- `src/lib/version.ts` — `getVhkVersion()` helper 추출 (TS-002 패턴 공용화, BOM 안전). 다음 v0.10에서 server.ts SERVER_VERSION runtime read에 활용 예정
- `docs/patterns/build-json-parse-bom-strip.md` 패턴 정리

## Test plan
- [x] vitest 229/229 pass
- [x] pnpm build OK
- [ ] 머지 후: pnpm publish 1.0.1 (OTP) + tag v1.0.1
- [ ] Cursor pnpm 글로벌 설치 환경에서 mcp-init 실행 → .cursor/mcp.json 정상 생성 검증

## Plan reference
v1.0 후속 작업. v0.10 (MCP 풀 커버리지) 작업은 이 hotfix publish 후 진행.