### PR TITLE
chore(release): v1.6.0 — 드리프트 감지(L2) + 견고성

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 (다음 릴리즈 누적 영역)
 
+## [1.6.0] - 2026-05-30
+
+> **L2 첫 삽 — 드리프트 감지 + 견고성.** sync 한 규칙·맥락이 원본과 조용히
+> 어긋나는 걸 vhk doctor 가 스스로 잡아낸다. cloud·publish·exec 견고성 보강 동반.
+
+### Added
+
+- **드리프트 감지 (`vhk doctor`)** — 규칙 드리프트(생성 파일이 RULES.md와 어긋남)와
+  맥락 드리프트(`context.md` 가 코드보다 낡음)를 자동 경고. **읽기전용**(자동수정 X),
+  `--check` 플래그 아닌 passive(이미 쓰는 doctor 안에서). CRLF 정규화로 거짓경보 방지.
+  sync 출력 대상은 `SYNC_TARGETS` 단일 레지스트리로 통합(목록 하드코딩 제거).
+
+### Changed
+
+- **exec timeout backstop** — `safeExecFile` 에 기본 10분 timeout(정상 build/test 무영향),
+  네트워크 호출 30초. 스트리밍(deploy·publish 2FA)은 면제(opt-in만). hang 방지.
+
+### Fixed
+
+- **cloud purge 원자화** — `vhk cloud push` 가 과거 gist 에 남은 제외 대상
+  (`memory.json`·`refs.json`)을 제거. 백업 파일 우선 반영 + PATCH 후 재검증. 프라이버시 보강.
+- **publish git 가드** — npm publish 후처리(add→commit→tag→push)를 단계별로 가드,
+  중간 실패 시 중단·안내(반쪽 릴리즈 방지).
+
 ## [1.5.1] - 2026-05-30
 
 > **메타데이터 패치.** 기능 변화 없음 — npm 페이지 안내문을 포지셔닝에 맞춰 즉시 반영하기 위한 재게시.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ---
 id: vhk-readme
 date: 2026-05-28
-tags: [vhk, cli, readme, v1.5.1, ga]
+tags: [vhk, cli, readme, v1.6.0, ga]
 ---
 
 # 🔧 VHK — Vibe Harness Kit
 
-> 🎉 **v1.5.1** — **규칙은 한 벌로 Cursor·Claude·Windsurf·Copilot·Antigravity에, 맥락은 클라우드로.**
+> 🎉 **v1.6.0** — **규칙은 한 벌로 Cursor·Claude·Windsurf·Copilot·Antigravity에, 맥락은 클라우드로.**
 > 도구·기기를 옮겨도 `vhk` 명령으로 그대로 불러옵니다. (포터빌리티)
 >
 > AI 코딩 에이전트를 부리는 사람을 위한 **한국어 풀사이클 CLI**.
@@ -55,7 +55,7 @@ vhk start
 vhk gate          # 퀵 5문항 — GO / 다듬기 / 다른 아이디어
 ```
 
-### 3. 그 외 기능 한눈에 (v1.5)
+### 3. 그 외 기능 한눈에 (v1.6)
 
 | 기능 | 한 줄 요약 | 진입 명령 |
 |------|-----------|-----------|
@@ -64,6 +64,7 @@ vhk gate          # 퀵 5문항 — GO / 다듬기 / 다른 아이디어
 | 🚧 **HARD_STOP 안전장치** | 블로커 3건 누적 → `.vhk/HARD_STOP` 트립와이어. `vhk resume --confirm` 만 해제 | `vhk blocker "<증상>"` |
 | 🔌 **MCP 24 tool** | Cursor·Claude Desktop 등에서 vhk를 채팅으로 호출 | `vhk mcp-init` |
 | 📋 **컨텍스트 영속화** | `.vhk/context.md` + `memory.json` + `brief.md` 로 세션 간 맥락 유지 | `vhk context` |
+| 🔀 **드리프트 감지** | 규칙 파일이 RULES.md와 어긋나거나 context가 코드보다 낡으면 자동 경고 (읽기전용) | `vhk doctor` |
 
 ### 4. 권장 일일 사이클
 
@@ -315,7 +316,7 @@ vhk ref open 1          # 1번 레퍼런스를 브라우저로 열기
 
 | 기능 | 설명 |
 |------|------|
-| **MCP 서버** | `vhk mcp` — stdio MCP 서버 첫 도입 (v0.6.0 당시 8개 도구 — save/undo/status/diff/ship/doctor/check/recap). 현재 v1.5 기준 **24개** 로 확장 — 위 "Cursor와 MCP로 연동하기" 섹션 참조 |
+| **MCP 서버** | `vhk mcp` — stdio MCP 서버 첫 도입 (v0.6.0 당시 8개 도구 — save/undo/status/diff/ship/doctor/check/recap). 현재 v1.6 기준 **24개** 로 확장 — 위 "Cursor와 MCP로 연동하기" 섹션 참조 |
 | **mcp-init** | `vhk mcp-init` — Cursor `.cursor/mcp.json` 자동 생성. 재시작 한 번으로 연동 완료 |
 | **자연어 라우팅 확장** | `vhk mcp설정` → `vhk mcp-init` 별칭 |
 | **보안** | MCP save 도구의 shell injection 차단 — 모든 git 호출에 shell 미경유 `safeExecFile` 사용 |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Vibe Harness Kit — AI 코딩 도구·기기를 바꿔도 규칙·맥락이 따라가는 포터빌리티 CLI (sync: Cursor·Claude·Windsurf·Copilot·Antigravity / cloud 백업)",
   "bin": {
     "vhk": "dist/index.js",


### PR DESCRIPTION
v1.5.1 → 1.6.0 (minor). 1.5.1 이후 누적분 출시.

## 포함
- feat: 드리프트 감지 vhk doctor (#43) — 규칙·맥락 어긋남 passive 경고
- fix: cloud purge 원자화 + publish git 가드 + exec timeout (#45)
- chore/docs: markdownlint(#41), 세션로그(#42)

## 변경 (이 PR)
- package.json 1.5.1 → 1.6.0
- CHANGELOG [1.6.0], README 배너/기능표(드리프트 추가)/MCP 줄 v1.6

## 검증
- build OK, 370 pass, vhk --version = 1.6.0, npm pack 7파일

머지 후 npm login + pnpm publish (사람).