### PR TITLE
feat(sync): vhk sync에 Windsurf(.windsurfrules) 출력 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ vhk 기획 끝났고 바로 시작
 | `vhk gate` | `검증`, `아이디어` | 아이디어 검증 (퀵 5문항 / 풀 13문항 / 스킵) |
 | `vhk init` | `시작`, `만들기` | 프로젝트 초기화 + 하네스 생성 |
 | `vhk recap` | `정리`, `오늘` | Git 변경 → `docs/log/` 세션 로그 |
-| `vhk sync` | `규칙`, `맞추기` | RULES.md → `.cursorrules` + CLAUDE.md |
+| `vhk sync` | `규칙`, `맞추기` | RULES.md → `.cursorrules` + CLAUDE.md + `.windsurfrules` |
 | `vhk check` | `점검`, `린트` | RULES.md 규칙 위반 검사 |
 | `vhk secure` | `보안` | 시크릿·키 유출 스캔 (`scan` / `스캔` 동일). **CRITICAL/HIGH 발견 시 exit code 1** (CI용) |
 | `vhk ship` | `출하` | 배포 체크리스트 + 회고 + 빌드 로그 |

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -69,6 +69,35 @@ export function toCursorrules(sections: RulesSection[], projectName: string): st
 }
 
 /**
+ * RULES.md 섹션을 .windsurfrules 포맷으로 변환
+ * Windsurf(Cascade)도 Cursor처럼 코딩 규칙 파일을 읽으므로 .cursorrules와 동일 섹션을 미러링한다.
+ */
+export function toWindsurfrules(sections: RulesSection[], projectName: string): string {
+  const codingSections = sections.filter(s =>
+    CURSORRULES_KEYS.some(k => s.title.includes(k))
+  )
+
+  const lines = [
+    `# ${projectName} — Windsurf Rules`,
+    '',
+    '> 코딩/디자인 전용. 기록/운영 → CLAUDE.md 참조.',
+    '> ⚡ 이 파일은 RULES.md에서 자동 생성됨 (vhk sync). 직접 수정 금지.',
+    '',
+    '## 필수 참조',
+    '- docs/PRD.md · docs/ARCHITECTURE.md · CLAUDE.md · RULES.md',
+    '',
+  ]
+
+  for (const section of codingSections) {
+    lines.push(`## ${section.title}`)
+    lines.push(section.content)
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+/**
  * RULES.md 섹션을 CLAUDE.md 포맷으로 변환
  */
 export function toClaudeMd(sections: RulesSection[], existing: string): string {
@@ -136,8 +165,12 @@ export async function sync() {
   fs.writeFileSync(claudePath, toClaudeMd(sections, existingClaude), 'utf-8')
   console.log(chalk.green(`  ${ko.sync.claudeDone}`))
 
+  const windsurfPath = path.join(cwd, '.windsurfrules')
+  fs.writeFileSync(windsurfPath, toWindsurfrules(sections, projectName), 'utf-8')
+  console.log(chalk.green(`  ${ko.sync.windsurfDone}`))
+
   console.log(chalk.bold.green(`\n${ko.sync.done}`))
-  console.log(chalk.dim('  RULES.md (원본) → .cursorrules + CLAUDE.md (자동 생성)'))
+  console.log(chalk.dim('  RULES.md (원본) → .cursorrules + CLAUDE.md + .windsurfrules (자동 생성)'))
   console.log(chalk.dim('  규칙 변경은 항상 RULES.md에서만 하세요.'))
 
   printNextStep({

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -221,6 +221,7 @@ export const ko = {
     noRules: '⚠️ RULES.md 파일이 없어요.',
     cursorrulesDone: '✅ .cursorrules 맞춤 완료',
     claudeDone: '✅ CLAUDE.md 맞춤 완료',
+    windsurfDone: '✅ .windsurfrules 맞춤 완료',
     done: '🔄 맞추기 완료!',
   },
   ship: {

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -1,16 +1,61 @@
 import { describe, it, expect } from 'vitest'
+import { parseRulesMd, toCursorrules, toWindsurfrules } from '../src/commands/sync.js'
 
-describe('vhk sync', () => {
-  it('RULES.md 없으면 경고 메시지', () => {
-    // TODO: RULES.md 없는 디렉토리에서 실행
-    expect(true).toBe(true)
+const SAMPLE_RULES = `# 데모 프로젝트 — Rules
+
+## 코딩 규칙
+- execSync 금지 → safeExecFile 사용
+- 파일명은 kebab-case
+
+## 기록 규칙
+- 세션 종료 시 docs/log/ 작성
+`
+
+describe('vhk sync — RULES.md 파싱', () => {
+  it('## 헤더 기준으로 섹션을 나눈다', () => {
+    const sections = parseRulesMd(SAMPLE_RULES)
+    const titles = sections.map(s => s.title)
+    expect(titles).toContain('코딩 규칙')
+    expect(titles).toContain('기록 규칙')
+  })
+})
+
+describe('vhk sync — .cursorrules 변환', () => {
+  it('코딩 규칙 섹션과 자동생성 경고를 포함한다', () => {
+    const sections = parseRulesMd(SAMPLE_RULES)
+    const out = toCursorrules(sections, '데모 프로젝트')
+    expect(out).toContain('# 데모 프로젝트 — Cursor Rules')
+    expect(out).toContain('자동 생성됨 (vhk sync). 직접 수정 금지')
+    expect(out).toContain('execSync 금지')
+  })
+})
+
+describe('vhk sync — .windsurfrules 변환', () => {
+  it('Windsurf 헤더를 단다', () => {
+    const sections = parseRulesMd(SAMPLE_RULES)
+    const out = toWindsurfrules(sections, '데모 프로젝트')
+    expect(out).toContain('# 데모 프로젝트 — Windsurf Rules')
   })
 
-  it('RULES.md → .cursorrules 변환', () => {
-    // TODO: 파싱 로직 단위 테스트
+  it('자동생성 경고 주석을 맨 위에 포함한다', () => {
+    const sections = parseRulesMd(SAMPLE_RULES)
+    const out = toWindsurfrules(sections, '데모 프로젝트')
+    expect(out).toContain('자동 생성됨 (vhk sync). 직접 수정 금지')
   })
 
-  it('CLAUDE.md의 "현재 상태" 섹션이 보존된다', () => {
-    // TODO: 기존 상태 섹션이 덮어써지지 않는지 확인
+  it('코딩 규칙 섹션을 담고, 기록 전용 섹션은 제외한다', () => {
+    const sections = parseRulesMd(SAMPLE_RULES)
+    const out = toWindsurfrules(sections, '데모 프로젝트')
+    expect(out).toContain('execSync 금지')
+    expect(out).not.toContain('docs/log/ 작성')
+  })
+
+  it('.cursorrules와 동일한 코딩 섹션을 미러링한다', () => {
+    const sections = parseRulesMd(SAMPLE_RULES)
+    const cursor = toCursorrules(sections, 'P')
+    const windsurf = toWindsurfrules(sections, 'P')
+    // 헤더만 다르고 규칙 본문은 양쪽 모두 동일하게 들어간다
+    expect(cursor).toContain('파일명은 kebab-case')
+    expect(windsurf).toContain('파일명은 kebab-case')
   })
 })


### PR DESCRIPTION
## 무엇

기존 `vhk sync` 는 RULES.md(SoT) → `.cursorrules` + `CLAUDE.md` **2개** 만 생성.
여기에 Windsurf(Cascade)용 `.windsurfrules` 출력 **1개** 추가 → 총 **3개**.
"IDE 바꿔도 규칙이 따라간다" 를 Windsurf까지 완성 (포터빌리티 쐐기).

## 변경

- `toWindsurfrules()` 추가 — `.cursorrules` 와 동일 코딩 섹션 미러링, 헤더만 Windsurf
- 자동생성 경고 주석 유지 (직접 수정 금지, RULES.md를 고치세요)
- `ko.sync.windsurfDone` 메시지 + 완료 안내문 3파일로 갱신
- `tests/sync.test.ts` 빈 TODO 스텁 → 실제 검증 6건으로 교체
- README sync 설명에 `.windsurfrules` 반영

## 제약 준수 (GA 정책)

- 기존 `vhk sync` 시그니처·기존 2개 출력 동작 **불변** (순수 추가)
- RULES.md 이름 그대로 유지

## 검증

- `pnpm build` ✅
- `pnpm test --run` → **297 pass** / 0 fail (신규 6건 포함)
- 스모크: 임시 폴더 `vhk sync` → 3파일 생성 + 경고 주석 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)