### PR TITLE
feat(safety): 배치 0 — sync 안전 가드 + restore + MCP undo 안전화 (지혈)

### DIFF
--- a/src/commands/restore.ts
+++ b/src/commands/restore.ts
@@ -1,0 +1,60 @@
+import chalk from 'chalk'
+import inquirer from 'inquirer'
+import { ko } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+import { listBackups, restoreBackup } from '../lib/backup.js'
+
+/**
+ * 백업 복원 — `.vhk/backups/<id>/` 로컬 복사본에서 파일 복원 (git 무관).
+ * undo 가 못 메우는 구멍(언커밋 sync 덮어쓰기)을 복구한다.
+ * 대화형: 목록 선택. 비대화형(TTY 아님): id 인자 필수 — 멈추지 않고 안내 후 종료.
+ */
+export async function restore(id?: string): Promise<void> {
+  console.log(chalk.bold(`\n${ko.restore.title}`))
+  console.log(chalk.gray('─'.repeat(40)))
+  console.log(chalk.dim(`  ${ko.restore.notGitNote}`))
+
+  const cwd = process.cwd()
+  const backups = listBackups(cwd)
+  if (backups.length === 0) {
+    console.log(chalk.yellow(`\n${ko.restore.noBackups}`))
+    return
+  }
+
+  let targetId = id
+  if (!targetId) {
+    // id 미지정 — 비대화형이면 선택 불가, 목록+안내 후 종료 (멈춤 금지)
+    if (!process.stdout.isTTY) {
+      console.log(chalk.cyan(`\n${ko.restore.listHeader}`))
+      for (const b of backups) console.log(`  ${b.id} (${b.files.length}개 파일)`)
+      console.log(chalk.yellow(`\n${ko.restore.nonTtyHint}`))
+      return
+    }
+    const { picked } = await inquirer.prompt<{ picked: string }>([
+      {
+        type: 'list',
+        name: 'picked',
+        message: ko.restore.selectPrompt,
+        choices: backups.map((b) => ({
+          name: `${b.id} (${b.files.length}개 파일)`,
+          value: b.id,
+        })),
+      },
+    ])
+    targetId = picked
+  }
+
+  try {
+    const restored = restoreBackup(targetId, cwd)
+    console.log(chalk.green(`\n${ko.restore.restored(restored.length, targetId)}`))
+    for (const r of restored) console.log(chalk.gray(`   ${r}`))
+    printNextStep({
+      message: '백업 복원 완료! 변경 내용을 확인하세요.',
+      command: 'vhk diff',
+      cursorHint: '변경사항 보여줘',
+    })
+  } catch {
+    console.log(chalk.red(`\n${ko.restore.notFound(targetId)}`))
+    process.exitCode = 1
+  }
+}

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,8 +1,11 @@
 import chalk from 'chalk'
 import fs from 'node:fs'
 import path from 'node:path'
+import inquirer from 'inquirer'
 import { ko } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
