### PR TITLE
chore(release): v1.6.1 — context-stale 드리프트 정밀화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 (다음 릴리즈 누적 영역)
 
+## [1.6.1] - 2026-05-30
+
+> **드리프트 정밀화 패치.** v1.6.0 의 맥락 드리프트 판정이 너무 거칠어 README 오타 같은
+> 무관 커밋에도 경고가 떴던 노이즈를 잡는다. 기능 추가 없음 — 정확성 수정.
+
+### Fixed
+
+- **맥락 드리프트(`vhk doctor`) 오경보 제거** — `context.md` 의 stale 판정을
+  단순 `HEAD sha` 변동에서 **file-change 기반**으로 정밀화. 이제 `context.md` 가 실제로
+  반영하는 소스(`package.json`·`goals/`·`docs/state/learnings.md` 내용변경 또는 추적트리
+  파일 추가/삭제/이름변경)가 바뀐 경우에만 stale 로 본다. README 오타·`src/` 내용수정
+  같은 무관 커밋은 더 이상 경고하지 않는다(`git diff --name-only`, `--diff-filter=ADR`).
+  매직넘버 없음, `ContextDriftResult` 시그니처·CRLF 정규화 불변.
+
 ## [1.6.0] - 2026-05-30
 
 > **L2 첫 삽 — 드리프트 감지 + 견고성.** sync 한 규칙·맥락이 원본과 조용히

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ---
 id: vhk-readme
 date: 2026-05-28
-tags: [vhk, cli, readme, v1.6.0, ga]
+tags: [vhk, cli, readme, v1.6.1, ga]
 ---
 
 # 🔧 VHK — Vibe Harness Kit
 
-> 🎉 **v1.6.0** — **규칙은 한 벌로 Cursor·Claude·Windsurf·Copilot·Antigravity에, 맥락은 클라우드로.**
+> 🎉 **v1.6.1** — **규칙은 한 벌로 Cursor·Claude·Windsurf·Copilot·Antigravity에, 맥락은 클라우드로.**
 > 도구·기기를 옮겨도 `vhk` 명령으로 그대로 불러옵니다. (포터빌리티)
 >
 > AI 코딩 에이전트를 부리는 사람을 위한 **한국어 풀사이클 CLI**.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Vibe Harness Kit — AI 코딩 도구·기기를 바꿔도 규칙·맥락이 따라가는 포터빌리티 CLI (sync: Cursor·Claude·Windsurf·Copilot·Antigravity / cloud 백업)",
   "bin": {
     "vhk": "dist/index.js",


### PR DESCRIPTION
#47 (context-stale file-change 정밀화) 머지분에 대한 버전 범프 PR.

## 변경
- `package.json` 1.6.0 → **1.6.1** (MCP `SERVER_VERSION = getVhkVersion()` 자동 도출 — 별도 수정 없음)
- `README.md` 배너 + frontmatter tags → v1.6.1
- `CHANGELOG.md` `[1.6.1]` Fixed 항목 (드리프트 오경보 제거)

## 검증
- `pnpm build && pnpm test:run` → **377 pass**
- `node dist/index.js --version` → **1.6.1**

머지 후 publish 는 사람이: `cd <worktree> && pnpm publish --no-git-checks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
