### PR TITLE
feat(doctor): 드리프트 감지 — 규칙·맥락 어긋남 passive 경고 (STEP 4)

### DIFF
--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -14,6 +14,8 @@ import { readJsonFile } from '../lib/read-json.js'
 import { listGoals } from '../lib/goal-frontmatter.js'
 import { selectActiveId } from './goal.js'
 import { getRecentLearnings, isHardStopActive } from '../lib/state-files.js'
+import { gitOut } from '../lib/git-repo.js'
+import { CONTEXT_GIT_MARKER } from '../lib/drift.js'
 
 const CONTEXT_PATH = '.vhk/context.md'
 
@@ -228,6 +230,13 @@ export async function context(): Promise<void> {
   lines.push('---')
   lines.push('')
   lines.push(`_생성: ${new Date().toLocaleString('ko-KR')}_`)
+  // 드리프트 점검용 — 생성 시점 git HEAD sha. git 아니면 생략.
+  try {
+    const sha = gitOut(['rev-parse', 'HEAD'], process.cwd()).trim()
+    if (sha) lines.push(`_${CONTEXT_GIT_MARKER}: ${sha}_`)
+  } catch {
+    /* git 아님 — 마커 생략 (드리프트 점검은 checked=false 로 skip) */
+  }
   lines.push('')
 
   mkdirSync('.vhk', { recursive: true })

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -6,6 +6,7 @@ import { printNextStep } from '../lib/next-step.js'
 import { ko } from '../i18n/ko.js'
 import { readJsonFile } from '../lib/read-json.js'
 import { safeExecFile } from '../lib/exec.js'
+import { checkRuleDrift, checkContextDrift } from '../lib/drift.js'
 
 export interface CheckResult {
   name: string
@@ -131,6 +132,25 @@ export async function doctor() {
     } else {
       console.log(chalk.dim(`    ⬚ ${file.name}`) + chalk.dim(` — ${file.hint}`))
     }
+  }
+
+  // 드리프트 점검 (passive — doctor 안에서 자동 경고, 읽기 전용)
+  console.log('')
+  console.log(chalk.bold(`  ${ko.doctor.driftTitle}`))
+  const ruleDrift = checkRuleDrift(cwd)
+  if (!ruleDrift.checked) {
+    console.log(chalk.dim(`    ${ko.doctor.driftNoRules}`))
+  } else {
+    const drifted = ruleDrift.results.filter(r => r.status === 'drifted')
+    if (drifted.length === 0) {
+      console.log(chalk.green(`    ${ko.doctor.driftRuleClean}`))
+    } else {
+      console.log(chalk.yellow(`    ${ko.doctor.driftRuleWarn(drifted.map(d => d.path).join(', '))}`))
+    }
+  }
+  const ctxDrift = checkContextDrift(cwd)
+  if (ctxDrift.checked && ctxDrift.stale) {
+    console.log(chalk.yellow(`    ${ko.doctor.driftContextWarn}`))
   }
 
   console.log('')

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -230,7 +230,9 @@ export async function sync() {
     const content = target.generate(sections, projectName)
     fs.writeFileSync(fullPath, content, 'utf-8')
     console.log(chalk.green(`  ${target.doneMessage}`))
-    if (content.includes('절삭됨')) {
+    // 절삭 마커는 antigravity 만 생성 — 느슨한 '절삭됨' 매칭은 사용자 규칙에 그 단어가
+    // 있을 때 오탐 → 전체 마커 문구로 한정.
+    if (content.includes('Antigravity 12,000자 제한으로 절삭됨')) {
       console.log(chalk.yellow(`    ⚠️  ${ko.sync.antigravityTruncated}`))
     }
   }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -167,6 +167,36 @@ export function toClaudeMd(sections: RulesSection[], existing: string): string {
   return lines.join('\n')
 }
 
+/**
+ * RULES.md 첫 줄에서 프로젝트명 도출. sync() 와 드리프트 점검이 **같은 로직**을
+ * 쓰도록 단일 출처로 분리 (둘이 다르게 도출하면 거짓 드리프트 발생).
+ */
+export function deriveProjectName(rulesContent: string): string {
+  const firstLine = rulesContent.split('\n')[0]
+  return firstLine.replace(/^#\s*/, '').replace(/\s*—.*/, '').trim() || 'Project'
+}
+
+export interface SyncTarget {
+  /** cwd 기준 상대 경로 (posix) */
+  path: string
+  /** RULES.md 섹션 → 파일 내용 (순수 함수) */
+  generate: (sections: RulesSection[], projectName: string) => string
+  /** 완료 메시지 (ko.sync.*) */
+  doneMessage: string
+}
+
+/**
+ * sync 출력 대상 단일 레지스트리 — sync() 가 쓰고, 드리프트 점검(`lib/drift.ts`)이 읽는다.
+ * 도구 추가 = 여기 항목 1개 추가 → sync·drift 자동 반영 (목록 중복/하드코딩 방지).
+ * CLAUDE.md 는 하이브리드(현재 상태 보존 + 기존 내용 병합)라 이 레지스트리에서 제외.
+ */
+export const SYNC_TARGETS: SyncTarget[] = [
+  { path: '.cursorrules', generate: toCursorrules, doneMessage: ko.sync.cursorrulesDone },
+  { path: '.windsurfrules', generate: toWindsurfrules, doneMessage: ko.sync.windsurfDone },
+  { path: '.github/copilot-instructions.md', generate: toCopilotInstructions, doneMessage: ko.sync.copilotDone },
+  { path: '.agents/rules/vhk-rules.md', generate: toAntigravityRules, doneMessage: ko.sync.antigravityDone },
+]
+
 export async function sync() {
   console.log(chalk.bold(`\n${ko.sync.title}\n`))
 
@@ -191,39 +221,27 @@ export async function sync() {
   const sections = parseRulesMd(rulesContent)
   console.log(chalk.dim(`  📄 RULES.md 파싱 완료 — ${sections.length}개 섹션`))
 
-  const firstLine = rulesContent.split('\n')[0]
-  const projectName = firstLine.replace(/^#\s*/, '').replace(/\s*—.*/, '').trim() || 'Project'
+  const projectName = deriveProjectName(rulesContent)
 
-  const cursorrulesPath = path.join(cwd, '.cursorrules')
-  fs.writeFileSync(cursorrulesPath, toCursorrules(sections, projectName), 'utf-8')
-  console.log(chalk.green(`  ${ko.sync.cursorrulesDone}`))
+  // 순수 미러 대상 — SYNC_TARGETS 레지스트리 루프 (드리프트 점검과 동일 출처)
+  for (const target of SYNC_TARGETS) {
+    const fullPath = path.join(cwd, target.path)
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true }) // 중첩 경로(.github/·.agents/rules/) 보장
+    const content = target.generate(sections, projectName)
+    fs.writeFileSync(fullPath, content, 'utf-8')
+    console.log(chalk.green(`  ${target.doneMessage}`))
+    if (content.includes('절삭됨')) {
+      console.log(chalk.yellow(`    ⚠️  ${ko.sync.antigravityTruncated}`))
+    }
+  }
 
+  // CLAUDE.md — 하이브리드(현재 상태 보존 + 병합)라 레지스트리 밖에서 별도 처리
   const claudePath = path.join(cwd, 'CLAUDE.md')
   const existingClaude = fs.existsSync(claudePath)
     ? fs.readFileSync(claudePath, 'utf-8')
     : `# 기록 규칙 (${projectName})\n\n## 현재 상태\n- **Phase:** __FILL__\n- **블로커:** 없음\n- **다음 액션:** __FILL__\n- **마지막 업데이트:** ${new Date().toISOString().split('T')[0]}`
   fs.writeFileSync(claudePath, toClaudeMd(sections, existingClaude), 'utf-8')
   console.log(chalk.green(`  ${ko.sync.claudeDone}`))
-
-  const windsurfPath = path.join(cwd, '.windsurfrules')
-  fs.writeFileSync(windsurfPath, toWindsurfrules(sections, projectName), 'utf-8')
-  console.log(chalk.green(`  ${ko.sync.windsurfDone}`))
-
-  // GitHub Copilot — 중첩 경로라 디렉토리 보장 필요 (기존 3개는 루트라 불필요했음)
-  const copilotPath = path.join(cwd, '.github', 'copilot-instructions.md')
-  fs.mkdirSync(path.dirname(copilotPath), { recursive: true })
-  fs.writeFileSync(copilotPath, toCopilotInstructions(sections, projectName), 'utf-8')
-  console.log(chalk.green(`  ${ko.sync.copilotDone}`))
-
-  // Antigravity — .agents/rules/ 중첩 경로 + 12k 절삭
-  const antigravityPath = path.join(cwd, '.agents', 'rules', 'vhk-rules.md')
-  fs.mkdirSync(path.dirname(antigravityPath), { recursive: true })
-  const antigravityDoc = toAntigravityRules(sections, projectName)
-  fs.writeFileSync(antigravityPath, antigravityDoc, 'utf-8')
-  console.log(chalk.green(`  ${ko.sync.antigravityDone}`))
-  if (antigravityDoc.includes('절삭됨')) {
-    console.log(chalk.yellow(`    ⚠️  ${ko.sync.antigravityTruncated}`))
-  }
 
   console.log(chalk.bold.green(`\n${ko.sync.done}`))
   console.log(chalk.dim('  RULES.md (원본) → .cursorrules + CLAUDE.md + .windsurfrules'))

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -204,6 +204,12 @@ export const ko = {
     updateAvailable: (latest: string) =>
       `🆕 v${latest} 사용 가능 — npm i -g @byh3071/vhk`,
     updateCurrent: '최신 버전을 쓰고 있어요',
+    driftTitle: '🔀 드리프트 점검 (규칙·맥락 어긋남):',
+    driftNoRules: '⬚ RULES.md 없음 — 규칙 드리프트 점검 생략',
+    driftRuleClean: '✅ 규칙 파일이 RULES.md와 일치',
+    driftRuleWarn: (files: string) =>
+      `⚠️ RULES.md와 어긋난 규칙 파일: ${files} — vhk sync 를 다시 실행하세요`,
+    driftContextWarn: '⚠️ .vhk/context.md 가 현재 코드보다 낡았어요 — vhk context 로 갱신하세요',
   },
   nlp: {
     matched: '이게 맞나요?',

--- a/src/lib/drift.ts
+++ b/src/lib/drift.ts
@@ -1,0 +1,92 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { parseRulesMd, deriveProjectName, SYNC_TARGETS } from '../commands/sync.js'
+import { gitOut } from './git-repo.js'
+
+/**
+ * 드리프트 = sync 원본(RULES.md)과 생성 파일이 조용히 어긋난 상태, 또는 context.md 가
+ * 코드보다 낡은 상태. 전부 **읽기 전용 감지** — 자동 수정 안 함.
+ */
+
+/**
+ * 비교용 정규화 — CRLF→LF + 끝 공백/빈줄 제거.
+ * `.gitattributes` 없고 core.autocrlf=true 인 환경에서 디스크 파일이 CRLF 로 체크아웃되어
+ * LF 재생성본과 매번 어긋나는 **거짓 드리프트**를 막는다. (줄 내용은 안 건드림.)
+ */
+export function normalizeForCompare(s: string): string {
+  return s.replace(/\r\n/g, '\n').replace(/[ \t]+$/gm, '').replace(/\n+$/, '\n')
+}
+
+export type RuleDriftStatus = 'drifted' | 'ok' | 'missing'
+export interface RuleDriftResult {
+  path: string
+  status: RuleDriftStatus
+}
+
+/**
+ * 규칙 드리프트 점검 — RULES.md 에서 **재생성한 기대값** vs 디스크 파일 비교.
+ * 다르면(수동수정·RULES변경·vhk업그레이드 무엇이든) 'drifted' = "다시 sync 필요".
+ * RULES.md 없으면 점검 불가(checked=false). 기대값을 박지 않고 매번 재생성 = 하드코딩 아님.
+ */
+export function checkRuleDrift(rootDir: string): { checked: boolean; results: RuleDriftResult[] } {
+  const rulesPath = path.join(rootDir, 'RULES.md')
+  if (!fs.existsSync(rulesPath)) return { checked: false, results: [] }
+
+  const rulesContent = fs.readFileSync(rulesPath, 'utf-8')
+  const sections = parseRulesMd(rulesContent)
+  const projectName = deriveProjectName(rulesContent)
+
+  const results: RuleDriftResult[] = []
+  for (const target of SYNC_TARGETS) {
+    const fullPath = path.join(rootDir, target.path)
+    if (!fs.existsSync(fullPath)) {
+      results.push({ path: target.path, status: 'missing' })
+      continue
+    }
+    const expected = normalizeForCompare(target.generate(sections, projectName))
+    const actual = normalizeForCompare(fs.readFileSync(fullPath, 'utf-8'))
+    results.push({ path: target.path, status: expected === actual ? 'ok' : 'drifted' })
+  }
+  return { checked: true, results }
+}
+
+/** context.md 푸터에 박는 git 마커 키. context.ts(쓰기)·drift(읽기) 공유 상수. */
+export const CONTEXT_GIT_MARKER = 'vhk-context-git'
+const CONTEXT_PATH = '.vhk/context.md'
+
+/** context.md 본문에서 생성 시점 git sha 추출 (없으면 null) — 순수, 테스트용. */
+export function extractContextSha(content: string): string | null {
+  const m = content.match(new RegExp(`${CONTEXT_GIT_MARKER}:\\s*([0-9a-f]{7,40})`))
+  return m ? m[1] : null
+}
+
+export interface ContextDriftResult {
+  checked: boolean
+  stale: boolean
+  generatedSha?: string
+  currentSha?: string
+}
+
+/**
+ * 맥락 드리프트 점검 — context.md 생성 시점 sha vs 현재 HEAD.
+ * context.md 없음 / sha 마커 없음(옛 파일) / git 아님 → 점검 불가(checked=false).
+ */
+export function checkContextDrift(rootDir: string): ContextDriftResult {
+  const ctxPath = path.join(rootDir, CONTEXT_PATH)
+  if (!fs.existsSync(ctxPath)) return { checked: false, stale: false }
+
+  const generatedSha = extractContextSha(fs.readFileSync(ctxPath, 'utf-8'))
+  if (!generatedSha) return { checked: false, stale: false }
+
+  let currentSha: string
+  try {
+    currentSha = gitOut(['rev-parse', 'HEAD'], rootDir).trim()
+  } catch {
+    return { checked: false, stale: false }
+  }
+  if (!currentSha) return { checked: false, stale: false }
+
+  // 짧은 sha 허용 — 한쪽이 다른 쪽의 접두면 같은 커밋.
+  const stale = !(currentSha.startsWith(generatedSha) || generatedSha.startsWith(currentSha))
+  return { checked: true, stale, generatedSha, currentSha }
+}

--- a/tests/drift.test.ts
+++ b/tests/drift.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  normalizeForCompare,
+  extractContextSha,
+  checkRuleDrift,
+  CONTEXT_GIT_MARKER,
+} from '../src/lib/drift.js'
+import { parseRulesMd, deriveProjectName, SYNC_TARGETS } from '../src/commands/sync.js'
+
+const SAMPLE_RULES = `# 드리프트데모 — Rules
+
+## 코딩 규칙
+- execSync 금지
+- kebab-case
+
+## 기록 규칙
+- 세션 로그
+`
+
+function makeProject(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-drift-'))
+  fs.writeFileSync(path.join(dir, 'RULES.md'), SAMPLE_RULES, 'utf-8')
+  // sync 와 동일하게 SYNC_TARGETS 로 생성 (드리프트 없는 초기 상태)
+  const sections = parseRulesMd(SAMPLE_RULES)
+  const name = deriveProjectName(SAMPLE_RULES)
+  for (const t of SYNC_TARGETS) {
+    const full = path.join(dir, t.path)
+    fs.mkdirSync(path.dirname(full), { recursive: true })
+    fs.writeFileSync(full, t.generate(sections, name), 'utf-8')
+  }
+  return dir
+}
+
+describe('normalizeForCompare', () => {
+  it('CRLF→LF 통일 — autocrlf 거짓 드리프트 방지', () => {
+    expect(normalizeForCompare('a\r\nb\r\n')).toBe(normalizeForCompare('a\nb\n'))
+  })
+  it('끝 공백/빈줄 차이 무시', () => {
+    expect(normalizeForCompare('a\nb   \n\n\n')).toBe(normalizeForCompare('a\nb\n'))
+  })
+  it('내용 차이는 유지', () => {
+    expect(normalizeForCompare('a\nb')).not.toBe(normalizeForCompare('a\nc'))
+  })
+})
+
+describe('checkRuleDrift', () => {
+  let dir: string
+  beforeEach(() => { dir = makeProject() })
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }) })
+
+  it('갓 생성된 상태 = 전부 ok', () => {
+    const r = checkRuleDrift(dir)
+    expect(r.checked).toBe(true)
+    expect(r.results.every(x => x.status === 'ok')).toBe(true)
+    expect(r.results.length).toBe(SYNC_TARGETS.length)
+  })
+
+  it('CRLF 로 체크아웃돼도 ok (정규화)', () => {
+    const cursor = path.join(dir, '.cursorrules')
+    const crlf = fs.readFileSync(cursor, 'utf-8').replace(/\n/g, '\r\n')
+    fs.writeFileSync(cursor, crlf, 'utf-8')
+    const r = checkRuleDrift(dir)
+    expect(r.results.find(x => x.path === '.cursorrules')?.status).toBe('ok')
+  })
+
+  it('생성 파일 직접 수정 = drifted', () => {
+    fs.appendFileSync(path.join(dir, '.cursorrules'), '\n## 손으로 추가한 규칙\n- 멋대로\n', 'utf-8')
+    const r = checkRuleDrift(dir)
+    expect(r.results.find(x => x.path === '.cursorrules')?.status).toBe('drifted')
+  })
+
+  it('RULES.md 변경 후 sync 안 함 = drifted', () => {
+    fs.writeFileSync(path.join(dir, 'RULES.md'), SAMPLE_RULES + '\n## 디자인\n- 새 규칙\n', 'utf-8')
+    const r = checkRuleDrift(dir)
+    // 코딩 섹션 키에 '디자인' 포함 → 생성물 바뀜 → 기존 파일과 어긋남
+    expect(r.results.some(x => x.status === 'drifted')).toBe(true)
+  })
+
+  it('생성 파일 없으면 missing', () => {
+    fs.rmSync(path.join(dir, '.cursorrules'))
+    const r = checkRuleDrift(dir)
+    expect(r.results.find(x => x.path === '.cursorrules')?.status).toBe('missing')
+  })
+
+  it('RULES.md 없으면 checked=false', () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-norules-'))
+    expect(checkRuleDrift(empty).checked).toBe(false)
+    fs.rmSync(empty, { recursive: true, force: true })
+  })
+})
+
+describe('extractContextSha', () => {
+  it('마커에서 sha 추출', () => {
+    const sha = 'abcdef0123456789abcdef0123456789abcdef01' // 40-hex
+    expect(sha.length).toBe(40)
+    expect(extractContextSha(`_생성: ...\n_${CONTEXT_GIT_MARKER}: ${sha}_\n`)).toBe(sha)
+  })
+  it('마커 없으면 null (옛 context.md)', () => {
+    expect(extractContextSha('_생성: 2026-05-30_\n')).toBeNull()
+  })
+})


