### PR TITLE
chore(v1.3.0): polish — README/ARCHITECTURE/printNextStep/gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@ dist/
 *.tsbuildinfo
 .DS_Store
 
+# Local env — never commit secrets
+.env
+.env.local
+.env.*.local
+
 # VHK runtime tripwire — local-only, never commit
 .vhk/HARD_STOP
 

--- a/README.md
+++ b/README.md
@@ -1,56 +1,89 @@
 ---
 id: vhk-readme
-date: 2026-05-24
-tags: [vhk, cli, readme, v1.0.0, ga]
+date: 2026-05-28
+tags: [vhk, cli, readme, v1.3.0, ga]
 ---
 
 # 🔧 VHK — Vibe Harness Kit
 
-> 🎉 **v1.0.0 GA** — 바이브코더의 올인원 CLI. 공개 API 안정성 보장.
+> 🎉 **v1.3.0** — 바이브코더의 올인원 CLI. 컨텍스트 + 자율 하네스.
 >
-> AI 코딩 에이전트를 부리는 사람을 위한 **한국어 풀사이클 CLI** (v1.0.0)
+> AI 코딩 에이전트를 부리는 사람을 위한 **한국어 풀사이클 CLI**.
 >
 > 🍽️ **VHK는 VHK로 부트스트랩됨** — 이 레포의 `docs/`, `CLAUDE.md`, `.cursorrules`도 `vhk init`이 만들었습니다.
 
 명령어를 외우지 않아도 됩니다. `vhk`만 치면 메뉴가 나오고, 한국어로 말해도 알아듣습니다.
 
-## 설치
+## 3분 안에 시작하기 (Getting Started)
+
+### 1. 설치
 
 ```bash
 npm install -g @byh3071/vhk
-```
-
-```bash
-# 한 번만 쓸 때
-npx @byh3071/vhk
-```
-
-로컬 개발 중:
-
-```powershell
-cd vhk-cli
-pnpm install
-pnpm build
-pnpm link --global
 vhk --version
 ```
 
-## 빠른 시작
+> Node.js ≥ 20 필요. `npx @byh3071/vhk` 로 1회성 실행도 가능.
+
+### 2. 첫 프로젝트 — `vhk start` (마법사)
+
+```bash
+mkdir my-app && cd my-app
+vhk start
+```
+
+`vhk start` 한 번이면 **git init → 문서 생성 → MCP 등록 → 컨텍스트 파일** 까지 자동으로 끝납니다.
+
+기획이 막 떠올랐다면 검증부터:
+
+```bash
+vhk gate          # 퀵 5문항 — GO / 다듬기 / 다른 아이디어
+```
+
+### 3. v1.3 핵심 기능 한눈에
+
+| 기능 | 한 줄 요약 | 진입 명령 |
+|------|-----------|-----------|
+| 🎯 **Goals 체계** | 단계별 미션 + 게이트 스크립트로 AI가 목표를 스스로 추적 | `vhk goal init` |
+| ▶️ **자율 루프** | `goal next → 작업 → goal check → goal done`. FAIL 3회면 자동 블로커 | `vhk goal next` |
+| 🚧 **HARD_STOP 안전장치** | 블로커 3건 누적 → `.vhk/HARD_STOP` 트립와이어. `vhk resume --confirm` 만 해제 | `vhk blocker "<증상>"` |
+| 🔌 **MCP 24 tool** | Cursor·Claude Desktop 등에서 vhk를 채팅으로 호출 | `vhk mcp-init` |
+| 📋 **컨텍스트 영속화** | `.vhk/context.md` + `memory.json` + `brief.md` 로 세션 간 맥락 유지 | `vhk context` |
+
+### 4. 권장 일일 사이클
+
+```text
+세션 시작 :  vhk context          # AI에 줄 프로젝트 맥락 갱신
+            vhk goal next         # 오늘 작업할 미션 자동 선택
+
+   개발 ...
+
+세션 종료 :  vhk goal check        # 게이트 스크립트로 통과 검증
+            vhk goal done         # 통과 시 status: DONE 으로 전이
+            vhk save              # add → commit → push 한 번에
+            vhk recap             # docs/log/ 에 오늘 기록
+```
+
+### 5. 자연어로도 됩니다
+
+```bash
+vhk 프로젝트 만들고 싶어
+vhk 기획 끝났고 바로 시작
+vhk 오늘 한 일 정리
+vhk 저장해줘
+vhk 다음 목표
+vhk 블로커 "API 호출 실패"
+```
+
+---
+
+## 빠른 시작 (인터랙티브 메뉴)
 
 ```bash
 vhk
 ```
 
 인자 없이 실행하면 **「뭘 도와드릴까요?」** 메뉴가 열립니다.
