### PR TITLE
fix(init): 루트 .gitignore 씨앗 생성 (.env·node_modules 보호)

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ vhk ref open 1          # 1번 레퍼런스를 브라우저로 열기
 - `COMMANDS.md`, `BACKLOG.md` (프로젝트 유형에 따라)
 - `.vhk/README.md` + `.vhk/context.md` (유형별 씨앗 — 규격: [`docs/spec.md`](docs/spec.md))
 - `.vhk/.gitignore` + `.vhkignore` (로컬 전용·클라우드 제외 규칙)
+- 루트 `.gitignore` (`.env`·`node_modules`·`dist` 보호 — 기존 파일은 보존하고 누락분만 추가)
 - `package.json` scripts: `save`, `check`, `scan`, `recap`, `ship`, `doctor` → `vhk` 호출
 
 ## 클라우드 백업 (vhk cloud)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -222,6 +222,39 @@ const VHK_PACKAGE_SCRIPTS: Record<string, string> = {
   doctor: 'vhk doctor',
 }
 
+/** 프로젝트 루트 .gitignore 기본 항목 (비밀·빌드 산출물 노출 방지) */
+export const ROOT_GITIGNORE_ENTRIES = [
+  '.env',
+  '.env.local',
+  '.env.*.local',
+  'node_modules/',
+  'dist/',
+  '*.tsbuildinfo',
+  '.DS_Store',
+]
+
+/**
+ * 루트 .gitignore 보장 — 없으면 생성, 있으면 누락 항목만 append (기존 내용 보존).
+ * 반환: 'created' | 'updated' | 'unchanged'
+ */
+export function ensureRootGitignore(projectDir: string): 'created' | 'updated' | 'unchanged' {
+  const gitignorePath = path.join(projectDir, '.gitignore')
+
+  if (!fs.existsSync(gitignorePath)) {
+    fs.writeFileSync(gitignorePath, ROOT_GITIGNORE_ENTRIES.join('\n') + '\n', 'utf-8')
+    return 'created'
+  }
+
+  const content = fs.readFileSync(gitignorePath, 'utf-8')
+  const existing = new Set(content.split('\n').map(l => l.trim()))
+  const missing = ROOT_GITIGNORE_ENTRIES.filter(e => !existing.has(e))
+  if (missing.length === 0) return 'unchanged'
+
+  const prefix = content.endsWith('\n') ? '' : '\n'
+  fs.appendFileSync(gitignorePath, `${prefix}\n# vhk init\n${missing.join('\n')}\n`, 'utf-8')
+  return 'updated'
+}
+
 export function enhancePackageScripts(projectDir: string): boolean {
   const pkgPath = path.join(projectDir, 'package.json')
   if (!fs.existsSync(pkgPath)) return false
@@ -256,5 +289,12 @@ async function writeInitExtras(projectDir: string) {
 
   if (enhancePackageScripts(projectDir)) {
     log.success(ko.init.scriptsDone)
+  }
+
+  const gitignoreResult = ensureRootGitignore(projectDir)
+  if (gitignoreResult === 'created') {
+    log.success(ko.init.gitignoreCreated)
+  } else if (gitignoreResult === 'updated') {
+    log.success(ko.init.gitignoreUpdated)
   }
 }

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -165,6 +165,8 @@ export const ko = {
     startDev: '이제 개발해 보세요! 🚀',
     commandsMdDone: '📋 COMMANDS.md 생성',
     scriptsDone: '📦 package.json scripts 추가',
+    gitignoreCreated: '🔒 .gitignore 생성 (.env·node_modules·dist 제외)',
+    gitignoreUpdated: '🔒 .gitignore 보강 (누락 항목 추가)',
   },
   recap: {
     title: '📝 오늘 한 일 정리',

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { generateFiles, enhancePackageScripts } from '../src/commands/init.js'
+import { generateFiles, enhancePackageScripts, ensureRootGitignore } from '../src/commands/init.js'
 import { COMMANDS_MD_TEMPLATE } from '../src/templates/commands-md.js'
 import { writeFile } from '../src/utils/file.js'
 
@@ -124,6 +124,38 @@ describe('vhk init — .vhk/ 프리셋 씨앗', () => {
     expect(ignore).toContain('memory.json')
     expect(ignore).toContain('refs.json')
     expect(ignore).toContain('HARD_STOP')
+  })
+})
+
+describe('vhk init — 루트 .gitignore 보장', () => {
+  it('없으면 생성하고 .env·node_modules·dist 포함', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-gi-'))
+    expect(ensureRootGitignore(dir)).toBe('created')
+    const content = fs.readFileSync(path.join(dir, '.gitignore'), 'utf-8')
+    expect(content).toContain('.env')
+    expect(content).toContain('node_modules/')
+    expect(content).toContain('dist/')
+    fs.rmSync(dir, { recursive: true })
+  })
+
+  it('기존 .gitignore 는 보존하고 누락 항목만 append', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-gi-'))
+    fs.writeFileSync(path.join(dir, '.gitignore'), '# 사용자 규칙\nmy-secret.txt\n.env\n', 'utf-8')
+    expect(ensureRootGitignore(dir)).toBe('updated')
+    const content = fs.readFileSync(path.join(dir, '.gitignore'), 'utf-8')
+    expect(content).toContain('my-secret.txt')   // 기존 보존
+    expect(content).toContain('# 사용자 규칙')      // 기존 보존
+    expect(content).toContain('node_modules/')     // 누락분 추가
+    // 이미 있던 .env 는 중복 추가되지 않음
+    expect(content.split('\n').filter(l => l.trim() === '.env').length).toBe(1)
+    fs.rmSync(dir, { recursive: true })
+  })
+
+  it('모든 항목이 이미 있으면 unchanged', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-gi-'))
+    ensureRootGitignore(dir)
+    expect(ensureRootGitignore(dir)).toBe('unchanged')
+    fs.rmSync(dir, { recursive: true })
   })
 })
 


### PR DESCRIPTION
## 무엇

E2E 실사용 검증에서 발견: `vhk init` 이 '.gitignore 없음' 경고만 하고 **만들지 않아**, 새 프로젝트에서 `.env`·`node_modules` 가 git 에 노출될 수 있었음. STEP 2 프라이버시 방향과 같은 맥락의 갭.

## 수정

- `ensureRootGitignore`: 없으면 생성, **있으면 누락 항목만 append (기존 내용 보존)**
- `generateFiles` 맵이 아닌 append-merge 방식 → 기존 .gitignore 덮어쓰기 위험 회피
- 항목: `.env`·`.env.local`·`.env.*.local`·`node_modules/`·`dist/`·`*.tsbuildinfo`·`.DS_Store`

## 안전

- 기존 .gitignore 보존 검증 (테스트 + E2E)
- 기존 init 시그니처·생성물 불변, writeInitExtras 에 1단계 추가

## 검증

- `pnpm test --run` → **323 pass** / 0 fail (신규 3건)
- E2E: 신규 생성 / 기존 보존+append 양쪽 실제 init 으로 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)