### PR TITLE
feat(mcp): Goal 0 완료 — MCP 풀 커버리지 24 tool + tsc 블로커 해결

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -3,26 +3,47 @@
 > 코딩/디자인 전용. 기록/운영 → CLAUDE.md 참조.
 
 ## 프로젝트 정체성
+
 - 한 줄 설명: 바이브코딩 풀사이클 CLI
-- 스택: Node.js + TypeScript + commander + inquirer + chalk
+- 레포: https://github.com/byh3071-cpu/vhk (public)
+- npm: @byh3071/vhk
 
 ## 필수 참조
-- docs/PRD.md · docs/ARCHITECTURE.md · CLAUDE.md
+
+- CLAUDE.md · docs/PRD.md · docs/ARCHITECTURE.md
+- goals/_meta.md · docs/state/next-task.md
 
 ## 기술 스택 (변경 시 ADR 필수)
-- Node.js
-- TypeScript
-- commander
-- inquirer
-- chalk
+
+- Node.js + TypeScript
+- commander (CLI) + inquirer (인터랙티브) + chalk (출력)
+- tsup (빌드) + vitest (테스트)
+- @modelcontextprotocol/sdk + zod (MCP)
+- pnpm (패키지 매니저)
+- src/i18n/ko.ts (한국어 i18n)
+- src/nlp-router.ts (자연어 라우팅)
 
 ## 코딩 규칙
+
 - TypeScript strict (any 금지)
 - try-catch 필수, 빈 catch 금지
 - console.log 프로덕션 제거
 - 커밋: feat: / fix: / refactor: / docs: / chore:
+- `execSync` 신규 사용 금지 → `safeExecFile` 사용
+- 모든 커맨드 파일에 `printNextStep()` 패턴 사용
+- 한국어 별칭 `.alias()` + `ko.ts` 메시지 필수
+- 신규 커맨드 시 `nlp-router.ts` 키워드 추가 필수
+
+## MCP 규칙
+
+- handler 내부 `process.exit()` 금지
+- MCP 모드에서 inquirer 프롬프트 호출 금지 (TTY 없음)
+- 신규 handler는 `runVhkCli(args, headline)` 헬퍼 패턴 사용
+- 대화형 커맨드 (gate/init/design palette/theme) 는 MCP 제외
+- 기존 tool API 시그니처 변경 금지 (GA 안정성)
 
 ## 디자인 Anti-patterns
+
 - 보라-파랑 기본 그라디언트 금지
 - 과도한 둥근 모서리 (>16px) 금지
 - 그림자 중첩 · 장식 SVG 남발 금지

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ### Added
 
+- **MCP 풀 커버리지 완료 (v1.1 Phase 3 / Goal 0 DONE)** — MCP tool 16 → 24:
+  - 신규 8 tool:
+    - `deploy`, `publish`, `migrate`, `update` — dry-info 핸들러 (인터랙티브 본질이라 실제 실행 미수행, 진단/안내만)
+    - `ref-list`, `memory-list`, `context-show`, `mcp-init` — `runVhkCli()` 서브프로세스 위임
+  - **G0.1**: registerTool 24 개 도달 (Goal 0 목표 달성)
+  - **G0.2**: server.ts inquirer import 0 (MCP 모드 안전성)
+  - **G0.3**: server.ts execSync 0 (safeExecFile 통일)
+  - `_meta` 게이트 통과 (typecheck/tests/build 모두 ✓)
+  - 대화형 본질 4 커맨드 (`gate`, `init`, `design palette`, `theme`, `start`) 는 MCP 제외 확정
+  - 테스트: 244/244 pass (mcp-server.test.ts 4 → 5 테스트, 24+ 단언 추가)
+
+### Fixed
+
+- **사전존재 typecheck 4 건 해결** (`_meta` M.1 영구 블로커):
+  - `src/commands/start.ts` + `src/lib/git.ts`: `import simpleGit` default → named export `{ simpleGit }` 로 전환 (simple-git 3.x dual export 호환)
+  - `src/lib/git.ts:83`: `DiffResult.files` union 정규화 — binary/name-status 항목 insertions/deletions 0 fallback
+  - `src/lib/notion-import.ts:79`: `BlockObjectResponse` discriminated union 인덱싱 시 `Record<string, ...>` 캐스팅
+
 - **MCP 풀 커버리지 1차 (v1.1 Phase 3 / Goal 0 진행 중)** — MCP tool 10 → 16:
   - 신규 6 tool: `sync`, `secure`, `audit`, `harness`, `context`, `brief`
   - 모두 비대화형. `runVhkCli()` 헬퍼로 `vhk` CLI 서브프로세스 위임 (MCP 모드에서 inquirer/ora 차단)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 ---
 id: claude-md-vhk