-
-```bash
-# 자연어로도 가능
-vhk 프로젝트 만들고 싶어
-vhk 기획 끝났고 바로 시작
-vhk 오늘 한 일 정리
-vhk 저장해줘
-vhk 변경사항 보여줘
-```
 
 ## 워크플로우 (권장 순서)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,17 +1,170 @@
 # Architecture — vhk
 
-## 기술 스택
-Node.js + TypeScript + commander + inquirer + chalk
+> 마지막 갱신: 2026-05-28 (v1.3.0)
+>
+> VHK CLI 의 내부 구조. 외부 사용자 가이드는 [README.md](../README.md), 운영/기록 규칙은 [CLAUDE.md](../CLAUDE.md) 참조.
 
-## 폴더 구조
-(프로젝트 구조를 여기에 작성)
+## 1. 한눈에 보기
 
-## 데이터 모델
-| 테이블 | 핵심 컬럼 | 설명 |
-|--------|----------|------|
-| __FILL__ | | |
+```text
+┌───────────────────────────────────────────────────────────┐
+│  사용자 / Cursor / Claude Desktop                          │
+└──────────────┬─────────────────────────┬──────────────────┘
+               │ CLI                     │ MCP (stdio, 24 tool)
+               ▼                         ▼
+        ┌──────────────┐         ┌──────────────────┐
+        │  src/index.ts │         │  src/mcp/server  │
+        │  (commander) │         │  (@mcp/sdk)      │
+        └──────┬───────┘         └──────────┬───────┘
+               │                            │
+               └─────────┬──────────────────┘
+                         ▼
+                 ┌───────────────┐
+                 │ src/commands/ │  ← 비즈니스 로직 단위
+                 └───────┬───────┘
+                         ▼
+                 ┌───────────────┐
+                 │   src/lib/    │  ← 재사용 유틸 (exec, git, secrets …)
+                 └───────┬───────┘
+                         ▼
+            ┌───────────────────────────┐
+            │  하네스 산출물 (프로젝트별)  │
+            │  goals/ · docs/state/      │
+            │  scripts/check-*.sh        │
+            │  .vhk/HARD_STOP            │
+            └───────────────────────────┘
+```
 
