### PR TITLE
fix(drift): context-stale를 file-change 기반으로 정밀화 (v1.6.1)

### DIFF
--- a/src/lib/drift.ts
+++ b/src/lib/drift.ts
@@ -68,8 +68,38 @@ export interface ContextDriftResult {
 }
 
 /**
- * 맥락 드리프트 점검 — context.md 생성 시점 sha vs 현재 HEAD.
- * context.md 없음 / sha 마커 없음(옛 파일) / git 아님 → 점검 불가(checked=false).
+ * context.md 가 **내용으로** 반영하는 추적 경로 (context.ts 생성 로직 기준).
+ * - package.json → 기술 스택 섹션 (deps/name/version)
+ * - goals/       → Active Goal 섹션 (frontmatter)
+ * - docs/state/learnings.md → Recent Learnings 섹션
+ * 디렉토리 구조 섹션은 파일 **추가/삭제/이름변경** 시만 바뀌므로 별도 ADR 필터로 점검.
+ * (VHK 명령어=하드코딩, memory/HARD_STOP=.vhk gitignore → 추적 안 됨, 여기 제외.)
+ */
+const CONTEXT_SOURCE_PATHS = ['package.json', 'goals', 'docs/state/learnings.md']
+
+/**
+ * generatedSha → HEAD 사이에 context.md 가 반영하는 소스가 실제로 바뀌었나.
+ * (1) content 경로 내용 변경(M/A/D)  OR  (2) 추적트리 파일 추가/삭제/이름변경(ADR).
+ * git diff --name-only 출력이 비어있지 않으면 변경. `--quiet`+필터 exit-code 모호성을 피하려고
+ * 출력 비교 방식 사용. genSha 유실(history rewrite 등)이면 gitOut 이 throw → 호출부에서 skip.
+ */
+function contextSourcesChanged(generatedSha: string, rootDir: string): boolean {
+  const content = gitOut(
+    ['diff', '--name-only', generatedSha, 'HEAD', '--', ...CONTEXT_SOURCE_PATHS],
+    rootDir
+  ).trim()
+  if (content) return true
+  const structural = gitOut(
+    ['diff', '--name-only', '--diff-filter=ADR', generatedSha, 'HEAD'],
+    rootDir
+  ).trim()
+  return structural.length > 0
+}
+
+/**
+ * 맥락 드리프트 점검 — context.md 생성 이후 **반영 소스가 실제로 바뀐 경우만** stale.
+ * 단순 HEAD 변동(README 오타 등 무관 커밋)으로는 stale 아님 = 노이즈 제거.
+ * context.md 없음 / sha 마커 없음(옛 파일) / git 아님 / diff 불가 → 점검 불가(checked=false).
  */
 export function checkContextDrift(rootDir: string): ContextDriftResult {
   const ctxPath = path.join(rootDir, CONTEXT_PATH)
@@ -86,7 +116,17 @@ export function checkContextDrift(rootDir: string): ContextDriftResult {
   }
   if (!currentSha) return { checked: false, stale: false }
 
-  // 짧은 sha 허용 — 한쪽이 다른 쪽의 접두면 같은 커밋.
-  const stale = !(currentSha.startsWith(generatedSha) || generatedSha.startsWith(currentSha))
+  // 짧은 sha 허용 — 한쪽이 다른 쪽의 접두면 같은 커밋 = 변동 없음 (git diff 불필요).
+  if (currentSha.startsWith(generatedSha) || generatedSha.startsWith(currentSha)) {
+    return { checked: true, stale: false, generatedSha, currentSha }
+  }
+
+  // HEAD 가 앞섰을 때만 context 반영 소스가 실제로 바뀌었는지 file-change 로 확인.
+  let stale: boolean
+  try {
+    stale = contextSourcesChanged(generatedSha, rootDir)
+  } catch {
+    return { checked: false, stale: false } // genSha 유실 등 → 점검 불가
+  }
   return { checked: true, stale, generatedSha, currentSha }
 }

--- a/tests/drift.test.ts
+++ b/tests/drift.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -6,6 +7,7 @@ import {
   normalizeForCompare,
   extractContextSha,
   checkRuleDrift,
+  checkContextDrift,
   CONTEXT_GIT_MARKER,
 } from '../src/lib/drift.js'
 import { parseRulesMd, deriveProjectName, SYNC_TARGETS } from '../src/commands/sync.js'