-date: 2026-05-23
+date: 2026-05-27
 tags: [process, documentation]
 ---
 
@@ -9,28 +9,59 @@ tags: [process, documentation]
 > 이 파일은 기록/운영 전용. 코딩/디자인 → .cursorrules 참조.
 > See also: AGENTS.md
 
+## 프로젝트 정보
+
+- **레포:** <https://github.com/byh3071-cpu/vhk> (public)
+- **npm:** @byh3071/vhk (public, scoped)
+- **버전:** v1.0.0 GA
+- **MCP tool:** 16/24 (Goal 0 진행 중)
+- **테스트:** 243+ pass (vitest)
+- **패키지 매니저:** pnpm
+
 ## 현재 상태
-- **Phase:** Phase 1 — MVP
-- **블로커:** 없음
-- **다음 액션:** __FILL__
-- **마지막 업데이트:** 2026-05-23
+
+- **Phase:** Phase 3 — MCP 풀 커버리지 (Goal 0 IN_PROGRESS)
+- **블로커:** typecheck 4건 에러 (start.ts, lib/git.ts, lib/notion-import.ts)
+- **다음 액션:** PR #16 머지 → typecheck fix → Goal 0 2차 iteration (MCP 16→24)
+- **마지막 업데이트:** 2026-05-27
+
+## 코딩 컨벤션
+
+- `execSync` 신규 사용 금지 → `safeExecFile` 사용
+- 모든 커맨드 파일에 `printNextStep()` 패턴 사용
+- 한국어 별칭 `.alias()` + `ko.ts` 메시지 필수
+- 자연어 라우터 키워드 추가 필수
+
+## MCP 모드 규칙
+
+- handler 내부 `process.exit()` 금지
+- MCP 모드에서 inquirer 프롬프트 호출 금지 (TTY 없음)
+- 신규 handler는 `runVhkCli(args, headline)` 헬퍼 패턴 사용 (`src/mcp/server.ts`)
+- 대화형 커맨드 (gate/init/design palette/theme) 는 MCP 제외
+- 기존 tool API 시그니처 변경 금지 (GA 안정성)
 
 ## ADR
+
 기술/라이브러리 선택 시 docs/adr/ADR-{번호}-{제목}.md 생성.
 
 ## 작업 로그
+
 세션 종료 시 docs/log/YYYY-MM-DD-{작업명}.md 생성.
 
 ## 트러블슈팅
+
 에러 해결 시 docs/troubleshooting/TS-{번호}-{증상}.md
 
 ## TIL
+
 새로 배운 개념 → docs/til.md 한 줄 추가
 
 ## /done 커맨드
+
 세션 종료 → /done → 요약 자동 생성 → docs/log/ 저장
 
 ## 종료 전 체크리스트
+
 1. ADR 2. 작업 로그 3. 트러블슈팅 4. TIL 5. /done
 
 ## Safety — HARD_STOP
@@ -38,7 +69,7 @@ tags: [process, documentation]
 - 매 작업 시작 시: `.vhk/HARD_STOP` 파일 존재 여부 확인. 존재하면 모든 자동화 즉시 중단.
   - PowerShell: `if (Test-Path .vhk/HARD_STOP) { Write-Host '🛑 HARD STOP'; exit 1 }`
   - bash: `[ -f .vhk/HARD_STOP ] && echo "🛑 HARD STOP" && exit 1`
-- 자동 생성 조건: 블로커 3 개 누적 (`docs/state/blockers.md`) / 토큰 예산 초과 감지
+- 자동 생성 조건: 블로커 3개 누적 (`docs/state/blockers.md`) / 토큰 예산 초과 감지
 - 해제: `vhk resume --confirm` 만 가능 (사람이 직접 실행, 자동 호출 금지)
 - 게이트 스크립트 (`scripts/check-*.sh`) 는 시작 시 이 파일을 검사한다
 - `.vhk/HARD_STOP` 자체는 `.gitignore` 에 등록되어 로컬 전용 신호로 동작