-## 외부 서비스
-| 서비스 | 용도 |
-|--------|------|
-| __FILL__ | |
+## 2. 기술 스택
+
+| 영역 | 선택 | 비고 |
+|------|------|------|
+| 런타임 | Node.js ≥ 20 | ESM 출력 |
+| 언어 | TypeScript (strict) | tsup 번들 |
+| CLI 프레임워크 | `commander` | `program.command()` 단위 |
+| 프롬프트 UX | `inquirer` | TTY 전용 (MCP 모드 차단) |
+| 출력 | `chalk`, `ora` | 색상 + 스피너 |
+| MCP | `@modelcontextprotocol/sdk` | stdio transport |
+| 테스트 | `vitest` | 293+ pass |
+| 패키지 매니저 | `pnpm` | `pnpm build` / `pnpm test` |
+
+## 3. 레이어별 책임
+
+### 3.1 CLI 레이어 — [src/index.ts](../src/index.ts) + [src/commands/](../src/commands/)
+
+- `src/index.ts` — commander 진입점, 한국어 별칭(`KO_ALIASES`) 매핑, 시작 메뉴(inquirer), 자연어 라우터 fallback
+- `src/commands/<name>.ts` — 명령 1개당 1파일. 시그니처: `export async function <name>(opts?)`
+- 출력 컨벤션:
+  - 헤더: `chalk.bold` + 이모지
+  - 다음 액션 안내: `lib/next-step.ts:printNextStep()` 패턴 통일
+  - 한국어 메시지는 [src/i18n/ko.ts](../src/i18n/ko.ts) 의 `t()` 키만 사용
+
+### 3.2 MCP 레이어 — [src/mcp/](../src/mcp/)
+
+- `server.ts` — `@modelcontextprotocol/sdk` stdio 서버. 24 tool 노출.
+- 핸들러 패턴: `runVhkCli(args, headline)` 헬퍼로 CLI 실행을 wrap (인터랙티브 프롬프트 차단)
+- 제외 커맨드 (TTY 필수): `gate`, `init`, `start`, `design palette`, `theme`, `goal`
+- 핸들러 내부 `process.exit()` 금지 — MCP 클라이언트 세션 강제 종료 위험
+
+### 3.3 라이브러리 — [src/lib/](../src/lib/)
+
+| 파일 | 책임 |
+|------|------|
+| `exec.ts` | `safeExecFile()` — argv 분리 기반 셸 인젝션 차단. `execSync` 신규 사용 금지의 SoT |
+| `git-repo.ts` / `git-porcelain.ts` / `git.ts` | git 호출 + porcelain 파서 |
+| `scan-secrets.ts` / `secret-patterns.ts` / `check-secure.ts` | 시크릿/키 패턴 매처 |
+| `goal-frontmatter.ts` | `goals/*.md` YAML frontmatter 파싱/갱신 |
+| `state-files.ts` | `docs/state/next-task.md` / `blockers.md` / `learnings.md` SoT IO |
+| `nlp-router.ts` / `nlp-run.ts` | 자연어 → 명령어 매핑 (트리거 키워드 사전) |
+| `next-step.ts` | `printNextStep({ message, command, cursorHint })` — 모든 명령 종료 시 일관된 안내 |
+| `read-json.ts` | JSON 파일 안전 읽기 |
+| `cli-args.ts` | 자연어 입력 감지 (단어 1개 + 한글) |
+| `version.ts` | `package.json` 버전 동적 조회 |
+| `adr.ts` / `rules-parser.ts` / `notion-import.ts` / `scan-files.ts` | 보조 |
+
+### 3.4 i18n + 템플릿
+
+- [src/i18n/ko.ts](../src/i18n/ko.ts) — 모든 사용자 노출 문자열의 SoT. v1.0 GA 부터 키 이름 안정 (추가만, 제거/이름 변경 금지).
+- [src/templates/](../src/templates/) — `vhk init` 산출물 템플릿 (CLAUDE.md, .cursorrules, docs/ 스캐폴딩).
+- [src/notion/](../src/notion/) — Notion PRD import 어댑터 (`vhk init --from-notion`).
+
+### 3.5 하네스 — 프로젝트 산출물
+
+CLI 가 만들어 내는 외부 아티팩트:
+
+```text
+goals/
+├── _meta.md              ← 공통 게이트 명세
+├── 0-mcp-full-coverage.md
+├── 1-goal-command.md
+└── 2-agent-loop.md       ← YAML frontmatter (status / priority / completed)
+
+docs/state/
+├── next-task.md          ← vhk goal next 산출
+├── blockers.md           ← vhk blocker 누적 (3건 → HARD_STOP)
+└── learnings.md          ← vhk learn 누적
+
+scripts/
+├── check-meta.sh         ← 공통 게이트
+├── check-goal-0.sh
+├── check-goal-1.sh
+└── check-goal-2.sh
+
+.vhk/
+├── HARD_STOP             ← 트립와이어 (gitignored)
+├── context.md            ← vhk context
+├── memory.json           ← vhk memory
+├── brief.md              ← vhk brief
+└── refs.json             ← vhk ref
+```
+
+자율 루프 한 사이클:
+
+```text
+vhk context → vhk goal next → (작업) → vhk goal check → vhk goal done
+                                          │ FAIL × 3 cycle
+                                          ▼
+                                   vhk blocker "<증상>"
+                                          │ 3건 누적
+                                          ▼
+                                  .vhk/HARD_STOP 자동
+                                          │
+                                          ▼
+                                  사람 검토 → vhk resume --confirm
+```
+
+## 4. 보안 가드레일
+
+| 가드 | 위치 | 위반 시 |
+|------|------|--------|
+| `execSync` 금지 → `safeExecFile` 강제 | `src/lib/exec.ts` | 셸 인젝션 회귀 위험 |
+| MCP handler 에서 `process.exit()` 금지 | `src/mcp/server.ts` | MCP 클라이언트 세션 강제 종료 |
+| MCP 에서 `inquirer` 호출 금지 | 모든 MCP handler | TTY 없음 → hang |
+| `.env` → `.gitignore` 자동 추가 | `vhk env` | 시크릿 평문 커밋 |
+| `vhk save` 전 시크릿 스캔 | `commands/save.ts` | CRITICAL/HIGH 발견 시 확인 프롬프트 |
+| `vhk resume` 자동 호출 금지 | `commands/agent.ts` | HARD_STOP 우회 (사람 개입 필수) |
+
+## 5. 빌드 / 배포
+
+- `pnpm build` — tsup → `dist/index.js` (CLI) + `dist/mcp/index.js` (MCP)
+- `pnpm test --run` — vitest 일괄
+- `prepublishOnly` — publish 전 build + test 강제
+- `vhk publish` — semver 범프 → 빌드 → 테스트 → `npm publish` → git tag
+- npm 패키지: `@byh3071/vhk` (public, scoped)
+- bin: `vhk` (`dist/index.js`), `vhk-mcp` (`dist/mcp/index.js`)
+
+## 6. 안정성 약속 (v1.0 GA → v2.0)
+
+- 명령어 이름 / CLI 인자 / `.vhk/` 파일 포맷 — breaking change 금지
+- MCP tool 시그니처 — breaking change 금지
+- `ko.ts` 의 `t()` 키 이름 — 신규 키 추가만, 기존 키 미제거
+- deprecation 절차: 제거 전 1개 마이너 버전(1.x.0) 에서 경고
+
+## 7. 참고
+
+- 운영 규칙: [CLAUDE.md](../CLAUDE.md), [AGENTS.md](../AGENTS.md)
+- Goal 사양: [goals/_meta.md](../goals/_meta.md)
+- 코딩 컨벤션: [.cursorrules](../.cursorrules), CLAUDE.md "코딩 컨벤션" 섹션
+- 작업 로그: [docs/log/](./log/)
+- ADR: [docs/adr/](./adr/)
+- 트러블슈팅: [docs/troubleshooting/](./troubleshooting/)

