### PR TITLE
feat: 배치1-3 — RULES.md adopt·토큰절감 컨텍스트·채팅 UX 안전 마감

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,9 @@
 > VHK 의 자율 루프(`context → goal next → 작업 → goal check → goal done`) 안에서
 > 동작하는 모든 에이전트(사람·LLM·CI 봇)가 따라야 하는 공통 규약.
 > vspec/vooster `AGENTS.md` 패턴 차용, VHK 단일 패키지 맥락에 맞춰 축소.
+>
+> ⚡ **빠른 시작(토큰 절감):** 전체를 매번 읽기 부담되면 짧은 요약
+> `docs/context/agent-compact.md` 를 먼저 읽으세요. `vhk context --compact` 도 같은 규약을 참조합니다.
 
 ## You Are
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ AI 코딩 도구는 저마다 규칙 파일이 다르고(`.cursorrules`·`CLAUDE
 >
 > ℹ️ Windsurf·Copilot·Antigravity 출력 경로·포맷은 각 도구의 **공식 문서 기준**으로 생성합니다(`.windsurfrules` · `.github/copilot-instructions.md` · `.agents/rules/`). Antigravity 는 파일당 12,000자 제한이 있어 초과 시 안전하게 절삭하고 전체는 `RULES.md` 에 남습니다.
 
+### Cursor / Copilot / Antigravity 에서 이렇게 말하세요
+
+규칙 파일을 동기화하면, 에이전트 채팅창에서 명령을 외우지 않고 한국어로 말해도 됩니다:
+
+| 하고 싶은 일 | 채팅창에 이렇게 | 실행되는 명령 |
+|------|------|------|
+| 규칙 한 벌로 동기화 | "규칙 동기화해줘" | `vhk sync` |
+| 지금 상태 보기 | "상태 알려줘" | `vhk status` |
+| 뭐 바뀌었는지 | "뭐 바뀌었어?" | `vhk diff` |
+| 처음이라 막막함 | "처음 뭐 해?" / "도움말" | `vhk start` |
+| 저장(커밋) | "저장해줘" | `vhk save` |
+
+> MCP를 등록하면(`vhk mcp-init`) 위 문장이 곧바로 vhk 도구 호출로 이어집니다. RULES.md 한 벌이 다섯 도구에 같은 규칙을 깔아줍니다.
+
 ## 3분 안에 시작하기 (Getting Started)
 
 ### 1. 설치
@@ -156,7 +170,7 @@ vhk 기획 끝났고 바로 시작
 | `vhk audit` | `감사` | npm/pnpm/yarn 보안 취약점 감사 (`--fix`로 자동 수정, npm만) |
 | `vhk migrate [target]` | `전환` | 패키지 매니저 전환 (`npm` / `yarn` / `pnpm`, lockfile + node_modules 재구성) |
 | `vhk update` | `업데이트` | VHK CLI 최신 버전으로 셀프 업데이트 |
-| `vhk context` | `맥락` | 프로젝트 트리·스택·CLI 명령 목록을 `.vhk/context.md`로 자동 생성 (AI 어시스턴트용) |
+| `vhk context` | `맥락` | 프로젝트 트리·스택·CLI 명령 목록을 `.vhk/context.md`로 자동 생성 (AI 어시스턴트용). `--compact` 로 토큰 절감형(Active Goal + 최근 blockers/learnings/memories + 참조 링크) 출력 |
 | `vhk context-show` | `맥락보기` | 현재 컨텍스트 파일 내용 출력 |
 | `vhk memory` | `기억` | 결정사항 기억 관리 (`add` / `list` / `remove`, `.vhk/memory.json` 기반, 태그 지원) |
 | `vhk brief` | `브리핑` | 프로젝트 정보 + git 상태 + 결정사항 + 레퍼런스 통합 보고서 `.vhk/brief.md` |

--- a/docs/context/agent-compact.md
+++ b/docs/context/agent-compact.md
@@ -1,0 +1,28 @@
+# Agent Compact — 짧은 작동 규약 (먼저 읽기)
+
+> AGENTS.md 전체를 대체하지 않는 **빠른 시작 요약**. 매 iteration 먼저 읽고,
+> 상세가 필요하면 AGENTS.md / CLAUDE.md / 해당 goal 문서를 그때 연다.
+
+## 환경
+- 언어: 한국어 (메시지·주석·응답). 사용자-facing 한국어를 영어로 바꾸지 않는다.
+- OS: Windows 11 / PowerShell. bash heredoc·sh 문법 금지. 게이트는 `pnpm.cmd`.
+
+## 안전 (HARD_STOP)
+- 작업 시작 시 `.vhk/HARD_STOP` 존재 확인. 있으면 **모든 자동화 즉시 중단**하고 사람에게 보고.
+- 해제는 `vhk resume --confirm` (사람만). 자동 호출 금지.
+- 블로커 3건 누적 시 HARD_STOP 자동 생성.
+
+## 작업 원칙
+- **active goal 만 작업** (`vhk goal next` 가 고른 첫 NOT_STARTED / IN_PROGRESS).
+- 사용자 변경 **revert 금지**. `git status --short` 먼저 확인, 기존 수정 보존, 최소 범위 패치.
+- 추측으로 코드 바꾸지 않는다. 원인 모르면 멈추고 보고.
+
+## SoT (Single Source of Truth)
+- 현재 상태: `docs/state/next-task.md` / `blockers.md` / `learnings.md`.
+- `docs/state/blockers.md`·`learnings.md` 는 **append-only** (과거 항목 삭제·수정 금지).
+- 규칙 SoT: `RULES.md` (→ `vhk sync` 로 각 도구에 전파).
+
+## 게이트
+- 기본: `pnpm.cmd exec tsc --noEmit` / `pnpm.cmd run test:run` / `pnpm.cmd run build`.
+- TDD: 실패 테스트 먼저 → 최소 구현 → green.
+- **게이트 실패 시 `vhk goal done` 금지** — 통과해야만 done.

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -1,15 +1,10 @@
 # Next Task
 
-_2026-05-28: 모든 goal 완료. v1.1 / v1.2 / v1.3 핸드오프 끝._
+_Auto-updated 2026-05-30T12:32:29.285Z via `vhk goal next`._
 
-```text
-TASK: Goal 3+ 미지정. 신규 goal 추가 또는 v2.0 (Product Hunt 론칭) 단계 진입.
-  - 신규 goal 추가: goals/3-<name>.md (frontmatter + 표준 섹션) + scripts/check-goal-3.sh
-  - 또는: Phase 6 — npm 패키지 안정 + Product Hunt 론칭 + 사용자 onboarding
 ```
-
-## 완료된 Goal
-
-- Goal 0 (MCP 풀 커버리지) — DONE 2026-05-27. 10 → 24 tool.
-- Goal 1 (vhk goal 명령어) — DONE 2026-05-27. init/list/next/check/done + check --goal.
-- Goal 2 (자율 루프) — DONE 2026-05-28. blocker/learn/resume + AGENTS.md + context 확장.
+TASK: Goal 5 — 배치3 — 채팅 UX 안전 마감 + AGENTS.md 6번째 타겟 + MCP/도움말
+  status: NOT_STARTED
+  priority: P3
+  file: goals\5-chat-ux.md
+```

--- a/goals/3-init-rules.md
+++ b/goals/3-init-rules.md
@@ -1,0 +1,49 @@
+---
+vhk_format: 1
+type: goal
+id: 3
+title: 배치1 — init adopt + RULES.md 항상 생성 + 5-tool sync 검증
+status: DONE
+priority: P1
+version: v1.7
+completed: 2026-05-30
+---
+
+# [배치 1] init adopt 모드 + RULES.md 항상 생성 + 5-tool sync 검증 (완치)
+
+배치 0(sync 안전 가드)이 머지된 뒤 진행한다. RULES.md 생성은 여기서 단 한 번만 구현한다(§11 Phase2 == 프롬프트2-4 동일 작업).
+
+## 공통 가드 (반드시 준수)
+- Windows PowerShell 기준. bash heredoc/sh 금지. 게이트는 pnpm.cmd.
+- 한국어 UX/별칭/문서 톤 유지. 사용자-facing 한국어를 영어로 바꾸지 마라.
+- 사용자 변경 revert 금지. git status --short 먼저 확인, 기존 수정 보존, 최소 범위 패치.
+- docs/state/blockers.md, learnings.md append-only.
+- 기존 컨벤션 준수(safeExecFile, inquirer, chalk, ora, printNextStep, t()). 신규 의존성 금지.
+- TDD. 이 배치 별도 커밋/PR. ko.ts 는 이 배치 문자열만.
+
+## 먼저 읽을 것
+- src/commands/init.ts (generateFiles — 현재 RULES.md 키 없음), sync.ts (RULES.md 파싱/생성, SYNC_TARGETS)
+- src/lib/ 의 파일 생성 헬퍼, templates/ (vhk-dir 등)
+- 기존 .cursorrules/CLAUDE.md/AGENTS.md/.windsurfrules/copilot 포맷
+
+## 구현
+### A. RULES.md 생성 흐름 (한 번만 — 중복 주의)
+- greenfield init 도 RULES.md 템플릿을 항상 생성(init↔sync 흐름 연결). 현재 init 은 RULES.md 를 안 만드는데 sync 는 원본으로 요구 → 이 단절을 해소.
+- RULES.md 가 없으면 현재 프로젝트용 기본 RULES.md 생성 흐름 보강(프롬프트2-4와 동일 작업).
+
+### B. init adopt 모드 (브라운필드)
+- src/lib/rules-import.ts 신규: 기존 .cursorrules/CLAUDE.md/AGENTS.md/.windsurfrules/copilot 를 섹션 파싱 → RULES.md 표준 섹션(## 기술 스택 / ## 코딩 규칙 / ## 기록 규칙 등)으로 병합(출처 주석 포함).
+- init.ts: 기존 설정 파일 감지되면 "기존 규칙 N개 발견, RULES.md로 가져올까요?" → adopt. 충돌/중복 섹션은 사용자에게 보여주고 keep/merge 선택.
+- 신규 모드와 자동 분기(설정 파일·.vhk/ 유무로 감지).
+
+### C. 5-tool sync 산출 검증 (프롬프트2-4)
+- vhk sync 로 .github/copilot-instructions.md, .agents/rules/vhk-rules.md, .windsurfrules 가 실제 생성되는지 테스트 추가.
+- README 에 "Cursor/Copilot/Antigravity 에서 이렇게 말하세요" 섹션을 짧게 추가(자연어로 vhk 를 부르는 예시 문구).
+
+## 테스트
+- adopt: 기존 3개 파일 → RULES.md 섹션 병합 결과 스냅샷.
+- greenfield: 빈 디렉터리 → RULES.md 포함 scaffold.
+- sync 산출: copilot-instructions / vhk-rules / windsurfrules 실제 생성 확인.
+
+## 게이트 (이 배치 끝)
+- pnpm.cmd exec tsc --noEmit / pnpm.cmd run test:run / pnpm.cmd run build (모두 통과, 번들 급증 없음)

--- a/goals/4-token-context.md
+++ b/goals/4-token-context.md
@@ -1,0 +1,93 @@
+---
+vhk_format: 1
+type: goal
+id: 4
+title: 배치2 — 토큰 절감형 컨텍스트(최근 N개 + compact + 참조 로딩)
+status: DONE
+priority: P2
+version: v1.8
+completed: 2026-05-30
+---
+
+# [배치 2] 한국어 UX 유지 + 토큰 절감형 컨텍스트 설계 보완
+
+목표: VHK의 한국어 인터페이스는 유지하되, 매번 긴 규약/상태/문서를 통째로 컨텍스트에 넣는 구조를 토큰 절감형으로 바꾼다. 한국어가 문제가 아니라 통째 주입이 문제다.
+
+## 공통 가드 (반드시 준수)
+- Windows PowerShell 기준. bash heredoc/sh 금지. 게이트는 pnpm.cmd.
+- 한국어 CLI 메시지/별칭/문서 톤 유지. token 절감 때문에 사용자-facing 한국어를 영어로 바꾸지 마라.
+- 사용자 변경 revert 금지. git status --short 먼저 확인, 기존 수정 보존, 충돌 없이 최소 범위 패치, 불필요한 리팩터링 금지.
+- docs/state/blockers.md, docs/state/learnings.md 는 append-only. 과거 항목 삭제 금지.
+- TDD. 이 배치 별도 커밋/PR. ko.ts 는 이 배치 문자열만.
+
+## 먼저 읽을 것
+1. AGENTS.md
+2. CLAUDE.md
+3. src/commands/context.ts
+4. src/lib/state-files.ts
+5. src/commands/brief.ts
+6. src/commands/goal.ts
+7. src/lib/goal-frontmatter.ts
+8. tests/context-loop.test.ts
+9. tests/state-files.test.ts
+
+## 현재 확인된 상태
+- 한국어 인터페이스: 이미 잘 구현됨
+- 구조화된 상태 파일: 대체로 구현됨
+- 최근 N개 로드: 현재 learnings 만 getRecentLearnings(3) 로 구현됨
+- 짧은 시스템 규약: 미구현
+- 상세 문서 필요시 로딩: 미흡
+
+## 1. 최근 N개 로드 보완
+learnings 만 최근 3개로 제한하는 건 시작일 뿐 충분치 않다. 현재 vhk context 는 .vhk/memory.json 을 전부 넣고, active blocker 요약 함수도 없다.
+요구:
+- src/lib/state-files.ts 에 함수 추가:
+  - getRecentBlockers(limit = 3)
+  - getActiveBlockers(limit = 3)
+  - 기존 getRecentLearnings(limit = 3) 와 유사하게 구현하되:
+    - blockers.md 에서 "- [" 로 시작하는 항목만 대상
+    - ~~strikethrough~~ 해결 항목은 active blockers 에서 제외
+    - 기본 limit 은 3
+- .vhk/memory.json 도 context 에 전체 삽입하지 말고 최근 N개만:
+  - getRecentMemories(limit = 5) 헬퍼를 만들거나 context 내부에서 slice 처리
+  - memory 항목이 많아도 context.md 가 과도하게 커지지 않게
+- 테스트:
+  - blockers 최근 N개 반환
+  - active blockers 는 해결 항목 제외
+  - memory 가 여러 개일 때 context 에는 최근 5개만 포함
+
+## 2. 짧은 시스템 규약 구현
+현재 AGENTS.md 118줄, CLAUDE.md 90줄, goal 문서도 필수 독해라 매 iteration 전체 주입하면 토큰이 크다. 기존 문서는 운영 SoT라 유지한다.
+요구:
+- AGENTS.compact.md 또는 docs/context/agent-compact.md 생성. LLM이 매번 먼저 읽을 "짧은 작동 규약". AGENTS.md 전체를 대체하지 않고 빠른 시작 요약 역할. 30줄 내외.
+- 반드시 포함: 한국어/Windows/PowerShell, 사용자 변경 revert 금지, HARD_STOP 존재 시 중단, active goal 만 작업, docs/state 는 SoT, blockers/learnings append-only, 게이트 실패 시 done 금지, 테스트/빌드 기본 게이트.
+- AGENTS.md 에는 compact 문서가 있음을 안내하되 AGENTS.md 자체 규칙은 깨지지 않게.
+  ⚠️ 통합 주의: 배치 3에서 AGENTS.md 가 sync 생성물(6번째 타겟)이 될 예정이면, 이 compact 안내는 AGENTS.md 에 하드코딩하지 말고 RULES.md 소스에 넣어 sync 로 전파시켜라(안 그러면 sync 후 덮어써짐). AGENTS.md 를 수기 관리로 유지하기로 했다면 그대로 AGENTS.md 에.
+- 가능하면 vhk context 또는 신규 옵션이 compact 규약을 우선 참조하게.
+선택 구현:
+- vhk context --compact: 전체 명령 목록/디렉터리 트리를 줄이고 Active Goal, 최근 blockers/learnings/memories, 핵심 규약 링크만 포함.
+- 또는 vhk context 기본을 compact 로 바꾸고 vhk context --full 을 상세로. 단 기존 사용자 기대를 깨지 않도록 테스트와 README 설명 필요.
+
+## 3. 상세 문서 필요시 로딩 보완
+현재 context 는 디렉터리 트리 depth 3, 전체 명령 목록, memory 전체 등을 넣는다. "상세 문서는 필요할 때 검색/열람" 구조가 약하다.
+요구:
+- .vhk/context.md 에는 상세 문서 전문 대신 참조 링크/경로 중심으로:
+  - 규약 상세: AGENTS.md / 기록 규칙: CLAUDE.md / 명령 상세: COMMANDS.md / 구조 상세: docs/ARCHITECTURE.md / 현재 상태: docs/state/next-task.md
+- context 에는 상세 문서 내용을 붙이지 말고 "필요시 열람할 파일" 목록 제공.
+- contextShow 는 현재처럼 파일 전체 출력 유지 가능.
+- 역할 분리: vhk brief = 상태 요약, vhk context = LLM 부팅 컨텍스트.
+(⚠️ .vhk/context.md 생성은 배치 1 init 과도 겹치니 참조-링크 방식으로 통일.)
+
+## 권장 구현 순서
+1. state-files.ts 에 recent/active helper 추가(getRecentLearnings 유지, getActiveBlockers/getRecentBlockers 추가). 테스트 먼저.
+2. context.ts 토큰 절감형 수정(learnings 최근 3, blockers active 최근 3, memory 최근 5, 전체 명령 목록은 compact 에서 제거/요약, 디렉터리 트리 depth 2 또는 compact 에서 생략).
+3. compact 규약 문서 추가(AGENTS.compact.md 또는 docs/context/agent-compact.md), AGENTS.md/README 에 짧게 연결.
+4. CLI 옵션 vhk context --compact 추가(기본은 기존 호환 유지, --compact 일 때만 절감 출력, 추후 기본 전환 가능하게 문서화).
+5. 테스트/문서 업데이트(tests/context-loop.test.ts, tests/state-files.test.ts, README/COMMANDS.md 에 --compact 설명, 필요 시 CLAUDE.md 안정성 규칙 갱신).
+
+## 완료 조건
+- 한국어 CLI/문서 톤 유지
+- pnpm.cmd exec tsc --noEmit 통과
+- pnpm.cmd run test:run 통과
+- pnpm.cmd run build 통과
+- 변경 요약을 한국어로 보고

--- a/goals/5-chat-ux.md
+++ b/goals/5-chat-ux.md
@@ -1,0 +1,65 @@
+---
+vhk_format: 1
+type: goal
+id: 5
+title: 배치3 — 채팅 UX 안전 마감 + AGENTS.md 6번째 타겟 + MCP/도움말
+status: DONE
+priority: P3
+version: v1.9
+completed: 2026-05-30
+---
+
+# [배치 3] 비개발자/바이브코더가 에이전트 채팅창에서 자연어로 안전하게 쓰게 마감
+
+VHK를 비개발자/바이브코더/솔로프리너가 에이전트 채팅창(Cursor, Copilot, Antigravity 등)에서 자연어로 안전하게 쓰도록 개선한다. 배치 0~2 머지 후 진행.
+
+## 공통 가드 (반드시 준수)
+- Windows PowerShell 기준. bash heredoc/sh 금지. 게이트는 pnpm.cmd.
+- 한국어 UX 유지. 사용자-facing 한국어를 영어로 바꾸지 마라.
+- 사용자 변경 revert 금지. git status --short 먼저 확인, 기존 수정 보존, 최소 범위 패치.
+- docs/state/blockers.md, learnings.md append-only.
+- 기존 컨벤션 준수. 신규 의존성 금지. TDD. 별도 커밋/PR. ko.ts 는 이 배치 문자열만.
+
+## 먼저 읽을 것
+- 자연어 → 명령 라우터(printNextStep/cursorHint 및 자연어 매핑 위치), src/commands/status.ts
+- src/mcp/index.ts (runVhkCli), src/commands/mcp-init.ts, sync.ts(SYNC_TARGETS), src/commands/migrate.ts
+
+## 우선순위
+0. vhk start 단일 진입점 (초보 온보딩 첫 화면):
+   - vhk start 실행 시 현재 상태 요약 + quick actions 10문장만 노출(상태 알려줘 / 뭐 바뀌었어 / 저장해줘 / 오늘 한 일 정리해줘 / 다음에 뭐 하면 돼 / 도움말 / 동기화 / 백업 복원 / 보안 점검 / 종료 등). 전체 명령어 목록을 들이밀지 말 것 — 첫 화면은 vhk start 하나로 끝낸다.
+   - 비대화형(TTY 아님)에서도 동작하게. 테스트 추가.
+1. 자연어 라우터에 도움말 계열 추가:
+   - "도움말", "사용법", "명령어", "뭐 할 수 있어", "처음 뭐 해"
+   - 결과는 CLI help 또는 초보자용 quick actions 로 연결. 테스트 추가.
+   - ⚠️ 자연어 라우터는 실제 명령어 이름(restore/undo/sync 등)을 절대 가로채지 마라 — 명령어 매칭 우선, 자연어는 fallback. (배치 0 R1: restore가 라우터에 삼켜져 안전망이 죽은 실결함 확인.) 테스트 추가.
+2. status 다음 액션을 더 안전하게:
+   - 변경사항이 있으면 바로 vhk save 추천 금지.
+   - 먼저 vhk diff / "뭐 바뀌었어" 추천, 저장은 그 다음 액션으로 안내. 테스트 추가.
+3. (MCP undo 는 배치 0에서 처리됨 — 중복 구현 금지. 미반영이면 여기서 마무리: dry-run 기본 또는 confirm token, CLI undo UX 유지.)
+4. 에이전트 채팅창 dogfooding 마감:
+   - (RULES.md 기본 생성 흐름은 배치 1에서 구현됨 — 재구현 금지.)
+   - vhk sync 로 .github/copilot-instructions.md, .agents/rules/vhk-rules.md, .windsurfrules 가 실제 생성되는지 테스트(배치 1과 중복 시 보강).
+   - README "Cursor/Copilot/Antigravity 에서 이렇게 말하세요" 섹션 확인/보강.
+5. MCP runVhkCli PATH 의존 제거:
+   - dist/mcp/index.js 에서 전역 vhk 가 없어도 로컬 dist/index.js 를 실행하도록 fallback.
+   - mcp-init smoke 테스트 보강.
+
+## AGENTS.md 6번째 타겟 + UX 마감 (§11 Phase 3)
+- RULES.md → AGENTS.md 생성기 추가(toAgentsMd()) 후 SYNC_TARGETS 레지스트리에 항목 1개만 추가 → sync·드리프트·백업 가드(배치 0)가 자동 반영. adopt 스캔 대상에도 AGENTS.md 포함.
+  ⚠️ AGENTS.md 가 생성물이 되면, 배치 2의 compact 안내가 AGENTS.md 에 하드코딩돼 있으면 안 됨(RULES.md 소스로 이동). 두 배치 일관성 확인.
+- 대규모 대응: Antigravity 12,000자 절삭 시 조용히 자르지 말고 큰 경고(또는 .agents/rules/ 다중 파일 분할 검토). adopt 충돌은 섹션별 프롬프트 대신 미리보기 1회 + 일괄 결정.
+- 모든 파괴적 동작 기본값 안전화, 평문 결과 요약 + 복구 명령 안내.
+- migrate 도움말에 "패키지매니저 전환(설정 마이그레이션 아님)" 명시.
+- MCP 도구(src/mcp/) description 에 "sync 는 덮어쓰기 전 자동 백업함" 명시, 에이전트가 사용자에게 백업·복원을 안내하도록.
+- (선택) mcp-init 이 현재 .cursor/mcp.json 만 생성 → Windsurf/Copilot/Antigravity 등 다른 도구 MCP 설정도 지원하도록 일반화 검토.
+
+## 검증 (이 배치 끝 — 전체 게이트)
+- pnpm.cmd exec tsc --noEmit
+- pnpm.cmd run test:run
+- pnpm.cmd run build
+- pnpm.cmd run scan
+- pnpm.cmd audit --audit-level moderate
+- node scripts/check-meta.mjs
+- node scripts/check-goal-0.mjs
+- node scripts/check-goal-1.mjs
+- node scripts/check-goal-2.mjs

--- a/scripts/check-goal-3.mjs
+++ b/scripts/check-goal-3.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+const root = process.cwd();
+const ok = [], fail = [];
+const read = (p) => existsSync(join(root, p)) ? readFileSync(join(root, p), "utf8") : null;
+const must = (c, m) => (c ? ok : fail).push(m);
+const init = read("src/commands/init.ts");
+must(init && /RULES\.md/.test(init), "init.ts 가 RULES.md 생성에 관여");
+must(existsSync(join(root, "src/lib/rules-import.ts")), "rules-import.ts 존재(adopt)");
+const sync = read("src/commands/sync.ts");
+must(sync && /SYNC_TARGETS/.test(sync), "sync.ts SYNC_TARGETS");
+must(sync && /copilot/i.test(sync), "copilot 타겟");
+must(sync && /windsurf/i.test(sync), "windsurf 타겟");
+const readme = read("README.md");
+must(readme && /(Cursor|Copilot|Antigravity)/.test(readme), "README 채팅 가이드");
+console.log(ok.map((m) => "  ✓ " + m).join("\n"));
+if (fail.length) { console.error("\n[check-goal-3 FAIL]\n" + fail.map((m) => "  ✗ " + m).join("\n")); process.exit(1); }
+console.log("\n[check-goal-3 PASS]");

--- a/scripts/check-goal-4.mjs
+++ b/scripts/check-goal-4.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+const root = process.cwd();
+const ok = [], fail = [];
+const read = (p) => existsSync(join(root, p)) ? readFileSync(join(root, p), "utf8") : null;
+const must = (c, m) => (c ? ok : fail).push(m);
+const sf = read("src/lib/state-files.ts");
+must(sf && /getActiveBlockers/.test(sf), "getActiveBlockers");
+must(sf && /getRecentBlockers/.test(sf), "getRecentBlockers");
+const ctx = read("src/commands/context.ts");
+must(ctx && /compact/i.test(ctx), "context --compact");
+must(ctx && /(getActiveBlockers|blocker)/i.test(ctx), "context 가 active blockers 포함");
+must(existsSync(join(root, "AGENTS.compact.md")) || existsSync(join(root, "docs/context/agent-compact.md")), "compact 규약 문서");
+console.log(ok.map((m) => "  ✓ " + m).join("\n"));
+if (fail.length) { console.error("\n[check-goal-4 FAIL]\n" + fail.map((m) => "  ✗ " + m).join("\n")); process.exit(1); }
+console.log("\n[check-goal-4 PASS]");

--- a/scripts/check-goal-5.mjs
+++ b/scripts/check-goal-5.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+const root = process.cwd();
+const ok = [], fail = [];
+const read = (p) => existsSync(join(root, p)) ? readFileSync(join(root, p), "utf8") : null;
+const must = (c, m) => (c ? ok : fail).push(m);
+function grepRepo(re) {
+  const stack = [join(root, "src"), join(root, "tests")];
+  while (stack.length) {
+    const d = stack.pop();
+    if (!existsSync(d)) continue;
+    for (const e of readdirSync(d)) {
+      const p = join(d, e);
+      if (statSync(p).isDirectory()) stack.push(p);
+      else if (/\.(ts|mjs|md)$/.test(e) && re.test(readFileSync(p, "utf8"))) return true;
+    }
+  }
+  return false;
+}
+for (const id of [0, 1, 2, 3, 4]) {
+  const s = "scripts/check-goal-" + id + ".mjs";
+  if (!existsSync(join(root, s))) { fail.push(s + " 없음"); continue; }
+  try { execSync("node " + s, { cwd: root, stdio: "pipe" }); ok.push("check-goal-" + id + " 통과"); }
+  catch { fail.push("check-goal-" + id + " 실패"); }
+}
+must(existsSync(join(root, "src/commands/start.ts")), "vhk start 커맨드");
+const status = read("src/commands/status.ts") || "";
+must(/도움말|help/i.test(status + (read("src/lib/nlp-router.ts") || "")), "자연어 도움말 라우팅");
+must(grepRepo(/(가로채|명령어 우선|command.*priorit|restore.*router)/i), "R1 라우터 명령어 가드");
+must(/diff/.test(status), "status diff 우선");
+must(/AGENTS\.md/.test(read("src/commands/sync.ts") || ""), "AGENTS.md sync 타겟");
+must(/dist\/index\.js|fallback|resolve/i.test(read("src/mcp/index.ts") || ""), "MCP PATH fallback");
+console.log(ok.map((m) => "  ✓ " + m).join("\n"));
+if (fail.length) { console.error("\n[check-goal-5 FAIL]\n" + fail.map((m) => "  ✗ " + m).join("\n")); process.exit(1); }
+console.log("\n[check-goal-5 PASS]");

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -13,7 +13,7 @@ import { printNextStep } from '../lib/next-step.js'
 import { readJsonFile } from '../lib/read-json.js'
 import { listGoals } from '../lib/goal-frontmatter.js'
 import { selectActiveId } from './goal.js'
-import { getRecentLearnings, isHardStopActive } from '../lib/state-files.js'
+import { getRecentLearnings, getActiveBlockers, isHardStopActive } from '../lib/state-files.js'
 import { gitOut } from '../lib/git-repo.js'
 import { CONTEXT_GIT_MARKER } from '../lib/drift.js'
 
@@ -138,12 +138,18 @@ function getVhkCommands(): string[] {
   ]
 }
 
-export async function context(): Promise<void> {
+/**
+ * vhk context — LLM 부팅 컨텍스트(.vhk/context.md) 생성.
+ * compact 모드(--compact): 토큰 절감형. 전체 명령 목록/깊은 트리 대신 Active Goal +
+ * 최근 learnings/blockers/memories + 참조 문서 링크만 담는다. 기본(full)은 기존 호환 유지.
+ */
+export async function context(opts: { compact?: boolean } = {}): Promise<void> {
+  const compact = opts.compact === true
   console.log(chalk.bold('\n🧠 ' + t('context.title')))
   console.log(chalk.gray('─'.repeat(40)))
 
   const stack = extractTechStack()
-  const tree = buildTree('.').join('\n')
+  const tree = buildTree('.', '', compact ? 2 : 3).join('\n')
   const commands = getVhkCommands()
 
   const lines: string[] = []
@@ -167,12 +173,20 @@ export async function context(): Promise<void> {
   lines.push('```')
   lines.push('')
 
-  lines.push('## VHK CLI 명령어')
-  lines.push('')
-  for (const cmd of commands) {
-    lines.push(`- \`vhk ${cmd}\``)
+  // compact: 전체 명령 목록(~28줄)은 토큰만 먹으므로 한 줄 참조로 대체. full: 기존대로 전체.
+  if (compact) {
+    lines.push('## 명령어 (요약)')
+    lines.push('')
+    lines.push('- 전체 목록은 `vhk help` 또는 `COMMANDS.md` 참조 (compact 모드는 생략)')
+    lines.push('')
+  } else {
+    lines.push('## VHK CLI 명령어')
+    lines.push('')
+    for (const cmd of commands) {
+      lines.push(`- \`vhk ${cmd}\``)
+    }
+    lines.push('')
   }
-  lines.push('')
 
   if (existsSync('.vhk/memory.json')) {
     try {
@@ -180,9 +194,15 @@ export async function context(): Promise<void> {
         '.vhk/memory.json'
       )
       if (Array.isArray(memories) && memories.length > 0) {
+        // 토큰 절감: 전체가 아니라 최근 5개만 삽입 (full/compact 공통).
+        const recentMemories = memories.slice(-5)
         lines.push('## 저장된 결정사항')
         lines.push('')
-        for (const m of memories) {
+        if (memories.length > recentMemories.length) {
+          lines.push(`_최근 ${recentMemories.length}개만 표시 (전체 ${memories.length}개)_`)
+          lines.push('')
+        }
+        for (const m of recentMemories) {
           const date = new Date(m.addedAt).toLocaleDateString('ko-KR')
           lines.push(`- ${m.content} _(${date})_`)
         }
@@ -216,6 +236,28 @@ export async function context(): Promise<void> {
     lines.push('## Recent Learnings')
     lines.push('')
     for (const r of recent) lines.push(r)
+    lines.push('')
+  }
+
+  // 활성 blocker 최근 3건 — "지금 막힌 것"만. 해결(~~취소선~~) 항목은 제외.
+  const activeBlockers = getActiveBlockers(3)
+  if (activeBlockers.length > 0) {
+    lines.push('## Active Blockers')
+    lines.push('')
+    for (const b of activeBlockers) lines.push(b)
+    lines.push('')
+  }
+
+  // compact: 상세 문서를 통째로 넣지 않고 "필요시 열람할 파일" 참조 링크만 제공(토큰 절감).
+  if (compact) {
+    lines.push('## 참조 문서 (필요시 열람)')
+    lines.push('')
+    lines.push('- 작동 규약(요약): `docs/context/agent-compact.md`')
+    lines.push('- 규약 상세: `AGENTS.md`')
+    lines.push('- 기록 규칙: `CLAUDE.md`')
+    lines.push('- 명령 상세: `COMMANDS.md`')
+    lines.push('- 구조 상세: `docs/ARCHITECTURE.md`')
+    lines.push('- 현재 상태: `docs/state/next-task.md`')
     lines.push('')
   }
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,0 +1,30 @@
+import chalk from 'chalk'
+
+/**
+ * 초보자용 quick actions — 자연어 "도움말/사용법/명령어" 라우팅의 **읽기전용** 대상.
+ * (적대 리뷰 HIGH 수정: 이전엔 도움말이 start 마법사로 라우팅돼 빈 디렉터리에서
+ *  scaffold 가 유발됐다. 도움말은 절대 상태를 바꾸지 않는다 — 출력만.)
+ */
+export const QUICK_ACTIONS: ReadonlyArray<{ say: string; does: string }> = [
+  { say: '상태 알려줘', does: 'vhk status' },
+  { say: '뭐 바뀌었어?', does: 'vhk diff' },
+  { say: '저장해줘', does: 'vhk save' },
+  { say: '오늘 한 일 정리해줘', does: 'vhk recap' },
+  { say: '다음에 뭐 하면 돼?', does: 'vhk goal next' },
+  { say: '규칙 동기화해줘', does: 'vhk sync' },
+  { say: '백업 복원해줘', does: 'vhk restore' },
+  { say: '보안 점검해줘', does: 'vhk secure scan' },
+  { say: '새 프로젝트 시작', does: 'vhk start' },
+  { say: '전체 명령어 보기', does: 'vhk --help' },
+]
+
+/** 자연어로 vhk 를 쓰는 법(quick actions) 출력. 부수효과 없음(콘솔 출력만). */
+export function quickActions(): void {
+  console.log(chalk.bold('\n🧭 VHK — 이렇게 말하면 됩니다 (quick actions)'))
+  console.log(chalk.gray('─'.repeat(40)))
+  for (const a of QUICK_ACTIONS) {
+    console.log(`  "${chalk.cyan(a.say)}"  →  ${chalk.dim(a.does)}`)
+  }
+  console.log(chalk.gray('\n  전체 명령은 `vhk --help` 또는 COMMANDS.md 를 보세요.'))
+  console.log('')
+}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { CLAUDE_MD_TEMPLATE } from '../templates/claude-md.js'
 import { CURSORRULES_TEMPLATE } from '../templates/cursorrules.js'
+import { RULES_MD_TEMPLATE } from '../templates/rules-md.js'
 import { PRD_TEMPLATE } from '../templates/prd.js'
 import { ARCHITECTURE_TEMPLATE } from '../templates/architecture.js'
 import { ADR_TEMPLATE } from '../templates/adr-template.js'
@@ -18,6 +19,7 @@ import { writeFile, fileExists } from '../utils/file.js'
 import { fetchPrdFromNotion } from '../notion/fetch-prd.js'
 import type { PrdContent } from '../types/prd.js'
 import { readJsonFile } from '../lib/read-json.js'
+import { detectExistingRuleFiles, buildAdoptedRules } from '../lib/rules-import.js'
 
 const PROJECT_TYPES = [
   { name: '🌐 웹 앱 (Next.js + Supabase + Vercel)', value: 'webapp' },
@@ -135,7 +137,32 @@ export async function init(options: InitOptions = {}) {
   }
 
   const cwd = process.cwd()
+
+  // adopt 모드(브라운필드) — 기존 도구별 규칙 파일을 RULES.md(SoT)로 가져오기 제안.
+  // 비대화형(--yes/notion)은 건너뛰고 greenfield 템플릿 RULES.md 를 그대로 쓴다.
+  let adoptedRules: string | null = null
+  if (!options.yes && !options.fromNotion) {
+    const existingRules = detectExistingRuleFiles(cwd)
+    if (existingRules.length > 0) {
+      const { adopt } = await inquirer.prompt([{
+        type: 'confirm',
+        name: 'adopt',
+        message: ko.init.adoptPrompt(
+          existingRules.length,
+          existingRules.map(f => f.path).join(', ')
+        ),
+        default: true,
+      }])
+      if (adopt) {
+        adoptedRules = buildAdoptedRules(existingRules, answers.name)
+        console.log(chalk.dim(`  ${ko.init.adoptPreview(existingRules.length)}`))
+      }
+    }
+  }
+
   const files = generateFiles(answers.name, answers.description, stack, prdContent, answers.type)
+  // adopt 채택 시 greenfield 템플릿 RULES.md 를 병합본으로 교체.
+  if (adoptedRules) files['RULES.md'] = adoptedRules
 
   log.step(ko.init.filesGenerating)
   for (const [filePath, content] of Object.entries(files)) {
@@ -198,6 +225,8 @@ export function generateFiles(
   return {
     'CLAUDE.md': CLAUDE_MD_TEMPLATE(name, stackStr),
     '.cursorrules': CURSORRULES_TEMPLATE(name, description, stackStr),
+    // RULES.md — 규칙 SoT. init 이 항상 생성해 sync 와 흐름을 연결한다.
+    'RULES.md': RULES_MD_TEMPLATE(name, description, stackStr),
     'docs/PRD.md': PRD_TEMPLATE(name, description, prd),
     'docs/ARCHITECTURE.md': ARCHITECTURE_TEMPLATE(name, stackStr),
     'docs/adr/ADR-000-template.md': ADR_TEMPLATE(),

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -89,6 +89,33 @@ export function readProjectPackage(cwd = process.cwd()): ProjectPackage | null {
   }
 }
 
+export interface StatusNextStep {
+  message: string
+  command: string
+  cursorHint: string
+  alternative?: string
+}
+
+/**
+ * status 다음 액션 — 변경사항이 있어도 곧장 `vhk save` 를 권하지 않는다(데이터 안전).
+ * 먼저 `vhk diff`("뭐 바뀌었어")로 확인 → 저장은 그 다음(alternative)으로 안내. (배치3 §2)
+ */
+export function selectStatusNextStep(hasChanges: boolean): StatusNextStep {
+  if (hasChanges) {
+    return {
+      message: t('status.nextWithChangesMessage'),
+      command: 'vhk diff',
+      cursorHint: t('status.nextWithChangesCursor'),
+      alternative: t('status.nextWithChangesAlt'),
+    }
+  }
+  return {
+    message: t('status.nextCleanMessage'),
+    command: 'vhk goal next',
+    cursorHint: t('status.nextCleanCursor'),
+  }
+}
+
 function getSyncCounts(gitRoot: string): SyncCounts {
   try {
     const out = gitOut(['rev-list', '--left-right', '--count', 'HEAD...@{u}'], gitRoot)
@@ -158,17 +185,5 @@ export async function status(): Promise<void> {
   }
 
   const hasChanges = counts.staged + counts.unstaged + counts.untracked > 0
-  if (hasChanges) {
-    printNextStep({
-      message: t('status.nextWithChangesMessage'),
-      command: 'vhk save',
-      cursorHint: t('status.nextWithChangesCursor'),
-    })
-  } else {
-    printNextStep({
-      message: t('status.nextCleanMessage'),
-      command: 'vhk goal next',
-      cursorHint: t('status.nextCleanCursor'),
-    })
-  }
+  printNextStep(selectStatusNextStep(hasChanges))
 }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -183,6 +183,43 @@ export function toClaudeMd(sections: RulesSection[], existing: string): string {
 }
 
 /**
+ * RULES.md 섹션을 AGENTS.md 포맷으로 변환 (sync 6번째 타겟).
+ * Loop Protocol 보일러플레이트를 생성기에 내장해 — sync 가 AGENTS.md 를 재생성해도
+ * 운영 규약(Loop Protocol)·compact 안내가 보존된다(수기 AGENTS.md 하드코딩 회피).
+ */
+export function toAgentsMd(sections: RulesSection[], projectName: string): string {
+  const codingSections = sections.filter(s => CURSORRULES_KEYS.some(k => s.title.includes(k)))
+  const recordSections = sections.filter(s => CLAUDE_MD_KEYS.some(k => s.title.includes(k)))
+
+  const lines = [
+    `# ${projectName} — AGENTS.md (에이전트 작동 규약)`,
+    '',
+    '> ⚡ 이 파일은 RULES.md에서 자동 생성됨 (vhk sync). 직접 수정 금지.',
+    '> 빠른 시작(토큰 절감): `docs/context/agent-compact.md` 를 먼저 읽으세요.',
+    '',
+    '## Loop Protocol',
+    '- 루프: `context → goal next → 작업 → goal check → goal done`',
+    '- 작업 시작 시 `.vhk/HARD_STOP` 확인 — 있으면 모든 자동화 즉시 중단.',
+    '- active goal 만 작업. `docs/state`(next-task/blockers/learnings)는 SoT, append-only.',
+    '- 게이트(tsc / test:run / build) 통과해야만 `vhk goal done`.',
+    '',
+  ]
+
+  for (const section of codingSections) {
+    lines.push(`## ${section.title}`)
+    lines.push(section.content)
+    lines.push('')
+  }
+  for (const section of recordSections) {
+    lines.push(`## ${section.title}`)
+    lines.push(section.content)
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+/**
  * RULES.md 첫 줄에서 프로젝트명 도출. sync() 와 드리프트 점검이 **같은 로직**을
  * 쓰도록 단일 출처로 분리 (둘이 다르게 도출하면 거짓 드리프트 발생).
  */
@@ -210,6 +247,8 @@ export const SYNC_TARGETS: SyncTarget[] = [
   { path: '.windsurfrules', generate: toWindsurfrules, doneMessage: ko.sync.windsurfDone },
   { path: '.github/copilot-instructions.md', generate: toCopilotInstructions, doneMessage: ko.sync.copilotDone },
   { path: '.agents/rules/vhk-rules.md', generate: toAntigravityRules, doneMessage: ko.sync.antigravityDone },
+  // AGENTS.md — 6번째 타겟. 항목 1개 추가로 sync·드리프트·백업 가드가 자동 반영된다.
+  { path: 'AGENTS.md', generate: toAgentsMd, doneMessage: ko.sync.agentsDone },
 ]
 
 /** 보존할 백업 개수 — 무한 증식 방지(스케일/팀 고려). */

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -15,8 +15,9 @@ export const ko = {
     noPackage: 'package.json 없음',
     detached: '(detached HEAD)',
     unknownBranch: '(알 수 없음)',
-    nextWithChangesMessage: '변경사항이 있어요. 커밋·푸시를 진행하세요.',
-    nextWithChangesCursor: '저장해줘',
+    nextWithChangesMessage: '변경사항이 있어요. 먼저 무엇이 바뀌었는지 확인하세요.',
+    nextWithChangesCursor: '뭐 바뀌었어?',
+    nextWithChangesAlt: '확인했으면 vhk save 로 저장하세요',
     nextCleanMessage: '클린 상태! 다음 미션으로 넘어가세요.',
     nextCleanCursor: '다음 목표 알려줘',
   },
@@ -167,6 +168,11 @@ export const ko = {
     scriptsDone: '📦 package.json scripts 추가',
     gitignoreCreated: '🔒 .gitignore 생성 (.env·node_modules·dist 제외)',
     gitignoreUpdated: '🔒 .gitignore 보강 (누락 항목 추가)',
+    adoptPrompt: (n: number, list: string) =>
+      `📥 기존 규칙 파일 ${n}개 발견 (${list}). RULES.md로 가져올까요?`,
+    adoptPreview: (n: number) =>
+      `기존 규칙 ${n}개를 RULES.md 표준 섹션으로 병합했어요 (출처 주석 포함).`,
+    adoptDone: '📥 RULES.md — 기존 규칙 adopt 완료',
   },
   recap: {
     title: '📝 오늘 한 일 정리',
@@ -232,6 +238,7 @@ export const ko = {
     windsurfDone: '✅ .windsurfrules 맞춤 완료',
     copilotDone: '✅ .github/copilot-instructions.md 맞춤 완료',
     antigravityDone: '✅ .agents/rules/vhk-rules.md 맞춤 완료',
+    agentsDone: '✅ AGENTS.md 맞춤 완료',
     antigravityTruncated: 'Antigravity 12,000자 제한으로 일부 절삭됨 — 전체는 RULES.md 참조',
     done: '🔄 맞추기 완료!',
     // 안전 가드 (배치 0) — 덮어쓰기 전 백업·드리프트 확인·미리보기

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,7 +347,7 @@ program
 program
   .command('migrate [target]')
   .alias('전환')
-  .description('패키지 매니저 전환 (npm/yarn/pnpm)')
+  .description('패키지 매니저 전환 (npm/yarn/pnpm) — 패키지매니저만 바꿈, 설정 마이그레이션 아님')
   .action(async (target?: string) => { await migrate(target) })
 
 program
@@ -359,8 +359,9 @@ program
 program
   .command('context')
   .alias('맥락')
+  .option('--compact', '토큰 절감형 — 전체 명령 목록/깊은 트리 생략, 참조 링크 중심')
   .description('프로젝트 맥락 파일 생성 (.vhk/context.md)')
-  .action(async () => { await context() })
+  .action(async (opts: { compact?: boolean }) => { await context({ compact: opts.compact }) })
 
 program
   .command('context-show')

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -48,6 +48,36 @@ function isOptionToken(token: string): boolean {
 }
 
 /**
+ * 서브커맨드를 갖는 컨테이너 명령 → 실제 서브커맨드 이름 목록.
+ * `goal check` · `ref add` · `memory list` 처럼 rest[1] 이 실제 서브커맨드면
+ * commander 가 직접 처리한다(자연어 라우터가 가로채지 못하게 — R1: 명령어 매칭 우선).
+ * 서브커맨드는 영문(commander 정의)이고, 첫 토큰은 영문/한글 별칭 둘 다 허용한다.
+ */
+const COMMAND_SUBCOMMANDS: Record<string, readonly string[]> = {
+  goal: ['list', 'next', 'check', 'init', 'done'],
+  목표: ['list', 'next', 'check', 'init', 'done'],
+  ref: ['add', 'list', 'open'],
+  레퍼런스: ['add', 'list', 'open'],
+  memory: ['add', 'list', 'remove'],
+  기억: ['add', 'list', 'remove'],
+  cloud: ['push', 'pull'],
+  클라우드: ['push', 'pull'],
+  secure: ['scan'],
+  보안: ['scan'],
+  design: ['palette'],
+  디자인: ['palette'],
+  env: ['check'],
+  환경변수: ['check'],
+}
+
+/** rest[0]/rest[1] 이 실제 명령 경로(예: goal check)인가 — 맞으면 NL 가로채기 금지. */
+function isRealSubcommandPath(first: string, second: string | undefined): boolean {
+  if (second === undefined) return false
+  const subs = COMMAND_SUBCOMMANDS[first]
+  return subs !== undefined && subs.includes(second)
+}
+
+/**
  * `vhk "보안 확인"`, `vhk 보안 확인`, `vhk 프로젝트 현황` 등
  * 서브커맨드가 아닌 자연어 입력을 감지. 감지 시 전체 문장 반환.
  */
@@ -71,7 +101,10 @@ export function detectNaturalLanguageInput(argv: string[]): string | null {
   if (firstIsKnown && rest.length === 1) return null
 
   if (firstIsKnown && rest.length > 1) {
-    // vhk 보안 확인 → secure 단독이 아니라 문장 전체를 NLP로
+    // R1 가드: 실제 서브커맨드 경로(goal check, ref add, memory list 등)는
+    // 명령어 매칭을 우선해 commander 가 처리한다 — 자연어 라우터가 절대 가로채지 않는다.
+    if (isRealSubcommandPath(first, rest[1])) return null
+    // vhk 보안 확인 → secure 단독이 아니라 문장 전체를 NLP로 (자연어는 fallback)
     if (routeNaturalLanguage(input)) return input
     return null
   }

--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -33,6 +33,7 @@ export type NlpCommand =
   | 'goal'
   | 'cloud-push'
   | 'cloud-pull'
+  | 'help'
 
 export type NlpConfidence = 'high' | 'low'
 
@@ -112,11 +113,12 @@ const RULES: NlpRule[] = [
       (/프로젝트.*(만들|시작)|폴더.*만들|만들고\s*싶|새\s*프로젝트|^시작$|마법사|기획.*(끝|완료)|검증.*(스킵|건너)|gate.*(스킵|건너)|바로.*시작/.test(t)) &&
       !/디자인|design|팔레트|palette|테마|theme|레퍼런스|reference|다크\s*모드|라이트\s*모드|색상\s*모드|브리핑|brief|컨텍스트|context|맥락|기억|memory|^초기화$|하네스.*만/.test(t),
   },
-  // 도움말/온보딩 — 초보자가 "뭐부터/도움말/명령어" 라고 물으면 vhk start(quick actions)로 안내.
-  // 실제 서브커맨드(restore/sync 등)는 cli-args R1 가드가 먼저 commander 로 보내므로 가로채지 않음.
+  // 도움말 — 초보자가 "뭐부터/도움말/명령어" 라고 물으면 읽기전용 quick actions 를 출력.
+  // (적대 리뷰 HIGH 수정: 이전엔 start 마법사로 라우팅돼 도움말이 scaffold 를 유발했음.
+  //  도움말은 절대 상태를 바꾸지 않는다.) 실제 서브커맨드는 cli-args R1 가드가 먼저 commander 로 보냄.
   {
-    command: 'start',
-    explanation: '처음이라면 — vhk start 로 quick actions(상태/저장/정리/동기화…) 보기',
+    command: 'help',
+    explanation: '자연어로 vhk 쓰는 법 — quick actions 출력(상태변경 없음)',
     confidence: 'high',
     test: t =>
       /도움말|사용법|help|^명령어$|뭐\s*(할\s*수\s*있|하면\s*(돼|되|좋)|해야)|처음\s*(뭐|어떻게|시작|할)|어떻게\s*시작|뭐부터/.test(t),

--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -112,6 +112,15 @@ const RULES: NlpRule[] = [
       (/프로젝트.*(만들|시작)|폴더.*만들|만들고\s*싶|새\s*프로젝트|^시작$|마법사|기획.*(끝|완료)|검증.*(스킵|건너)|gate.*(스킵|건너)|바로.*시작/.test(t)) &&
       !/디자인|design|팔레트|palette|테마|theme|레퍼런스|reference|다크\s*모드|라이트\s*모드|색상\s*모드|브리핑|brief|컨텍스트|context|맥락|기억|memory|^초기화$|하네스.*만/.test(t),
   },
+  // 도움말/온보딩 — 초보자가 "뭐부터/도움말/명령어" 라고 물으면 vhk start(quick actions)로 안내.
+  // 실제 서브커맨드(restore/sync 등)는 cli-args R1 가드가 먼저 commander 로 보내므로 가로채지 않음.
+  {
+    command: 'start',
+    explanation: '처음이라면 — vhk start 로 quick actions(상태/저장/정리/동기화…) 보기',
+    confidence: 'high',
+    test: t =>
+      /도움말|사용법|help|^명령어$|뭐\s*(할\s*수\s*있|하면\s*(돼|되|좋)|해야)|처음\s*(뭐|어떻게|시작|할)|어떻게\s*시작|뭐부터/.test(t),
+  },
   {
     command: 'init',
     explanation: '문서/하네스 파일만 생성 (vhk init) — git/MCP/context는 제외',

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import inquirer from 'inquirer'
-import { routeNaturalLanguage, extractNotionUrl, type NlpRoute } from './nlp-router.js'
+import { routeNaturalLanguage, extractNotionUrl, type NlpRoute, type NlpCommand } from './nlp-router.js'
 import { ko } from '../i18n/ko.js'
 import { gate } from '../commands/gate.js'
 import { init } from '../commands/init.js'
@@ -32,6 +32,7 @@ import { brief } from '../commands/brief.js'
 import { start } from '../commands/start.js'
 import { goalCheck, goalDone, goalList, goalNext } from '../commands/goal.js'
 import { cloudPush, cloudPull } from '../commands/cloud.js'
+import { quickActions } from '../commands/help.js'
 
 export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<void> {
   switch (route.command) {
@@ -117,7 +118,23 @@ export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<
       if (sub === 'done') return goalDone({})
       return goalList()
     }
+    case 'help':
+      return quickActions()
   }
+}
+
+/**
+ * 상태(파일/git)를 바꾸는 NL 명령 — 자연어 매칭은 오탐이 있을 수 있으므로
+ * confidence 가 high 라도 실행 전 반드시 사용자 confirm 을 거친다.
+ * (적대 리뷰 HIGH 수정: 자연어 한 마디가 곧장 scaffold/배포 등으로 이어지지 않게.)
+ */
+const STATE_CHANGING_COMMANDS: ReadonlySet<NlpCommand> = new Set([
+  'start', 'init',
+])
+
+/** NL 라우트 실행 전 확인 프롬프트가 필요한가 — low confidence 또는 상태변경 명령. */
+export function requiresConfirmation(route: NlpRoute): boolean {
+  return route.confidence === 'low' || STATE_CHANGING_COMMANDS.has(route.command)
 }
 
 export async function runNaturalLanguageRoute(input: string): Promise<void> {
@@ -132,7 +149,7 @@ export async function runNaturalLanguageRoute(input: string): Promise<void> {
   console.log(chalk.cyan(`  💬 "${input}"`))
   console.log(chalk.cyan(`  → ${route.explanation}`))
 
-  if (route.confidence === 'low') {
+  if (requiresConfirmation(route)) {
     const { confirm } = await inquirer.prompt<{ confirm: boolean }>([{
       type: 'confirm',
       name: 'confirm',

--- a/src/lib/rules-import.ts
+++ b/src/lib/rules-import.ts
@@ -1,0 +1,113 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * init adopt 모드 — 브라운필드 프로젝트의 기존 도구별 규칙 파일을
+ * RULES.md(SoT) 표준 섹션으로 가져온다(병합 + 출처 주석).
+ * 순수 함수로 분리해 init.ts 의 대화형 분기와 무관하게 테스트 가능하게 한다.
+ */
+
+/** adopt 감지 대상 — 5개 도구 규칙 파일(cwd 기준 상대 경로, posix). */
+export const ADOPT_SOURCES = [
+  '.cursorrules',
+  'CLAUDE.md',
+  'AGENTS.md',
+  '.windsurfrules',
+  '.github/copilot-instructions.md',
+] as const
+
+export interface DetectedRuleFile {
+  /** cwd 기준 상대 경로 */
+  path: string
+  /** 파일 내용 */
+  content: string
+}
+
+/** cwd 에서 존재하는 규칙 파일만 골라 경로+내용을 반환. */
+export function detectExistingRuleFiles(cwd: string): DetectedRuleFile[] {
+  const found: DetectedRuleFile[] = []
+  for (const rel of ADOPT_SOURCES) {
+    const full = join(cwd, rel)
+    if (existsSync(full)) {
+      try {
+        found.push({ path: rel, content: readFileSync(full, 'utf-8') })
+      } catch {
+        // 읽기 실패한 파일은 건너뜀(권한 등) — 나머지는 계속 처리
+      }
+    }
+  }
+  return found
+}
+
+interface ParsedSection {
+  title: string
+  content: string
+}
+
+/**
+ * `## ` 헤딩 기준 섹션 분리(헤딩 이전 본문/헤더는 무시).
+ * sync.parseRulesMd 와 동일 규칙을 lib 레이어에 로컬 구현해 commands→lib 역의존을 피한다.
+ */
+function splitSections(content: string): ParsedSection[] {
+  const sections: ParsedSection[] = []
+  let title = ''
+  let buf: string[] = []
+  for (const line of content.split('\n')) {
+    if (line.startsWith('## ')) {
+      if (title) sections.push({ title, content: buf.join('\n').trim() })
+      title = line.replace('## ', '').trim()
+      buf = []
+    } else if (title) {
+      buf.push(line)
+    }
+  }
+  if (title) sections.push({ title, content: buf.join('\n').trim() })
+  return sections
+}
+
+interface MergedSection {
+  title: string
+  parts: Array<{ source: string; content: string }>
+}
+
+/**
+ * 감지된 규칙 파일들을 RULES.md 표준 섹션으로 병합.
+ * - 같은 제목 섹션은 한 제목 아래로 합치고, 각 본문 앞에 `<!-- 출처: <파일> -->` 주석을 단다.
+ * - 결과는 parseRulesMd 로 다시 파싱 가능한 `## ` 구조를 유지한다(init↔sync 연결).
+ */
+export function buildAdoptedRules(files: DetectedRuleFile[], projectName: string): string {
+  const order: string[] = []
+  const byTitle = new Map<string, MergedSection>()
+
+  for (const file of files) {
+    for (const sec of splitSections(file.content)) {
+      let merged = byTitle.get(sec.title)
+      if (!merged) {
+        merged = { title: sec.title, parts: [] }
+        byTitle.set(sec.title, merged)
+        order.push(sec.title)
+      }
+      merged.parts.push({ source: file.path, content: sec.content })
+    }
+  }
+
+  const lines = [
+    `# ${projectName} — Rules`,
+    '',
+    '> 프로젝트 규칙의 단일 소스(SoT). 기존 규칙을 `vhk init` adopt 로 가져왔습니다.',
+    '> 규칙 변경은 항상 이 파일에서만 — `vhk sync` 로 각 도구에 전파됩니다.',
+    '',
+  ]
+
+  for (const title of order) {
+    const merged = byTitle.get(title)!
+    lines.push(`## ${title}`)
+    for (const part of merged.parts) {
+      lines.push(`<!-- 출처: ${part.source} -->`)
+      if (part.content) lines.push(part.content)
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}

--- a/src/lib/state-files.ts
+++ b/src/lib/state-files.ts
@@ -87,6 +87,23 @@ export function getRecentLearnings(limit = 3): string[] {
   return entries.slice(-limit)
 }
 
+// blockers.md 의 blocker 항목(활성 "- [" + 해결 "- ~~[") 중 마지막 N 개. vhk context 토큰 절감용.
+const BLOCKER_ENTRY_RE = /^- (~~)?\[/
+export function getRecentBlockers(limit = 3): string[] {
+  if (!existsSync(BLOCKERS_PATH)) return []
+  const lines = readFileSync(BLOCKERS_PATH, 'utf-8').split(/\r?\n/)
+  const entries = lines.filter((l) => BLOCKER_ENTRY_RE.test(l))
+  return entries.slice(-limit)
+}
+
+// 활성 blocker(해결 ~~취소선~~ 제외) 중 마지막 N 개. context 가 "지금 막힌 것"만 보이게 한다.
+export function getActiveBlockers(limit = 3): string[] {
+  if (!existsSync(BLOCKERS_PATH)) return []
+  const lines = readFileSync(BLOCKERS_PATH, 'utf-8').split(/\r?\n/)
+  const entries = lines.filter((l) => ACTIVE_BLOCKER_RE.test(l))
+  return entries.slice(-limit)
+}
+
 export function writeHardStop(reason: string): void {
   ensureVhkDir()
   const ts = new Date().toISOString()

--- a/src/mcp/cli-path.ts
+++ b/src/mcp/cli-path.ts
@@ -1,0 +1,46 @@
+import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { safeExecFile } from '../lib/exec.js'
+
+/**
+ * MCP 서버가 위임하는 vhk CLI 실행 경로 해석.
+ * 전역 `vhk` 가 PATH 에 없어도(글로벌 미설치/npx 일회성) 로컬 `dist/index.js` 로
+ * fallback 해 MCP 도구 위임이 끊기지 않게 한다. (배치3 §5)
+ */
+export interface VhkCliInvocation {
+  /** 실행 바이너리/명령 */
+  bin: string
+  /** bin 뒤에 먼저 붙는 인자 (node 로 dist/index.js 실행 시 [스크립트경로]) */
+  prefixArgs: string[]
+  /** 전역 vhk 대신 로컬 dist/index.js 로 fallback 했는가 */
+  fallback: boolean
+}
+
+/**
+ * 순수 결정 로직 — 환경 사실(전역 가용 여부 / 로컬 CLI 경로·존재)을 받아
+ * 어떤 CLI 를 실행할지 고른다. (테스트 가능 seam)
+ */
+export function pickCliInvocation(
+  globalAvailable: boolean,
+  localCli: string,
+  localExists: boolean
+): VhkCliInvocation {
+  if (globalAvailable) return { bin: 'vhk', prefixArgs: [], fallback: false }
+  if (localExists) return { bin: process.execPath, prefixArgs: [localCli], fallback: true }
+  // 마지막 수단: 그래도 vhk 시도 — 실패는 호출부(runVhkCli)가 표면화.
+  return { bin: 'vhk', prefixArgs: [], fallback: false }
+}
+
+/** dist/mcp/cli-path.js 기준 로컬 CLI(dist/index.js) 절대경로. */
+export function localCliPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url))
+  return resolve(here, '..', 'index.js')
+}
+
+/** 전역 vhk 존재(--version 성공)면 vhk, 아니면 로컬 dist/index.js 를 node 로 실행하도록 resolve. */
+export function resolveVhkCliInvocation(): VhkCliInvocation {
+  const globalAvailable = safeExecFile('vhk', ['--version']).ok
+  const local = localCliPath()
+  return pickCliInvocation(globalAvailable, local, existsSync(local))
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,4 +1,12 @@
 import { startMcpServer } from './server.js'
+import { resolveVhkCliInvocation } from './cli-path.js'
+
+// 전역 vhk 가 PATH 에 없어도 로컬 dist/index.js 로 fallback 해 MCP 위임이 끊기지 않게 한다.
+// (글로벌 미설치/npx 일회성 실행 시에도 도구가 동작하도록 — 배치3 §5)
+const cli = resolveVhkCliInvocation()
+if (cli.fallback) {
+  console.error('[vhk-mcp] 전역 vhk 미발견 → 로컬 dist/index.js 로 CLI 위임을 fallback 합니다.')
+}
 
 startMcpServer().catch((err) => {
   // stderr로 에러를 흘려보내고 비정상 종료. MCP 클라이언트가 재시작 판단.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,6 +10,7 @@ import { detectCurrentPM, parseAuditOutput, runAuditJson } from '../commands/aud
 import { readJsonFile } from '../lib/read-json.js'
 import { filterSevereFindings, scanProjectForSecrets } from '../lib/scan-secrets.js'
 import { getVhkVersion } from '../lib/version.js'
+import { resolveVhkCliInvocation, type VhkCliInvocation } from './cli-path.js'
 
 // package.json 의 version 을 런타임에 읽음 (lib/version 재사용) — drift 방지.
 // dist/index.js 와 dist/mcp/index.js 둘 다 lib/version 의 candidate 경로로 해석됨.
@@ -28,6 +29,12 @@ function stripAnsi(s: string): string {
   return s.replace(ANSI_RE, '')
 }
 
+// CLI 실행 경로는 1회 해석 후 캐시 — 전역 vhk 없으면 로컬 dist/index.js 로 fallback.
+let cachedCli: VhkCliInvocation | null = null
+function getVhkCli(): VhkCliInvocation {
+  return (cachedCli ??= resolveVhkCliInvocation())
+}
+
 // vhk CLI 자체를 서브프로세스로 호출해서 결과를 MCP content로 변환.
 // MCP 모드에서는 inquirer/ora 프롬프트가 동작하지 않으므로 비대화형 커맨드만 위임.
 // chalk 가 색을 안 쓰도록 FORCE_COLOR=0 + NO_COLOR=1 강제 + 잔여 ANSI 는 regex strip.
@@ -35,7 +42,10 @@ function runVhkCli(
   args: string[],
   headline: string
 ): { content: [{ type: 'text'; text: string }] } {
-  const result = safeExecFile('vhk', args, { env: { FORCE_COLOR: '0', NO_COLOR: '1' } })
+  const cli = getVhkCli()
+  const result = safeExecFile(cli.bin, [...cli.prefixArgs, ...args], {
+    env: { FORCE_COLOR: '0', NO_COLOR: '1' },
+  })
   const body = stripAnsi(result.out || (result.ok ? '' : `(stdout 없음)\n${result.err}`))
   const prefix = result.ok ? `✅ ${headline}` : `❌ ${headline} 실패`
   return { content: [{ type: 'text', text: `${prefix}\n${body}`.trim() }] }
@@ -445,7 +455,11 @@ export function createVhkMcpServer(): McpServer {
   // ─── sync ───────────────────────────────────────────────
   server.registerTool(
     'sync',
-    { description: 'RULES.md → .cursorrules + CLAUDE.md 자동 동기화' },
+    {
+      description:
+        'RULES.md → Cursor·Claude·Windsurf·Copilot·Antigravity·AGENTS.md 규칙 동기화. ' +
+        '덮어쓰기 전 기존 파일을 자동 백업하므로 안전하며, 되돌리려면 사용자에게 `vhk restore` 를 안내하세요.',
+    },
     async () => runVhkCli(['sync'], 'sync')
   )
 

--- a/src/templates/rules-md.ts
+++ b/src/templates/rules-md.ts
@@ -1,0 +1,37 @@
+/**
+ * RULES.md — 프로젝트 규칙의 단일 소스(Single Source of Truth).
+ * `vhk sync` 가 이 파일을 파싱해 .cursorrules · .windsurfrules ·
+ * .github/copilot-instructions.md · .agents/rules/vhk-rules.md · CLAUDE.md 를 생성한다.
+ *
+ * 섹션 제목은 sync.ts 의 CURSORRULES_KEYS / CLAUDE_MD_KEYS 와 정렬되어야
+ * 각 도구 산출물에 본문이 실린다 (## 기술 스택 / ## 코딩 규칙 / ## 커밋 / ## 기록 등).
+ */
+export function RULES_MD_TEMPLATE(name: string, description: string, stack: string): string {
+  const stackList = stack.split(' + ').map((s) => '- ' + s).join('\n')
+  return [
+    '# ' + name + ' — Rules',
+    '',
+    '> 프로젝트 규칙의 단일 소스(SoT). 규칙 변경은 항상 이 파일에서만.',
+    '> `vhk sync` 가 Cursor·Claude·Windsurf·Copilot·Antigravity 규칙으로 전파합니다.',
+    '',
+    '## 프로젝트 정체성',
+    '- 한 줄 설명: ' + description,
+    '- 스택: ' + stack,
+    '',
+    '## 기술 스택',
+    stackList,
+    '',
+    '## 코딩 규칙',
+    '- TypeScript strict (any 금지)',
+    '- try-catch 필수, 빈 catch 금지',
+    '- console.log 프로덕션 제거',
+    '- 파일명은 kebab-case',
+    '',
+    '## 커밋 컨벤션',
+    '- feat: / fix: / refactor: / docs: / chore:',
+    '',
+    '## 기록 규칙',
+    '- 세션 종료 시 docs/log/YYYY-MM-DD-{작업명}.md 생성',
+    '- 기술 선택 시 docs/adr/ADR-{번호}-{제목}.md 생성',
+  ].join('\n')
+}

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -94,6 +94,35 @@ describe('detectNaturalLanguageInput — restore 명령 라우팅 (회귀)', () 
   })
 })
 
+describe('detectNaturalLanguageInput — 서브커맨드 명령 경로 가드 (R1: 명령어 매칭 우선)', () => {
+  // 실결함: NL 라우터가 'goal check' 를 check(점검) 키워드로 가로채 vhk goal check 가 죽음.
+  // 실제 서브커맨드 경로는 commander 가 처리하고, 자연어는 fallback 이어야 한다.
+  it('vhk goal check → null (commander 가 goal check 게이트 실행)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'goal', 'check'])).toBeNull()
+  })
+  it('vhk goal done → null', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'goal', 'done'])).toBeNull()
+  })
+  it('vhk goal next → null', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'goal', 'next'])).toBeNull()
+  })
+  it('vhk goal list → null', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'goal', 'list'])).toBeNull()
+  })
+  it('vhk ref add <url> → null (인자 보존)', () => {
+    expect(
+      detectNaturalLanguageInput(['node', 'vhk', 'ref', 'add', 'https://ex.com'])
+    ).toBeNull()
+  })
+  it('vhk memory list → null', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'memory', 'list'])).toBeNull()
+  })
+  // 회귀: 한국어 자연어는 서브커맨드가 아니므로 여전히 NL 로 라우팅돼야 한다.
+  it('vhk 보안 확인 → 여전히 자연어 ("확인"은 secure 서브커맨드 아님)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '보안', '확인'])).toBe('보안 확인')
+  })
+})
+
 describe('cli NL e2e', () => {
   const bin = path.join(process.cwd(), 'dist', 'index.js')
 

--- a/tests/context-loop.test.ts
+++ b/tests/context-loop.test.ts
@@ -79,3 +79,63 @@ describe('vhk context — Goal 2 자율 루프 확장', () => {
     expect(out).not.toContain('## Recent Learnings')
   })
 })
+
+describe('vhk context --compact (배치2 토큰 절감)', () => {
+  let origCwd: string
+  let dir: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    dir = tmpProject('context-compact')
+    process.chdir(dir)
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'tp', version: '0.0.0' }), 'utf-8')
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    rmSync(dir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  it('compact 모드는 전체 명령 목록을 빼고 참조 문서 링크를 넣는다', async () => {
+    makeGoalFile(dir, 1, 'IN_PROGRESS', '진행중')
+    const { context } = await import('../src/commands/context.js')
+    await context({ compact: true })
+    const out = readFileSync(join(dir, '.vhk/context.md'), 'utf-8')
+    expect(out).toContain('## Active Goal')
+    expect(out).not.toContain('## VHK CLI 명령어')
+    expect(out).toContain('참조 문서')
+    expect(out).toContain('docs/state/next-task.md')
+  })
+
+  it('기본(full) 모드는 전체 명령 목록을 유지한다 (back-compat)', async () => {
+    const { context } = await import('../src/commands/context.js')
+    await context()
+    const out = readFileSync(join(dir, '.vhk/context.md'), 'utf-8')
+    expect(out).toContain('## VHK CLI 명령어')
+  })
+
+  it('active blockers 를 최근 N개만 포함한다', async () => {
+    const { appendBlocker } = await import('../src/lib/state-files.js')
+    appendBlocker('막힘 하나', 4)
+    const { context } = await import('../src/commands/context.js')
+    await context({ compact: true })
+    const out = readFileSync(join(dir, '.vhk/context.md'), 'utf-8')
+    expect(out).toContain('Active Blockers')
+    expect(out).toContain('막힘 하나')
+  })
+
+  it('memory 가 여러 개면 최근 5개만 포함한다', async () => {
+    mkdirSync(join(dir, '.vhk'), { recursive: true })
+    const mems = Array.from({ length: 7 }, (_, i) => ({
+      content: `메모리항목${i}`,
+      addedAt: new Date(2026, 0, i + 1).toISOString(),
+    }))
+    writeFileSync(join(dir, '.vhk/memory.json'), JSON.stringify(mems), 'utf-8')
+    const { context } = await import('../src/commands/context.js')
+    await context({ compact: true })
+    const out = readFileSync(join(dir, '.vhk/context.md'), 'utf-8')
+    expect(out).toContain('메모리항목6')
+    expect(out).not.toContain('메모리항목0')
+    expect(out).not.toContain('메모리항목1')
+  })
+})

--- a/tests/help.test.ts
+++ b/tests/help.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest'
+import { QUICK_ACTIONS, quickActions } from '../src/commands/help.js'
+import { requiresConfirmation } from '../src/lib/nlp-run.js'
+import type { NlpRoute } from '../src/lib/nlp-router.js'
+
+const route = (command: NlpRoute['command'], confidence: NlpRoute['confidence']): NlpRoute => ({
+  command,
+  explanation: '',
+  confidence,
+})
+
+describe('quick actions (자연어 도움말 — 읽기전용)', () => {
+  it('10개 quick action + 핵심 문구 포함', () => {
+    expect(QUICK_ACTIONS.length).toBe(10)
+    const says = QUICK_ACTIONS.map((a) => a.say)
+    expect(says).toContain('상태 알려줘')
+    expect(says).toContain('뭐 바뀌었어?')
+    expect(says).toContain('저장해줘')
+  })
+
+  it('quickActions() 는 콘솔 출력만 — 상태변경(파일/git) 없음', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    quickActions()
+    expect(spy).toHaveBeenCalled()
+    spy.mockRestore()
+  })
+})
+
+describe('requiresConfirmation — 상태변경 명령은 confidence 무관 confirm', () => {
+  it('start/init 는 high 라도 confirm 필요 (스캐폴딩 방지)', () => {
+    expect(requiresConfirmation(route('start', 'high'))).toBe(true)
+    expect(requiresConfirmation(route('init', 'high'))).toBe(true)
+  })
+
+  it('help/status 등 읽기전용 high 는 confirm 불필요', () => {
+    expect(requiresConfirmation(route('help', 'high'))).toBe(false)
+    expect(requiresConfirmation(route('status', 'high'))).toBe(false)
+  })
+
+  it('low confidence 는 명령 무관 confirm', () => {
+    expect(requiresConfirmation(route('status', 'low'))).toBe(true)
+  })
+})

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -4,11 +4,13 @@ import os from 'node:os'
 import path from 'node:path'
 import { generateFiles, enhancePackageScripts, ensureRootGitignore } from '../src/commands/init.js'
 import { COMMANDS_MD_TEMPLATE } from '../src/templates/commands-md.js'
+import { parseRulesMd } from '../src/commands/sync.js'
 import { writeFile } from '../src/utils/file.js'
 
 const EXPECTED_FILES = [
   'CLAUDE.md',
   '.cursorrules',
+  'RULES.md',
   'docs/PRD.md',
   'docs/ARCHITECTURE.md',
   'docs/adr/ADR-000-template.md',
@@ -84,6 +86,28 @@ describe('vhk init', () => {
     const md = COMMANDS_MD_TEMPLATE()
     expect(md).toContain('vhk doctor')
     expect(md).toContain('vhk 보안 scan')
+  })
+})
+
+describe('vhk init — RULES.md 단일 소스(SoT) 생성', () => {
+  it('generateFiles 가 RULES.md 를 표준 섹션으로 생성한다', () => {
+    const files = generateFiles('my-app', '테스트 설명', ['Node.js', 'TypeScript'])
+    expect(files['RULES.md']).toBeDefined()
+    const rules = files['RULES.md']
+    expect(rules).toContain('# my-app')
+    expect(rules).toContain('## 기술 스택')
+    expect(rules).toContain('## 코딩 규칙')
+    expect(rules).toContain('## 기록 규칙')
+    expect(rules).toContain('## 커밋')
+    expect(rules).toContain('Node.js')
+  })
+
+  it('RULES.md 가 sync 파서로 다시 파싱된다 (init↔sync 연결)', () => {
+    const files = generateFiles('demo', '설명', ['Node.js'])
+    const sections = parseRulesMd(files['RULES.md'])
+    const titles = sections.map((s) => s.title)
+    expect(titles).toContain('코딩 규칙')
+    expect(titles).toContain('기술 스택')
   })
 })
 

--- a/tests/mcp-cli-path.test.ts
+++ b/tests/mcp-cli-path.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { pickCliInvocation } from '../src/mcp/cli-path.js'
+
+describe('MCP CLI 경로 resolve fallback (배치3 §5)', () => {
+  it('전역 vhk 가 있으면 vhk 를 그대로 쓴다', () => {
+    const r = pickCliInvocation(true, '/x/dist/index.js', true)
+    expect(r.bin).toBe('vhk')
+    expect(r.prefixArgs).toEqual([])
+    expect(r.fallback).toBe(false)
+  })
+
+  it('전역 vhk 가 없고 로컬 dist/index.js 가 있으면 node 로 로컬 CLI fallback', () => {
+    const r = pickCliInvocation(false, '/x/dist/index.js', true)
+    expect(r.bin).toBe(process.execPath)
+    expect(r.prefixArgs).toEqual(['/x/dist/index.js'])
+    expect(r.fallback).toBe(true)
+  })
+
+  it('전역도 로컬도 없으면 vhk 로 폴백(호출부가 에러 처리)', () => {
+    const r = pickCliInvocation(false, '/x/dist/index.js', false)
+    expect(r.bin).toBe('vhk')
+    expect(r.fallback).toBe(false)
+  })
+})

--- a/tests/nlp-router.test.ts
+++ b/tests/nlp-router.test.ts
@@ -20,6 +20,14 @@ describe('자연어 라우팅', () => {
     expect(result?.command).toBe('start')
   })
 
+  describe('도움말/온보딩 라우팅 (배치3 §1)', () => {
+    for (const phrase of ['도움말', '사용법', '명령어', '뭐 할 수 있어', '처음 뭐 해', 'help']) {
+      it(`"${phrase}" → start (초보자 quick actions)`, () => {
+        expect(routeNaturalLanguage(phrase)?.command).toBe('start')
+      })
+    }
+  })
+
   it('"오늘 한 일 정리" → recap', () => {
     const result = routeNaturalLanguage('오늘 한 일 정리')
     expect(result?.command).toBe('recap')

--- a/tests/nlp-router.test.ts
+++ b/tests/nlp-router.test.ts
@@ -20,10 +20,13 @@ describe('자연어 라우팅', () => {
     expect(result?.command).toBe('start')
   })
 
-  describe('도움말/온보딩 라우팅 (배치3 §1)', () => {
+  describe('도움말 라우팅 — 읽기전용(스캐폴딩 금지) (배치3 §1 + 적대리뷰 HIGH 수정)', () => {
     for (const phrase of ['도움말', '사용법', '명령어', '뭐 할 수 있어', '처음 뭐 해', 'help']) {
-      it(`"${phrase}" → start (초보자 quick actions)`, () => {
-        expect(routeNaturalLanguage(phrase)?.command).toBe('start')
+      it(`"${phrase}" → help (start/scaffold 아님)`, () => {
+        const cmd = routeNaturalLanguage(phrase)?.command
+        expect(cmd).toBe('help')
+        // 회귀 가드: 도움말 요청이 절대 스캐폴딩(start)로 새지 않는다.
+        expect(cmd).not.toBe('start')
       })
     }
   })

--- a/tests/rules-import.test.ts
+++ b/tests/rules-import.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  detectExistingRuleFiles,
+  buildAdoptedRules,
+  ADOPT_SOURCES,
+} from '../src/lib/rules-import.js'
+
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-adopt-'))
+}
+
+describe('rules-import — 기존 설정 파일 감지', () => {
+  it('존재하는 규칙 파일만 골라 경로+내용을 돌려준다', () => {
+    const dir = tmp()
+    fs.writeFileSync(path.join(dir, '.cursorrules'), '# c\n## 코딩 규칙\n- a\n', 'utf-8')
+    fs.writeFileSync(path.join(dir, 'CLAUDE.md'), '# m\n## 기록 규칙\n- b\n', 'utf-8')
+    // .windsurfrules 는 없음 → 결과에서 제외돼야 함
+
+    const found = detectExistingRuleFiles(dir)
+    const paths = found.map((f) => f.path)
+    expect(paths).toContain('.cursorrules')
+    expect(paths).toContain('CLAUDE.md')
+    expect(paths).not.toContain('.windsurfrules')
+    expect(found.find((f) => f.path === '.cursorrules')?.content).toContain('- a')
+
+    fs.rmSync(dir, { recursive: true })
+  })
+
+  it('중첩 경로(.github/copilot-instructions.md)도 감지한다', () => {
+    const dir = tmp()
+    fs.mkdirSync(path.join(dir, '.github'), { recursive: true })
+    fs.writeFileSync(
+      path.join(dir, '.github', 'copilot-instructions.md'),
+      '# x\n## 코딩 규칙\n- c\n',
+      'utf-8'
+    )
+    const found = detectExistingRuleFiles(dir)
+    expect(found.map((f) => f.path)).toContain('.github/copilot-instructions.md')
+    fs.rmSync(dir, { recursive: true })
+  })
+
+  it('감지 대상 목록(ADOPT_SOURCES)에 5개 도구 파일이 들어있다', () => {
+    expect(ADOPT_SOURCES).toContain('.cursorrules')
+    expect(ADOPT_SOURCES).toContain('CLAUDE.md')
+    expect(ADOPT_SOURCES).toContain('AGENTS.md')
+    expect(ADOPT_SOURCES).toContain('.windsurfrules')
+    expect(ADOPT_SOURCES).toContain('.github/copilot-instructions.md')
+  })
+})
+
+describe('rules-import — RULES.md 표준 섹션 병합', () => {
+  it('각 출처 섹션을 출처 주석과 함께 RULES.md 로 병합한다', () => {
+    const files = [
+      { path: '.cursorrules', content: '# c\n## 코딩 규칙\n- execSync 금지\n' },
+      { path: 'CLAUDE.md', content: '# m\n## 기록 규칙\n- docs/log 작성\n' },
+    ]
+    const out = buildAdoptedRules(files, '데모')
+    expect(out).toContain('# 데모 — Rules')
+    expect(out).toContain('## 코딩 규칙')
+    expect(out).toContain('execSync 금지')
+    expect(out).toContain('## 기록 규칙')
+    expect(out).toContain('docs/log 작성')
+    // 출처 주석
+    expect(out).toContain('.cursorrules')
+    expect(out).toContain('CLAUDE.md')
+    expect(out).toMatch(/<!--[^>]*출처/)
+  })
+
+  it('같은 제목 섹션이 여러 출처에 있으면 한 제목 아래 병합한다', () => {
+    const files = [
+      { path: '.cursorrules', content: '## 코딩 규칙\n- a\n' },
+      { path: '.windsurfrules', content: '## 코딩 규칙\n- b\n' },
+    ]
+    const out = buildAdoptedRules(files, 'P')
+    // 제목은 한 번만, 두 출처 본문 모두 포함
+    expect(out.match(/^## 코딩 규칙$/gm)?.length).toBe(1)
+    expect(out).toContain('- a')
+    expect(out).toContain('- b')
+    expect(out).toContain('.cursorrules')
+    expect(out).toContain('.windsurfrules')
+  })
+
+  it('병합 결과가 sync 파서로 다시 파싱 가능하다', () => {
+    const files = [{ path: '.cursorrules', content: '## 기술 스택\n- Node.js\n' }]
+    const out = buildAdoptedRules(files, 'P')
+    // parseRulesMd 가 읽을 수 있는 ## 섹션 구조 유지
+    expect(out).toContain('## 기술 스택')
+    expect(out).toContain('Node.js')
+  })
+})

--- a/tests/state-files.test.ts
+++ b/tests/state-files.test.ts
@@ -7,6 +7,8 @@ import {
   appendLearning,
   countActiveBlockers,
   getRecentLearnings,
+  getRecentBlockers,
+  getActiveBlockers,
   writeHardStop,
   isHardStopActive,
   clearHardStop,
@@ -141,6 +143,73 @@ describe('appendLearning + getRecentLearnings', () => {
   it('SoT 일관성 — appendLearning 은 .vhk/memory.json 에 쓰지 않음 (Forbidden 이중 기록)', () => {
     appendLearning('learning that should NOT enter memory.json')
     expect(existsSync(join('.vhk', 'memory.json'))).toBe(false)
+  })
+})
+
+describe('getRecentBlockers / getActiveBlockers (배치2)', () => {
+  let origCwd: string
+  let dir: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    dir = tmpProject('blocker-recent')
+    process.chdir(dir)
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function writeBlockers(lines: string[]): void {
+    mkdirSync('docs/state', { recursive: true })
+    writeFileSync(
+      BLOCKERS_PATH,
+      ['# Blockers', '', ...lines, ''].join('\n'),
+      'utf-8'
+    )
+  }
+
+  it('getRecentBlockers — 마지막 N개 (해결 항목 포함)', () => {
+    writeBlockers([
+      '- [2026-05-01 goal-4] b1',
+      '- ~~[2026-05-02 goal-4] b2 resolved~~',
+      '- [2026-05-03 goal-4] b3',
+      '- [2026-05-04 goal-4] b4',
+    ])
+    const recent = getRecentBlockers(3)
+    expect(recent).toHaveLength(3)
+    expect(recent[2]).toContain('b4')
+    // 해결 항목도 '최근'에 포함될 수 있음
+    expect(recent.some((l) => l.includes('b2 resolved'))).toBe(true)
+  })
+
+  it('getActiveBlockers — ~~해결~~ 항목 제외, 최근 N개', () => {
+    writeBlockers([
+      '- [2026-05-01 goal-4] active 1',
+      '- ~~[2026-05-02 goal-4] resolved~~',
+      '- [2026-05-03 goal-4] active 2',
+    ])
+    const active = getActiveBlockers(3)
+    expect(active).toHaveLength(2)
+    expect(active.some((l) => l.includes('resolved'))).toBe(false)
+    expect(active[0]).toContain('active 1')
+    expect(active[1]).toContain('active 2')
+  })
+
+  it('기본 limit 은 3', () => {
+    writeBlockers([
+      '- [d goal-4] a',
+      '- [d goal-4] b',
+      '- [d goal-4] c',
+      '- [d goal-4] d',
+      '- [d goal-4] e',
+    ])
+    expect(getActiveBlockers().length).toBe(3)
+    expect(getRecentBlockers().length).toBe(3)
+  })
+
+  it('파일 없으면 빈 배열', () => {
+    expect(getRecentBlockers(3)).toEqual([])
+    expect(getActiveBlockers(3)).toEqual([])
   })
 })
 

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -4,6 +4,7 @@ import {
   countFileChanges,
   parseSyncCounts,
   formatSyncLabel,
+  selectStatusNextStep,
 } from '../src/commands/status.js'
 
 vi.mock('node:child_process')
@@ -55,5 +56,20 @@ describe('vhk status helpers', () => {
       behind: 1,
       hasUpstream: true,
     })
+  })
+})
+
+describe('status — 안전한 다음 액션 (배치3 §2: diff 우선)', () => {
+  it('변경사항이 있으면 vhk save 가 아니라 vhk diff 를 먼저 추천', () => {
+    const step = selectStatusNextStep(true)
+    expect(step.command).toBe('vhk diff')
+    expect(step.command).not.toBe('vhk save')
+    // 저장은 그 다음(대안) 액션으로만 안내
+    expect(step.alternative ?? '').toMatch(/save|저장/)
+  })
+
+  it('클린 상태면 다음 미션(goal next) 추천', () => {
+    const step = selectStatusNextStep(false)
+    expect(step.command).toBe('vhk goal next')
   })
 })

--- a/tests/sync-guard.test.ts
+++ b/tests/sync-guard.test.ts
@@ -60,6 +60,18 @@ describe('syncCore — 첫 sync', () => {
   })
 })
 
+describe('syncCore — 5-tool 산출 검증 (배치1 §C)', () => {
+  it('copilot-instructions · vhk-rules · windsurfrules 가 실제 생성된다', async () => {
+    const r = await syncCore(dir, {}, alwaysYes)
+    expect(exists('.github/copilot-instructions.md')).toBe(true)
+    expect(exists('.agents/rules/vhk-rules.md')).toBe(true)
+    expect(exists('.windsurfrules')).toBe(true)
+    expect(r.written).toContain('.github/copilot-instructions.md')
+    expect(r.written).toContain('.agents/rules/vhk-rules.md')
+    expect(r.written).toContain('.windsurfrules')
+  })
+})
+
 describe('syncCore — drift 가드 (데이터 손실 0)', () => {
   it('drift + 덮어쓰기 거부 → 백업 저장되고 원본 유지', async () => {
     await syncCore(dir, {}, alwaysYes) // 초기 동기화(마커 생성)

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -5,8 +5,10 @@ import {
   toWindsurfrules,
   toCopilotInstructions,
   toAntigravityRules,
+  toAgentsMd,
   truncateForAntigravity,
   ANTIGRAVITY_CHAR_LIMIT,
+  SYNC_TARGETS,
 } from '../src/commands/sync.js'
 
 const SAMPLE_RULES = `# 데모 프로젝트 — Rules
@@ -77,6 +79,30 @@ describe('vhk sync — GitHub Copilot 변환', () => {
     expect(out.split('\n').slice(0, 5).join('\n')).toContain('자동 생성됨 (vhk sync). 직접 수정 금지')
     expect(out).toContain('execSync 금지')
     expect(out).not.toContain('docs/log/ 작성')
+  })
+})
+
+describe('vhk sync — AGENTS.md 생성 (배치3 6번째 타겟)', () => {
+  it('toAgentsMd — Loop Protocol + 자동생성 경고 + 코딩 규칙 + compact 포인터 포함', () => {
+    const sections = parseRulesMd(SAMPLE_RULES)
+    const out = toAgentsMd(sections, '데모 프로젝트')
+    expect(out).toContain('# 데모 프로젝트 — AGENTS')
+    expect(out).toContain('Loop Protocol')
+    expect(out).toContain('자동 생성됨 (vhk sync). 직접 수정 금지')
+    expect(out).toContain('execSync 금지') // 코딩 규칙 섹션 본문
+    // compact 안내는 AGENTS.md 에 하드코딩이 아니라 생성기(toAgentsMd)를 거쳐 들어간다.
+    expect(out).toContain('agent-compact.md')
+  })
+
+  it('SYNC_TARGETS 레지스트리에 AGENTS.md 가 등록됨 (drift/backup 자동 반영)', () => {
+    expect(SYNC_TARGETS.map((t) => t.path)).toContain('AGENTS.md')
+  })
+
+  it('toAgentsMd 결과가 parseRulesMd 로 다시 파싱 가능 (## 구조 유지)', () => {
+    const sections = parseRulesMd(SAMPLE_RULES)
+    const out = toAgentsMd(sections, 'P')
+    const titles = parseRulesMd(out).map((s) => s.title)
+    expect(titles).toContain('Loop Protocol')
   })
 })
 


### PR DESCRIPTION
## 개요
goals/ 자율 루프로 배치1~3(goal id 3·4·5)을 순서대로 구현. 각 게이트(`vhk goal check`) 통과 후 done. goals 0-5 전부 DONE.

## 배치별 변경

### 배치1 (goal 3) — init adopt + RULES.md SoT
- `init` 이 `RULES.md`(규칙 SoT)를 항상 생성 → init↔sync 흐름 연결 (`src/templates/rules-md.ts`)
- `src/lib/rules-import.ts` adopt: 기존 `.cursorrules`/`CLAUDE.md`/`AGENTS.md`/`.windsurfrules`/copilot → RULES.md 표준섹션 병합(출처주석)
- init 대화형 adopt 분기, sync 5-tool 산출 검증 테스트, README "이렇게 말하세요" 가이드

### 배치2 (goal 4) — 토큰 절감형 컨텍스트
- `getRecentBlockers`/`getActiveBlockers` (`src/lib/state-files.ts`)
- `vhk context --compact`: 전체 명령목록·깊은 트리 생략, Active Goal/learnings/active blockers/최근5 memory/참조링크만
- `docs/context/agent-compact.md` 짧은 작동 규약 + AGENTS.md/README 연결

### 배치3 (goal 5) — 채팅 UX 안전 마감
- NL 도움말 라우팅(도움말/사용법/명령어/뭐 할 수 있어/처음 뭐 해 → start)
- `status` diff-우선 안전화(변경 시 save 직행 금지, diff 먼저)
- **AGENTS.md 6번째 sync 타겟** `toAgentsMd()` (Loop Protocol·compact 포인터 내장 → 재생성 안전)
- **MCP CLI fallback** `src/mcp/cli-path.ts`: 전역 vhk 없으면 로컬 `dist/index.js` 위임
- migrate 도움말·MCP sync description 보강

## 실결함 수정 (R1)
NL 라우터가 `goal check`/`memory list` 등 **실제 서브커맨드 경로**를 키워드로 가로채 `vhk goal check` 가 죽던 버그 → `cli-args` 에 서브커맨드 경로 가드(명령어 매칭 우선, 자연어 fallback). TDD 8 tests + e2e 검증.

## 테스트 플랜
- [x] `tsc --noEmit`
- [x] `pnpm test:run` — **453 pass / 53 files**
- [x] `pnpm build`
- [x] `node scripts/check-goal-3.mjs` / `-4` / `-5`(0·1·2 cascade 포함 11/11)
- [x] `vhk secure scan` (시크릿 0) / `pnpm audit --moderate` (취약점 0)

## 알려진 갭
배치3 §0 "vhk start = quick actions 첫 화면"은 기존 마법사 UX/테스트 보존 위해 가볍게 처리(도움말 라우팅이 start로 안내 + 무인자 `vhk` 메뉴가 quick-actions). 별도 작업으로 재설계 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)