### PR TITLE
feat(goal): 중복 id 감지 findDuplicateIds + 콜론 보존 테스트

### DIFF
--- a/src/lib/goal-frontmatter.ts
+++ b/src/lib/goal-frontmatter.ts
@@ -110,6 +110,22 @@ export function listGoals(goalsDir: string): ParsedGoal[] {
   return parsed
 }
 
+// id 가 중복된 goal 들을 감지. 중복된 id 를 오름차순으로 반환 (없으면 []).
+// listGoals 는 중복 시 첫 매치만 사용하므로, 호출자가 경고를 띄울 수 있게 분리 제공.
+export function findDuplicateIds(goals: ParsedGoal[]): number[] {
+  const counts = new Map<number, number>()
+  for (const g of goals) {
+    const id = g.frontmatter.id
+    if (typeof id !== 'number') continue
+    counts.set(id, (counts.get(id) ?? 0) + 1)
+  }
+  const dups: number[] = []
+  for (const [id, n] of counts) {
+    if (n > 1) dups.push(id)
+  }
+  return dups.sort((a, b) => a - b)
+}
+
 // frontmatter status 갱신 (extraFields 가 있으면 추가/덮어쓰기).
 // frontmatter 가 없는 파일은 그대로 반환 (silent no-op — 호출자가 사전 검사 권장).
 export function updateFrontmatterStatus(

--- a/tests/goal-frontmatter.test.ts
+++ b/tests/goal-frontmatter.test.ts
@@ -7,7 +7,14 @@ import {
   parseGoalFile,
   listGoals,
   updateFrontmatterStatus,
+  findDuplicateIds,
+  type ParsedGoal,
 } from '../src/lib/goal-frontmatter.js'
+
+// 테스트용 최소 ParsedGoal 생성 (id 만 의미 있음).
+function goalWithId(id: number): ParsedGoal {
+  return { filePath: `${id}.md`, frontmatter: { id }, body: '' }
+}
 
 function tmpDir(name: string): string {
   const dir = join(tmpdir(), `vhk-goal-test-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
@@ -61,6 +68,18 @@ title: 한국어 제목 with spaces
 body`
     const { frontmatter } = parseFrontmatter(content)
     expect(frontmatter.title).toBe('한국어 제목 with spaces')
+  })
+
+  // 특성화 테스트 — 기존 동작 가드 (즉시 통과). title 값에 콜론이 있어도
+  // 첫 콜론만 키 구분에 쓰이고 나머지는 값으로 보존됨을 못박는다.
+  it('title 값의 콜론 보존 (첫 콜론만 키 구분)', () => {
+    const content = `---
+type: goal
+title: 도구: 맥락 동기화
+---
+body`
+    const { frontmatter } = parseFrontmatter(content)
+    expect(frontmatter.title).toBe('도구: 맥락 동기화')
   })
 })
 
@@ -141,5 +160,25 @@ describe('listGoals', () => {
 
   it('디렉토리 없으면 빈 배열', () => {
     expect(listGoals('/nonexistent/dir')).toEqual([])
+  })
+})
+
+describe('findDuplicateIds', () => {
+  it('id 가 겹치는 goal 들의 중복 id 를 오름차순 반환', () => {
+    const goals = [goalWithId(2), goalWithId(1), goalWithId(1), goalWithId(2)]
+    expect(findDuplicateIds(goals)).toEqual([1, 2])
+  })
+
+  it('중복 없으면 빈 배열', () => {
+    expect(findDuplicateIds([goalWithId(0), goalWithId(1), goalWithId(2)])).toEqual([])
+  })
+
+  it('각 중복 id 는 한 번만 보고 (3개 겹쳐도 단일 항목)', () => {
+    const goals = [goalWithId(1), goalWithId(1), goalWithId(1)]
+    expect(findDuplicateIds(goals)).toEqual([1])
+  })
+
+  it('빈 입력은 빈 배열', () => {
+    expect(findDuplicateIds([])).toEqual([])
   })
 })


### PR DESCRIPTION
## 무엇 (병렬 세션 인계)

`goals/*.md` 에 같은 `id` 가 둘 이상이면 `listGoals` 가 첫 매치만 써서 조용히 누락됨. 호출자가 경고할 수 있게 **순수 함수 `findDuplicateIds`** 분리(TDD).

## 포함

- `findDuplicateIds(goals)`: 중복 id 오름차순 반환(없으면 `[]`) — [goal-frontmatter.ts](src/lib/goal-frontmatter.ts)
- title 값 **콜론 보존** 특성화 테스트(회귀 가드 — 파서는 첫 콜론만 키 구분)
- 테스트 추가 (TDD)

## 스코프 (의도적)

- 순수 함수 + 테스트만. **경고 출력 배선(goal list/ko.ts)은 후속** — 빌딩블록 선반영.
- 기존 `listGoals` 동작 불변, 신규 export만.

> 병렬 세션 작업 인계 → origin/main 기준 깨끗한 브랜치(worktree)로 분리 제출.

🤖 Generated with [Claude Code](https://claude.com/claude-code)