### PR TITLE
feat(mcp): Goal 0 1차 — MCP tool 10→16 (sync/secure/audit/harness/context/brief)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ### Added
 
+- **MCP 풀 커버리지 1차 (v1.1 Phase 3 / Goal 0 진행 중)** — MCP tool 10 → 16:
+  - 신규 6 tool: `sync`, `secure`, `audit`, `harness`, `context`, `brief`
+  - 모두 비대화형. `runVhkCli()` 헬퍼로 `vhk` CLI 서브프로세스 위임 (MCP 모드에서 inquirer/ora 차단)
+  - `audit` 는 fix 프롬프트 비활성화 (MCP non-interactive 보장)
+  - 기존 10 tool 시그니처 무변경 (v1.0 GA 안정성 약속 유지)
+  - `tests/mcp-server.test.ts` — 등록 tool 개수 + 이름 단언 (`_registeredTools` introspection)
+  - MCP 서버 버전 0.7.1 → 1.1.0
+  - 남은 후보 (다음 iteration): `gate`/`init`/`start` (대화형 → MCP OUT 또는 비대화형 wrap), `deploy`, `env-sync`, `publish`, `design`, `theme`, `ref`, `migrate`, `update`, `memory`
 - **goals/ 구조 (v1.1 Phase 2.5)** — vspec/vooster 패턴 dogfooding:
   - `goals/_meta.md` — 공통 게이트 (typecheck/tests/build) 정의
   - `goals/0-mcp-full-coverage.md` — MCP 풀 커버리지 (10→24 tool) 미션 명세

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -6,10 +6,23 @@ import { safeExecFile } from '../lib/exec.js'
 import { parseEnvKeys } from '../commands/env.js'
 import { readJsonFile } from '../lib/read-json.js'
 
-const SERVER_VERSION = '0.7.1'
+const SERVER_VERSION = '1.1.0'
 
 function isGitRepo(): boolean {
   return safeExecFile('git', ['rev-parse', '--is-inside-work-tree']).ok
+}
+
+// vhk CLI 자체를 서브프로세스로 호출해서 결과를 MCP content로 변환.
+// MCP 모드에서는 inquirer/ora 프롬프트가 동작하지 않으므로 비대화형 커맨드만 위임.
+// 호출 측은 stdout을 받아 그대로 반환 — chalk ANSI는 클라이언트에서 적당히 처리.
+function runVhkCli(
+  args: string[],
+  headline: string
+): { content: [{ type: 'text'; text: string }] } {
+  const result = safeExecFile('vhk', args)
+  const body = result.out || (result.ok ? '' : `(stdout 없음)\n${result.err}`)
+  const prefix = result.ok ? `✅ ${headline}` : `❌ ${headline} 실패`
+  return { content: [{ type: 'text', text: `${prefix}\n${body}`.trim() }] }
 }
 
 export function createVhkMcpServer(): McpServer {
@@ -356,6 +369,48 @@ export function createVhkMcpServer(): McpServer {
       }
       return { content: [{ type: 'text', text: lines.join('\n') }] }
     }
+  )
+
+  // ─── sync ───────────────────────────────────────────────
+  server.registerTool(
+    'sync',
+    { description: 'RULES.md → .cursorrules + CLAUDE.md 자동 동기화' },
+    async () => runVhkCli(['sync'], 'sync')
+  )
+
+  // ─── secure ─────────────────────────────────────────────
+  server.registerTool(
+    'secure',
+    { description: '시크릿/환경변수 보안 스캔 (.env 노출 + 키 패턴 탐지)' },
+    async () => runVhkCli(['secure'], 'secure')
+  )
+
+  // ─── audit ──────────────────────────────────────────────
+  server.registerTool(
+    'audit',
+    { description: 'npm/pnpm/yarn 보안 취약점 감사 (자동 fix 없음 — MCP non-interactive)' },
+    async () => runVhkCli(['audit'], 'audit')
+  )
+
+  // ─── harness ────────────────────────────────────────────
+  server.registerTool(
+    'harness',
+    { description: 'lint + typecheck + test + build 통합 품질 점검' },
+    async () => runVhkCli(['harness'], 'harness')
+  )
+
+  // ─── context ────────────────────────────────────────────
+  server.registerTool(
+    'context',
+    { description: '프로젝트 맥락 파일(.vhk/context.md) 생성 — 기술 스택 + 디렉토리 + 명령어 + 결정사항' },
+    async () => runVhkCli(['context'], 'context')
+  )
+
+  // ─── brief ──────────────────────────────────────────────
+  server.registerTool(
+    'brief',
+    { description: '프로젝트 브리핑(.vhk/brief.md) 생성 — git 상태 + 결정사항 + 다음 단계 제안' },
+    async () => runVhkCli(['brief'], 'brief')
   )
 
   return server

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -3,6 +3,16 @@ import { describe, it, expect, vi } from 'vitest'
 vi.mock('node:child_process')
 vi.mock('node:fs')
 