+import { normalizeForCompare } from '../lib/drift.js'
+import { saveBackup, pruneBackups, ensureVhkIgnored } from '../lib/backup.js'
 
 interface RulesSection {
   title: string
@@ -197,7 +200,152 @@ export const SYNC_TARGETS: SyncTarget[] = [
   { path: '.agents/rules/vhk-rules.md', generate: toAntigravityRules, doneMessage: ko.sync.antigravityDone },
 ]
 
-export async function sync() {
+/** 보존할 백업 개수 — 무한 증식 방지(스케일/팀 고려). */
+const BACKUP_KEEP = 10
+/** 로컬 전용 sync 마커 — 존재 여부로 첫 sync 판정. 추적/클라우드 제외. */
+const SYNCED_MARKER_REL = path.join('.vhk', '.synced')
+
+export interface SyncOptions {
+  /** 미리보기만 — 디스크 변경 없음 */
+  dryRun?: boolean
+  /** drift 확인 프롬프트 생략(덮어쓰기 동의 간주) */
+  yes?: boolean
+}
+
+export interface SyncPlanItem {
+  path: string
+  newContent: string
+  doneMessage: string
+  /** 디스크에 이미 존재? */
+  exists: boolean
+  /** 기존 파일이 RULES.md 생성본과 다름(=수작업 수정 가능성). 정규화 비교(거짓 드리프트 방지). */
+  drift: boolean
+}
+
+export interface SyncResult {
+  dryRun: boolean
+  firstSync: boolean
+  backupId: string | null
+  backedUp: string[]
+  written: string[]
+  skipped: string[]
+  truncated: string[]
+  plan: SyncPlanItem[]
+}
+
+/**
+ * SYNC_TARGETS(순수 미러) + CLAUDE.md(하이브리드) 를 균일한 계획으로.
+ * drift 판정은 `normalizeForCompare`(lib/drift) 재활용 — CRLF/끝공백 거짓경보 방지.
+ */
+export function buildSyncPlan(
+  rootDir: string,
+  sections: RulesSection[],
+  projectName: string
+): SyncPlanItem[] {
+  const plan: SyncPlanItem[] = []
+  for (const target of SYNC_TARGETS) {
+    const fullPath = path.join(rootDir, target.path)
+    const exists = fs.existsSync(fullPath)
+    const newContent = target.generate(sections, projectName)
+    const drift = exists
+      ? normalizeForCompare(fs.readFileSync(fullPath, 'utf-8')) !== normalizeForCompare(newContent)
+      : false
+    plan.push({ path: target.path, newContent, doneMessage: target.doneMessage, exists, drift })
+  }
+  // CLAUDE.md — 하이브리드(현재 상태 보존 + 병합). 레지스트리 밖이지만 같은 가드 적용.
+  const claudePath = path.join(rootDir, 'CLAUDE.md')
+  const claudeExists = fs.existsSync(claudePath)
+  const existingClaude = claudeExists
+    ? fs.readFileSync(claudePath, 'utf-8')
+    : `# 기록 규칙 (${projectName})\n\n## 현재 상태\n- **Phase:** __FILL__\n- **블로커:** 없음\n- **다음 액션:** __FILL__\n- **마지막 업데이트:** ${new Date().toISOString().split('T')[0]}`
+  const claudeNew = toClaudeMd(sections, existingClaude)
+  const claudeDrift = claudeExists
+    ? normalizeForCompare(existingClaude) !== normalizeForCompare(claudeNew)
+    : false
+  plan.push({
+    path: 'CLAUDE.md',
+    newContent: claudeNew,
+    doneMessage: ko.sync.claudeDone,
+    exists: claudeExists,
+    drift: claudeDrift,
+  })
+  return plan
+}
+
+/**
+ * sync 핵심 — fs 작업 + 안전 가드. **콘솔 출력 없이 결과만 반환**(테스트 가능 seam).
+ * 절대 손실 금지: 덮어쓰기 전 (drift || 첫 sync) 파일을 무조건 백업.
+ * confirmOverwrite: drift 파일을 덮어쓸지 결정 — TTY면 inquirer, 비대화형/--yes면 자동 true 를 호출부가 주입.
+ * 백업이 먼저라 confirm 결과와 무관하게 원본은 항상 복구 가능.
+ */
+export async function syncCore(
+  rootDir: string,
+  opts: SyncOptions,
+  confirmOverwrite: (drifted: SyncPlanItem[]) => Promise<boolean>
+): Promise<SyncResult> {
+  const rulesContent = fs.readFileSync(path.join(rootDir, 'RULES.md'), 'utf-8')
+  const sections = parseRulesMd(rulesContent)
+  const projectName = deriveProjectName(rulesContent)
+  const plan = buildSyncPlan(rootDir, sections, projectName)
+  const firstSync = !fs.existsSync(path.join(rootDir, SYNCED_MARKER_REL))
+
+  // --dry-run — 어떤 디스크 변경도 하지 않는다(백업·쓰기·마커 전부 생략)
+  if (opts.dryRun) {
+    return {
+      dryRun: true,
+      firstSync,
+      backupId: null,
+      backedUp: [],
+      written: [],
+      skipped: [],
+      truncated: [],
+      plan,
+    }
+  }
+
+  // 덮어쓰기 전 백업 — 존재 && (drift || 첫 sync)
+  const toBackup = plan.filter((p) => p.exists && (p.drift || firstSync)).map((p) => p.path)
+  let backupId: string | null = null
+  let backedUp: string[] = []
+  if (toBackup.length) {
+    const info = saveBackup(toBackup, rootDir)
+    pruneBackups(BACKUP_KEEP, rootDir)
+    backupId = info.id
+    backedUp = info.files
+  }
+
+  // drift 동의 — drift 있을 때만 묻는다(백업은 이미 저장됨)
+  const drifted = plan.filter((p) => p.drift)
+  const overwriteDrift = drifted.length ? await confirmOverwrite(drifted) : true
+
+  const written: string[] = []
+  const skipped: string[] = []
+  const truncated: string[] = []
+  for (const item of plan) {
+    // drift 인데 덮어쓰기 거부 → 사용자 수정 보존(쓰기 스킵). 신규·무드리프트는 항상 쓴다.
+    if (item.drift && !overwriteDrift) {
+      skipped.push(item.path)
+      continue
+    }
+    const fullPath = path.join(rootDir, item.path)
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true }) // 중첩 경로(.github/·.agents/rules/) 보장
+    fs.writeFileSync(fullPath, item.newContent, 'utf-8')
+    written.push(item.path)
+    // 절삭 마커는 antigravity 만 생성 — 전체 마커 문구로 한정(오탐 방지)
+    if (item.newContent.includes('Antigravity 12,000자 제한으로 절삭됨')) {
+      truncated.push(item.path)
+    }
+  }
+
+  // 동기화 마커(로컬 전용) — 다음 실행 firstSync 판정용
+  fs.mkdirSync(path.join(rootDir, '.vhk'), { recursive: true })
+  fs.writeFileSync(path.join(rootDir, SYNCED_MARKER_REL), new Date().toISOString() + '\n', 'utf-8')
+  ensureVhkIgnored(rootDir, '.synced')
+
+  return { dryRun: false, firstSync, backupId, backedUp, written, skipped, truncated, plan }
+}
+
+export async function sync(opts: SyncOptions = {}): Promise<void> {
   console.log(chalk.bold(`\n${ko.sync.title}\n`))
 
   const cwd = process.cwd()
@@ -217,33 +365,60 @@ export async function sync() {
     return
   }
 
-  const rulesContent = fs.readFileSync(rulesPath, 'utf-8')
-  const sections = parseRulesMd(rulesContent)
+  const sections = parseRulesMd(fs.readFileSync(rulesPath, 'utf-8'))
   console.log(chalk.dim(`  📄 RULES.md 파싱 완료 — ${sections.length}개 섹션`))
 
-  const projectName = deriveProjectName(rulesContent)
-
-  // 순수 미러 대상 — SYNC_TARGETS 레지스트리 루프 (드리프트 점검과 동일 출처)
-  for (const target of SYNC_TARGETS) {
-    const fullPath = path.join(cwd, target.path)
-    fs.mkdirSync(path.dirname(fullPath), { recursive: true }) // 중첩 경로(.github/·.agents/rules/) 보장
-    const content = target.generate(sections, projectName)
-    fs.writeFileSync(fullPath, content, 'utf-8')
-    console.log(chalk.green(`  ${target.doneMessage}`))
-    // 절삭 마커는 antigravity 만 생성 — 느슨한 '절삭됨' 매칭은 사용자 규칙에 그 단어가
-    // 있을 때 오탐 → 전체 마커 문구로 한정.
-    if (content.includes('Antigravity 12,000자 제한으로 절삭됨')) {
-      console.log(chalk.yellow(`    ⚠️  ${ko.sync.antigravityTruncated}`))
-    }
+  // 비대화형(CI/MCP subprocess: isTTY=false)·--yes → 자동 덮어쓰기(멈춤 금지).
+  // TTY → drift 시 inquirer 확인(기본 거부). 어느 쪽이든 백업이 먼저라 손실 0.
+  const interactive = !!process.stdout.isTTY && !opts.yes
+  const confirmOverwrite = async (drifted: SyncPlanItem[]): Promise<boolean> => {
+    if (!interactive) return true
+    for (const d of drifted) console.log(chalk.yellow(`  ${ko.sync.driftWarn(d.path)}`))
+    const { confirm } = await inquirer.prompt<{ confirm: boolean }>([
+      {
+        type: 'confirm',
+        name: 'confirm',
+        message: ko.sync.driftConfirm(drifted.length),
+        default: false,
+      },
+    ])
+    return confirm
   }
 
-  // CLAUDE.md — 하이브리드(현재 상태 보존 + 병합)라 레지스트리 밖에서 별도 처리
-  const claudePath = path.join(cwd, 'CLAUDE.md')
-  const existingClaude = fs.existsSync(claudePath)
-    ? fs.readFileSync(claudePath, 'utf-8')
-    : `# 기록 규칙 (${projectName})\n\n## 현재 상태\n- **Phase:** __FILL__\n- **블로커:** 없음\n- **다음 액션:** __FILL__\n- **마지막 업데이트:** ${new Date().toISOString().split('T')[0]}`
-  fs.writeFileSync(claudePath, toClaudeMd(sections, existingClaude), 'utf-8')
-  console.log(chalk.green(`  ${ko.sync.claudeDone}`))
+  const result = await syncCore(cwd, opts, confirmOverwrite)
+
+  if (result.dryRun) {
+    console.log(chalk.cyan(`\n${ko.sync.dryRunHeader}`))
+    for (const item of result.plan) {
+      console.log(ko.sync.dryRunWouldWrite(item.path, item.exists && item.drift))
+    }
+    const wouldBackup = result.plan
+      .filter((p) => p.exists && (p.drift || result.firstSync))
+      .map((p) => p.path)
+    if (wouldBackup.length) {
+      console.log(chalk.dim(`\n  백업 예정(${wouldBackup.length}): ${wouldBackup.join(', ')}`))
+    }
+    return
+  }
+
+  if (result.backupId) {
+    if (result.firstSync) console.log(chalk.cyan(`  ${ko.sync.firstSync}`))
+    if (!process.stdout.isTTY) {
+      console.log(chalk.yellow(`  ${ko.sync.nonTtyAuto(result.backedUp.length, result.backupId)}`))
+    } else {
+      console.log(chalk.cyan(`  ${ko.sync.backupSaved(result.backedUp.length, result.backupId)}`))
+    }
+  }
+  for (const p of result.written) {
+    const item = result.plan.find((i) => i.path === p)
+    if (item) console.log(chalk.green(`  ${item.doneMessage}`))
+  }
+  for (const _ of result.truncated) {
+    console.log(chalk.yellow(`    ⚠️  ${ko.sync.antigravityTruncated}`))
+  }
+  for (const p of result.skipped) {
+    console.log(chalk.gray(`  ${ko.sync.skipped(p)}`))
+  }
 
   console.log(chalk.bold.green(`\n${ko.sync.done}`))
   console.log(chalk.dim('  RULES.md (원본) → .cursorrules + CLAUDE.md + .windsurfrules'))

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -140,6 +140,9 @@ export function toAntigravityRules(sections: RulesSection[], projectName: string
   return truncateForAntigravity(buildCodingDoc('Antigravity Rules', sections, projectName))
 }
 
+/** CLAUDE.md 자동생성 규칙 섹션 경고 배너 — 출력과 멱등 dedup 이 공유하는 단일 출처. */
+const CLAUDE_AUTOGEN_BANNER = '> ⚡ 아래 규칙 섹션은 RULES.md에서 자동 생성됨 (vhk sync). 직접 수정 금지.'
+
 /**
  * RULES.md 섹션을 CLAUDE.md 포맷으로 변환
  */
@@ -148,18 +151,25 @@ export function toClaudeMd(sections: RulesSection[], existing: string): string {
     CLAUDE_MD_KEYS.some(k => s.title.includes(k))
   )
 
-  // 멱등성: '## 현재 상태' 캡처가 자동생성 배너(> ⚡ …)까지 흡수하면 toClaudeMd 가 매번
-  // 배너를 또 추가해 CLAUDE.md 가 무한 증가 → 매 sync drift → 백업 churn. 배너 경계에서 멈춘다.
-  const statusMatch = existing.match(/## 현재 상태[\s\S]*?(?=\n## |\n> ⚡|$)/)
+  // 멱등성: 기존 본문에서 이전 자동생성 배너(정확히 일치하는 줄)를 모두 제거 후 정확히 1개만
+  // 재삽입. 이러면 배너가 header/현재상태 어디에 끼었든 누적되지 않고(매 sync drift→백업 churn
+  // 방지), 사용자가 '## 현재 상태'에 직접 쓴 임의 '> ⚡' 인용줄은 배너 문구 전체와 일치하지 않아
+  // 보존된다. (배너 접두만 보던 이전 수정의 사용자-인용줄 절단 회귀를 제거.)
+  const cleaned = existing
+    .split('\n')
+    .filter(line => line.trim() !== CLAUDE_AUTOGEN_BANNER)
+    .join('\n')
+
+  const statusMatch = cleaned.match(/## 현재 상태[\s\S]*?(?=\n## |$)/)
   const statusSection = statusMatch ? statusMatch[0].trimEnd() : ''
-  const header = existing.split('## ')[0].trim()
+  const header = cleaned.split('## ')[0].trim()
 
   const lines = [
     header,
     '',
     statusSection,
     '',
-    '> ⚡ 아래 규칙 섹션은 RULES.md에서 자동 생성됨 (vhk sync). 직접 수정 금지.',
+    CLAUDE_AUTOGEN_BANNER,
     '',
   ]
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -148,8 +148,10 @@ export function toClaudeMd(sections: RulesSection[], existing: string): string {
     CLAUDE_MD_KEYS.some(k => s.title.includes(k))
   )
 
-  const statusMatch = existing.match(/## 현재 상태[\s\S]*?(?=\n## |$)/)
-  const statusSection = statusMatch ? statusMatch[0] : ''
+  // 멱등성: '## 현재 상태' 캡처가 자동생성 배너(> ⚡ …)까지 흡수하면 toClaudeMd 가 매번
+  // 배너를 또 추가해 CLAUDE.md 가 무한 증가 → 매 sync drift → 백업 churn. 배너 경계에서 멈춘다.
+  const statusMatch = existing.match(/## 현재 상태[\s\S]*?(?=\n## |\n> ⚡|$)/)
+  const statusSection = statusMatch ? statusMatch[0].trimEnd() : ''
   const header = existing.split('## ')[0].trim()
 
   const lines = [
@@ -247,6 +249,8 @@ export function buildSyncPlan(
     const fullPath = path.join(rootDir, target.path)
     const exists = fs.existsSync(fullPath)
     const newContent = target.generate(sections, projectName)
+    // drift = 정규화 후 비교. 공백/EOL(CRLF)-only 차이는 의도적으로 drift 아님(거짓경보·백업 churn 방지)
+    // → 그 차이는 백업 없이 덮어써질 수 있으나 규칙 본문은 절대 손실 안 됨(범위 한정).
     const drift = exists
       ? normalizeForCompare(fs.readFileSync(fullPath, 'utf-8')) !== normalizeForCompare(newContent)
       : false

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -234,6 +234,31 @@ export const ko = {
     antigravityDone: '✅ .agents/rules/vhk-rules.md 맞춤 완료',
     antigravityTruncated: 'Antigravity 12,000자 제한으로 일부 절삭됨 — 전체는 RULES.md 참조',
     done: '🔄 맞추기 완료!',
+    // 안전 가드 (배치 0) — 덮어쓰기 전 백업·드리프트 확인·미리보기
+    backupSaved: (n: number, id: string) =>
+      `🛟 덮어쓰기 전 ${n}개 파일 백업함 → .vhk/backups/${id} (복원: vhk restore)`,
+    firstSync: '🛟 첫 sync — 기존 파일을 백업한 뒤 생성합니다.',
+    driftWarn: (p: string) =>
+      `⚠️ ${p} 가 RULES.md 생성본과 다릅니다 (직접 수정했을 수 있어요).`,
+    driftConfirm: (n: number) =>
+      `위 ${n}개 파일의 기존 내용을 덮어쓸까요? (백업은 이미 저장됨)`,
+    skipped: (p: string) => `⏭️  건너뜀: ${p} (덮어쓰기 거부 — 백업만 보관)`,
+    dryRunHeader: '🔎 미리보기 (--dry-run) — 실제 파일 변경 없음',
+    dryRunWouldWrite: (p: string, drift: boolean) =>
+      `  ${drift ? '✏️  변경됨' : '·  동일'} : ${p}`,
+    nonTtyAuto: (n: number, id: string) =>
+      `🤖 비대화형(CI/에이전트) — ${n}개 백업 후 진행. 복원: vhk restore ${id}`,
+  },
+  restore: {
+    title: '🛟 백업 복원',
+    notGitNote: '백업은 .vhk/backups/ 의 로컬 복사본에서 복원됩니다 (git 무관).',
+    noBackups: '복원할 백업이 없습니다. (vhk sync 가 덮어쓰기 전 자동 생성)',
+    selectPrompt: '복원할 백업을 선택하세요:',
+    listHeader: '📋 사용 가능한 백업 (최신순):',
+    restored: (n: number, id: string) => `✅ ${n}개 파일 복원 완료 (백업 ${id})`,
+    notFound: (id: string) => `❌ 백업을 찾을 수 없습니다: ${id}`,
+    nonTtyHint: '비대화형 모드 — 복원할 백업 id 를 인자로 지정하세요: vhk restore <id>',
+    cancelled: '복원 취소됨',
   },
   cloud: {
     pushTitle: '☁️ .vhk 클라우드 백업 (gist 올리기)',

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { doctor } from './commands/doctor.js'
 import { ship } from './commands/ship.js'
 import { save } from './commands/save.js'
 import { undo } from './commands/undo.js'
+import { restore } from './commands/restore.js'
 import { diff } from './commands/diff.js'
 import { status } from './commands/status.js'
 import { startMcpServer } from './mcp/server.js'
@@ -52,6 +53,7 @@ const KO_ALIASES: Record<string, string> = {
   doctor: '환경',
   save: '저장',
   undo: '되돌리기',
+  restore: '복원',
   status: '상태',
   diff: '변경',
   deploy: '배포',
@@ -157,8 +159,10 @@ program
   .command('sync')
   .alias('맞추기')
   .alias('규칙')
-  .description('RULES.md → .cursorrules + CLAUDE.md 동기화')
-  .action(sync)
+  .option('--dry-run', '미리보기만 — 파일 변경 없음')
+  .option('-y, --yes', 'drift 확인 프롬프트 생략(덮어쓰기 동의)')
+  .description('RULES.md → .cursorrules + CLAUDE.md 동기화 (덮어쓰기 전 자동 백업)')
+  .action(async (opts: { dryRun?: boolean; yes?: boolean }) => { await sync(opts) })
 
 program
   .command('check')
@@ -223,6 +227,13 @@ program
   .alias('되돌리기')
   .description('최근 커밋 되돌리기')
   .action(async () => { await undo() })
+
+program
+  .command('restore')
+  .alias('복원')
+  .argument('[id]', '복원할 백업 id (생략 시 목록에서 선택)')
+  .description('sync 백업 복원 (.vhk/backups/ — 언커밋 덮어쓰기 복구)')
+  .action(async (id?: string) => { await restore(id) })
 
 program
   .command('status')

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -70,8 +70,10 @@ export function saveBackup(files: string[], rootDir: string, stamp?: string): Ba
   const baseId = stamp ?? fsSafeStamp(new Date())
   let id = baseId
   let n = 1
+  // suffix 는 zero-pad — listBackups 의 문자열 정렬이 시간순과 어긋나지 않게
+  // (base-10 < base-2 같은 렉시컬 뒤틀림 방지 → pruneBackups 가 진짜 최신을 안 지움).
   while (fs.existsSync(path.join(rootDir, BACKUPS_REL, id))) {
-    id = `${baseId}-${n++}`
+    id = `${baseId}-${String(n++).padStart(3, '0')}`
   }
   const backupDir = path.join(rootDir, BACKUPS_REL, id)
   const saved: string[] = []

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -65,7 +65,14 @@ function walkRelFiles(baseDir: string, cur = baseDir): string[] {
  * 첫 호출에서 `.vhk/.gitignore` 에 backups/ 보장.
  */
 export function saveBackup(files: string[], rootDir: string, stamp?: string): BackupInfo {
-  const id = stamp ?? fsSafeStamp(new Date())
+  // 충돌 방지: 같은 ms(또는 같은 명시 stamp)로 재호출 시 기존 백업을 덮어쓰면 직전 원본이
+  // 영구 유실된다. 디렉터리가 이미 있으면 suffix 를 붙여 유니크화(시간순 정렬도 보존).
+  const baseId = stamp ?? fsSafeStamp(new Date())
+  let id = baseId
+  let n = 1
+  while (fs.existsSync(path.join(rootDir, BACKUPS_REL, id))) {
+    id = `${baseId}-${n++}`
+  }
   const backupDir = path.join(rootDir, BACKUPS_REL, id)
   const saved: string[] = []
 

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -1,0 +1,127 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * vhk 자체 백업 — git 비의존 복구. 덮어쓰기 직전 원본을 `.vhk/backups/<id>/` 로 복사한다.
+ * undo(git 커밋만 되돌림)의 구멍(언커밋 sync 덮어쓰기 복구 불가)을 메운다.
+ * 보존 정책(pruneBackups)으로 무한 증식 방지, `.vhk/.gitignore`·cloud 제외로 추적/유출 방지.
+ */
+
+const BACKUPS_REL = path.join('.vhk', 'backups')
+const VHK_GITIGNORE_REL = path.join('.vhk', '.gitignore')
+
+export interface BackupInfo {
+  /** 백업 디렉터리명 = 파일시스템 안전 타임스탬프 (정렬하면 시간순) */
+  id: string
+  /** 백업 디렉터리 절대/상대 경로 */
+  dir: string
+  /** 백업된 파일들의 rootDir 기준 상대경로 */
+  files: string[]
+}
+
+/**
+ * 파일시스템 안전 타임스탬프 — ISO 의 ':' '.' 를 '-' 로 치환.
+ * ⚠️ Windows 는 파일명에 ':' 를 허용하지 않으므로 raw ISO 를 디렉터리명으로 쓰면 실패한다.
+ * 예: 2026-05-30T09:19:17.358Z → 2026-05-30T09-19-17-358Z
+ */
+export function fsSafeStamp(d: Date): string {
+  return d.toISOString().replace(/[:.]/g, '-')
+}
+
+/**
+ * `.vhk/.gitignore` 에 주어진 항목들이 없으면 추가 (없으면 파일 생성). 기존 내용 보존.
+ * 로컬 전용 산출물(backups/·.synced 등)이 추적/클라우드로 새지 않게 자기방어.
+ * `backups/` 는 `backups` 와 동치로 간주(중복 추가 방지).
+ */
+export function ensureVhkIgnored(rootDir: string, ...entries: string[]): void {
+  const giPath = path.join(rootDir, VHK_GITIGNORE_REL)
+  fs.mkdirSync(path.dirname(giPath), { recursive: true })
+  let content = fs.existsSync(giPath) ? fs.readFileSync(giPath, 'utf-8') : ''
+  const present = new Set(content.split('\n').map((l) => l.trim().replace(/\/$/, '')))
+  const missing = entries.filter((e) => !present.has(e.trim().replace(/\/$/, '')))
+  if (missing.length === 0) return
+  if (content.length > 0 && !content.endsWith('\n')) content += '\n'
+  content += missing.join('\n') + '\n'
+  fs.writeFileSync(giPath, content, 'utf-8')
+}
+
+/** 백업 디렉터리 안의 모든 파일을 rootDir(여기선 backupDir) 기준 상대경로(posix)로 수집. */
+function walkRelFiles(baseDir: string, cur = baseDir): string[] {
+  const out: string[] = []
+  for (const entry of fs.readdirSync(cur)) {
+    const full = path.join(cur, entry)
+    if (fs.statSync(full).isDirectory()) {
+      out.push(...walkRelFiles(baseDir, full))
+    } else {
+      out.push(path.relative(baseDir, full).split(path.sep).join('/'))
+    }
+  }
+  return out
+}
+
+/**
+ * 주어진 파일들 중 **실제로 존재하는 것만** `.vhk/backups/<stamp>/<상대경로>` 로 복사.
+ * 중첩 경로(.github/·.agents/rules/)는 구조 보존. `stamp` 미지정 시 현재시각.
+ * 첫 호출에서 `.vhk/.gitignore` 에 backups/ 보장.
+ */
+export function saveBackup(files: string[], rootDir: string, stamp?: string): BackupInfo {
+  const id = stamp ?? fsSafeStamp(new Date())
+  const backupDir = path.join(rootDir, BACKUPS_REL, id)
+  const saved: string[] = []
+
+  for (const rel of files) {
+    const src = path.join(rootDir, rel)
+    if (!fs.existsSync(src)) continue
+    const dest = path.join(backupDir, rel)
+    fs.mkdirSync(path.dirname(dest), { recursive: true })
+    fs.copyFileSync(src, dest)
+    saved.push(rel)
+  }
+
+  ensureVhkIgnored(rootDir, 'backups/')
+  return { id, dir: backupDir, files: saved }
+}
+
+/** 백업 목록 — 최신순(id 역정렬). 백업 폴더 없으면 빈 배열. */
+export function listBackups(rootDir: string): BackupInfo[] {
+  const root = path.join(rootDir, BACKUPS_REL)
+  if (!fs.existsSync(root)) return []
+  return fs
+    .readdirSync(root)
+    .filter((e) => fs.statSync(path.join(root, e)).isDirectory())
+    .sort()
+    .reverse()
+    .map((id) => {
+      const dir = path.join(root, id)
+      return { id, dir, files: walkRelFiles(dir) }
+    })
+}
+
+/**
+ * 백업 id 의 파일들을 원래 상대경로로 복원(현재 파일 덮어씀). 복원된 상대경로 목록 반환.
+ * 없는 id 면 throw.
+ */
+export function restoreBackup(id: string, rootDir: string): string[] {
+  const backupDir = path.join(rootDir, BACKUPS_REL, id)
+  if (!fs.existsSync(backupDir)) {
+    throw new Error(`백업 없음: ${id}`)
+  }
+  const rels = walkRelFiles(backupDir)
+  for (const rel of rels) {
+    const src = path.join(backupDir, rel)
+    const dest = path.join(rootDir, rel)
+    fs.mkdirSync(path.dirname(dest), { recursive: true })
+    fs.copyFileSync(src, dest)
+  }
+  return rels
+}
+
+/** 보존 정책 — 최근 keepN 개만 남기고 오래된 백업 삭제. 삭제한 id 목록 반환. */
+export function pruneBackups(keepN: number, rootDir: string): string[] {
+  const all = listBackups(rootDir) // 최신순
+  const toDelete = all.slice(Math.max(0, keepN))
+  for (const b of toDelete) {
+    fs.rmSync(b.dir, { recursive: true, force: true })
+  }
+  return toDelete.map((b) => b.id)
+}

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -70,8 +70,8 @@ export function saveBackup(files: string[], rootDir: string, stamp?: string): Ba
   const baseId = stamp ?? fsSafeStamp(new Date())
   let id = baseId
   let n = 1
-  // suffix 는 zero-pad — listBackups 의 문자열 정렬이 시간순과 어긋나지 않게
-  // (base-10 < base-2 같은 렉시컬 뒤틀림 방지 → pruneBackups 가 진짜 최신을 안 지움).
+  // suffix 는 가독성용 zero-pad. 정렬 정확성은 listBackups 의 숫자 비교(backupOrderKey)가
+  // 보장하므로 자릿수를 넘겨도(예: 1000+) 시간순이 안 깨진다.
   while (fs.existsSync(path.join(rootDir, BACKUPS_REL, id))) {
     id = `${baseId}-${String(n++).padStart(3, '0')}`
   }
@@ -92,14 +92,29 @@ export function saveBackup(files: string[], rootDir: string, stamp?: string): Ba
 }
 
 /** 백업 목록 — 최신순(id 역정렬). 백업 폴더 없으면 빈 배열. */
+/**
+ * 백업 id 정렬 키 — baseId(시간순 ISO 문자열, 'Z' 종료) + 숫자 suffix.
+ * 단순 문자열 정렬은 충돌 suffix 에서 base-1000 < base-999 처럼 렉시컬 뒤틀림이 생긴다
+ * (zero-pad 도 자릿수 넘으면 재발). 숫자로 비교해 어떤 suffix 폭에서도 시간순을 보장.
+ */
+function backupOrderKey(id: string): [string, number] {
+  const m = /^(.*Z)(?:-(\d+))?$/.exec(id)
+  return m ? [m[1], m[2] ? parseInt(m[2], 10) : 0] : [id, 0]
+}
+
+/** 백업 목록 — 최신순. 백업 폴더 없으면 빈 배열. */
 export function listBackups(rootDir: string): BackupInfo[] {
   const root = path.join(rootDir, BACKUPS_REL)
   if (!fs.existsSync(root)) return []
   return fs
     .readdirSync(root)
     .filter((e) => fs.statSync(path.join(root, e)).isDirectory())
-    .sort()
-    .reverse()
+    .sort((a, b) => {
+      const [ba, na] = backupOrderKey(a)
+      const [bb, nb] = backupOrderKey(b)
+      if (ba !== bb) return ba < bb ? 1 : -1 // base 시간 역순(최신 먼저)
+      return nb - na // 같은 base 면 suffix 큰(나중) 것 먼저
+    })
     .map((id) => {
       const dir = path.join(root, id)
       return { id, dir, files: walkRelFiles(dir) }

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -13,6 +13,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'doctor', '환경', '진단',
   'save', '저장',
   'undo', '되돌리기',
+  'restore', '복원',
   'status', '상태', '현황',
   'diff', '변경', '차이',
   'mcp',

--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -10,6 +10,7 @@ export type NlpCommand =
   | 'doctor'
   | 'save'
   | 'undo'
+  | 'restore'
   | 'diff'
   | 'status'
   | 'mcp-init'
@@ -69,6 +70,14 @@ function matchesKeywords(text: string, command: NlpCommand): boolean {
 }
 
 const RULES: NlpRule[] = [
+  // restore 는 cloud-pull/undo 보다 먼저 평가 — "백업 복원/되돌려" 가 클라우드 복원이나
+  // 커밋 되돌리기로 새지 않도록. "백업" 한정이라 bare "복원해"(=cloud-pull)·"되돌려"(=undo)는 안 가로챔.
+  {
+    command: 'restore',
+    explanation: 'sync 백업 복원 (vhk restore)',
+    confidence: 'high',
+    test: t => /백업/.test(t) && /(복원|복구|되돌려|되살려|롤백|restore)/.test(t),
+  },
   // 영문 `vhk cloud push|pull [id]` 은 commander 가 직접 처리(가로채기 금지) — 한국어 표현만 매칭.
   {
     command: 'cloud-pull',

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -12,6 +12,7 @@ import { doctor } from '../commands/doctor.js'
 import { ship } from '../commands/ship.js'
 import { save } from '../commands/save.js'
 import { undo } from '../commands/undo.js'
+import { restore } from '../commands/restore.js'
 import { status } from '../commands/status.js'
 import { diff } from '../commands/diff.js'
 import { mcpInit } from '../commands/mcp-init.js'
@@ -65,6 +66,8 @@ export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<
       return save()
     case 'undo':
       return undo()
+    case 'restore':
+      return restore(route.args?.[0])
     case 'status':
       return status()
     case 'diff':

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -123,30 +123,60 @@ export function createVhkMcpServer(): McpServer {
   )
 
   // ─── undo ───────────────────────────────────────────────
-  server.registerTool('undo', { description: '최근 커밋 되돌리기 (soft reset, 변경사항은 유지)' }, async () => {
-    if (!isGitRepo()) {
-      return { content: [{ type: 'text', text: '❌ git 저장소가 아닙니다.' }] }
-    }
+  // 안전화: 에이전트 채팅창에서 즉시 git reset 은 위험 → 기본 dry-run.
+  // 되돌릴 대상을 먼저 보고하고, confirm:true 일 때만 실제 reset 실행.
+  server.registerTool(
+    'undo',
+    {
+      description: '최근 커밋 되돌리기 (soft reset). 기본은 미리보기 — confirm:true 일 때만 실제 실행.',
+      inputSchema: {
+        confirm: z
+          .boolean()
+          .optional()
+          .describe('true 일 때만 실제 git reset 실행 (기본 false = 미리보기만)'),
+      },
+    },
+    async ({ confirm }) => {
+      if (!isGitRepo()) {
+        return { content: [{ type: 'text', text: '❌ git 저장소가 아닙니다.' }] }
+      }
 
-    const last = safeExecFile('git', ['log', '--oneline', '-1'])
-    if (!last.ok || !last.out) {
-      return { content: [{ type: 'text', text: '📭 되돌릴 커밋이 없습니다.' }] }
-    }
+      const last = safeExecFile('git', ['log', '--oneline', '-1'])
+      if (!last.ok || !last.out) {
+        return { content: [{ type: 'text', text: '📭 되돌릴 커밋이 없습니다.' }] }
+      }
 
-    const reset = safeExecFile('git', ['reset', '--soft', 'HEAD~1'])
-    if (!reset.ok) {
-      return { content: [{ type: 'text', text: `❌ reset 실패: ${reset.err}` }] }
-    }
+      // 기본 dry-run — 명시적 confirm 없이는 reset 하지 않는다.
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text:
+                `🔎 미리보기 — 되돌릴 커밋:\n${last.out}\n\n` +
+                `실제로 되돌리려면 confirm: true 로 다시 호출하세요.\n` +
+                `(soft reset — 변경사항은 스테이징 영역에 보존됩니다.)\n` +
+                `또는 터미널에서 \`vhk undo\` (대화형 확인).`,
+            },
+          ],
+        }
+      }
 
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `✅ 되돌리기 완료!\n취소된 커밋: ${last.out}\n💡 변경사항은 스테이징 영역에 남아있습니다.`,
-        },
-      ],
+      const reset = safeExecFile('git', ['reset', '--soft', 'HEAD~1'])
+      if (!reset.ok) {
+        return { content: [{ type: 'text', text: `❌ reset 실패: ${reset.err}` }] }
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `✅ 되돌리기 완료!\n취소된 커밋: ${last.out}\n💡 변경사항은 스테이징 영역에 남아있습니다.`,
+          },
+        ],
+      }
     }
-  })
+  )
 
   // ─── status ─────────────────────────────────────────────
   server.registerTool('status', { description: '프로젝트 상태 대시보드 (브랜치/변경사항/최근 커밋)' }, async () => {

--- a/src/templates/vhk-dir.ts
+++ b/src/templates/vhk-dir.ts
@@ -39,6 +39,8 @@ export function VHK_GITIGNORE_TEMPLATE(): string {
     'memory.json',
     'refs.json',
     'HARD_STOP',
+    '# sync 덮어쓰기 전 자동 백업 (로컬 복구용 — vhk restore). 추적/클라우드 제외.',
+    'backups/',
     '',
   ].join('\n')
 }

--- a/tests/backup.test.ts
+++ b/tests/backup.test.ts
@@ -109,6 +109,22 @@ describe('saveBackup', () => {
     expect(list.length).toBe(12)
     expect(list[0].id).toBe(lastId) // 가장 최근 생성본이 목록 최상단(최신순)
   })
+
+  // 회귀: suffix 자릿수를 넘는(1000+) 충돌도 숫자 정렬이라 시간순 유지 (zero-pad 폭에 의존 안 함).
+  // 문자열 정렬이면 'base-999' > 'base-1001' 로 뒤틀려 pruneBackups 가 진짜 최신을 evict.
+  it('suffix 4자리 경계도 숫자 정렬 (base-1001 > base-1000 > base-999)', () => {
+    const base = '2026-09-09T00-00-00-000Z'
+    const root = path.join(dir, '.vhk', 'backups')
+    for (const id of [`${base}-999`, `${base}-1000`, `${base}-1001`]) {
+      fs.mkdirSync(path.join(root, id), { recursive: true })
+      fs.writeFileSync(path.join(root, id, 'f'), 'x', 'utf-8')
+    }
+    expect(listBackups(dir).map((b) => b.id)).toEqual([
+      `${base}-1001`,
+      `${base}-1000`,
+      `${base}-999`,
+    ])
+  })
 })
 
 describe('listBackups', () => {

--- a/tests/backup.test.ts
+++ b/tests/backup.test.ts
@@ -96,6 +96,19 @@ describe('saveBackup', () => {
     expect(fs.readFileSync(path.join(b.dir, '.cursorrules'), 'utf-8')).toBe('SECOND')
     expect(listBackups(dir).length).toBe(2)
   })
+
+  // 회귀: suffix 가 zero-pad 안 되면 base-10 < base-2 (렉시컬) 라 11회+ 충돌 시 listBackups
+  // 최신순이 뒤틀려 pruneBackups 가 진짜 최신을 지운다. zero-pad 로 정렬 안정화 확인.
+  it('동일 stamp 12회 충돌 → listBackups 최신순 유지 (suffix zero-pad)', () => {
+    write('.cursorrules', 'x')
+    let lastId = ''
+    for (let i = 0; i < 12; i++) {
+      lastId = saveBackup(['.cursorrules'], dir, '2026-09-09T00-00-00-000Z').id
+    }
+    const list = listBackups(dir)
+    expect(list.length).toBe(12)
+    expect(list[0].id).toBe(lastId) // 가장 최근 생성본이 목록 최상단(최신순)
+  })
 })
 
 describe('listBackups', () => {

--- a/tests/backup.test.ts
+++ b/tests/backup.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  saveBackup,
+  listBackups,
+  restoreBackup,
+  pruneBackups,
+  fsSafeStamp,
+} from '../src/lib/backup.js'
+
+let dir: string
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-backup-'))
+})
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+function write(rel: string, content: string): void {
+  const full = path.join(dir, rel)
+  fs.mkdirSync(path.dirname(full), { recursive: true })
+  fs.writeFileSync(full, content, 'utf-8')
+}
+function read(rel: string): string {
+  return fs.readFileSync(path.join(dir, rel), 'utf-8')
+}
+
+describe('fsSafeStamp', () => {
+  it('콜론·점 제거 — Windows 파일명 금지문자 안전', () => {
+    const s = fsSafeStamp(new Date('2026-05-30T09:19:17.358Z'))
+    expect(s).not.toMatch(/[:.]/)
+    expect(s).toBe('2026-05-30T09-19-17-358Z')
+  })
+})
+
+describe('saveBackup', () => {
+  it('존재 파일 백업 + 중첩 구조 보존', () => {
+    write('.cursorrules', 'orig cursor')
+    write('.github/copilot-instructions.md', 'orig copilot')
+    const info = saveBackup(
+      ['.cursorrules', '.github/copilot-instructions.md'],
+      dir,
+      '2026-01-01T00-00-00-000Z'
+    )
+    expect(info.id).toBe('2026-01-01T00-00-00-000Z')
+    expect(info.files.sort()).toEqual(
+      ['.cursorrules', '.github/copilot-instructions.md'].sort()
+    )
+    expect(read('.vhk/backups/2026-01-01T00-00-00-000Z/.cursorrules')).toBe('orig cursor')
+    expect(read('.vhk/backups/2026-01-01T00-00-00-000Z/.github/copilot-instructions.md')).toBe(
+      'orig copilot'
+    )
+  })
+
+  it('존재하지 않는 파일은 건너뜀', () => {
+    write('.cursorrules', 'x')
+    const info = saveBackup(['.cursorrules', '.windsurfrules'], dir, '2026-01-01T00-00-00-000Z')
+    expect(info.files).toEqual(['.cursorrules'])
+  })
+
+  it('.vhk/.gitignore 에 backups/ 자동 추가 (없을 때 생성)', () => {
+    write('.cursorrules', 'x')
+    saveBackup(['.cursorrules'], dir, '2026-01-01T00-00-00-000Z')
+    expect(read('.vhk/.gitignore')).toMatch(/(^|\n)backups\/(\n|$)/)
+  })
+
+  it('기존 .vhk/.gitignore 보존하며 append', () => {
+    write('.vhk/.gitignore', 'memory.json\nrefs.json\n')
+    write('.cursorrules', 'x')
+    saveBackup(['.cursorrules'], dir, '2026-01-01T00-00-00-000Z')
+    const gi = read('.vhk/.gitignore')
+    expect(gi).toContain('memory.json')
+    expect(gi).toContain('backups/')
+  })
+
+  it('이미 backups/ 있으면 중복 추가 안 함', () => {
+    write('.vhk/.gitignore', 'backups/\n')
+    write('.cursorrules', 'x')
+    saveBackup(['.cursorrules'], dir, '2026-01-01T00-00-00-000Z')
+    const count = read('.vhk/.gitignore')
+      .split('\n')
+      .filter((l) => l.trim() === 'backups/').length
+    expect(count).toBe(1)
+  })
+})
+
+describe('listBackups', () => {
+  it('최신순 정렬', () => {
+    write('.cursorrules', 'x')
+    saveBackup(['.cursorrules'], dir, '2026-01-01T00-00-00-000Z')
+    saveBackup(['.cursorrules'], dir, '2026-02-01T00-00-00-000Z')
+    expect(listBackups(dir).map((b) => b.id)).toEqual([
+      '2026-02-01T00-00-00-000Z',
+      '2026-01-01T00-00-00-000Z',
+    ])
+  })
+  it('백업 폴더 없으면 빈 배열', () => {
+    expect(listBackups(dir)).toEqual([])
+  })
+})
+
+describe('restoreBackup', () => {
+  it('백업 내용으로 복원 — 현재 파일 덮어씀', () => {
+    write('.cursorrules', 'orig')
+    saveBackup(['.cursorrules'], dir, '2026-01-01T00-00-00-000Z')
+    write('.cursorrules', 'modified by user')
+    const restored = restoreBackup('2026-01-01T00-00-00-000Z', dir)
+    expect(restored).toEqual(['.cursorrules'])
+    expect(read('.cursorrules')).toBe('orig')
+  })
+  it('중첩 경로 복원 (삭제된 파일도)', () => {
+    write('.github/copilot-instructions.md', 'orig')
+    saveBackup(['.github/copilot-instructions.md'], dir, '2026-01-01T00-00-00-000Z')
+    fs.rmSync(path.join(dir, '.github/copilot-instructions.md'))
+    restoreBackup('2026-01-01T00-00-00-000Z', dir)
+    expect(read('.github/copilot-instructions.md')).toBe('orig')
+  })
+  it('없는 id → throw', () => {
+    expect(() => restoreBackup('nope', dir)).toThrow()
+  })
+})
+
+describe('pruneBackups', () => {
+  it('최근 N개만 유지, 나머지 삭제', () => {
+    write('.cursorrules', 'x')
+    for (const m of ['01', '02', '03', '04']) {
+      saveBackup(['.cursorrules'], dir, `2026-${m}-01T00-00-00-000Z`)
+    }
+    const deleted = pruneBackups(2, dir)
+    expect(listBackups(dir).map((b) => b.id)).toEqual([
+      '2026-04-01T00-00-00-000Z',
+      '2026-03-01T00-00-00-000Z',
+    ])
+    expect(deleted.sort()).toEqual(
+      ['2026-01-01T00-00-00-000Z', '2026-02-01T00-00-00-000Z'].sort()
+    )
+  })
+  it('N 이하면 삭제 0', () => {
+    write('.cursorrules', 'x')
+    saveBackup(['.cursorrules'], dir, '2026-01-01T00-00-00-000Z')
+    expect(pruneBackups(5, dir)).toEqual([])
+  })
+})

--- a/tests/backup.test.ts
+++ b/tests/backup.test.ts
@@ -84,6 +84,18 @@ describe('saveBackup', () => {
       .filter((l) => l.trim() === 'backups/').length
     expect(count).toBe(1)
   })
+
+  // 회귀: 같은 ms 타임스탬프로 연속 백업 시 디렉터리 충돌로 첫 백업이 덮여 영구 유실되면 안 됨.
+  it('같은 stamp 재호출 → 유니크 디렉터리 (첫 백업 덮어쓰기 방지)', () => {
+    write('.cursorrules', 'FIRST')
+    const a = saveBackup(['.cursorrules'], dir, '2026-09-09T00-00-00-000Z')
+    write('.cursorrules', 'SECOND')
+    const b = saveBackup(['.cursorrules'], dir, '2026-09-09T00-00-00-000Z')
+    expect(a.id).not.toBe(b.id)
+    expect(fs.readFileSync(path.join(a.dir, '.cursorrules'), 'utf-8')).toBe('FIRST')
+    expect(fs.readFileSync(path.join(b.dir, '.cursorrules'), 'utf-8')).toBe('SECOND')
+    expect(listBackups(dir).length).toBe(2)
+  })
 })
 
 describe('listBackups', () => {

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -76,6 +76,24 @@ describe('read-json BOM', () => {
   })
 })
 
+describe('detectNaturalLanguageInput — restore 명령 라우팅 (회귀)', () => {
+  // restore/복원 이 KNOWN_COMMAND_TOKENS 에 없으면 NLP 가 가로채 commander 핸들러가 안 돈다.
+  it('vhk restore <id> → null (commander 가 처리)', () => {
+    expect(
+      detectNaturalLanguageInput(['node', 'vhk', 'restore', '2026-05-30T09-19-17-358Z'])
+    ).toBeNull()
+  })
+  it('vhk 복원 <id> → null', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '복원', 'abc'])).toBeNull()
+  })
+  it('vhk restore (단독) → null', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'restore'])).toBeNull()
+  })
+  it('vhk 복원 (단독) → null', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '복원'])).toBeNull()
+  })
+})
+
 describe('cli NL e2e', () => {
   const bin = path.join(process.cwd(), 'dist', 'index.js')
 

--- a/tests/nlp-router.test.ts
+++ b/tests/nlp-router.test.ts
@@ -201,4 +201,22 @@ describe('자연어 라우팅', () => {
   it('"cloud pull 8fa29db959b3" → null (gistId 인자 보존 위해 commander)', () => {
     expect(routeNaturalLanguage('cloud pull 8fa29db959b3')).toBeNull()
   })
+
+  // restore(로컬 sync 백업) — "백업" + 복원동사. cloud-pull/undo 보다 우선.
+  it('"백업 복원해줘" → restore (cloud-pull 로 안 샘)', () => {
+    expect(routeNaturalLanguage('백업 복원해줘')?.command).toBe('restore')
+  })
+  it('"백업 되돌려" → restore (undo 로 안 샘)', () => {
+    expect(routeNaturalLanguage('백업 되돌려')?.command).toBe('restore')
+  })
+  it('"sync 백업 복구" → restore', () => {
+    expect(routeNaturalLanguage('sync 백업 복구')?.command).toBe('restore')
+  })
+  // 회귀 가드 — "백업" 없는 표현은 종전대로
+  it('"백업해줘" 는 여전히 cloud-push (복원동사 없음)', () => {
+    expect(routeNaturalLanguage('백업해줘')?.command).toBe('cloud-push')
+  })
+  it('"롤백해줘" 는 여전히 undo (백업 없음)', () => {
+    expect(routeNaturalLanguage('롤백해줘')?.command).toBe('undo')
+  })
 })

--- a/tests/sync-guard.test.ts
+++ b/tests/sync-guard.test.ts
@@ -116,4 +116,30 @@ describe('buildSyncPlan — drift 판정', () => {
     const plan = buildSyncPlan(dir, sections, name)
     expect(plan.map((p) => p.path)).toContain('CLAUDE.md')
   })
+
+  // 회귀: toClaudeMd 비멱등 → 매 sync 마다 CLAUDE.md drift → 백업 churn → pruneBackups 가
+  // 진짜 사용자 백업을 밀어내 영구 소실. 멱등성으로 churn 차단.
+  it('CLAUDE.md 멱등 — 반복 sync 가 drift 를 만들지 않음 (백업 churn 방지)', async () => {
+    await syncCore(dir, {}, alwaysYes) // 1회차
+    const after1 = read('CLAUDE.md')
+    await syncCore(dir, {}, alwaysYes) // 2회차 (원본 무변경)
+    const after2 = read('CLAUDE.md')
+    expect(after2).toBe(after1) // 바이트 동일 = 멱등 (배너 누적 없음)
+    const sections = parseRulesMd(read('RULES.md'))
+    const plan = buildSyncPlan(dir, sections, deriveProjectName(read('RULES.md')))
+    expect(plan.find((p) => p.path === 'CLAUDE.md')?.drift).toBe(false)
+  })
+
+  it('반복 sync 가 백업을 churn 하지 않음 — 사용자 원본 백업 보존', async () => {
+    fs.writeFileSync(path.join(dir, '.cursorrules'), '6개월 튜닝한 손글 규칙\n', 'utf-8')
+    await syncCore(dir, {}, alwaysYes) // Day1 — 원본 백업
+    const day1 = listBackups(dir)[0]
+    expect(
+      fs.readFileSync(path.join(day1.dir, '.cursorrules'), 'utf-8')
+    ).toBe('6개월 튜닝한 손글 규칙\n')
+    // 원본 무변경 상태로 sync 12회 더 — CLAUDE.md 가 churn 하면 Day1 백업이 evict 됨
+    for (let i = 0; i < 12; i++) await syncCore(dir, {}, alwaysYes)
+    const stillThere = listBackups(dir).some((b) => b.id === day1.id)
+    expect(stillThere).toBe(true) // Day1 백업이 남아있어야 (멱등이면 백업 자체가 1회만)
+  })
 })