--- a/docs/state/learnings.md
+++ b/docs/state/learnings.md
@@ -4,3 +4,9 @@ _Append-only. 한 줄 = 한 교훈. iteration 시작 시 전체 파일이 컨텍
 _Format: `- [YYYY-MM-DD goal-N] 한 줄 교훈.`_
 
 - [2026-05-27 _meta] goals/ 구조는 vspec/vooster 패턴을 차용. 단일 패키지 VHK 에 맞춰 _meta 게이트는 tsc + vitest + tsup build 3 개로 축소. lint 는 미설정 상태 — 도입 시 _meta 에 M.4 로 추가.
+- [2026-05-27 goal-0] simple-git 3.x 는 `import simpleGit` (default) 대신 `import { simpleGit }` (named) 가 TS 타입 호환 안정적. default 는 `typeof index` 로 추론되어 callable 안 됨.
+- [2026-05-27 goal-0] Notion SDK BlockObjectResponse 는 discriminated union — 동적 키 인덱싱 (`block[type]`) 시 `Record<string, ...>` 캐스팅 필요. `as any` 대신 좁은 Record 타입으로 안전성 유지.
+- [2026-05-27 goal-0] simple-git `DiffResult.files` 는 text/binary/name-status union — binary 항목은 insertions/deletions 부재. 정규화 시 `'insertions' in f` 가드로 0 fallback.
+- [2026-05-27 goal-0] MCP 풀 커버리지 전략: 비대화형 = `runVhkCli()` 서브프로세스 위임 / 대화형 본질 = dry-info 핸들러 (진단만, 실제 실행 X). 대화형 강제 wrap 보다 사용자에게 CLI 안내가 안전.
+- [2026-05-27 goal-0] McpServer `_registeredTools` private 멤버 introspection 으로 등록 tool 단언 가능 — SDK `1.29.0` 기준. SDK 메이저 업그레이드 시 깨질 수 있으므로 골격 테스트 한정 사용.
+- [2026-05-27 goal-0] Goal 0 완료. registerTool 24 도달 (10 baseline + 6 1차 + 8 2차). 대화형 4 커맨드 (gate/init/design palette/theme/start) MCP 제외 확정.

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -3,10 +3,18 @@
 _수동 갱신. 자동화는 Goal 1 의 `vhk goal next` 도입 후 활성화._
 
 ```
-TASK: Goal 0 — MCP 풀 커버리지 시작
-  - 다음 후보 tool 1 개 선택 (gate / init / sync 중)
-  - src/commands/<x>.ts 의 함수 시그니처 확인
-  - server.ts 에 registerTool 추가 + tests/ 에 단위 테스트
-  - bash scripts/check-goal-0.sh 통과 확인
-  - 작은 커밋: feat(mcp): expose <tool> tool
+TASK: Goal 1 — vhk goal 명령어 구현 (v1.2)
+  - goals/1-goal-command.md 의 Completion Check 항목 5 개 서브커맨드 구현
+    (init / list / next / check / done)
+  - YAML frontmatter 파서 (정규식 기반, gray-matter 의존성 추가 금지)
+  - `vhk check --goal N` goal-aware 확장
+  - tests/goal-*.test.ts 단위 테스트
+  - COMMANDS.md + README.md 명령어 표 갱신
+  - 게이트: scripts/check-goal-1.sh 작성 + 통과
 ```
+
+## Goal 0 완료 (2026-05-27)
+
+- MCP tool 10 → 24 도달
+- _meta 게이트 (tsc/tests/build) 모두 ✓
+- 대화형 본질 4 커맨드 (gate/init/design palette/theme/start) MCP 제외 확정

--- a/goals/0-mcp-full-coverage.md
+++ b/goals/0-mcp-full-coverage.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 0
 title: MCP 풀 커버리지 — 10 tool → 24 tool 확장
-status: NOT_STARTED
+status: DONE
 priority: P0
 version: v1.1
