### PR TITLE
chore(release): v1.5.1 — npm 안내문 즉시 반영

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 (다음 릴리즈 누적 영역)
 
+## [1.5.1] - 2026-05-30
+
+> **메타데이터 패치.** 기능 변화 없음 — npm 페이지 안내문을 포지셔닝에 맞춰 즉시 반영하기 위한 재게시.
+
+### Changed
+
+- npm `description`/`keywords` 를 포터빌리티 포지셔닝으로 갱신
+  ("풀사이클 CLI" → "도구·기기를 바꿔도 규칙·맥락이 따라가는 포터빌리티 CLI",
+  keywords 에 portability·cursor·claude·windsurf·copilot·context-sync 추가).
+  *(코드 변경은 #39 에서 머지됨, 본 릴리즈는 버전 범프만.)*
+
 ## [1.5.0] - 2026-05-30
 
 > **포터빌리티 확장 릴리즈.** v1.4.0 게시 이후 누적분 — 특히 `vhk sync` 대상이

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ---
 id: vhk-readme
 date: 2026-05-28
-tags: [vhk, cli, readme, v1.5.0, ga]
+tags: [vhk, cli, readme, v1.5.1, ga]
 ---
 
 # 🔧 VHK — Vibe Harness Kit
 
-> 🎉 **v1.5.0** — **규칙은 한 벌로 Cursor·Claude·Windsurf·Copilot·Antigravity에, 맥락은 클라우드로.**
+> 🎉 **v1.5.1** — **규칙은 한 벌로 Cursor·Claude·Windsurf·Copilot·Antigravity에, 맥락은 클라우드로.**
 > 도구·기기를 옮겨도 `vhk` 명령으로 그대로 불러옵니다. (포터빌리티)
 >
 > AI 코딩 에이전트를 부리는 사람을 위한 **한국어 풀사이클 CLI**.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Vibe Harness Kit — AI 코딩 도구·기기를 바꿔도 규칙·맥락이 따라가는 포터빌리티 CLI (sync: Cursor·Claude·Windsurf·Copilot·Antigravity / cloud 백업)",
   "bin": {
     "vhk": "dist/index.js",


### PR DESCRIPTION
## 왜

#39 에서 npm `description`/`keywords` 를 포터빌리티로 갱신했지만, **npm 페이지엔 재게시해야 반영**됨. 1.5.1 패치로 즉시 띄운다.

- **기능 변화 0** — 버전 범프 + CHANGELOG/README 만
- 1.5.0 → 1.5.1, CHANGELOG [1.5.1], README 배너 v1.5.1

## 검증
- build ✅ / **337 pass** / `vhk --version` = 1.5.1 / pack 7파일

> 머지 후 `npm login` + `pnpm publish` (사람).

🤖 Generated with [Claude Code](https://claude.com/claude-code)