--- a/tests/sync-guard.test.ts
+++ b/tests/sync-guard.test.ts
@@ -7,6 +7,7 @@ import {
   buildSyncPlan,
   parseRulesMd,
   deriveProjectName,
+  toClaudeMd,
 } from '../src/commands/sync.js'
 import { listBackups } from '../src/lib/backup.js'
 
@@ -141,5 +142,40 @@ describe('buildSyncPlan — drift 판정', () => {
     for (let i = 0; i < 12; i++) await syncCore(dir, {}, alwaysYes)
     const stillThere = listBackups(dir).some((b) => b.id === day1.id)
     expect(stillThere).toBe(true) // Day1 백업이 남아있어야 (멱등이면 백업 자체가 1회만)
+  })
+})
+
+describe('toClaudeMd — 멱등성 + 사용자 콘텐츠 보존 (라운드2 회귀)', () => {
+  const sections = parseRulesMd(RULES)
+  const name = deriveProjectName(RULES)
+  const bannerCount = (s: string) => (s.match(/⚡ 아래 규칙 섹션은/g) || []).length
+
+  it('정상(현재 상태 有) 멱등 + 배너 1개', () => {
+    const a = toClaudeMd(sections, `# 기록 규칙 (${name})\n\n## 현재 상태\n- **Phase:** P5\n\n## 기록 규칙\n- 세션 로그\n`)
+    expect(toClaudeMd(sections, a)).toBe(a)
+    expect(bannerCount(a)).toBe(1)
+  })
+
+  it("'## 현재 상태' 섹션 없는 CLAUDE.md 도 멱등 (배너 header 흡수 churn 방지)", () => {
+    const a = toClaudeMd(sections, `# 기록 규칙 (${name})\n\n## 기록 규칙\n- 세션 로그\n`)
+    expect(toClaudeMd(sections, a)).toBe(a)
+    expect(bannerCount(a)).toBe(1)
+  })
+
+  it('이미 배너 여러 개 누적된(옛 버그 오염) CLAUDE.md → 1개로 수렴', () => {
+    const banner = '> ⚡ 아래 규칙 섹션은 RULES.md에서 자동 생성됨 (vhk sync). 직접 수정 금지.'
+    const a = toClaudeMd(
+      sections,
+      `# 기록 규칙 (${name})\n\n## 현재 상태\n- **Phase:** P5\n\n${banner}\n\n${banner}\n\n## 기록 규칙\n- 세션 로그\n`
+    )
+    expect(bannerCount(a)).toBe(1)
+  })
+
+  it("사용자가 '현재 상태'에 직접 쓴 '> ⚡' 인용줄 보존 (이전 수정의 절단 회귀 제거)", () => {
+    const c = `# 기록 규칙 (${name})\n\n## 현재 상태\n- **Phase:** P5\n> ⚡ 사용자가 직접 쓴 강조 메모\n- **다음 액션:** 출시\n\n## 기록 규칙\n- 세션 로그\n`
+    const out = toClaudeMd(sections, c)
+    expect(out).toContain('사용자가 직접 쓴 강조 메모')
+    expect(out).toContain('다음 액션')
+    expect(toClaudeMd(sections, out)).toBe(out) // 보존하면서도 멱등
   })
 })