+completed: 2026-05-27
 ---
 
 # Mission: Expose every CLI command through MCP (Goal 0 dogfooding)

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import inquirer from 'inquirer'
-import simpleGit from 'simple-git'
+import { simpleGit } from 'simple-git'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { init } from './init.js'

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -23,12 +23,24 @@ function resolveCmd(cmd: string, args: string[]): { bin: string; argv: string[] 
   return { bin: platformCmd(cmd), argv: args }
 }
 
-export function safeExecFile(cmd: string, args: string[]): ExecResult {
+export interface SafeExecOptions {
+  // process.env 위에 병합할 환경변수. MCP 모드 ANSI 차단 (FORCE_COLOR=0, NO_COLOR=1) 등에 사용.
+  // 전체 교체 아닌 병합 — process.env 의 PATH/HOME 등을 잃지 않음.
+  env?: Record<string, string>
+}
+
+export function safeExecFile(
+  cmd: string,
+  args: string[],
+  opts: SafeExecOptions = {}
+): ExecResult {
   const { bin, argv } = resolveCmd(cmd, args)
+  const env = opts.env ? { ...process.env, ...opts.env } : undefined
   try {
     const out = execFileSync(bin, argv, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      env,
     }).toString()
     return { ok: true, out: out.trim() }
   } catch (err) {

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import simpleGit, { type SimpleGit } from 'simple-git'
+import { simpleGit, type SimpleGit } from 'simple-git'
 import { filterTrackedPaths } from './check-secure.js'
 
 const git: SimpleGit = simpleGit()
@@ -80,7 +80,18 @@ export async function getSessionDiff(since?: string): Promise<SessionDiff> {
   const sinceDate = since || new Date().toISOString().split('T')[0]
   try {
     const diffSummary = await git.diffSummary([`--since=${sinceDate}`])
-    return buildSessionDiffFromSummary(diffSummary)
+    // simple-git DiffResult.files 는 text/binary/name-status 의 union.
+    // binary/name-status 항목은 insertions/deletions 가 없으므로 0 으로 정규화.
+    const normalized = diffSummary.files.map((f) => ({
+      file: f.file,
+      insertions: 'insertions' in f ? f.insertions : 0,
+      deletions: 'deletions' in f ? f.deletions : 0,
+    }))
+    return buildSessionDiffFromSummary({
+      insertions: diffSummary.insertions,
+      deletions: diffSummary.deletions,
+      files: normalized,
+    })
   } catch {
     return { filesChanged: 0, insertions: 0, deletions: 0, files: [] }
   }

--- a/src/lib/notion-import.ts
+++ b/src/lib/notion-import.ts
@@ -76,7 +76,10 @@ async function fetchAllBlocks(client: Client, blockId: string): Promise<NotionBl
 
 function extractText(block: NotionBlock): string {
   const type = block.type
-  const data = block[type] as { rich_text?: Array<{ plain_text: string }> } | undefined
+  // Notion BlockObjectResponse 는 discriminated union — 동적 키 접근에는 Record 캐스팅 필요.
+  const data = (block as unknown as Record<string, { rich_text?: Array<{ plain_text: string }> }>)[
+    type
+  ]
   if (!data?.rich_text) return ''
   return data.rich_text.map(t => t.plain_text).join('')
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -4,6 +4,8 @@ import { z } from 'zod'
 import { existsSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs'
 import { safeExecFile } from '../lib/exec.js'
 import { parseEnvKeys } from '../commands/env.js'
+import { detectPlatform } from '../commands/deploy.js'
+import { bumpVersion } from '../commands/publish.js'
 import { readJsonFile } from '../lib/read-json.js'
 
 const SERVER_VERSION = '1.1.0'
@@ -411,6 +413,155 @@ export function createVhkMcpServer(): McpServer {
     'brief',
     { description: '프로젝트 브리핑(.vhk/brief.md) 생성 — git 상태 + 결정사항 + 다음 단계 제안' },
     async () => runVhkCli(['brief'], 'brief')
+  )
+
+  // ─── deploy ─────────────────────────────────────────────
+  // 실제 배포는 inquirer 프롬프트가 필수이므로 MCP 모드에서는 정보 조회만 제공.
+  server.registerTool(
+    'deploy',
+    {
+      description:
+        '배포 플랫폼 자동 감지 + CLI 설치 확인 (MCP 모드: 실제 배포 미수행 — `vhk deploy` 안내)',
+    },
+    async () => {
+      const platform = detectPlatform()
+      if (!platform) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: '❌ 배포 플랫폼 미감지 (vercel.json / netlify.toml / wrangler.toml 없음).\n플랫폼 설정 파일 추가 후 다시 시도.',
+            },
+          ],
+        }
+      }
+      const cliCheck = safeExecFile(platform, ['--version'])
+      const cliStatus = cliCheck.ok
+        ? `✓ ${platform} CLI 설치됨 (${cliCheck.out})`
+        : `✗ ${platform} CLI 미설치 — npm i -g ${platform}`
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `🚀 감지된 플랫폼: ${platform}\n${cliStatus}\n\n실제 배포는 터미널에서: vhk deploy`,
+          },
+        ],
+      }
+    }
+  )
+
+  // ─── publish ────────────────────────────────────────────
+  // bump type + 최종 confirm 이 inquirer 필수 → MCP 는 dry-info 만 제공.
+  server.registerTool(
+    'publish',
+    {
+      description:
+        '현재 버전 + bump 후보 표시 (MCP 모드: 실제 npm publish 미수행 — `vhk publish` 안내)',
+    },
+    async () => {
+      if (!existsSync('package.json')) {
+        return { content: [{ type: 'text', text: '❌ package.json 없음.' }] }
+      }
+      try {
+        const pkg = readJsonFile<{ version?: string; name?: string }>('package.json')
+        const v = pkg.version ?? '0.0.0'
+        const lines = [
+          `📦 ${pkg.name ?? '(이름 없음)'} 현재 v${v}`,
+          `  patch → v${bumpVersion(v, 'patch')}`,
+          `  minor → v${bumpVersion(v, 'minor')}`,
+          `  major → v${bumpVersion(v, 'major')}`,
+          '',
+          '실제 배포는 터미널에서: vhk publish',
+        ]
+        return { content: [{ type: 'text', text: lines.join('\n') }] }
+      } catch (e) {
+        return {
+          content: [{ type: 'text', text: `❌ package.json 파싱 실패: ${String(e)}` }],
+        }
+      }
+    }
+  )
+
+  // ─── migrate ────────────────────────────────────────────
+  // 전환 = lock/node_modules 삭제 + install. 실수 시 영향 큼 → MCP 는 진단만.
+  server.registerTool(
+    'migrate',
+    {
+      description:
+        '패키지 매니저 감지 + 전환 후보 가용성 (MCP 모드: 실제 전환 미수행 — `vhk migrate <target>` 안내)',
+    },
+    async () => {
+      const current = existsSync('pnpm-lock.yaml')
+        ? 'pnpm'
+        : existsSync('yarn.lock')
+          ? 'yarn'
+          : existsSync('package-lock.json')
+            ? 'npm'
+            : null
+      const candidates = (['npm', 'yarn', 'pnpm'] as const).filter((pm) => pm !== current)
+      const lines = [`현재 PM: ${current ?? '감지 불가 (lock 파일 없음)'}`]
+      for (const pm of candidates) {
+        const r = safeExecFile(pm, ['--version'])
+        lines.push(`  ${pm}: ${r.ok ? `✓ v${r.out}` : '✗ 미설치'}`)
+      }
+      lines.push('', '실제 전환은 터미널에서: vhk migrate <pnpm|npm|yarn>')
+      return { content: [{ type: 'text', text: lines.join('\n') }] }
+    }
+  )
+
+  // ─── update ─────────────────────────────────────────────
+  // npm update -g 는 글로벌 영향. MCP 는 버전 비교만 (--check 의미).
+  server.registerTool(
+    'update',
+    {
+      description:
+        'VHK 현재/최신 버전 비교 (MCP 모드: --check 만 — 실제 업데이트 미수행)',
+    },
+    async () => {
+      const cur = safeExecFile('vhk', ['--version'])
+      const latest = safeExecFile('npm', ['view', '@byh3071/vhk', 'version'])
+      const lines = [
+        `현재: ${cur.ok ? `v${cur.out.replace(/^v/, '')}` : '확인 실패'}`,
+        `최신: ${latest.ok ? `v${latest.out.replace(/^v/, '')}` : '확인 실패 (네트워크 또는 npm registry)'}`,
+      ]
+      if (cur.ok && latest.ok) {
+        const same = cur.out.replace(/^v/, '') === latest.out.replace(/^v/, '')
+        lines.push(
+          same
+            ? '✓ 최신 버전입니다.'
+            : '⬆️  업데이트 가능. 터미널에서: vhk update (또는 npm update -g @byh3071/vhk)'
+        )
+      }
+      return { content: [{ type: 'text', text: lines.join('\n') }] }
+    }
+  )
+
+  // ─── ref-list ───────────────────────────────────────────
+  server.registerTool(
+    'ref-list',
+    { description: '저장된 레퍼런스 URL 목록 보기 (add/open 은 인자/대화형 → CLI 전용)' },
+    async () => runVhkCli(['ref', 'list'], 'ref list')
+  )
+
+  // ─── memory-list ────────────────────────────────────────
+  server.registerTool(
+    'memory-list',
+    { description: '저장된 결정사항(memory) 목록 보기 (add/remove 는 인자 필요 → CLI 전용)' },
+    async () => runVhkCli(['memory', 'list'], 'memory list')
+  )
+
+  // ─── context-show ───────────────────────────────────────
+  server.registerTool(
+    'context-show',
+    { description: '.vhk/context.md 파일 내용 보기 (없으면 `vhk context` 안내)' },
+    async () => runVhkCli(['context-show'], 'context-show')
+  )
+
+  // ─── mcp-init ───────────────────────────────────────────
+  server.registerTool(
+    'mcp-init',
+    { description: '.cursor/mcp.json 생성/갱신 — vhk MCP 서버 등록 (Cursor 재시작 필요)' },
+    async () => runVhkCli(['mcp-init'], 'mcp-init')
   )
 
   return server

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -14,15 +14,24 @@ function isGitRepo(): boolean {
   return safeExecFile('git', ['rev-parse', '--is-inside-work-tree']).ok
 }
 
