### PR TITLE
chore: .markdownlint.json — 에디터 노이즈 정리

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,8 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD024": { "siblings_only": true },
+  "MD022": false,
+  "MD032": false,
+  "MD060": false
+}


### PR DESCRIPTION
## 무엇

VS Code markdownlint 확장이 내던 경고(CHANGELOG MD024/MD022/MD032, README MD060)를 레포 정책 파일로 침묵. **문서 내용·구조 변경 0** — 이 규칙들은 CI/빌드 게이트가 아니라 에디터 노이즈였음.

- `MD024 siblings_only`: changelog 버전별 `### Added/Fixed` 반복 = 정상 포맷
- `MD060 off`: README compact 표 스타일
- `MD022/MD032 off`: 헤딩 밑 리스트 바로 붙이는 문서 스타일
- `MD013 off`: 줄 길이 제한 해제

설정 파일 1개만. 코드/문서 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)