### PR TITLE
feat(goals): vspec 패턴 차용 goals/ 구조 도입 (v1.1 Phase 2.5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 dist/
 *.tsbuildinfo
 .DS_Store
+
+# VHK runtime tripwire — local-only, never commit
+.vhk/HARD_STOP

--- a/.vhk/README.md
+++ b/.vhk/README.md
@@ -1,0 +1,20 @@
+# `.vhk/` — VHK runtime state
+
+이 디렉토리는 VHK 의 로컬 런타임 신호용. 커밋되는 파일과 커밋되지 않는
+파일이 섞여 있다.
+
+## 트래킹 정책
+
+| 파일 | 트래킹 | 용도 |
+| --- | --- | --- |
+| `README.md` | ✅ | 본 안내 |
+| `HARD_STOP` | ❌ (로컬 only) | 존재하면 모든 자동화 즉시 중단. `vhk resume --confirm` 으로만 해제. |
+
+## HARD_STOP 규칙
+
+- 다음 조건에서 자동 생성:
+  - 블로커 3 개 누적 (`docs/state/blockers.md`)
+  - 토큰 예산 초과 감지 (옵션)
+- 해제: `vhk resume --confirm` (사람이 직접 실행, 자동 호출 금지)
+- 게이트 스크립트 (`scripts/check-*.sh`) 는 시작 시 이 파일을 검사하고
+  존재하면 exit 1 한다.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ### Added
 
+- **goals/ 구조 (v1.1 Phase 2.5)** — vspec/vooster 패턴 dogfooding:
+  - `goals/_meta.md` — 공통 게이트 (typecheck/tests/build) 정의
+  - `goals/0-mcp-full-coverage.md` — MCP 풀 커버리지 (10→24 tool) 미션 명세
+  - `goals/1-goal-command.md` — v1.2 `vhk goal init/list/next/check/done` 명세
+  - `goals/2-agent-loop.md` — v1.3 자율 루프 (`blocker/learn/resume`) 명세
+  - `scripts/check-meta.sh` + `scripts/check-goal-0.sh` — 게이트 검증
+  - `docs/state/{next-task,blockers,learnings}.md` — 상태 머신 SoT
+  - `.vhk/HARD_STOP` 안전장치 규칙 + `CLAUDE.md` Safety 섹션
 - `vhk start` (한국어 alias `시작`, `새프로젝트`) — 새 프로젝트 시작 올인원 마법사. 4단계 자동 진행:
   1. `git init` — 이미 repo면 스킵
   2. `vhk init` — `--skip-gate` 자동 적용, 문서/하네스 파일 생성

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,3 +32,20 @@ tags: [process, documentation]
 
 ## 종료 전 체크리스트
 1. ADR 2. 작업 로그 3. 트러블슈팅 4. TIL 5. /done
+
+## Safety — HARD_STOP
+
+- 매 작업 시작 시: `.vhk/HARD_STOP` 파일 존재 여부 확인. 존재하면 모든 자동화 즉시 중단.
+  - PowerShell: `if (Test-Path .vhk/HARD_STOP) { Write-Host '🛑 HARD STOP'; exit 1 }`
+  - bash: `[ -f .vhk/HARD_STOP ] && echo "🛑 HARD STOP" && exit 1`
+- 자동 생성 조건: 블로커 3 개 누적 (`docs/state/blockers.md`) / 토큰 예산 초과 감지
+- 해제: `vhk resume --confirm` 만 가능 (사람이 직접 실행, 자동 호출 금지)
+- 게이트 스크립트 (`scripts/check-*.sh`) 는 시작 시 이 파일을 검사한다
+- `.vhk/HARD_STOP` 자체는 `.gitignore` 에 등록되어 로컬 전용 신호로 동작
+
+## Goals / State 체계 (v1.1+)
+
+- 단계별 미션은 `goals/<n>-<name>.md` (YAML frontmatter + 표준 섹션)
+- 공통 게이트는 `goals/_meta.md` + `scripts/check-meta.sh`
+- 현재 상태 SoT 는 `docs/state/next-task.md` / `blockers.md` / `learnings.md`
+- 자세한 규약은 `goals/_meta.md` 와 `goals/0-mcp-full-coverage.md` 참조

--- a/docs/state/blockers.md
+++ b/docs/state/blockers.md
@@ -1,0 +1,4 @@
+# Blockers
+
+_Append-only. 해결된 항목은 삭제하지 말고 ~~취소선~~으로 표기._
+_Format: `- [YYYY-MM-DD goal-N] 짧은 증상 — 시도한 것 — 현재 상태.`_

--- a/docs/state/learnings.md
+++ b/docs/state/learnings.md
@@ -1,0 +1,6 @@
+# Learnings
+
+_Append-only. 한 줄 = 한 교훈. iteration 시작 시 전체 파일이 컨텍스트에 들어감._
+_Format: `- [YYYY-MM-DD goal-N] 한 줄 교훈.`_
+
+- [2026-05-27 _meta] goals/ 구조는 vspec/vooster 패턴을 차용. 단일 패키지 VHK 에 맞춰 _meta 게이트는 tsc + vitest + tsup build 3 개로 축소. lint 는 미설정 상태 — 도입 시 _meta 에 M.4 로 추가.

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -1,0 +1,12 @@
+# Next Task
+
+_수동 갱신. 자동화는 Goal 1 의 `vhk goal next` 도입 후 활성화._
+
+```
+TASK: Goal 0 — MCP 풀 커버리지 시작
+  - 다음 후보 tool 1 개 선택 (gate / init / sync 중)
+  - src/commands/<x>.ts 의 함수 시그니처 확인
+  - server.ts 에 registerTool 추가 + tests/ 에 단위 테스트
+  - bash scripts/check-goal-0.sh 통과 확인
+  - 작은 커밋: feat(mcp): expose <tool> tool
+```

--- a/goals/0-mcp-full-coverage.md
+++ b/goals/0-mcp-full-coverage.md
@@ -1,0 +1,108 @@
+---
+vhk_format: 1
+type: goal
+id: 0
+title: MCP 풀 커버리지 — 10 tool → 24 tool 확장
+status: NOT_STARTED
+priority: P0
+version: v1.1
+---
+
+# Mission: Expose every CLI command through MCP (Goal 0 dogfooding)
+
+## Your Identity
+
+You are a TypeScript engineer working in the small-step style.
+Each new MCP tool is one self-contained patch:
+register → schema → handler delegate → test → docs.
+You never break an existing tool's input/output contract.
+You delegate to the matching `src/commands/*.ts` function instead of
+re-implementing logic.
+
+## The Goal
+
+VHK 의 모든 CLI 명령어가 MCP tool 로도 노출된다. 구체적으로:
+
+1. 기존 10 tool (`save`, `undo`, `status`, `diff`, `ship`, `doctor`, `check`,
+   `recap`, `env`, `env-check`) 은 시그니처 변경 없이 유지된다.
+2. 신규 14+ tool 이 `src/mcp/server.ts` 에 등록된다. 후보:
+   - `gate`, `init`, `sync`, `secure`, `deploy`, `publish`,
+   - `design`, `theme`, `ref` (add/list/open 통합 또는 분리),
+   - `harness`, `audit`, `migrate`, `update`,
+   - `context`, `memory`, `brief`,
+   - `start` (대화형 마법사 — MCP 비호환 시 OUT 처리하고 사유 기록).
+3. 각 신규 tool 에 대응되는 `tests/mcp/<tool>.test.ts` 가 존재하고 통과한다.
+4. `vhk mcp` 기동 시 24+ tool 목록이 출력된다 (수동 확인 OK, 자동 테스트 권장).
+5. inquirer 프롬프트가 MCP 모드에서 호출되지 않는다 (TTY 가드 또는
+   non-interactive 분기).
+6. `_meta` 의 모든 게이트가 통과한다 (typecheck / tests / build).
+
+## Mandatory Reading Order
+
+매 iteration 마다 아래 순서로 읽어라. 이미 읽은 파일은 `bash
+scripts/check-goal-0.sh` 가 변경 없음을 보고하면 재독을 생략한다.
+
+1. `CLAUDE.md` + `AGENTS.md` — 프로젝트 규칙
+2. `goals/_meta.md` — 공통 게이트
+3. `src/mcp/server.ts` — 현재 MCP 서버 구조 (단일 파일 registry)
+4. `src/commands/<대상>.ts` — handler 가 위임할 CLI 구현체 (한 번에 1개)
+5. `tests/mcp/` 또는 `tests/` 의 기존 MCP 테스트 — 신규 테스트 작성 시 참고
+6. `docs/state/next-task.md` — 현재 진행할 태스크
+7. `docs/state/blockers.md` — 막힌 것들
+
+## Tool 등록 패턴 (server.ts 단일 파일)
+
+기존 패턴 (`server.ts` 의 `save`/`undo`/... 섹션) 을 그대로 따른다.
+신규 tool 추가 시 별도 `handlers/` 디렉토리는 만들지 않는다 — 단일 파일
+registry 가 현재의 SoT 다. 디렉토리 분리는 본 goal 범위 밖.
+
+```ts
+server.registerTool(
+  '<tool-name>',
+  {
+    description: '<한국어 짧은 설명>',
+    inputSchema: { /* zod schema */ },
+  },
+  async (input) => {
+    // 1) git/파일 사전조건 체크 (필요 시)
+    // 2) src/commands/<x>.ts 의 함수 호출 또는 safeExecFile 위임
+    // 3) { content: [{ type: 'text', text: '...' }] } 반환
+  }
+)
+```
+
+## Completion Check
+
+`bash scripts/check-goal-0.sh` 가 exit 0 을 반환한다. 구체적으로:
+
+- [ ] `_meta` 모든 게이트 통과
+- [ ] `src/mcp/server.ts` 의 `registerTool` 호출 수 ≥ 24
+- [ ] 신규 tool 각각에 대해 `tests/mcp/<tool>.test.ts` 또는
+      `tests/<tool>.mcp.test.ts` 가 존재
+- [ ] inquirer import 가 server.ts 에 없음 (또는 TTY 가드 적용)
+- [ ] `README.md` / `COMMANDS.md` 의 MCP 섹션이 신규 tool 을 반영
+
+## Forbidden Actions
+
+- 기존 10 tool 의 input/output 시그니처 변경 (Breaking change)
+- handler 내부에서 `process.exit()` 호출
+- `execSync` 신규 사용 (→ `safeExecFile` 사용)
+- MCP handler 안에서 inquirer 호출 (TTY 없음)
+- `node_modules/` 직접 수정
+- `package.json` 의 기존 명령어 시그니처 변경 (GA 정책)
+- 한 iteration 에서 여러 tool 동시 추가 (한 번에 1개 — 작은 커밋)
+- `start` 명령처럼 본질적으로 대화형인 커맨드를 강제로 MCP 화 (대신 OUT 결정 + 사유 기록)
+
+## When Stuck
+
+3 iteration 동안 진전이 없으면:
+
+1. `docs/state/blockers.md` 에 증상 + 시도한 것 + 현재 상태 기록.
+2. 현재 tool 건너뛰고 다음 후보 tool 로 이동.
+3. 블로커 3 개 누적 시 `.vhk/HARD_STOP` 생성 → 사람에게 에스컬레이션.
+
+## Updating State
+
+iteration 끝마다 `docs/state/next-task.md` 와 `docs/state/learnings.md` 를
+손으로 업데이트한다. 자동화는 Goal 2 (`vhk learn`, `vhk blocker`) 에서
+제공된다.

--- a/goals/1-goal-command.md
+++ b/goals/1-goal-command.md
@@ -1,0 +1,91 @@
+---
+vhk_format: 1
+type: goal
+id: 1
+title: vhk goal 명령어 — goals/ 체계를 CLI 로 노출
+status: NOT_STARTED
+priority: P0
+version: v1.2
+---
+
+# Mission: Ship `vhk goal` — the dogfooded goals/ workflow as a first-class CLI
+
+## Your Identity
+
+You are a CLI ergonomics engineer. You prefer parsing well-formed YAML
+frontmatter to inventing new file formats. You add subcommands one at a time,
+each with a test, and you keep `printNextStep()` consistent across the family.
+You favor file-based source-of-truth (`goals/*.md`) over hidden state.
+
+## The Goal
+
+`goals/` 패턴을 VHK 사용자에게도 제공한다. Goal 0 의 dogfooding 결과를
+v1.2 의 사용자용 명령어로 졸업시킨다. 구체적으로:
+
+1. `vhk goal init` — 현재 프로젝트에 `goals/` + `docs/state/` + `scripts/`
+   스캐폴딩 생성 (vhk 자체 레포 구조 기반 템플릿).
+2. `vhk goal list` — `goals/*.md` 의 YAML frontmatter 파싱 후 표 출력
+   (id, title, status, priority).
+3. `vhk goal next` — `status: NOT_STARTED` 중 id 최소값을 active 로 선택,
+   `docs/state/next-task.md` 갱신.
+4. `vhk goal check [--id N]` — id 미지정 시 active goal, 지정 시 해당 goal 의
+   `scripts/check-goal-N.sh` 실행. exit code 그대로 전달.
+5. `vhk goal done [--id N]` — 게이트 재검증 후 frontmatter `status` 를
+   `DONE` 으로 갱신. 검증 실패 시 변경하지 않음.
+6. 한국어 별칭 + `src/i18n/ko.ts` 메시지 + 자연어 라우터 키워드 추가
+   (예: "다음 목표", "목표 점검", "목표 완료").
+7. `_meta` 모든 게이트 통과.
+
+## Mandatory Reading Order
+
+1. `CLAUDE.md` + `AGENTS.md`
+2. `goals/_meta.md`
+3. `goals/0-mcp-full-coverage.md` — frontmatter / 섹션 포맷 참조
+4. `src/commands/init.ts` — 스캐폴딩 패턴 참조 (`goal init` 베이스)
+5. `src/commands/memory.ts` — 서브커맨드 + 파일 SoT 패턴 참조 (`add/list/remove`)
+6. `src/i18n/ko.ts` — 메시지 키 규약
+7. `src/nlp-router.ts` — 자연어 키워드 등록 방식
+
+## YAML Frontmatter 표준
+
+```yaml
+---
+vhk_format: 1
+type: goal
+id: <number>
+title: <string>
+status: NOT_STARTED | IN_PROGRESS | DONE | BLOCKED
+priority: P0 | P1 | P2
+version: <semver>
+---
+```
+
+파서는 `gray-matter` 미사용을 권장 (의존성 추가 회피). 정규식 + 직접 파싱.
+
+## Completion Check
+
+`bash scripts/check-goal-1.sh` 가 exit 0 을 반환한다. 구체적으로:
+
+- [ ] 5 개 서브커맨드 (`init/list/next/check/done`) 모두 구현 + 단위 테스트
+- [ ] `vhk goal list` 가 본 레포의 `goals/` 를 파싱해서 4 개 항목 출력
+- [ ] `vhk goal next` 가 `docs/state/next-task.md` 를 멱등하게 갱신
+- [ ] `vhk goal check` 가 `scripts/check-goal-N.sh` 의 exit code 를 그대로 전달
+- [ ] `vhk goal done` 이 게이트 실패 시 frontmatter 를 변경하지 않음
+- [ ] `COMMANDS.md` + `README.md` 명령어 표 업데이트
+- [ ] `_meta` 게이트 통과
+
+## Forbidden Actions
+
+- 새 의존성 추가 (`gray-matter` 등 frontmatter 파서) — 정규식 기반 파싱 사용
+- frontmatter 키 이름 변경 (vspec/vooster 호환성 유지)
+- 게이트 실패에도 `done` 으로 마킹 (실패 = 보존)
+- 본 goal 범위 안에서 Goal 2 의 `blocker/learn/resume` 명령 선구현
+- `execSync` 신규 사용
+
+## When Stuck
+
+Goal 0 의 동일 프로토콜 적용. 3 iteration 정체 → blockers.md → 다음 태스크.
+
+## Dependencies
+
+- Goal 0 완료 (MCP 풀 커버리지) 이후 진입 권장. 단, 병렬 진행 가능.

--- a/goals/2-agent-loop.md
+++ b/goals/2-agent-loop.md
@@ -1,0 +1,87 @@
+---
+vhk_format: 1
+type: goal
+id: 2
+title: 자율 루프 — context → goal → check 사이클 + 안전장치
+status: NOT_STARTED
+priority: P1
+version: v1.3
+---
+
+# Mission: Close the autonomous loop — context, goal, check, learn, stop
+
+## Your Identity
+
+You design feedback loops. You prefer fewer commands that compose cleanly
+over many one-off scripts. You treat `.vhk/HARD_STOP` as a tripwire that
+must never be removed automatically. Every state mutation gets a timestamped
+log entry.
+
+## The Goal
+
+Goal 1 의 `vhk goal *` 위에 자율 루프 보조 명령을 얹어, 사람이 매번
+지시하지 않아도 `context → goal next → 작업 → goal check → goal done` 사이클이
+스스로 진행되도록 한다. 단, 멈춰야 할 때는 즉시 멈춘다.
+
+1. `vhk blocker "<설명>"` — `docs/state/blockers.md` 에 타임스탬프 + 현재
+   active goal id 와 함께 append. 누적 3 개 이상이면 `.vhk/HARD_STOP` 자동
+   생성 (`vhk resume` 으로만 해제).
+2. `vhk learn "<교훈>"` — `docs/state/learnings.md` 에 날짜 + active goal id
+   prefix 로 append. 동시에 `vhk memory add` 와 동일한 결정사항 저장소에도
+   기록 (single SoT 보장).
+3. `vhk resume` — `.vhk/HARD_STOP` 제거. 직전에 표시한 사유를 사람이 콘솔에
+   타이핑(`--confirm` flag) 해야만 제거. 자동 호출 금지.
+4. `vhk context` 가 active goal 의 next-task 와 최근 learning 3 개를 자동
+   포함하도록 확장.
+5. `_meta` 모든 게이트 통과.
+
+## Mandatory Reading Order
+
+1. `CLAUDE.md` + `AGENTS.md`
+2. `goals/_meta.md`
+3. `goals/1-goal-command.md` — frontmatter 파서 재사용
+4. `src/commands/context.ts` — context 명령의 현재 출력 포맷
+5. `src/commands/memory.ts` — append-only SoT 파일 관리 패턴
+6. `docs/state/blockers.md` / `learnings.md` — 현재 누적 상태
+
+## 자율 루프 흐름
+
+```
+1. vhk context                  → 현재 상태 + active goal + 최근 교훈 로드
+2. vhk goal next                → 다음 목표 자동 선택
+3. (개발 작업 수행)
+4. vhk goal check
+   ├─ PASS → vhk goal done → 다음 goal
+   └─ FAIL → 3 사이클 진전 없으면 → vhk blocker → 다음 태스크 자동 전환
+5. 블로커 3 개 누적 → .vhk/HARD_STOP 자동 생성 → 자동화 즉시 중단
+```
+
+## Completion Check
+
+`bash scripts/check-goal-2.sh` 가 exit 0 을 반환한다. 구체적으로:
+
+- [ ] `vhk blocker`, `vhk learn`, `vhk resume` 3 개 구현 + 테스트
+- [ ] 블로커 3 개 누적 시 `.vhk/HARD_STOP` 자동 생성 검증 테스트
+- [ ] `vhk resume` 이 `--confirm` 없이 호출되면 거부하는 테스트
+- [ ] `vhk context` 출력에 `## Active Goal` + `## Recent Learnings` 섹션 포함
+- [ ] `vhk memory list` 와 `vhk learn` 의 SoT 일관성 테스트 (이중 기록 금지)
+- [ ] `_meta` 게이트 통과
+
+## Forbidden Actions
+
+- `vhk resume` 의 자동 호출 (사람 손이 닿아야만 해제)
+- `.vhk/HARD_STOP` 파일을 lockfile 외의 용도로 재사용
+- blockers.md / learnings.md 의 과거 항목 수정 (append-only)
+- `vhk learn` 과 별개로 `vhk memory add` 도 호출해서 이중 기록
+- 본 goal 범위 안에서 멀티 에이전트 / 워커 풀 도입
+
+## When Stuck
+
+Goal 0/1 의 동일 프로토콜 적용. 단, 본 goal 의 안전장치 자체가 막혔다면
+`docs/state/blockers.md` 가 아니라 직접 사람에게 보고 (자기 자신을 호출하면
+무한루프).
+
+## Dependencies
+
+- Goal 1 완료 후 진입. `vhk goal *` 가 SoT 로 기능해야 본 goal 의 상태
+  전이가 의미 있음.

--- a/goals/_meta.md
+++ b/goals/_meta.md
@@ -1,0 +1,71 @@
+---
+vhk_format: 1
+type: meta
+project: vhk-cli
+version: v1.1
+---
+
+# Goal _meta: Cross-cutting invariants (VHK)
+
+이 goal 은 numeric goal 스택과 별개의 **메타 게이트 모음**이다.
+모든 goal 에 공통으로 적용되는 universal claim — typecheck / tests / build —
+을 한 곳에 모아, 각 goal-local gate 가 자기 goal 고유의 universal claim 에만
+집중할 수 있게 한다.
+
+> 출처: vspec/vooster `goals/_meta.md` 패턴 차용. VHK 맥락에 맞게
+> 단일 패키지(pnpm 단일 워크스페이스, eslint 미설정) 기준으로 변형.
+
+## Why this exists
+
+이전엔 같은 명령(`pnpm test:run`, `tsc --noEmit`, `pnpm build`)이 각 goal
+체크 스크립트에 중복되었다. 중복을 한 곳에 모으면:
+
+- 각 goal-local gate 가 자기 universal claim 에만 집중
+- 변경 감지 캐시(향후 도입) 효율 상승
+- CI 와 로컬 사이의 실행 주체 분리 가능
+
+## The Goal
+
+다음 조건이 **모두** 성립한다:
+
+1. **Every TypeScript source file** in `src/` 와 `tests/` 가 `tsc --noEmit`
+   기준으로 컴파일된다 (`pnpm exec tsc --noEmit`).
+2. **Every vitest test** 가 통과한다 (`pnpm test:run`). 현재 baseline 223+.
+3. **tsup build** 가 성공한다 (`pnpm build`). `dist/index.js` 와
+   `dist/mcp/index.js` 가 생성된다.
+4. **새 기능에 대한 테스트가 최소 1개 이상** 추가됨 (PR 단위).
+5. **README.md / COMMANDS.md** 명령어 표에 신규 명령어가 반영됨.
+
+각 condition 은 source-of-truth 로부터 enumerate 된다:
+
+| Condition | Source of truth | Iteration |
+| --- | --- | --- |
+| typecheck | `tsconfig.json` | `pnpm exec tsc --noEmit` |
+| tests | `vitest` 자동 탐색 (`tests/**`) | `pnpm test:run` |
+| build | `tsup.config.ts` | `pnpm build` |
+
+## Env flags
+
+| Env | Effect |
+| --- | --- |
+| `VHK_GATES_SKIP_DEEP=1` | M.2 (vitest) 와 M.3 (build) 를 스킵. 빠른 iteration 용 typecheck-only 패스. |
+| `VHK_GATES_SKIP_META=1` | numeric goal sweep 에서 `_meta` 제외 (CI 에서 별도 step 으로 enforce 할 때 사용). |
+
+## Forbidden Actions (전역)
+
+- `node_modules/` 직접 수정 금지
+- `package.json` 의 기존 명령어 시그니처 breaking change 금지 (GA 정책)
+- `execSync` 신규 사용 금지 → `safeExecFile` 사용
+- MCP 모드에서 inquirer 프롬프트 호출 금지 (TTY 없음)
+- 토큰/시크릿 코드·커밋에 평문 노출 금지 (`.env` + `.gitignore`)
+
+## Relation to numeric goals
+
+| 위치 | _meta 로 이동 |
+| --- | --- |
+| `goals/0-mcp-full-coverage` typecheck 중복 | M.1 |
+| `goals/0-mcp-full-coverage` 테스트 중복 | M.2 |
+| `goals/1-goal-command` build 중복 | M.3 |
+
+각 numeric goal 의 `.md` 본문에서 cross-cutting 부분은 "see goals/_meta.md"
+포인터로 대체되어 있다.

--- a/scripts/check-goal-0.sh
+++ b/scripts/check-goal-0.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# scripts/check-goal-0.sh — Goal 0 (MCP full coverage) gate.
+#
+# Mirrors goals/0-mcp-full-coverage.md "Completion Check" section.
+# Pre-conditions:
+#   - goals/_meta.md gates pass (delegated to scripts/check-meta.sh)
+# Goal-local claims:
+#   G0.1  src/mcp/server.ts has >= 24 registerTool() calls
+#   G0.2  server.ts does not import inquirer (TTY-incompatible in MCP mode)
+#   G0.3  src/mcp/server.ts does not use execSync (use safeExecFile)
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [ -f ".vhk/HARD_STOP" ]; then
+  echo "🛑 .vhk/HARD_STOP detected — refusing to run goal 0 gate."
+  exit 1
+fi
+
+# ─── meta first ─────────────────────────────────────────────────────────
+echo "[goal 0] running _meta gate first"
+if ! bash "$ROOT/scripts/check-meta.sh"; then
+  echo "    ✗ _meta failed — fix cross-cutting gates first"
+  exit 1
+fi
+
+PASS=true
+SERVER_FILE="src/mcp/server.ts"
+
+if [ ! -f "$SERVER_FILE" ]; then
+  echo "    ✗ $SERVER_FILE missing"
+  exit 1
+fi
+
+# ─── G0.1 registerTool count ────────────────────────────────────────────
+echo "[G0.1] registerTool count >= 24"
+TOOL_COUNT=$(grep -c "registerTool(" "$SERVER_FILE" || true)
+if [ "${TOOL_COUNT:-0}" -ge 24 ]; then
+  echo "    ✓ pass ($TOOL_COUNT tools registered)"
+else
+  echo "    ✗ fail (found $TOOL_COUNT, need >= 24)"
+  PASS=false
+fi
+
+# ─── G0.2 no inquirer import in MCP server ──────────────────────────────
+echo "[G0.2] server.ts does not import inquirer"
+if grep -E "from ['\"]inquirer['\"]" "$SERVER_FILE" >/dev/null 2>&1; then
+  echo "    ✗ fail — inquirer import found in $SERVER_FILE"
+  PASS=false
+else
+  echo "    ✓ pass"
+fi
+
+# ─── G0.3 no execSync ───────────────────────────────────────────────────
+echo "[G0.3] server.ts does not use execSync"
+if grep -E "\bexecSync\b" "$SERVER_FILE" >/dev/null 2>&1; then
+  echo "    ✗ fail — execSync found (use safeExecFile)"
+  PASS=false
+else
+  echo "    ✓ pass"
+fi
+
+if [ "$PASS" = true ]; then
+  echo "✅ goal 0 gate passes"
+  exit 0
+fi
+
+echo "❌ goal 0 gate failed"
+exit 1

--- a/scripts/check-meta.sh
+++ b/scripts/check-meta.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# scripts/check-meta.sh — VHK cross-cutting meta gate.
+#
+# Mirrors goals/_meta.md. Runs the universal claims that apply to every
+# numeric goal:
+#   M.1  tsc --noEmit clean
+#   M.2  pnpm test:run passes
+#   M.3  pnpm build produces dist/index.js + dist/mcp/index.js
+#
+# Env:
+#   VHK_GATES_SKIP_DEEP=1   skip M.2 (tests) + M.3 (build) for fast iter
+#   VHK_GATES_SKIP_META=1   skip the entire suite (CI runs steps explicitly)
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [ "${VHK_GATES_SKIP_META:-}" = "1" ]; then
+  echo "[meta] skipped (VHK_GATES_SKIP_META=1)"
+  exit 0
+fi
+
+# Hard stop short-circuit. If a previous run tripped HARD_STOP, refuse to
+# pretend gates are green.
+if [ -f ".vhk/HARD_STOP" ]; then
+  echo "🛑 .vhk/HARD_STOP detected — run 'vhk resume --confirm' before re-checking."
+  exit 1
+fi
+
+PASS=true
+LOG_DIR="$(mktemp -d 2>/dev/null || echo .vhk-meta-logs)"
+mkdir -p "$LOG_DIR"
+
+# ─── M.1 TypeScript clean ───────────────────────────────────────────────
+echo "[M.1] tsc --noEmit"
+TSC_LOG="$LOG_DIR/tsc.log"
+if pnpm exec tsc --noEmit >"$TSC_LOG" 2>&1; then
+  echo "    ✓ pass"
+else
+  echo "    ✗ fail — see $TSC_LOG"
+  PASS=false
+fi
+
+# ─── M.2 vitest ────────────────────────────────────────────────────────
+echo "[M.2] pnpm test:run"
+if [ "${VHK_GATES_SKIP_DEEP:-}" = "1" ]; then
+  echo "    ⊘ skipped (VHK_GATES_SKIP_DEEP=1)"
+else
+  TEST_LOG="$LOG_DIR/vitest.log"
+  if pnpm test:run >"$TEST_LOG" 2>&1; then
+    echo "    ✓ pass"
+  else
+    echo "    ✗ fail — see $TEST_LOG"
+    PASS=false
+  fi
+fi
+
+# ─── M.3 tsup build ────────────────────────────────────────────────────
+echo "[M.3] pnpm build"
+if [ "${VHK_GATES_SKIP_DEEP:-}" = "1" ]; then
+  echo "    ⊘ skipped (VHK_GATES_SKIP_DEEP=1)"
+else
+  BUILD_LOG="$LOG_DIR/build.log"
+  if pnpm build >"$BUILD_LOG" 2>&1; then
+    if [ -f "dist/index.js" ] && [ -f "dist/mcp/index.js" ]; then
+      echo "    ✓ pass"
+    else
+      echo "    ✗ fail — dist artifacts missing"
+      PASS=false
+    fi
+  else
+    echo "    ✗ fail — see $BUILD_LOG"
+    PASS=false
+  fi
+fi
+
+if [ "$PASS" = true ]; then
+  echo "✅ _meta gates pass"
+  exit 0
+fi
+
+echo "❌ _meta gates failed — logs in $LOG_DIR"
+exit 1


### PR DESCRIPTION
## Summary

- v1.1 Phase 2.5 — vspec/vooster 자율 빌드 하네스의 `goals/` 패턴을 dogfooding 용으로 도입
- `vhk goal` 사용자 명령(v1.2) 출시 전, 자체 레포에서 먼저 패턴 검증
- 코드 변경 0, 문서/스크립트/상태 파일만 추가 (테스트 241/241 그대로 통과)

## 추가 파일

| 파일 | 역할 |
| --- | --- |
| `goals/_meta.md` | 공통 게이트 (tsc / vitest / tsup build) |
| `goals/0-mcp-full-coverage.md` | MCP 10 → 24 tool 확장 미션 |
| `goals/1-goal-command.md` | v1.2 `vhk goal init/list/next/check/done` 명세 |
| `goals/2-agent-loop.md` | v1.3 자율 루프 (`blocker/learn/resume`) 명세 |
| `scripts/check-meta.sh` | `_meta` 게이트 실행기 |
| `scripts/check-goal-0.sh` | Goal 0 게이트 (`_meta` → registerTool count → inquirer/execSync 가드) |
| `docs/state/{next-task,blockers,learnings}.md` | 상태 머신 SoT (append-only) |
| `.vhk/README.md` + `.gitignore` 갱신 | `HARD_STOP` 안전장치 정책 |
| `CLAUDE.md` Safety 섹션 | `HARD_STOP` 규칙 + Goals 체계 안내 |
| `CHANGELOG.md` | Unreleased 항목 추가 |

## 노션 스펙과의 차이 (조정 사항)

- VHK 에 `lint` / `typecheck` 스크립트 없음 → `_meta` 게이트는 `tsc --noEmit` + `pnpm test:run` + `pnpm build` 3 개로 축소. lint 도입 시 M.4 로 추가 예정 (`docs/state/learnings.md` 에 기록)
- `src/mcp/handlers/` 디렉토리 없음 → 단일 파일 `src/mcp/server.ts` 가 현 SoT. Goal 0 본문에 "handlers/ 분리는 본 goal 범위 밖" 명시
- 기존 MCP tool 10 개 = `save/undo/status/diff/ship/doctor/check/recap/env/env-check` (노션 표에서 `env`/`env-check` 누락 → 실제 코드 기준 정정)

## 사전존재 이슈 (이번 PR 무관, 별도 처리 권장)

`pnpm exec tsc --noEmit` 시 4 건 에러 — `start.ts`, `lib/git.ts`, `lib/notion-import.ts`. simple-git 타입 호환 + Notion SDK block type narrowing. 이번 변경과 무관하나 `_meta` 게이트 통과를 위해 별도 트러블슈팅 필요.

## Test plan

- [x] `pnpm test:run` → 241/241 pass
- [ ] (수동) `bash scripts/check-meta.sh` 로컬 실행 → tsc 사전이슈로 fail 예상. tsc 픽스 후 재실행
- [ ] (수동) `bash scripts/check-goal-0.sh` → 현재 registerTool count 10 이므로 G0.1 fail 예상 (정상 — Goal 0 미착수 상태)

## 다음 단계

머지 후 사람이 Phase 3 (Goal 0 — MCP 풀 커버리지) 진입 여부 결정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)