+// ANSI escape sequence (color / cursor / formatting). MCP 클라이언트 일부가
+// raw escape 를 그대로 노출해서 가독성 깨짐 → defensive strip.
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1B\[[0-9;?]*[ -/]*[@-~]/g
+
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, '')
+}
+
 // vhk CLI 자체를 서브프로세스로 호출해서 결과를 MCP content로 변환.
 // MCP 모드에서는 inquirer/ora 프롬프트가 동작하지 않으므로 비대화형 커맨드만 위임.
-// 호출 측은 stdout을 받아 그대로 반환 — chalk ANSI는 클라이언트에서 적당히 처리.
+// chalk 가 색을 안 쓰도록 FORCE_COLOR=0 + NO_COLOR=1 강제 + 잔여 ANSI 는 regex strip.
 function runVhkCli(
   args: string[],
   headline: string
 ): { content: [{ type: 'text'; text: string }] } {
-  const result = safeExecFile('vhk', args)
-  const body = result.out || (result.ok ? '' : `(stdout 없음)\n${result.err}`)
+  const result = safeExecFile('vhk', args, { env: { FORCE_COLOR: '0', NO_COLOR: '1' } })
+  const body = stripAnsi(result.out || (result.ok ? '' : `(stdout 없음)\n${result.err}`))
   const prefix = result.ok ? `✅ ${headline}` : `❌ ${headline} 실패`
   return { content: [{ type: 'text', text: `${prefix}\n${body}`.trim() }] }
 }

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -27,15 +27,31 @@ describe('MCP Server', () => {
     }
   })
 