@@ -100,5 +102,91 @@ describe('extractContextSha', () => {
   })
   it('마커 없으면 null (옛 context.md)', () => {
     expect(extractContextSha('_생성: 2026-05-30_\n')).toBeNull()
+  })
+})
+
+describe('checkContextDrift — file-change 기반 정밀화', () => {
+  let dir: string
+  const git = (args: string[]) => execFileSync('git', args, { cwd: dir, stdio: 'pipe' })
+  const head = () =>
+    execFileSync('git', ['rev-parse', 'HEAD'], { cwd: dir, encoding: 'utf-8' }).trim()
+  const writeCtx = (sha: string) => {
+    fs.mkdirSync(path.join(dir, '.vhk'), { recursive: true })
+    fs.writeFileSync(
+      path.join(dir, '.vhk/context.md'),
+      `# ctx\n\n---\n_생성: x_\n_${CONTEXT_GIT_MARKER}: ${sha}_\n`,
+      'utf-8'
+    )
+  }
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-ctxdrift-'))
+    git(['init'])
+    git(['config', 'user.email', 't@t.com'])
+    git(['config', 'user.name', 't'])
+    git(['config', 'commit.gpgsign', 'false'])
+    fs.writeFileSync(path.join(dir, 'package.json'), '{"name":"x","version":"1.0.0"}', 'utf-8')
+    fs.writeFileSync(path.join(dir, 'README.md'), 'hello\n', 'utf-8')
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true })
+    fs.writeFileSync(path.join(dir, 'src', 'index.ts'), 'export const a = 1\n', 'utf-8')
+    git(['add', '-A'])
+    git(['commit', '-m', 'init'])
+  })
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }) })
+
+  it('같은 HEAD = not stale', () => {
+    writeCtx(head())
+    const r = checkContextDrift(dir)
+    expect(r.checked).toBe(true)
+    expect(r.stale).toBe(false)
+  })
+
+  it('README 오타 커밋(무관 내용수정) = not stale', () => {
+    writeCtx(head())
+    fs.writeFileSync(path.join(dir, 'README.md'), 'helllo\n', 'utf-8')
+    git(['commit', '-am', 'fix typo'])
+    const r = checkContextDrift(dir)
+    expect(r.checked).toBe(true)
+    expect(r.stale).toBe(false) // HEAD 앞섰어도 context 소스 안 바뀜 → not stale
+  })
+
+  it('src 코드 내용수정(content·트리 무관) = not stale', () => {
+    writeCtx(head())
+    fs.writeFileSync(path.join(dir, 'src', 'index.ts'), 'export const a = 2\n', 'utf-8')
+    git(['commit', '-am', 'edit src'])
+    expect(checkContextDrift(dir).stale).toBe(false)
+  })
+
+  it('package.json 변경(기술스택 영향) = stale', () => {
+    writeCtx(head())
+    fs.writeFileSync(path.join(dir, 'package.json'), '{"name":"x","version":"2.0.0"}', 'utf-8')
+    git(['commit', '-am', 'bump'])
+    expect(checkContextDrift(dir).stale).toBe(true)
+  })
+
+  it('새 파일 추가(구조변동 ADR) = stale', () => {
+    writeCtx(head())
+    fs.writeFileSync(path.join(dir, 'src', 'new.ts'), 'export const b = 1\n', 'utf-8')
+    git(['add', '-A'])
+    git(['commit', '-m', 'add file'])
+    expect(checkContextDrift(dir).stale).toBe(true)
+  })
+
+  it('마커 없는 옛 context.md = checked false', () => {
+    fs.mkdirSync(path.join(dir, '.vhk'), { recursive: true })
+    fs.writeFileSync(path.join(dir, '.vhk', 'context.md'), '_생성: x_\n', 'utf-8')
+    expect(checkContextDrift(dir).checked).toBe(false)
+  })
+
+  it('git 아님 = checked false', () => {
+    const nogit = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-nogit-'))
+    fs.mkdirSync(path.join(nogit, '.vhk'), { recursive: true })
+    fs.writeFileSync(
+      path.join(nogit, '.vhk', 'context.md'),
+      `_${CONTEXT_GIT_MARKER}: abc1234_\n`,
+      'utf-8'
+    )
+    expect(checkContextDrift(nogit).checked).toBe(false)
+    fs.rmSync(nogit, { recursive: true, force: true })
   })
 })


### PR DESCRIPTION
## 무엇 / 왜

v1.6.0 의 `checkContextDrift` 가 **HEAD sha 만 다르면 무조건 stale** 로 판정 → README 오타 1커밋에도 `vhk doctor` 가 "context.md 낡음" 경고. 노이즈였음. (출시된 wart, 정확성 수정.)

## 바뀐 점

`generatedSha → HEAD` 사이에 context.md 가 **실제로 반영하는 소스가 바뀌었을 때만** stale:

- **content 경로** (`package.json`, `goals/`, `docs/state/learnings.md`) 내용 변경 → stale
- **추적트리 파일 추가/삭제/이름변경** (`--diff-filter=ADR`) = 디렉토리 구조 섹션 영향 → stale
- 매직넘버(N커밋) 안 씀 — `git diff --name-only` 출력 유무로 판정
- 같은 커밋 → diff 생략(조기반환), `genSha` 유실(history rewrite 등) → `checked=false` skip

`ContextDriftResult` 시그니처 · `extractContextSha` · CRLF 정규화 = **불변 (GA)**.

### 0단계 감사 — 관련 경로 확정 근거

`src/commands/context.ts` 생성 로직 기준 context.md 가 반영하는 **추적** 소스:

| context.md 섹션 | 소스 | 추적? |
|---|---|---|
| 기술 스택 | `package.json` | ✅ |
| 디렉토리 구조 | 전체 트리 (구조변동만) | ✅ ADR |
| VHK 명령어 | 하드코딩 | ❌ |
| 저장된 결정사항 | `.vhk/memory.json` | ❌ gitignore |
| Active Goal | `goals/<n>.md` | ✅ |
| Recent Learnings | `docs/state/learnings.md` | ✅ |
| HARD_STOP | `.vhk/HARD_STOP` | ❌ gitignore |

> `RULES.md`·`src/` **내용**은 context.md 에 안 들어감 → 관련 경로 아님.

## 테스트 (tests/drift.test.ts +7)

- 같은 HEAD → not stale
- README 오타 커밋(무관 내용수정) → **not stale** ✅ (버그 해결)
- src 코드 내용수정 → not stale ✅
- package.json 변경 → stale ✅
- 새 파일 추가(ADR) → stale ✅
- 마커 없는 옛 context.md / git 아님 → checked false

`pnpm build && pnpm test:run` → **377 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