--- a/src/commands/mcp-init.ts
+++ b/src/commands/mcp-init.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
 import { readJsonFile } from '../lib/read-json.js'
+import { printNextStep } from '../lib/next-step.js'
 
 type McpEntry = { command: string; args: string[] }
 type McpConfig = { mcpServers: Record<string, McpEntry> }
@@ -93,8 +94,9 @@ export async function mcpInit(): Promise<void> {
   console.log(chalk.green('\n✅ Cursor MCP 설정 완료!'))
   console.log(chalk.cyan('📁 생성된 파일:'))
   console.log(`   ${configPath}`)
-  console.log(chalk.cyan('\n🔄 다음 단계:'))
-  console.log('   1. Cursor를 재시작하세요')
-  console.log('   2. Cursor 채팅에서 vhk 도구를 사용할 수 있습니다')
-  console.log(chalk.gray('\n💡 예: "프로젝트 상태 알려줘" → Cursor가 vhk status 호출'))
+  printNextStep({
+    message: t('mcp.nextMessage'),
+    command: 'vhk mcp',
+    cursorHint: t('mcp.nextCursor'),
+  })
 }

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -12,6 +12,7 @@ import {
   getExecErrorMessage,
 } from '../lib/git-repo.js'
 import { filterSevereFindings, scanProjectForSecrets } from '../lib/scan-secrets.js'