-  it('Goal 0 v1.1 신규 6 tool이 등록되어 있다', async () => {
+  it('Goal 0 1차 — 신규 6 tool (sync/secure/audit/harness/context/brief)', async () => {
     const names = await getRegisteredToolNames()
     for (const t of ['sync', 'secure', 'audit', 'harness', 'context', 'brief']) {
       expect(names).toContain(t)
     }
   })
 
-  it('총 16+ tool이 등록되어 있다 (Goal 0 진행 중 baseline)', async () => {
+  it('Goal 0 2차 — 신규 8 tool (deploy/publish/migrate/update/ref-list/memory-list/context-show/mcp-init)', async () => {
     const names = await getRegisteredToolNames()
-    expect(names.length).toBeGreaterThanOrEqual(16)
+    for (const t of [
+      'deploy',
+      'publish',
+      'migrate',
+      'update',
+      'ref-list',
+      'memory-list',
+      'context-show',
+      'mcp-init',
+    ]) {
+      expect(names).toContain(t)
+    }
+  })
+
+  it('Goal 0 완료 baseline — registerTool 24개 이상', async () => {
+    const names = await getRegisteredToolNames()
+    expect(names.length).toBeGreaterThanOrEqual(24)
   })
 })


### PR DESCRIPTION
## Summary

- **Goal 0 (MCP 풀 커버리지) 완료** — MCP tool 16 → 24
- `_meta` M.1 영구 블로커였던 사전존재 typecheck 4 건 해결
- `goals/0-mcp-full-coverage.md` status `DONE` 마킹 + state 머신 갱신

## 커밋 구성 (4 commits)

| # | sha | scope | 요약 |
| --- | --- | --- | --- |
| 1 | `0af86b8` | chore(docs) | CLAUDE.md + .cursorrules — Phase 3 IN_PROGRESS + MCP 모드 규칙 |
| 2 | `631f759` | fix | 사전존재 tsc 4 건 (simple-git default→named, DiffResult union, Notion BlockObjectResponse 인덱싱) |
| 3 | `82ada08` | feat(mcp) | Goal 0 완료 — 신규 8 tool + tests 244/244 |
| 4 | `9a16de5` | docs(goals) | Goal 0 DONE 마킹 + next-task.md Goal 1 전환 + learnings 6 건 |

## 신규 MCP tool 8 종 — 2 가지 전략

### dry-info 핸들러 (대화형 본질 — 진단/안내만)

| tool | 이유 | 동작 |
| --- | --- | --- |
| `deploy` | inquirer 플랫폼 select + confirm | `detectPlatform()` + CLI 가용성 체크 |
| `publish` | inquirer bump select + confirm | 현재 버전 + patch/minor/major 후보 표시 |
| `migrate` | lock 삭제 + install 위험 | 현재 PM + 전환 후보 가용성 |
| `update` | npm update -g 글로벌 영향 | `vhk --version` vs `npm view` 비교 |

### `runVhkCli()` 서브프로세스 위임 (비대화형 안전)

| tool | 위임 |
| --- | --- |
| `ref-list` | `vhk ref list` |
| `memory-list` | `vhk memory list` |
| `context-show` | `vhk context-show` |
| `mcp-init` | `vhk mcp-init` |

## 게이트 검증 — `bash scripts/check-goal-0.sh` exit 0

- ✓ `_meta` M.1 — `tsc --noEmit` clean
- ✓ `_meta` M.2 — `pnpm test:run` 244/244 pass
- ✓ `_meta` M.3 — `pnpm build` 성공
- ✓ G0.1 — `registerTool` count 24 (>= 24)
- ✓ G0.2 — `server.ts` inquirer import 0
- ✓ G0.3 — `server.ts` execSync 0

## tsc 4 건 수정 요약

| 파일 | 증상 | 수정 |
| --- | --- | --- |
| `start.ts:35`, `git.ts:5` | `simpleGit` default not callable | `import { simpleGit }` named export |
| `git.ts:83` | `DiffResult.files` union 비호환 | binary 항목 insertions/deletions 0 정규화 |
| `notion-import.ts:79` | `BlockObjectResponse` 인덱싱 implicit any | `Record<string, ...>` 캐스팅 |

## MCP 제외 확정 (대화형 본질)

`gate` / `init` / `design palette` / `theme` / `start` — inquirer 가 본질이라 MCP wrap 시 사용자 경험 저하. `runVhkCli` 대신 CLI 호출 안내가 안전.

## Test plan

- [x] `pnpm exec tsc --noEmit` exit 0
- [x] `pnpm test:run` 244/244 pass
- [x] `pnpm build` 성공
- [x] `bash scripts/check-goal-0.sh` exit 0
- [ ] (수동) MCP 클라이언트(Cursor/Claude Desktop) 에서 신규 8 tool 호출 검증
- [ ] (수동) `deploy` / `publish` / `migrate` / `update` dry-info 메시지가 사용자에게 명확한지 검토

## 다음 (Goal 1)

`vhk goal init/list/next/check/done` 5 개 서브커맨드 구현. `docs/state/next-task.md` 참조.

🤖 Generated with [Claude Code](https://claude.com/claude-code)