### PR TITLE
fix(goal): 엣지케이스 보강 — 중복 id 경고 + --id 메시지 통일

### DIFF
--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -6,6 +6,7 @@ import { printNextStep } from '../lib/next-step.js'
 import { safeExecFile } from '../lib/exec.js'
 import {
   listGoals,
+  findDuplicateIds,
   updateFrontmatterStatus,
   type GoalStatus,
   type ParsedGoal,
@@ -62,6 +63,12 @@ export async function goalList(): Promise<void> {
     console.log(
       `  [${id}] ${icon} ${status.padEnd(11)} ${pri} ${ver} ${fm.title ?? '(untitled)'}`
     )
+  }
+  // ① 중복 id 경고 — listGoals 는 첫 매치만 쓰므로 조용한 누락을 알린다.
+  const dups = findDuplicateIds(goals)
+  if (dups.length > 0) {
+    console.log('')
+    console.log(chalk.yellow(`  ${ko.goal.duplicateId(dups.join(', '))}`))
   }
 }
 
@@ -185,6 +192,12 @@ export async function goalCheck(opts: { id?: string }): Promise<void> {
     process.exitCode = 1
     return
   }
+  // ② 없는 goal id 는 게이트 검사 전에 통일된 메시지로 거부 (done 과 동일).
+  if (!goals.some((g) => g.frontmatter.id === id)) {
+    console.log(chalk.red(`  ❌ ${ko.goal.notFound(id)}`))
+    process.exitCode = 1
+    return
+  }
   const scriptPath = findGateScript(id)
   if (!scriptPath) {
     console.log(
@@ -218,7 +231,8 @@ export async function goalDone(opts: { id?: string }): Promise<void> {
   }
   const target = goals.find((g) => g.frontmatter.id === id)
   if (!target) {
-    console.log(chalk.red(`  ❌ goal id ${id} 파일 없음.`))
+    // ② check 와 동일한 메시지로 통일.
+    console.log(chalk.red(`  ❌ ${ko.goal.notFound(id)}`))
     process.exitCode = 1
     return
   }

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -358,6 +358,9 @@ export const ko = {
     initTitle: '🏗️  goals/ 구조 스캐폴딩',
     checkTitle: '✅ Goal 게이트 검증',
     doneTitle: '🏁 Goal 완료 처리',
+    duplicateId: (ids: string) =>
+      `⚠ 중복된 goal id: ${ids} — 같은 id 파일이 여러 개면 첫 매치만 사용됩니다. id 를 유일하게 고치세요.`,
+    notFound: (id: number) => `goal id ${id} 없음 — vhk goal list 로 확인하세요.`,
   },
   agent: {
     blockerTitle: '🛑 Blocker 기록',

--- a/tests/goal.test.ts
+++ b/tests/goal.test.ts
@@ -277,3 +277,87 @@ describe('goalDone — Forbidden: 게이트 실패 시 frontmatter 변경 금지
     }
   })
 })
+
+describe('goal 엣지케이스 보강 (roadmap §4)', () => {
+  let origCwd: string
+  let origExitCode: number | string | undefined
+  beforeEach(() => {
+    origCwd = process.cwd()
+    origExitCode = process.exitCode
+    mockSafeExecFile.mockReset()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    process.exitCode = origExitCode
+    vi.restoreAllMocks()
+  })
+
+  // ① 중복 id 경고
+  it('goalList — 중복 id 면 경고 출력', async () => {
+    const dir = tmpProject('dup')
+    makeGoalFile(dir, 1, 'NOT_STARTED')
+    // 같은 id(1) 의 두 번째 파일 (다른 파일명)
+    writeFileSync(
+      join(dir, 'goals', '1-dup.md'),
+      `---\nvhk_format: 1\ntype: goal\nid: 1\ntitle: Dup\nstatus: NOT_STARTED\n---\nbody\n`,
+      'utf-8'
+    )
+    process.chdir(dir)
+    try {
+      const { goalList } = await import('../src/commands/goal.js')
+      const logSpy = vi.spyOn(console, 'log')
+      await goalList()
+      const joined = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(joined).toMatch(/중복된 goal id/)
+      expect(joined).toMatch(/\b1\b/)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('goalList — 중복 없으면 경고 안 함', async () => {
+    const dir = tmpProject('nodup')
+    makeGoalFile(dir, 0, 'NOT_STARTED')
+    makeGoalFile(dir, 1, 'NOT_STARTED')
+    process.chdir(dir)
+    try {
+      const { goalList } = await import('../src/commands/goal.js')
+      const logSpy = vi.spyOn(console, 'log')
+      await goalList()
+      const joined = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(joined).not.toMatch(/중복된 goal id/)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  // ② 없는 --id 메시지 통일 — check 와 done 이 같은 메시지
+  it('goalCheck/goalDone — 없는 --id 면 둘 다 "goal id N 없음" 통일', async () => {
+    const dir = tmpProject('notfound')
+    makeGoalFile(dir, 0, 'NOT_STARTED')
+    process.chdir(dir)
+    try {
+      const goal = await import('../src/commands/goal.js')
+
+      const checkSpy = vi.spyOn(console, 'log')
+      await goal.goalCheck({ id: '99' })
+      const checkOut = checkSpy.mock.calls.map((c) => String(c[0])).join('\n')
+
+      checkSpy.mockClear()
+      await goal.goalDone({ id: '99' })
+      const doneOut = checkSpy.mock.calls.map((c) => String(c[0])).join('\n')
+
+      // 둘 다 동일한 not-found 문구 ("goal id 99 없음")
+      expect(checkOut).toMatch(/goal id 99 없음/)
+      expect(doneOut).toMatch(/goal id 99 없음/)
+      // 옛 불일치 메시지(스크립트 없음 / 파일 없음)로 새지 않음
+      expect(checkOut).not.toMatch(/게이트 스크립트 없음/)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## 무엇 (roadmap §4 자투리 정리)

코드 STEP 마무리 전 goal 견고성 3건.

| # | 구멍 | 해결 |
|---|------|------|
| ① | 같은 id 파일 2개 → 조용히 첫 매치만 사용 | `goalList` 가 `findDuplicateIds`(순수함수, #34) 로 감지·경고 |
| ② | 없는 `--id` 시 check='스크립트 없음' / done='파일 없음' 불일치 | 둘 다 goal 존재 먼저 검사 → `goal id N 없음` 통일 |
| ③ | title 콜론 잘림 우려 | 파서가 이미 첫 콜론만 키 분리·나머지 보존 — #34 특성화 테스트로 잠금. **수정 불필요(확인)** |

## 제약 준수

- 기존 시그니처·frontmatter 키 불변, 새 의존성 0
- 테스트 3건 추가 → **337 pass** / 0 fail

> 병렬 세션 인계 후 worktree(origin/main 기준)로 작업. v1.5.0 publish 전 코드 트랙 마무리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)