--- a/tests/sync-guard.test.ts
+++ b/tests/sync-guard.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  syncCore,
+  buildSyncPlan,
+  parseRulesMd,
+  deriveProjectName,
+} from '../src/commands/sync.js'
+import { listBackups } from '../src/lib/backup.js'
+
+const RULES = `# 데모 — Rules
+
+## 코딩 규칙
+- execSync 금지
+
+## 기록 규칙
+- 세션 로그
+`
+
+let dir: string
+const alwaysYes = async (): Promise<boolean> => true
+const alwaysNo = async (): Promise<boolean> => false
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-syncg-'))
+  fs.writeFileSync(path.join(dir, 'RULES.md'), RULES, 'utf-8')
+})
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(dir, rel), 'utf-8')
+}
+function exists(rel: string): boolean {
+  return fs.existsSync(path.join(dir, rel))
+}
+
+describe('syncCore — 첫 sync', () => {
+  it('타겟 생성 + .synced 마커 + firstSync=true', async () => {
+    const r = await syncCore(dir, {}, alwaysYes)
+    expect(r.firstSync).toBe(true)
+    expect(exists('.cursorrules')).toBe(true)
+    expect(exists('CLAUDE.md')).toBe(true)
+    expect(exists('.vhk/.synced')).toBe(true)
+    expect(r.written).toContain('.cursorrules')
+  })
+
+  it('기존 파일 있으면 첫 sync 에서 백업(+gitignore 등록)', async () => {
+    fs.writeFileSync(path.join(dir, '.cursorrules'), '손으로 만든 규칙\n', 'utf-8')
+    const r = await syncCore(dir, {}, alwaysYes)
+    expect(r.backupId).not.toBeNull()
+    expect(r.backedUp).toContain('.cursorrules')
+    const gi = read('.vhk/.gitignore')
+    expect(gi).toContain('backups/')
+    expect(gi).toContain('.synced')
+  })
+})
+
+describe('syncCore — drift 가드 (데이터 손실 0)', () => {
+  it('drift + 덮어쓰기 거부 → 백업 저장되고 원본 유지', async () => {
+    await syncCore(dir, {}, alwaysYes) // 초기 동기화(마커 생성)
+    fs.writeFileSync(path.join(dir, '.cursorrules'), '내 손글 규칙\n', 'utf-8') // 사용자 수정 = drift
+    const r = await syncCore(dir, {}, alwaysNo) // 덮어쓰기 거부
+    expect(r.backupId).not.toBeNull()
+    expect(r.skipped).toContain('.cursorrules')
+    expect(read('.cursorrules')).toBe('내 손글 규칙\n') // 원본 보존
+    // 백업에 사용자 원본이 들어있어 복구 가능
+    const backups = listBackups(dir)
+    expect(backups.length).toBeGreaterThan(0)
+    const backed = fs.readFileSync(path.join(backups[0].dir, '.cursorrules'), 'utf-8')
+    expect(backed).toBe('내 손글 규칙\n')
+  })
+
+  it('drift + 자동 승인(비대화형) → 백업 후 재생성본으로 덮어씀 (멈춤 없음)', async () => {
+    await syncCore(dir, {}, alwaysYes)
+    fs.writeFileSync(path.join(dir, '.cursorrules'), 'drift\n', 'utf-8')
+    const r = await syncCore(dir, {}, alwaysYes) // 비대화형 = 자동 true
+    expect(r.backupId).not.toBeNull()
+    expect(r.written).toContain('.cursorrules')
+    expect(read('.cursorrules')).not.toBe('drift\n')
+    expect(read('.cursorrules')).toContain('Cursor Rules')
+  })
+})
+
+describe('syncCore — --dry-run', () => {
+  it('디스크 미변경 + 백업도 안 만듦', async () => {
+    await syncCore(dir, {}, alwaysYes)
+    fs.writeFileSync(path.join(dir, '.cursorrules'), 'drift now\n', 'utf-8')
+    const r = await syncCore(dir, { dryRun: true }, alwaysNo)
+    expect(r.dryRun).toBe(true)
+    expect(r.written).toEqual([])
+    expect(read('.cursorrules')).toBe('drift now\n') // 변경 안 됨
+    expect(listBackups(dir).length).toBe(0) // 백업 생성 안 함
+  })
+})
+
+describe('buildSyncPlan — drift 판정', () => {
+  it('무수정=not drift, 수작업 수정=drift', async () => {
+    await syncCore(dir, {}, alwaysYes)
+    const sections = parseRulesMd(read('RULES.md'))
+    const name = deriveProjectName(read('RULES.md'))
+    let plan = buildSyncPlan(dir, sections, name)
+    expect(plan.find((p) => p.path === '.cursorrules')?.drift).toBe(false)
+
+    fs.writeFileSync(path.join(dir, '.cursorrules'), 'hand edit\n', 'utf-8')
+    plan = buildSyncPlan(dir, sections, name)
+    expect(plan.find((p) => p.path === '.cursorrules')?.drift).toBe(true)
+  })
+
+  it('CLAUDE.md 도 계획에 포함 (하이브리드 가드)', async () => {
+    const sections = parseRulesMd(read('RULES.md'))
+    const name = deriveProjectName(read('RULES.md'))
+    const plan = buildSyncPlan(dir, sections, name)
+    expect(plan.map((p) => p.path)).toContain('CLAUDE.md')
+  })
+})


