### PR TITLE
chore(release): v1.5.0 — sync 5종 + goal 보강 (npm↔README 갭 해소)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 (다음 릴리즈 누적 영역)
 
+## [1.5.0] - 2026-05-30
+
+> **포터빌리티 확장 릴리즈.** v1.4.0 게시 이후 누적분 — 특히 `vhk sync` 대상이
+> 3종 → 5종으로 늘었다. v1.4.0 npm 패키지는 3종(Cursor·Claude·Windsurf)만 담고
+> 있어 README 의 5종 약속과 어긋났는데, 이 릴리즈로 일치시킨다.
+
+### Added
+
+- **`vhk sync` 대상 확대 — GitHub Copilot + Antigravity** (3종 → 5종).
+  `RULES.md` → `.cursorrules` + `CLAUDE.md` + `.windsurfrules` +
+  `.github/copilot-instructions.md` + `.agents/rules/vhk-rules.md`.
+  경로·포맷은 각 도구 공식 문서 기준. Antigravity 는 파일당 12,000자 제한이 있어
+  UTF-8 바이트 기준으로 안전 절삭(구조 경계 + 마커), 전체는 `RULES.md` 에 남는다.
+- **GitHub Actions CI** — PR·main 푸시마다 빌드+테스트 자동 검증.
+- **`.vhk/` RFC 0001 초안** (`docs/rfc/`) + **포터빌리티 Pain 블로그 초안** (`docs/blog/`) — 둘 다 draft.
+
+### Fixed
+
+- **goal 엣지케이스** — ① 중복 `id` 감지 시 `vhk goal list` 가 경고 출력
+  (조용한 누락 방지) ② 없는 `--id` 에 `check`/`done` 이 `goal id N 없음` 으로
+  메시지 통일 ③ title 의 콜론 보존 특성화 테스트(회귀 가드).
+
+### Docs
+
+- README 포지셔닝 전면 교체 — "올인원 CLI" → "도구·기기를 옮겨도 규칙·맥락이 따라간다"(포터빌리티). 과장 방지 단서(자동 아님·개인메모 제외·git clone) 명시.
+
 ## [1.4.0] - 2026-05-29
 
 > **포터빌리티 릴리즈.** AI 도구·컴퓨터가 바뀌어도 프로젝트 맥락이 따라온다.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ---
 id: vhk-readme
 date: 2026-05-28
-tags: [vhk, cli, readme, v1.4.0, ga]
+tags: [vhk, cli, readme, v1.5.0, ga]
 ---
 
 # 🔧 VHK — Vibe Harness Kit
 
-> 🎉 **v1.4.0** — **규칙은 한 벌로 Cursor·Claude·Windsurf·Copilot·Antigravity에, 맥락은 클라우드로.**
+> 🎉 **v1.5.0** — **규칙은 한 벌로 Cursor·Claude·Windsurf·Copilot·Antigravity에, 맥락은 클라우드로.**
 > 도구·기기를 옮겨도 `vhk` 명령으로 그대로 불러옵니다. (포터빌리티)
 >
 > AI 코딩 에이전트를 부리는 사람을 위한 **한국어 풀사이클 CLI**.
@@ -55,7 +55,7 @@ vhk start
 vhk gate          # 퀵 5문항 — GO / 다듬기 / 다른 아이디어
 ```
 
-### 3. 그 외 기능 한눈에 (v1.4)
+### 3. 그 외 기능 한눈에 (v1.5)
 
 | 기능 | 한 줄 요약 | 진입 명령 |
 |------|-----------|-----------|
@@ -315,7 +315,7 @@ vhk ref open 1          # 1번 레퍼런스를 브라우저로 열기
 
 | 기능 | 설명 |
 |------|------|
-| **MCP 서버** | `vhk mcp` — stdio MCP 서버 첫 도입 (v0.6.0 당시 8개 도구 — save/undo/status/diff/ship/doctor/check/recap). 현재 v1.4 기준 **24개** 로 확장 — 위 "Cursor와 MCP로 연동하기" 섹션 참조 |
+| **MCP 서버** | `vhk mcp` — stdio MCP 서버 첫 도입 (v0.6.0 당시 8개 도구 — save/undo/status/diff/ship/doctor/check/recap). 현재 v1.5 기준 **24개** 로 확장 — 위 "Cursor와 MCP로 연동하기" 섹션 참조 |
 | **mcp-init** | `vhk mcp-init` — Cursor `.cursor/mcp.json` 자동 생성. 재시작 한 번으로 연동 완료 |
 | **자연어 라우팅 확장** | `vhk mcp설정` → `vhk mcp-init` 별칭 |
 | **보안** | MCP save 도구의 shell injection 차단 — 모든 git 호출에 shell 미경유 `safeExecFile` 사용 |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Vibe Harness Kit — 바이브코딩 풀사이클 CLI",
   "bin": {
     "vhk": "dist/index.js",


### PR DESCRIPTION
## 왜 (중요)

**게시된 npm v1.4.0 = sync 3종(Cursor·Claude·Windsurf)** 인데, 그 이후 머지된 #30 으로 main/README 는 **5종(+Copilot·Antigravity)** 을 약속함. → `npm i` 하면 README 보다 적게 나오는 갭. 이 릴리즈가 그 갭을 닫는다.

## 포함 (v1.4.0 이후 누적)

- **sync 5종 확대** (#30) — 헤드라인, 갭의 원인
- goal 엣지케이스 보강 (#36)
- CI (#32), RFC 초안 (#33), Pain 블로그 초안 (#35)

## 변경 (이 PR)

- package.json 1.4.0 → **1.5.0** (minor)
- CHANGELOG [1.5.0]
- README 배너/태그/기능표 v1.5

## 검증

- build ✅ / **337 pass** / `vhk --version` = 1.5.0
- `npm pack --dry-run` 7파일(dist+README+LICENSE) 85.5kB 깨끗

> 머지 후 `npm login` + `pnpm publish` 는 사람이 (npm 인증 필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)