### PR DESCRIPTION
## 무엇 (로드맵 STEP 4 · L2 첫 삽)

sync 생성물이 RULES.md와 어긋나거나(규칙 드리프트), context.md가 코드보다 낡으면(맥락 드리프트) **`vhk doctor`가 자동 경고.** 읽기전용(자동수정 X). 비개발자는 계기판 못 읽으니 VHK가 대신 챙기는 안전망.

## 설계 (하드코딩 아님 — 검수 반영)

- **기대값 안 박음:** RULES.md에서 **매번 재생성** vs 디스크 비교. 다르면 드리프트.
- **단일 출처:** `SYNC_TARGETS` 레지스트리 + `deriveProjectName` 을 sync()·drift 가 **공유** → 목록/로직 중복 0. 도구 추가 = 항목 1개.
- **passive:** `--check` 플래그 아님 — 이미 쓰는 `vhk doctor` 안에서 자동(페르소나 맞춤).

## must-fix 2 (검수서 발견, 반영)

1. **CRLF 정규화** — `.gitattributes` 없고 autocrlf=true 환경에서 디스크 CRLF ↔ 재생성 LF 거짓 드리프트 → `\r\n→\n` 정규화. **실측: CRLF 커밋 파일도 '일치' 확인.**
2. **deriveProjectName/SYNC_TARGETS 단일출처** — sync·drift 도출 불일치 방지.

## 검증

- `pnpm test:run` → **348 pass** (drift 11건 신규)
- 실측 4경로: sync 5파일 동일 / CRLF 안전 / 손수정·RULES변경 경고 / context stale(새 커밋 후) 경고
- 기존 sync 출력·시그니처 불변(GA), 새 의존성 0
- 스코프: CLAUDE.md(하이브리드)·RULES.md 없는 레포는 제외(점검 불가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)