### PR DESCRIPTION
파괴적 경로(파일 덮어쓰기 / git 되돌리기)를 **손실 불가능**하게 만드는 최우선 지혈 배치.

## 문제 (확인됨)
1. `vhk sync` 가 `.cursorrules`/`.windsurfrules`/copilot/antigravity 를 백업·확인 없이 통째 덮어씀 → 수작업 규칙 유실.
2. `undo` 는 git 커밋만 되돌려 언커밋 sync 덮어쓰기 복구 불가.
3. MCP `undo` 가 즉시 `git reset --soft HEAD~1` 실행 → 에이전트 채팅창서 위험.

## A. 백업/복원 인프라
- `src/lib/backup.ts` (신규): `saveBackup`/`listBackups`/`restoreBackup`/`pruneBackups`/`ensureVhkIgnored`. `.vhk/backups/<타임스탬프>/` 로 구조 보존 복사. ⚠️ **Windows 파일명 콜론 금지** → `fsSafeStamp` 로 `:`·`.` → `-`. 보존 정책 최근 10개.
- `src/commands/restore.ts` (신규) + 레지스트리 등록 + 별칭 `복원` + NL 라우팅. undo 의 구멍(언커밋 sync 덮어쓰기 복구)을 메움. NL "백업 복원/되돌려" 는 cloud-pull·undo 보다 우선(백업 한정 → 회귀 0).