+import { printNextStep } from '../lib/next-step.js'
 import { t } from '../i18n/ko.js'
 
 export function formatDefaultCommitMessage(date = new Date()): string {
@@ -112,8 +113,18 @@ export async function save(): Promise<void> {
 
     if (process.exitCode !== 1) {
       console.log(chalk.green(`\n✅ ${t('save.done', lines.length)}`))
+      printNextStep({
+        message: t('save.nextOkMessage'),
+        command: 'vhk recap',
+        cursorHint: t('save.nextOkCursor'),
+      })
     } else {
       console.log(chalk.green(`\n✅ ${t('save.doneLocalOnly', lines.length)}`))
+      printNextStep({
+        message: t('save.nextPushFailMessage'),
+        command: 'vhk doctor',
+        cursorHint: t('save.nextPushFailCursor'),
+      })
     }
   } catch (err) {
     spinner.fail(t('save.failed'))

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk'
 import { normalizePorcelain } from '../lib/git-porcelain.js'
 import { getGitRoot, gitOut } from '../lib/git-repo.js'
 import { readJsonFile } from '../lib/read-json.js'
+import { printNextStep } from '../lib/next-step.js'
 import { t } from '../i18n/ko.js'
 
 export interface FileChangeCounts {
@@ -156,5 +157,18 @@ export async function status(): Promise<void> {
     console.log(chalk.dim(`📦 ${t('status.noPackage')}`))
   }
 
-  console.log('')
+  const hasChanges = counts.staged + counts.unstaged + counts.untracked > 0
+  if (hasChanges) {
+    printNextStep({
+      message: t('status.nextWithChangesMessage'),
+      command: 'vhk save',
+      cursorHint: t('status.nextWithChangesCursor'),
+    })
+  } else {
+    printNextStep({
+      message: t('status.nextCleanMessage'),
+      command: 'vhk goal next',
+      cursorHint: t('status.nextCleanCursor'),
+    })
+  }
 }

--- a/src/commands/undo.ts
+++ b/src/commands/undo.ts
@@ -8,6 +8,7 @@ import {
   gitRun,
   hasGitRemote,
 } from '../lib/git-repo.js'
+import { printNextStep } from '../lib/next-step.js'
 import { t } from '../i18n/ko.js'
 
 export function parseRecentCommits(logOutput: string): string[] {
@@ -122,6 +123,11 @@ export async function undo(): Promise<void> {
     if (risky) {
       console.log(chalk.yellow(`\n💡 ${t('undo.forcePushHint')}`))
     }
+    printNextStep({
+      message: t('undo.nextMessage'),
+      command: 'vhk save',
+      cursorHint: t('undo.nextCursor'),
+    })
   } catch (err) {
     console.log(chalk.red(`❌ ${t('undo.failed')}`))
     const msg = err instanceof Error ? err.message : String(err)

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -6,6 +6,7 @@ import ora from 'ora'
 import { t } from '../i18n/ko.js'
 import { readJsonFile } from '../lib/read-json.js'
 import { safeExecFile } from '../lib/exec.js'
+import { printNextStep } from '../lib/next-step.js'
 
 const PACKAGE = '@byh3071/vhk'
 
@@ -72,10 +73,20 @@ export async function update(): Promise<void> {
     updateSpinner.succeed(`v${latest}으로 업데이트 완료!`)
     console.log(chalk.green.bold(`\n🎉 VHK CLI v${latest} 업데이트 완료!`))
     console.log(chalk.gray('   변경 사항은 GitHub Releases를 확인하세요.'))
+    printNextStep({
+      message: t('update.nextOkMessage'),
+      command: 'vhk --version',
+      cursorHint: t('update.nextOkCursor'),
+    })
   } else {
     updateSpinner.fail('업데이트 실패')
     console.log(chalk.red(upd.err.slice(0, 300)))
     console.log(chalk.yellow('\n수동으로 업데이트하세요:'))
     console.log(chalk.gray(`   npm update -g ${PACKAGE}`))
+    printNextStep({
+      message: t('update.nextFailMessage'),
+      command: 'vhk doctor',
+      cursorHint: t('update.nextFailCursor'),
+    })
   }
 }

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -15,6 +15,10 @@ export const ko = {
     noPackage: 'package.json 없음',
     detached: '(detached HEAD)',
     unknownBranch: '(알 수 없음)',
+    nextWithChangesMessage: '변경사항이 있어요. 커밋·푸시를 진행하세요.',
+    nextWithChangesCursor: '저장해줘',
+    nextCleanMessage: '클린 상태! 다음 미션으로 넘어가세요.',
+    nextCleanCursor: '다음 목표 알려줘',
   },
   save: {
     title: '저장하기',
@@ -38,6 +42,10 @@ export const ko = {
     commitOkPushFailed: '로컬 커밋은 됐지만 원격 push에 실패했습니다. git push를 직접 확인하세요.',
     done: (n: number) => `${n}개 파일 저장 완료!`,
     doneLocalOnly: (n: number) => `${n}개 파일 로컬 저장됨 (push는 실패)`,
+    nextOkMessage: '저장 완료! 오늘 작업을 정리해두면 좋아요.',
+    nextOkCursor: '오늘 한 일 정리해줘',
+    nextPushFailMessage: '커밋은 됐지만 push 실패. 원격을 확인하세요.',
+    nextPushFailCursor: '왜 push 실패인지 알려줘',
   },
   undo: {
     title: '되돌리기',
@@ -58,6 +66,8 @@ export const ko = {
     forcePushHint:
       '원격과 맞추려면: git push --force-with-lease (혼자 작업한 브랜치에서만, 팀과 합의 후)',
     failed: '되돌리기 실패',
+    nextMessage: '변경사항이 스테이징 영역에 남았어요. 메시지 고쳐서 다시 저장하세요.',
+    nextCursor: '커밋 메시지 바꿔서 저장해줘',
   },
   diff: {
     title: '변경사항 확인',
@@ -272,6 +282,8 @@ export const ko = {
   mcp: {
     initTitle: 'Cursor MCP 연동 설정',
     serverStarted: 'VHK MCP 서버 시작됨',
+    nextMessage: 'Cursor / Claude Desktop 을 재시작한 뒤 채팅에서 vhk 도구를 호출하세요.',
+    nextCursor: '프로젝트 상태 알려줘',
   },
   deploy: {
     title: '배포하기',
@@ -309,6 +321,10 @@ export const ko = {
   },
   update: {
     title: 'VHK CLI 업데이트',
+    nextOkMessage: '업데이트 완료! 새 버전 확인하세요.',
+    nextOkCursor: 'vhk 버전 알려줘',
+    nextFailMessage: '업데이트 실패. 환경 점검부터 해보세요.',
+    nextFailCursor: 'vhk doctor 실행해줘',
   },
   context: {
     title: '프로젝트 컨텍스트 생성',

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,7 +219,7 @@ program
 
 program
   .command('mcp')
-  .description('MCP 서버 시작 (Cursor 등 MCP 클라이언트용)')
+  .description('MCP 서버 시작 (24 tool stdio — Cursor·Claude Desktop 등)')
   .action(async () => {
     await startMcpServer()
   })
@@ -227,7 +227,7 @@ program
 program
   .command('mcp-init')
   .alias('mcp설정')
-  .description('Cursor MCP 연동 설정 자동 생성 (.cursor/mcp.json)')
+  .description('Cursor·Claude Desktop MCP 연동 설정 자동 생성 (.cursor/mcp.json)')
   .action(async () => {
     await mcpInit()
   })


### PR DESCRIPTION
## Summary

v1.3.0 publish 후 정합/품질 보강. 사용자 영향 0 (코드/메시지만 변경, 기존 API 무변경).

- 📚 **README Getting Started** 강화 — 3분 안에 시작 가능하도록 상단 재구성 + v1.3 핵심 기능표 + 일일 사이클
- 🛠 **vhk --help** mcp / mcp-init 설명에 v1.3 정합 (24 tool / Cursor·Claude Desktop)
- 🏛 **docs/ARCHITECTURE.md** 작성 — CLI/MCP/lib/하네스 레이어별 책임 + 보안 가드레일 + 안정성 약속
- ✨ **printNextStep()** status/save/undo/mcp-init/update 5개 명령에 일관된 다음 액션 안내 추가
- 🔒 **.gitignore** .env / .env.local / .env.*.local 패턴 추가

## Commits (논리 단위)

1. \`e27f669\` chore: .gitignore에 .env 추가
2. \`7cdf74a\` docs: README.md Getting Started 강화 (v1.3.0)
3. \`7693939\` chore: --help 출력 최신화
4. \`c17fa15\` docs: ARCHITECTURE.md 작성
5. \`e96609d\` feat(dx): printNextStep() 누락 커맨드 추가

## Out of scope

- npm publish ❌ (v1.3.0 publish 완료, 버전 무변경)
- package.json 버전 ❌
- breaking change ❌

## 별도 처리 (이 PR 외)

랜딩 페이지 (https://yohanstudio.co/vhk) v1.3 반영은 **Yohan-Studio 레포 \`chore/vhk-v1.3.0-landing\` 브랜치에 로컬 커밋** 으로 분리.
prod 사이트 자동 배포 방지 위해 push 미진행 — 검토 후 직접 push/merge 결정 필요.

변경 요지:
- Hero: 30개+ → 35개 명령어, 가치 메시지 갱신
- Features: vhkCommands 9 → 13 (goal/blocker/learn/resume), MCP 24 tool 엔트리 카드 추가
- Spec: v1.0 → v1.3, goals/ + docs/state/ + scripts/ + .vhk/HARD_STOP 트리 추가
- Roadmap: Layer 1 desc 갱신

## Test plan

- [x] \`pnpm build\` 성공
- [x] \`pnpm test --run\` 293 pass
- [ ] (수동) \`vhk --help\` mcp/mcp-init 설명 확인
- [ ] (수동) \`vhk status\` / \`vhk save\` / \`vhk undo\` / \`vhk mcp-init\` / \`vhk update\` 실행 시 printNextStep 출력 확인
- [ ] (별도 레포) Yohan-Studio \`chore/vhk-v1.3.0-landing\` 브랜치 검토 후 PR/머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)