+interface ToolRegistryShape {
+  _registeredTools: Record<string, unknown>
+}
+
+async function getRegisteredToolNames(): Promise<string[]> {
+  const { createVhkMcpServer } = await import('../src/mcp/server.js')
+  const server = createVhkMcpServer() as unknown as ToolRegistryShape
+  return Object.keys(server._registeredTools)
+}
+
 describe('MCP Server', () => {
   it('서버 인스턴스가 생성된다', async () => {
     const { createVhkMcpServer } = await import('../src/mcp/server.js')
@@ -10,11 +20,22 @@ describe('MCP Server', () => {
     expect(server).toBeDefined()
   })
 
-  it('서버 이름이 vhk이고 버전이 0.6.0이다', async () => {
-    const { createVhkMcpServer } = await import('../src/mcp/server.js')
-    const server = createVhkMcpServer()
-    // McpServer의 내부 메타데이터 노출 방식이 SDK 버전에 따라 다름.
-    // 최소한 객체가 생성되었는지 확인. 실제 도구 동작은 통합 테스트 영역.
-    expect(server).toBeDefined()
+  it('기존 10 tool이 등록되어 있다 (v1.0 안정성 약속)', async () => {
+    const names = await getRegisteredToolNames()
+    for (const t of ['save', 'undo', 'status', 'diff', 'ship', 'doctor', 'check', 'recap', 'env', 'env-check']) {
+      expect(names).toContain(t)
+    }
+  })
+
+  it('Goal 0 v1.1 신규 6 tool이 등록되어 있다', async () => {
+    const names = await getRegisteredToolNames()
+    for (const t of ['sync', 'secure', 'audit', 'harness', 'context', 'brief']) {
+      expect(names).toContain(t)
+    }
+  })
+
+  it('총 16+ tool이 등록되어 있다 (Goal 0 진행 중 baseline)', async () => {
+    const names = await getRegisteredToolNames()
+    expect(names.length).toBeGreaterThanOrEqual(16)
   })
 })


### PR DESCRIPTION
## Summary

- Goals 0 (MCP 풀 커버리지) 첫 iteration. MCP tool 10 → 16
- 비대화형 6 tool 추가: `sync`, `secure`, `audit`, `harness`, `context`, `brief`
- 기존 10 tool 시그니처 무변경 (v1.0 GA 안정성 약속 유지)

## 변경

| 파일 | 변경 |
| --- | --- |
| `src/mcp/server.ts` | `runVhkCli()` 헬퍼 + 6 `registerTool`. SERVER_VERSION 0.7.1 → 1.1.0 |
| `tests/mcp-server.test.ts` | `_registeredTools` introspection 으로 등록 tool 단언 (4 테스트) |
| `CHANGELOG.md` | Unreleased 항목 추가 |

## 추가 tool

| tool | 위임 | 목적 |
| --- | --- | --- |
| sync | `vhk sync` | RULES.md → .cursorrules + CLAUDE.md 동기화 |
| secure | `vhk secure` | 시크릿/.env 스캔 |
| audit | `vhk audit` | npm/pnpm/yarn 보안 감사 (fix 프롬프트 OFF) |
| harness | `vhk harness` | lint/typecheck/test/build 통합 점검 |
| context | `vhk context` | .vhk/context.md 생성 |
| brief | `vhk brief` | .vhk/brief.md 생성 |

## 설계 결정

- **위임 헬퍼**: `runVhkCli(args, headline)` — `safeExecFile('vhk', ...)` 로 서브프로세스 분리. MCP 모드에서 동작하지 않는 inquirer/ora 의 영향 없이 비대화형 커맨드만 안전 노출
- **인터랙티브 우회**: `audit` 는 critical/high 발견 시 fix 프롬프트가 뜨므로 MCP 호출 경로에서는 fix=false 로 동작 (CLI 측 비대화형 분기 활용)
- **테스트 introspection**: SDK 의 `_registeredTools` private 멤버를 `as unknown` 캐스팅으로 조회. SDK 업그레이드 시 깨질 수 있으나 현재 `1.29.0` 기준 안정

## 제외 (다음 iteration)

- `gate`/`init`/`start`/`design-palette`/`theme`: 대화형 본질 → MCP OUT 또는 비대화형 wrap 별도 검토
- `deploy`/`publish`/`env-sync`/`ref`/`memory`/`migrate`/`update`: 다음 iteration 에서 추가 (인자 스키마 + zod 필관리자 것들 포함)

## 사전존재 이슈 (이번 PR 무관)

`pnpm exec tsc --noEmit` 시 4 건 에러 — `start.ts`, `lib/git.ts`, `lib/notion-import.ts`. simple-git 타입 호환 + Notion SDK block type narrowing. `_meta` M.1 게이트가 이로 인해 fail. 별도 트러블슈팅 PR 권장.

## Test plan

- [x] `pnpm test:run` → 243/243 pass (10 신규 단언 통과)
- [x] `pnpm build` → 성공
- [ ] (수동) MCP 클라이언트(Cursor/Claude Desktop)에서 신규 6 tool 호출 검증
- [ ] (수동) `bash scripts/check-goal-0.sh` — registerTool count 16 (목표 24 미달, 정상 — 진행 중)

🤖 Generated with [Claude Code](https://claude.com/claude-code)