## B. sync 안전 가드 (`src/commands/sync.ts`)
- SYNC_TARGETS 4개 + CLAUDE.md(하이브리드) 를 `buildSyncPlan` 으로 균일 처리.
- 덮어쓰기 전 (drift || 첫 sync) 파일 **무조건 백업** → 손실 0.
- drift 판정 = `normalizeForCompare`(lib/drift) 재활용 (CRLF 거짓경보 방지).
- `--dry-run`: 디스크 미변경 미리보기. `--yes`: 확인 생략.
- TTY: drift 시 inquirer 확인(기본 거부). 비대화형(CI/MCP: `isTTY=false`): **멈추지 않고** 자동 백업 후 진행.
- `syncCore` seam(콘솔 분리 + confirm 주입)으로 테스트 가능화.
- `.vhk/.synced` 마커로 첫 sync 판정. `backups/`·`.synced` 는 `.vhk/.gitignore` 자동 등록.

> 0단계 감사: cloud 백업은 **평면구조만** 수집(`collectVhkFiles` = top-level 파일만) → `backups/` 서브폴더는 구조적으로 gist 에 안 올라감. DEFAULT_CLOUD_EXCLUDES 추가 불필요(스코프 절약).

## C. MCP undo 안전화 (`src/mcp/server.ts`)
- `confirm` 파라미터 추가, **기본 dry-run**. 되돌릴 커밋 먼저 보고 → `confirm:true` 일 때만 실제 reset. CLI undo 대화형 UX 는 그대로.

## 테스트 (TDD)
- `tests/backup.test.ts` (13) — 콜론치환/구조보존/gitignore/복원/prune
- `tests/sync-guard.test.ts` (7) — drift 거부→원본보존+백업, --dry-run 미변경, 비대화형 자동진행, 첫 sync 백업
- `tests/nlp-router.test.ts` — restore 라우팅 우선순위 + 회귀 가드

## 게이트
- `tsc --noEmit` 0 · `build` 성공 · `test:run` **402 pass**
- e2e 스모크(temp dir): dry-run 무변경·백업0 / real sync 원본백업·재생성·gitignore 등록 → **데이터 손실 0 확인**
- 신규 의존성 0. 기존 시그니처 불변(`sync` 는 opts 추가 — 하위호환). dogfooding 미실행(지시 준수).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
