### PR TITLE
ci: GitHub Actions — PR·푸시마다 빌드+테스트 (ci-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+# PR + main 푸시마다 빌드+테스트 자동 실행 (초록불/빨간불 문지기)
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: pnpm 설치
+        uses: pnpm/action-setup@v4
+        with:
+          # 로컬 개발 환경과 정확히 일치 (Node 24 + pnpm 11.2.2).
+          # pnpm 9 는 workspace overrides 거부, pnpm 11.5 는 Node 20 builtin 미지원 → 둘 다 고정.
+          version: 11.2.2
+
+      - name: Node 24 + pnpm 캐시
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: 의존성 설치
+        run: pnpm install --frozen-lockfile
+
+      # build 가 test 보다 먼저: cli-args e2e 테스트가 dist/index.js 를 spawn 한다.
+      - name: 빌드
+        run: pnpm build
+
+      # 네트워크 의존 없음 — cloud gist 실호출은 유닛테스트 대상 아님(순수 로직만 테스트).
+      - name: 테스트
+        run: pnpm test:run


### PR DESCRIPTION
## 무엇 (로드맵 STEP 3)

PR·main 푸시마다 자동 빌드+테스트 → 초록불/빨간불 문지기. **#31 대체** — #31은 병렬 세션의 RFC·roadmap이 base에 혼입돼 3파일이 됐어서, ci.yml 만 담아 origin/main 에서 새로 분기(개별 PR 원칙).

## ci.yml

- 트리거: main 푸시 + 모든 PR
- Node 24 + pnpm 11.2.2 고정(로컬 일치) + pnpm 캐시
- `install --frozen-lockfile` → `build` → `test:run` (build 먼저 — e2e 가 dist spawn)
- 네트워크 의존 0

## 검증

- #31에서 동일 ci.yml 이 이미 **CI green**(28s, 전 스텝 통과) 확인됨 — 환경 불일치 2건(pnpm 9 거부 / pnpm 11.5 Node20 미지원) 해결한 최종본
- 이 PR diff = **ci.yml 1파일만** (RFC/roadmap/goal 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)