### PR TITLE
feat(safety): 배치4 goal 6 — Safety Mode + 위험작업 가드 + R1 단일소스화

### DIFF
--- a/.vhk/config.json
+++ b/.vhk/config.json
@@ -1,0 +1,3 @@
+{
+  "safetyMode": "standard"
+}

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -1,10 +1,10 @@
 # Next Task
 
-_Auto-updated 2026-05-30T12:32:29.285Z via `vhk goal next`._
+_Auto-updated 2026-05-30T13:43:41.593Z via `vhk goal next`._
 
 ```
-TASK: Goal 5 — 배치3 — 채팅 UX 안전 마감 + AGENTS.md 6번째 타겟 + MCP/도움말
+TASK: Goal 6 — 배치4 — Safety Mode + 위험 작업 가드 (lite/standard/strict)
   status: NOT_STARTED
-  priority: P3
-  file: goals\5-chat-ux.md
+  priority: P1
+  file: goals\6-safety-modes.md
 ```

--- a/goals/6-safety-modes.md
+++ b/goals/6-safety-modes.md
@@ -1,0 +1,56 @@
+---
+vhk_format: 1
+type: goal
+id: 6
+title: 배치4 — Safety Mode + 위험 작업 가드 (lite/standard/strict)
+status: DONE
+priority: P1
+version: v2.0
+completed: 2026-05-30
+---
+
+# [배치 4] Safety Mode + 위험 작업 가드 (goal 6)
+
+위험 작업을 "그냥 실행"하지 못하게 막는 안전 레이어. PRD 프레임: **"검증 루프 강제"지 "전문 개발자 대체"가 아니다** — 항상 기계 게이트 위에 얹는다.
+
+## 공통 가드 (반드시 준수)
+- Windows PowerShell. bash heredoc/sh 금지. 게이트는 pnpm.cmd.
+- 한국어 UX/문서 톤. 사용자-facing 한국어를 영어로 바꾸지 마라.
+- 직렬 goal. 게이트 통과 전 done/머지 금지. sync/undo/MCP 자동 실행 금지.
+- blockers.md·learnings.md append-only. 사용자 변경 revert 금지. 최소 범위 패치.
+- 모든 신규 동작 TDD(실패테스트 → 최소구현 → green). 신규 의존성 금지.
+
+## Mandatory Reading Order (먼저 읽을 것)
+1. AGENTS.md / docs/context/agent-compact.md (작동 규약)
+2. src/lib/read-json.ts (JSON 읽기 헬퍼 + stripBom)
+3. src/commands/undo.ts (기존 high-risk confirm 패턴)
+4. src/lib/cli-args.ts (COMMAND_SUBCOMMANDS / isRealSubcommandPath — R1)
+5. scripts/check-goal-5.mjs (R1 게이트 — 교체 대상)
+6. src/i18n/ko.ts / src/index.ts (커맨드 등록 + 별칭 + 자연어 키워드)
+
+## 신규/수정 파일
+- src/lib/config.ts — .vhk/config.json 읽기/쓰기 (없으면 기본값)
+- src/lib/safety-mode.ts — 모드 정의: lite / standard / strict
+- src/lib/risk-policy.ts — high-risk 액션 판정 + 모드·채널별 정책
+- src/commands/mode.ts — `vhk mode [lite|standard|strict]` 조회/변경
+- src/commands/verify.ts — 저장/위험 작업 전 검증 묶음(메타러너 자리만, lite)
+- .vhk/config.json — 기본 {"safetyMode":"standard"}
+- scripts/check-goal-6.mjs — 게이트
+
+## high-risk 액션 (정책 적용 대상)
+undo / deploy / publish / migrate / cloud pull / resume / env write / delete
+- CLI 경로 → confirm 강제 (사용자 y/N)
+- MCP·자연어 → preview / dry-run (실제 실행 전 무엇을 할지 출력)
+- standard 기본. strict = 더 많은 작업에 confirm, lite = 경고만.
+
+## R1 2건 (roadmap §6 — 이 배치 포함)
+1. COMMAND_SUBCOMMANDS(cli-args.ts)가 commander 정의의 하드코딩 복제 → 새 서브커맨드 누락 시
+   자연어 라우터가 명령을 가로채는 R1 재발. 단일 소스화하거나, 최소한 둘의 드리프트를 잡는
+   스냅샷/가드 테스트를 추가하라. (테스트 없이 끝내지 마라)
+2. scripts/check-goal-5.mjs 의 R1 게이트가 주석 grep만 함 → 가드 코드가 삭제돼도 통과.
+   `isRealSubcommandPath` 코드 구조를 실제로 검증하도록 게이트를 교체하라.
+
+## 게이트 (전부 통과해야 done)
+- pnpm.cmd exec tsc --noEmit / pnpm.cmd run test:run / pnpm.cmd run build
+- pnpm.cmd run scan / pnpm.cmd audit --audit-level moderate
+- node scripts/check-meta.mjs / node scripts/check-goal-0..6.mjs

--- a/scripts/check-goal-5.mjs
+++ b/scripts/check-goal-5.mjs
@@ -28,7 +28,14 @@ for (const id of [0, 1, 2, 3, 4]) {
 must(existsSync(join(root, "src/commands/start.ts")), "vhk start 커맨드");
 const status = read("src/commands/status.ts") || "";
 must(/도움말|help/i.test(status + (read("src/lib/nlp-router.ts") || "")), "자연어 도움말 라우팅");
-must(grepRepo(/(가로채|명령어 우선|command.*priorit|restore.*router)/i), "R1 라우터 명령어 가드");
+// R1 가드: 주석 문구 grep 이 아니라 실제 가드 코드 구조를 검증(가드 삭제 시 게이트 실패).
+const cliArgsSrc = read("src/lib/cli-args.ts") || "";
+must(
+  /function isRealSubcommandPath/.test(cliArgsSrc) &&
+    /isRealSubcommandPath\(/.test(cliArgsSrc.replace(/function isRealSubcommandPath/, "")) &&
+    /COMMAND_SUBCOMMANDS/.test(cliArgsSrc),
+  "R1 라우터 명령어 가드(isRealSubcommandPath 정의+호출+레지스트리)"
+);
 must(/diff/.test(status), "status diff 우선");
 must(/AGENTS\.md/.test(read("src/commands/sync.ts") || ""), "AGENTS.md sync 타겟");
 must(/dist\/index\.js|fallback|resolve/i.test(read("src/mcp/index.ts") || ""), "MCP PATH fallback");

--- a/scripts/check-goal-6.mjs
+++ b/scripts/check-goal-6.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+const root = process.cwd();
+const ok = [], fail = [];
+const read = (p) => existsSync(join(root, p)) ? readFileSync(join(root, p), "utf8") : null;
+const must = (c, m) => (c ? ok : fail).push(m);
+
+// ── 파일 존재 ─────────────────────────────────────────────
+const config = read("src/lib/config.ts");
+const safety = read("src/lib/safety-mode.ts");
+const policy = read("src/lib/risk-policy.ts");
+const mode = read("src/commands/mode.ts");
+must(config, "config.ts 존재");
+must(safety, "safety-mode.ts 존재");
+must(policy, "risk-policy.ts 존재");
+must(mode, "mode.ts 존재");
+must(existsSync(join(root, "src/commands/verify.ts")), "verify.ts 존재(lite)");
+
+// ── 세 모드 정의 ──────────────────────────────────────────
+must(safety && /lite/.test(safety) && /standard/.test(safety) && /strict/.test(safety), "lite/standard/strict 모드 정의");
+must(safety && /DEFAULT_SAFETY_MODE\s*[:=][^\n]*["']standard["']/.test(safety), "기본 모드 standard");
+
+// ── config 읽기/쓰기 + config.json 경로 ───────────────────
+must(config && /readConfig/.test(config) && /writeConfig/.test(config), "config read/write");
+must(config && /config\.json/.test(config), "config.json 경로 참조");
+
+// ── high-risk 8종 + 정책 분기 ─────────────────────────────
+const HIGH = ["undo", "deploy", "publish", "migrate", "cloud", "resume", "env", "delete"];
+must(policy && HIGH.every((a) => policy.includes(a)), "high-risk 8종 포함");
+must(policy && /HIGH_RISK_ACTIONS/.test(policy), "HIGH_RISK_ACTIONS 목록");
+must(policy && /resolveGuard/.test(policy), "정책 함수 resolveGuard");
+must(policy && /confirm/.test(policy) && /preview/.test(policy), "confirm/preview 가드 분기");
+must(policy && /["']cli["']/.test(policy) && /["'](mcp|nl)["']/.test(policy), "채널 분기(CLI=confirm vs MCP/자연어=preview)");
+
+// ── .vhk/config.json 기본값 standard (없으면 코드 기본값으로 대체 검증) ──
+const conf = read(".vhk/config.json");
+must(
+  conf ? /"safetyMode"\s*:\s*"standard"/.test(conf) : (safety && /DEFAULT_SAFETY_MODE/.test(safety)),
+  ".vhk/config.json 기본 standard (또는 코드 기본값 standard)"
+);
+
+// ── R1 #1: 가드 코드 존재 + 드리프트 가드 테스트 ──────────
+const cliArgs = read("src/lib/cli-args.ts") || "";
+must(/isRealSubcommandPath/.test(cliArgs), "R1 가드 함수 isRealSubcommandPath 존재");
+must(existsSync(join(root, "tests/command-registry.test.ts")), "R1 드리프트 가드 테스트 존재");
+
+// ── R1 #2: check-goal-5 가 주석 grep 아니라 코드구조 검증 ──
+const g5 = read("scripts/check-goal-5.mjs") || "";
+must(/isRealSubcommandPath/.test(g5), "check-goal-5 가 isRealSubcommandPath 코드구조 검증으로 교체됨");
+
+console.log(ok.map((m) => "  ✓ " + m).join("\n"));
+if (fail.length) { console.error("\n[check-goal-6 FAIL]\n" + fail.map((m) => "  ✗ " + m).join("\n")); process.exit(1); }
+console.log("\n[check-goal-6 PASS]");

--- a/scripts/check-goal-6.mjs
+++ b/scripts/check-goal-6.mjs
@@ -1,53 +1,64 @@
 #!/usr/bin/env node
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
 const root = process.cwd();
 const ok = [], fail = [];
 const read = (p) => existsSync(join(root, p)) ? readFileSync(join(root, p), "utf8") : null;
 const must = (c, m) => (c ? ok : fail).push(m);
 
-// ── 파일 존재 ─────────────────────────────────────────────
-const config = read("src/lib/config.ts");
+// ── 파일 + 모드 + 정책 엔진 ───────────────────────────────
 const safety = read("src/lib/safety-mode.ts");
+const config = read("src/lib/config.ts");
 const policy = read("src/lib/risk-policy.ts");
-const mode = read("src/commands/mode.ts");
-must(config, "config.ts 존재");
-must(safety, "safety-mode.ts 존재");
-must(policy, "risk-policy.ts 존재");
-must(mode, "mode.ts 존재");
-must(existsSync(join(root, "src/commands/verify.ts")), "verify.ts 존재(lite)");
-
-// ── 세 모드 정의 ──────────────────────────────────────────
-must(safety && /lite/.test(safety) && /standard/.test(safety) && /strict/.test(safety), "lite/standard/strict 모드 정의");
-must(safety && /DEFAULT_SAFETY_MODE\s*[:=][^\n]*["']standard["']/.test(safety), "기본 모드 standard");
-
-// ── config 읽기/쓰기 + config.json 경로 ───────────────────
-must(config && /readConfig/.test(config) && /writeConfig/.test(config), "config read/write");
-must(config && /config\.json/.test(config), "config.json 경로 참조");
-
-// ── high-risk 8종 + 정책 분기 ─────────────────────────────
+const guard = read("src/lib/safety-guard.ts");
+must(safety && /lite/.test(safety) && /standard/.test(safety) && /strict/.test(safety), "lite/standard/strict 모드");
+must(safety && /DEFAULT_SAFETY_MODE\s*[:=][^\n]*["']standard["']/.test(safety), "기본 모드 standard (코드 기본값)");
+must(config && /readConfig/.test(config) && /writeConfig/.test(config) && /config\.json/.test(config), "config read/write");
+must(existsSync(join(root, "src/commands/mode.ts")) && existsSync(join(root, "src/commands/verify.ts")), "mode/verify 커맨드");
 const HIGH = ["undo", "deploy", "publish", "migrate", "cloud", "resume", "env", "delete"];
-must(policy && HIGH.every((a) => policy.includes(a)), "high-risk 8종 포함");
-must(policy && /HIGH_RISK_ACTIONS/.test(policy), "HIGH_RISK_ACTIONS 목록");
-must(policy && /resolveGuard/.test(policy), "정책 함수 resolveGuard");
-must(policy && /confirm/.test(policy) && /preview/.test(policy), "confirm/preview 가드 분기");
-must(policy && /["']cli["']/.test(policy) && /["'](mcp|nl)["']/.test(policy), "채널 분기(CLI=confirm vs MCP/자연어=preview)");
+must(policy && /HIGH_RISK_ACTIONS/.test(policy) && HIGH.every((a) => policy.includes(a)), "high-risk 8종 단일 레지스트리");
+must(policy && /resolveGuard/.test(policy) && /["']cli["']/.test(policy) && /["'](mcp|nl)["']/.test(policy), "resolveGuard 채널 분기");
 
-// ── .vhk/config.json 기본값 standard (없으면 코드 기본값으로 대체 검증) ──
-const conf = read(".vhk/config.json");
-must(
-  conf ? /"safetyMode"\s*:\s*"standard"/.test(conf) : (safety && /DEFAULT_SAFETY_MODE/.test(safety)),
-  ".vhk/config.json 기본 standard (또는 코드 기본값 standard)"
-);
+// ── 단일 chokepoint runGuarded 존재 ───────────────────────
+must(guard && /export\s+async\s+function\s+runGuarded/.test(guard), "runGuarded 단일 chokepoint 존재");
+must(guard && /confirm/.test(guard) && /approved/.test(guard) && /preview|미리보기/.test(guard), "runGuarded: CLI confirm + 명시승인 + preview 비실행");
 
-// ── R1 #1: 가드 코드 존재 + 드리프트 가드 테스트 ──────────
+// ── 구조: high-risk 진입점이 runGuarded 를 경유(배선 누락 없음) ──
+const idx = read("src/index.ts") || "";
+const EXECUTING = ["deploy", "publish", "migrate", "env-write", "cloud-pull"];
+must(EXECUTING.every((a) => idx.includes(`guardCli('${a}'`)), "CLI high-risk(deploy/publish/migrate/env-write/cloud-pull) 가 guardCli 경유");
+must(/runGuarded/.test(idx), "index.ts guardCli → runGuarded");
+const nlp = read("src/lib/nlp-run.ts") || "";
+must(/runGuarded/.test(nlp) && /NL_RISK_ACTION/.test(nlp), "자연어 dispatch high-risk → runGuarded(비차단 버그 제거)");
+must(!/function nlSafetyNotice/.test(nlp), "비차단 nlSafetyNotice 함수 제거됨");
+
+// ── MCP: high-risk 툴 기본 비실행(info-only / dry-run) ─────
+const server = read("src/mcp/server.ts") || "";
+must(/기본은 미리보기|기본 dry-run|미리보기만|confirm:\s*true 일 때만/.test(server), "MCP undo 기본 dry-run(미리보기)");
+must(/실제 배포는 터미널|실제 배포 미수행|실제 npm publish 미수행|실제 전환 미수행/.test(server), "MCP deploy/publish/migrate 정보 조회만(실행 X)");
+
+// ── 행동 e2e: standard + 확인 없이 vhk deploy → 실행 안 됨 ──
+const bin = join(root, "dist", "index.js");
+if (!existsSync(bin)) {
+  fail.push("dist/index.js 없음 — pnpm run build 먼저 (행동 e2e 불가)");
+} else {
+  const tmp = mkdtempSync(join(tmpdir(), "vhk-g6-"));
+  writeFileSync(join(tmp, "package.json"), JSON.stringify({ name: "tp", version: "0.0.0" }), "utf8");
+  const r = spawnSync(process.execPath, [bin, "deploy"], { encoding: "utf8", cwd: tmp, env: { ...process.env, NO_COLOR: "1" } });
+  const out = String(r.stdout || "") + String(r.stderr || "");
+  rmSync(tmp, { recursive: true, force: true });
+  must(/위험 작업\(deploy\)/.test(out) && /실행하지 않/.test(out) && !/어떤 플랫폼에 배포/.test(out), "행동: standard + 확인없음 deploy → 차단(실행 안 됨)");
+}
+
+// ── R1 가드 + 드리프트 테스트(신규 컨테이너까지) ──────────
 const cliArgs = read("src/lib/cli-args.ts") || "";
-must(/isRealSubcommandPath/.test(cliArgs), "R1 가드 함수 isRealSubcommandPath 존재");
-must(existsSync(join(root, "tests/command-registry.test.ts")), "R1 드리프트 가드 테스트 존재");
-
-// ── R1 #2: check-goal-5 가 주석 grep 아니라 코드구조 검증 ──
+must(/isRealSubcommandPath/.test(cliArgs) && /command-registry/.test(cliArgs), "R1 가드 + registry 단일소스 파생");
+const driftTest = read("tests/command-registry.test.ts") || "";
+must(existsSync(join(root, "tests/command-registry.test.ts")) && /신규 컨테이너|새 컨테이너|program\.commands/.test(driftTest), "드리프트 가드 테스트(신규 컨테이너 명령 포함)");
 const g5 = read("scripts/check-goal-5.mjs") || "";
-must(/isRealSubcommandPath/.test(g5), "check-goal-5 가 isRealSubcommandPath 코드구조 검증으로 교체됨");
+must(/isRealSubcommandPath/.test(g5), "check-goal-5 코드구조 검증");
 
 console.log(ok.map((m) => "  ✓ " + m).join("\n"));
 if (fail.length) { console.error("\n[check-goal-6 FAIL]\n" + fail.map((m) => "  ✗ " + m).join("\n")); process.exit(1); }

--- a/scripts/check-goal-6.mjs
+++ b/scripts/check-goal-6.mjs
@@ -27,12 +27,18 @@ must(guard && /confirm/.test(guard) && /approved/.test(guard) && /preview|미리
 
 // ── 구조: high-risk 진입점이 runGuarded 를 경유(배선 누락 없음) ──
 const idx = read("src/index.ts") || "";
-const EXECUTING = ["deploy", "publish", "migrate", "env-write", "cloud-pull"];
-must(EXECUTING.every((a) => idx.includes(`guardCli('${a}'`)), "CLI high-risk(deploy/publish/migrate/env-write/cloud-pull) 가 guardCli 경유");
+// 가드대상(high-risk + strict-extra) CLI 진입점 전체가 guardCli 경유 (5개 아니라 9개)
+const EXECUTING = ["deploy", "publish", "migrate", "env-write", "cloud-pull", "undo", "resume", "save", "sync"];
+must(EXECUTING.every((a) => idx.includes(`guardCli('${a}'`)), "CLI 가드대상 9종 전부 guardCli 경유(undo/resume/save/sync 포함)");
 must(/runGuarded/.test(idx), "index.ts guardCli → runGuarded");
+// 인라인 메뉴 switch 등 가드대상 핸들러 직접 호출(바이패스) 없음
+must(![...idx.matchAll(/return\s+(undo|save|sync|deploy|publish|migrate|env|cloudPull|resume)\(/g)].length, "메뉴/직접 호출 가드 미경유 없음");
 const nlp = read("src/lib/nlp-run.ts") || "";
-must(/runGuarded/.test(nlp) && /NL_RISK_ACTION/.test(nlp), "자연어 dispatch high-risk → runGuarded(비차단 버그 제거)");
+must(/runGuarded/.test(nlp) && /NL_GUARDED_ACTIONS/.test(nlp), "자연어 dispatch high-risk → runGuarded(단일소스 NL_GUARDED_ACTIONS)");
+must(!/NL_RISK_ACTION\s*[:=]/.test(nlp), "손관리 NL_RISK_ACTION 제거(risk-policy 단일소스 파생)");
 must(!/function nlSafetyNotice/.test(nlp), "비차단 nlSafetyNotice 함수 제거됨");
+// 완전성 가드 테스트 존재(드리프트 자동탐지)
+must(existsSync(join(root, "tests/safety-coverage.test.ts")), "완전성 가드 테스트 존재(무바이패스 자동검증)");
 
 // ── MCP: high-risk 툴 기본 비실행(info-only / dry-run) ─────
 const server = read("src/mcp/server.ts") || "";

--- a/src/commands/mode.ts
+++ b/src/commands/mode.ts
@@ -1,0 +1,42 @@
+import chalk from 'chalk'
+import { readConfig, writeConfig } from '../lib/config.js'
+import { SAFETY_MODES, SAFETY_MODE_DESC, isSafetyMode } from '../lib/safety-mode.js'
+import { printNextStep } from '../lib/next-step.js'
+
+/**
+ * `vhk mode [lite|standard|strict]` — Safety Mode 조회/변경.
+ * 인자 없으면 현재 모드 + 세 모드 설명 출력. 인자 있으면 검증 후 .vhk/config.json 에 기록.
+ */
+export async function mode(target?: string): Promise<void> {
+  console.log(chalk.bold('\n🛡️  Safety Mode'))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  const current = readConfig().safetyMode
+
+  if (!target) {
+    console.log(chalk.cyan(`\n  현재 모드: ${chalk.bold(current)}`))
+    console.log(chalk.dim(`  ${SAFETY_MODE_DESC[current]}`))
+    console.log('')
+    for (const m of SAFETY_MODES) {
+      const mark = m === current ? '●' : '○'
+      console.log(`  ${mark} ${m.padEnd(9)} ${chalk.dim(SAFETY_MODE_DESC[m])}`)
+    }
+    printNextStep({
+      message: '모드를 바꾸려면:',
+      command: 'vhk mode strict',
+      cursorHint: '안전 모드 strict로 바꿔줘',
+    })
+    return
+  }
+
+  if (!isSafetyMode(target)) {
+    console.log(chalk.red(`\n  ❌ 알 수 없는 모드: ${target}`))
+    console.log(chalk.dim(`     가능: ${SAFETY_MODES.join(' | ')}`))
+    process.exitCode = 1
+    return
+  }
+
+  writeConfig({ ...readConfig(), safetyMode: target })
+  console.log(chalk.green(`\n  ✅ Safety Mode → ${chalk.bold(target)}`))
+  console.log(chalk.dim(`  ${SAFETY_MODE_DESC[target]}`))
+}

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -1,0 +1,37 @@
+import chalk from 'chalk'
+import { readConfig } from '../lib/config.js'
+import { SAFETY_MODE_DESC } from '../lib/safety-mode.js'
+import { printNextStep } from '../lib/next-step.js'
+
+/**
+ * 저장/위험 작업 전 돌려야 하는 검증 묶음 — 현재는 "메타러너 자리"(lite).
+ * 실제 실행은 사용자/CI 가 돌리는 기계 게이트를 가리키고, 여기선 묶음을 안내만 한다.
+ * (PRD: 검증 루프 강제 ≠ 전문 개발자 대체. 기계 게이트 위에 얹는 안내층.)
+ */
+export function verificationChecklist(): string[] {
+  return [
+    '타입 체크 — pnpm exec tsc --noEmit',
+    '테스트 — pnpm run test:run',
+    '빌드 — pnpm run build',
+    '보안 스캔 — vhk secure scan',
+  ]
+}
+
+export async function verify(): Promise<void> {
+  console.log(chalk.bold('\n🔎 검증 묶음 (verify — lite)'))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  const mode = readConfig().safetyMode
+  console.log(chalk.dim(`  현재 Safety Mode: ${mode} — ${SAFETY_MODE_DESC[mode]}`))
+  console.log(chalk.cyan('\n  위험 작업/저장 전 권장 검증:'))
+  for (const item of verificationChecklist()) {
+    console.log(`   ☐ ${item}`)
+  }
+  console.log(chalk.dim('\n  ※ 메타러너(자동 실행) 자리 — 현재는 묶음 안내만(lite).'))
+
+  printNextStep({
+    message: '검증 통과 후 저장하세요:',
+    command: 'vhk save',
+    cursorHint: '저장해줘',
+  })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Command, Help } from 'commander'
+import { pathToFileURL } from 'node:url'
 import chalk from 'chalk'
 import inquirer from 'inquirer'
 import { detectNaturalLanguageInput } from './lib/cli-args.js'
@@ -34,6 +35,8 @@ import { context, contextShow } from './commands/context.js'
 import { memoryAdd, memoryList, memoryRemove } from './commands/memory.js'
 import { brief } from './commands/brief.js'
 import { start } from './commands/start.js'
+import { mode } from './commands/mode.js'
+import { verify } from './commands/verify.js'
 import { cloudPush, cloudPull } from './commands/cloud.js'
 import { goalCheck, goalDone, goalInit, goalList, goalNext } from './commands/goal.js'
 import { blocker, learn, resume } from './commands/agent.js'
@@ -364,6 +367,18 @@ program
   .action(async (opts: { compact?: boolean }) => { await context({ compact: opts.compact }) })
 
 program
+  .command('mode [target]')
+  .alias('모드')
+  .description('Safety Mode 조회/변경 (lite|standard|strict) — 위험 작업 가드 강도')
+  .action(async (target?: string) => { await mode(target) })
+
+program
+  .command('verify')
+  .alias('사전점검')
+  .description('저장/위험 작업 전 검증 묶음 안내 (lite)')
+  .action(async () => { await verify() })
+
+program
   .command('context-show')
   .alias('맥락보기')
   .description('현재 컨텍스트 파일 내용 출력')
@@ -517,9 +532,18 @@ program.action(async () => {
   }
 })
 
-const nlInput = detectNaturalLanguageInput(process.argv)
-if (nlInput !== null) {
-  await runNaturalLanguageRoute(nlInput)
-} else {
-  await program.parseAsync(process.argv)
+// 메인 모듈로 직접 실행될 때만 파싱한다(import 되면 program 만 노출).
+// env 가 아니라 import.meta.url ↔ argv[1] 비교라, VITEST 환경을 물려받은 spawn 자식도 정상 실행.
+const isMainModule =
+  !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+
+if (isMainModule) {
+  const nlInput = detectNaturalLanguageInput(process.argv)
+  if (nlInput !== null) {
+    await runNaturalLanguageRoute(nlInput)
+  } else {
+    await program.parseAsync(process.argv)
+  }
 }
+
+export { program }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,37 @@ import { brief } from './commands/brief.js'
 import { start } from './commands/start.js'
 import { mode } from './commands/mode.js'
 import { verify } from './commands/verify.js'
+import { runGuarded } from './lib/safety-guard.js'
+
+/**
+ * CLI high-risk 작업 가드 — 단일 chokepoint(runGuarded) 경유.
+ * standard/strict 면 confirm(거부/비대화형 → 중단), lite 면 경고만. `--yes` 로 명시 승인.
+ * (각 호출부는 한 줄로 위임만 — 결정 로직은 runGuarded 한 곳.)
+ */
+async function guardCli(
+  action: string,
+  approved: boolean,
+  run: () => Promise<void> | void,
+): Promise<void> {
+  await runGuarded(
+    action,
+    {
+      channel: 'cli',
+      approved,
+      confirm: async () => {
+        const { ok } = await inquirer.prompt<{ ok: boolean }>([{
+          type: 'confirm',
+          name: 'ok',
+          message: `⚠️ 위험 작업(${action})을 실행할까요?`,
+          default: false,
+        }])
+        return ok
+      },
+      log: (m) => console.log(chalk.yellow(`  ${m}`)),
+    },
+    run,
+  )
+}
 import { cloudPush, cloudPull } from './commands/cloud.js'
 import { goalCheck, goalDone, goalInit, goalList, goalNext } from './commands/goal.js'
 import { blocker, learn, resume } from './commands/agent.js'
@@ -203,8 +234,9 @@ cloudCmd
   .command('pull')
   .alias('내리기')
   .argument('[gistId]', '복원할 gist id (생략 시 .vhk/cloud.json 사용)')
+  .option('--yes', '확인 없이 실행 (위험 작업 명시 승인)')
   .description('gist 에서 .vhk/ 복원')
-  .action(async (gistId?: string) => { await cloudPull(gistId) })
+  .action(async (gistId: string | undefined, opts: { yes?: boolean }) => { await guardCli('cloud-pull', opts?.yes === true, () => cloudPull(gistId)) })
 
 program
   .command('ship')
@@ -269,14 +301,16 @@ program
 program
   .command('deploy')
   .alias('배포')
+  .option('--yes', '확인 없이 실행 (위험 작업 명시 승인)')
   .description('프로덕션 배포 (Vercel/Netlify/Cloudflare 자동 감지)')
-  .action(async () => { await deploy() })
+  .action(async (opts: { yes?: boolean }) => { await guardCli('deploy', opts?.yes === true, () => deploy()) })
 
 program
   .command('env')
   .alias('환경변수')
+  .option('--yes', '확인 없이 실행 (위험 작업 명시 승인)')
   .description('.env → .env.example 동기화 + .gitignore 자동 추가')
-  .action(async () => { await env() })
+  .action(async (opts: { yes?: boolean }) => { await guardCli('env-write', opts?.yes === true, () => env()) })
 
 program
   .command('env-check')
@@ -287,8 +321,9 @@ program
 program
   .command('publish')
   .alias('출시')
+  .option('--yes', '확인 없이 실행 (위험 작업 명시 승인)')
   .description('npm 배포 (버전 범프 → 빌드 → 테스트 → publish)')
-  .action(async () => { await publish() })
+  .action(async (opts: { yes?: boolean }) => { await guardCli('publish', opts?.yes === true, () => publish()) })
 
 program
   .command('design')
@@ -350,8 +385,9 @@ program
 program
   .command('migrate [target]')
   .alias('전환')
+  .option('--yes', '확인 없이 실행 (위험 작업 명시 승인)')
   .description('패키지 매니저 전환 (npm/yarn/pnpm) — 패키지매니저만 바꿈, 설정 마이그레이션 아님')
-  .action(async (target?: string) => { await migrate(target) })
+  .action(async (target: string | undefined, opts: { yes?: boolean }) => { await guardCli('migrate', opts?.yes === true, () => migrate(target)) })
 
 program
   .command('update')

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,7 +196,7 @@ program
   .option('--dry-run', '미리보기만 — 파일 변경 없음')
   .option('-y, --yes', 'drift 확인 프롬프트 생략(덮어쓰기 동의)')
   .description('RULES.md → .cursorrules + CLAUDE.md 동기화 (덮어쓰기 전 자동 백업)')
-  .action(async (opts: { dryRun?: boolean; yes?: boolean }) => { await sync(opts) })
+  .action(async (opts: { dryRun?: boolean; yes?: boolean }) => { await guardCli('sync', opts?.yes === true, () => sync(opts)) })
 
 program
   .command('check')
@@ -254,14 +254,16 @@ program
 program
   .command('save')
   .alias('저장')
+  .option('--yes', '확인 없이 실행 (strict 모드 가드 명시 승인)')
   .description('변경사항 저장 (git add → commit → push)')
-  .action(async () => { await save() })
+  .action(async (opts: { yes?: boolean }) => { await guardCli('save', opts?.yes === true, () => save()) })
 
 program
   .command('undo')
   .alias('되돌리기')
+  .option('--yes', '확인 없이 실행 (위험 작업 명시 승인)')
   .description('최근 커밋 되돌리기')
-  .action(async () => { await undo() })
+  .action(async (opts: { yes?: boolean }) => { await guardCli('undo', opts?.yes === true, () => undo()) })
 
 program
   .command('restore')
@@ -508,7 +510,7 @@ program
   .alias('재개')
   .option('--confirm', '사람 확인 — 자동 호출 금지 (Forbidden 위반)')
   .description('.vhk/HARD_STOP 해제 (사용자가 사유 확인 후 --confirm 필요)')
-  .action(async (opts: { confirm?: boolean }) => { await resume(opts) })
+  .action(async (opts: { confirm?: boolean }) => { await guardCli('resume', opts?.confirm === true, () => resume(opts)) })
 
 program.on('command:*', async (operands: string[]) => {
   const unknown = operands[0] ?? ''
@@ -552,15 +554,15 @@ program.action(async () => {
     case 'secure':
       return secure()
     case 'sync':
-      return sync()
+      return guardCli('sync', false, () => sync())
     case 'doctor':
       return doctor()
     case 'ship':
       return ship()
     case 'save':
-      return save()
+      return guardCli('save', false, () => save())
     case 'undo':
-      return undo()
+      return guardCli('undo', false, () => undo())
     case 'status':
       return status()
     case 'diff':

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -1,4 +1,5 @@
 import { routeNaturalLanguage } from './nlp-router.js'
+import { CONTAINER_SUBCOMMANDS, CONTAINER_ALIASES } from './command-registry.js'
 
 /** Commander에 등록된 서브커맨드·별칭 (첫 토큰) */
 export const KNOWN_COMMAND_TOKENS = new Set([
@@ -40,6 +41,8 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'blocker', '블로커',
   'learn', '교훈',
   'resume', '재개',
+  'mode', '모드',
+  'verify', '사전점검',
   'help',
 ])
 
@@ -51,24 +54,18 @@ function isOptionToken(token: string): boolean {
  * 서브커맨드를 갖는 컨테이너 명령 → 실제 서브커맨드 이름 목록.
  * `goal check` · `ref add` · `memory list` 처럼 rest[1] 이 실제 서브커맨드면
  * commander 가 직접 처리한다(자연어 라우터가 가로채지 못하게 — R1: 명령어 매칭 우선).
- * 서브커맨드는 영문(commander 정의)이고, 첫 토큰은 영문/한글 별칭 둘 다 허용한다.
+ *
+ * 단일 소스: `command-registry.ts` 에서 파생(영문) + 한글 별칭도 같은 집합을 공유.
+ * (이전엔 여기 하드코딩 복제였다 → commander 정의와 드리프트 → R1 재발 위험. 레지스트리로 통일.)
  */
-const COMMAND_SUBCOMMANDS: Record<string, readonly string[]> = {
-  goal: ['list', 'next', 'check', 'init', 'done'],
-  목표: ['list', 'next', 'check', 'init', 'done'],
-  ref: ['add', 'list', 'open'],
-  레퍼런스: ['add', 'list', 'open'],
-  memory: ['add', 'list', 'remove'],
-  기억: ['add', 'list', 'remove'],
-  cloud: ['push', 'pull'],
-  클라우드: ['push', 'pull'],
-  secure: ['scan'],
-  보안: ['scan'],
-  design: ['palette'],
-  디자인: ['palette'],
-  env: ['check'],
-  환경변수: ['check'],
-}
+const COMMAND_SUBCOMMANDS: Record<string, readonly string[]> = (() => {
+  const map: Record<string, readonly string[]> = { ...CONTAINER_SUBCOMMANDS }
+  for (const [alias, canonical] of Object.entries(CONTAINER_ALIASES)) {
+    const subs = CONTAINER_SUBCOMMANDS[canonical]
+    if (subs) map[alias] = subs
+  }
+  return map
+})()
 
 /** rest[0]/rest[1] 이 실제 명령 경로(예: goal check)인가 — 맞으면 NL 가로채기 금지. */
 function isRealSubcommandPath(first: string, second: string | undefined): boolean {

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -1,0 +1,30 @@
+/**
+ * 컨테이너 명령 → 서브커맨드(또는 위치 인자 값)의 **단일 소스**.
+ * R1 가드(cli-args.ts)와 드리프트 가드 테스트(tests/command-registry.test.ts)가
+ * 같은 출처를 본다 — commander 정의와 따로 노는 하드코딩 복제를 제거하기 위함.
+ *
+ * 새 서브커맨드를 commander 에 추가하면 여기도 추가해야 한다. 누락하면
+ * 드리프트 가드 테스트가 실패해 R1(자연어 라우터가 명령 가로채기) 재발을 사전에 잡는다.
+ */
+export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
+  goal: ['list', 'next', 'check', 'init', 'done'],
+  ref: ['add', 'list', 'open'],
+  memory: ['add', 'list', 'remove'],
+  cloud: ['push', 'pull'],
+  secure: ['scan'],
+  design: ['palette'],
+  env: ['check'],
+  mode: ['lite', 'standard', 'strict'],
+}
+
+/** 한국어 별칭 → 영문 컨테이너 명령. 별칭도 같은 서브커맨드 집합을 공유한다. */
+export const CONTAINER_ALIASES: Record<string, string> = {
+  목표: 'goal',
+  레퍼런스: 'ref',
+  기억: 'memory',
+  클라우드: 'cloud',
+  보안: 'secure',
+  디자인: 'design',
+  환경변수: 'env',
+  모드: 'mode',
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,36 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { readJsonFile } from './read-json.js'
+import { type SafetyMode, DEFAULT_SAFETY_MODE, isSafetyMode } from './safety-mode.js'
+
+/**
+ * .vhk/config.json — 프로젝트별 VHK 설정(로컬). 현재는 safetyMode 만.
+ * 파일이 없으면 항상 기본값(standard)으로 동작 — 읽기는 절대 throw 하지 않는다.
+ */
+export const CONFIG_DIR = '.vhk'
+export const CONFIG_PATH = join(CONFIG_DIR, 'config.json')
+
+export interface VhkConfig {
+  safetyMode: SafetyMode
+}
+
+export const DEFAULT_CONFIG: VhkConfig = { safetyMode: DEFAULT_SAFETY_MODE }
+
+export function readConfig(rootDir: string = process.cwd()): VhkConfig {
+  const full = join(rootDir, CONFIG_PATH)
+  if (!existsSync(full)) return { ...DEFAULT_CONFIG }
+  try {
+    const raw = readJsonFile<Partial<VhkConfig>>(full)
+    return {
+      safetyMode: isSafetyMode(raw.safetyMode) ? raw.safetyMode : DEFAULT_CONFIG.safetyMode,
+    }
+  } catch {
+    // 손상/파싱 실패 → 기본값. 설정 깨졌다고 명령이 죽지 않게.
+    return { ...DEFAULT_CONFIG }
+  }
+}
+
+export function writeConfig(config: VhkConfig, rootDir: string = process.cwd()): void {
+  mkdirSync(join(rootDir, CONFIG_DIR), { recursive: true })
+  writeFileSync(join(rootDir, CONFIG_PATH), JSON.stringify(config, null, 2) + '\n', 'utf-8')
+}

--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -34,6 +34,8 @@ export type NlpCommand =
   | 'cloud-push'
   | 'cloud-pull'
   | 'help'
+  | 'mode'
+  | 'verify'
 
 export type NlpConfidence = 'high' | 'low'
 
@@ -122,6 +124,20 @@ const RULES: NlpRule[] = [
     confidence: 'high',
     test: t =>
       /도움말|사용법|help|^명령어$|뭐\s*(할\s*수\s*있|하면\s*(돼|되|좋)|해야)|처음\s*(뭐|어떻게|시작|할)|어떻게\s*시작|뭐부터/.test(t),
+  },
+  // Safety Mode — 위험 작업 가드 강도 조회/변경.
+  {
+    command: 'mode',
+    explanation: 'Safety Mode 조회/변경 (vhk mode)',
+    confidence: 'high',
+    test: t =>
+      /안전\s*모드|safety\s*mode|모드\s*(바꿔|변경|설정|확인|보여|뭐)|위험\s*작업\s*(가드|모드)/.test(t),
+  },
+  {
+    command: 'verify',
+    explanation: '저장/위험 작업 전 검증 묶음 (vhk verify)',
+    confidence: 'high',
+    test: t => /검증\s*묶음|사전\s*검증|저장\s*전\s*(검증|확인)|^verify$/.test(t),
   },
   {
     command: 'init',

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -33,6 +33,11 @@ import { start } from '../commands/start.js'
 import { goalCheck, goalDone, goalList, goalNext } from '../commands/goal.js'
 import { cloudPush, cloudPull } from '../commands/cloud.js'
 import { quickActions } from '../commands/help.js'
+import { mode } from '../commands/mode.js'
+import { verify } from '../commands/verify.js'
+import { readConfig } from './config.js'
+import { resolveGuard } from './risk-policy.js'
+import type { SafetyMode } from './safety-mode.js'
 
 export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<void> {
   switch (route.command) {
@@ -120,6 +125,10 @@ export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<
     }
     case 'help':
       return quickActions()
+    case 'mode':
+      return mode()
+    case 'verify':
+      return verify()
   }
 }
 
@@ -135,6 +144,33 @@ const STATE_CHANGING_COMMANDS: ReadonlySet<NlpCommand> = new Set([
 /** NL 라우트 실행 전 확인 프롬프트가 필요한가 — low confidence 또는 상태변경 명령. */
 export function requiresConfirmation(route: NlpRoute): boolean {
   return route.confidence === 'low' || STATE_CHANGING_COMMANDS.has(route.command)
+}
+
+/** 자연어 명령 → high-risk 액션(risk-policy) 매핑. 자연어로 부를 수 있는 위험 작업만. */
+const NL_RISK_ACTION: Partial<Record<NlpCommand, string>> = {
+  undo: 'undo',
+  deploy: 'deploy',
+  publish: 'publish',
+  migrate: 'migrate',
+  'cloud-pull': 'cloud-pull',
+}
+
+/**
+ * 자연어로 high-risk 작업을 부를 때 Safety Mode 에 따른 안내 문구.
+ * 자연어 채널은 confirm 대신 preview(무엇을 할지 안내) — 에이전트/자연어의 "그냥 실행" 방지.
+ * 저위험이면 null.
+ */
+export function nlSafetyNotice(command: NlpCommand, mode: SafetyMode): string | null {
+  const action = NL_RISK_ACTION[command]
+  if (!action) return null
+  const guard = resolveGuard(action, mode, 'nl')
+  if (guard === 'warn') {
+    return `⚠️ 위험 작업(${action}) — lite 모드라 경고만 하고 진행합니다.`
+  }
+  if (guard === 'preview') {
+    return `🔎 위험 작업(${action}) 미리보기 — 실행 전 무엇을 할지 확인하세요. (Safety Mode: ${mode})`
+  }
+  return null
 }
 
 export async function runNaturalLanguageRoute(input: string): Promise<void> {
@@ -161,6 +197,10 @@ export async function runNaturalLanguageRoute(input: string): Promise<void> {
       return
     }
   }
+  // 자연어로 부른 high-risk 작업은 Safety Mode 에 따라 preview/경고를 먼저 보여준다.
+  const notice = nlSafetyNotice(route.command, readConfig().safetyMode)
+  if (notice) console.log(chalk.yellow(`  ${notice}`))
+
   console.log('')
 
   await dispatchNlpRoute(route, input)

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -36,6 +36,7 @@ import { quickActions } from '../commands/help.js'
 import { mode } from '../commands/mode.js'
 import { verify } from '../commands/verify.js'
 import { runGuarded } from './safety-guard.js'
+import { NL_GUARDED_ACTIONS } from './risk-policy.js'
 
 export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<void> {
   switch (route.command) {
@@ -144,14 +145,6 @@ export function requiresConfirmation(route: NlpRoute): boolean {
   return route.confidence === 'low' || STATE_CHANGING_COMMANDS.has(route.command)
 }
 
-/** 자연어 명령 → high-risk 액션(risk-policy) 매핑. 자연어로 부를 수 있는 위험 작업만. */
-const NL_RISK_ACTION: Partial<Record<NlpCommand, string>> = {
-  undo: 'undo',
-  deploy: 'deploy',
-  publish: 'publish',
-  migrate: 'migrate',
-  'cloud-pull': 'cloud-pull',
-}
 
 export async function runNaturalLanguageRoute(input: string): Promise<void> {
   const route = routeNaturalLanguage(input)
@@ -182,7 +175,7 @@ export async function runNaturalLanguageRoute(input: string): Promise<void> {
   // 자연어로 부른 high-risk 작업은 단일 가드(runGuarded) 경유 — 기본 비실행(preview).
   // 자연어는 명시 승인 수단이 없으므로 high-risk 는 실행되지 않고 안내만 한다.
   // (이전 nlSafetyNotice 는 preview 만 찍고 dispatch 로 그대로 실행하던 비차단 버그 — 제거.)
-  const riskAction = NL_RISK_ACTION[route.command]
+  const riskAction = NL_GUARDED_ACTIONS[route.command]
   if (riskAction) {
     await runGuarded(
       riskAction,

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -35,9 +35,7 @@ import { cloudPush, cloudPull } from '../commands/cloud.js'
 import { quickActions } from '../commands/help.js'
 import { mode } from '../commands/mode.js'
 import { verify } from '../commands/verify.js'
-import { readConfig } from './config.js'
-import { resolveGuard } from './risk-policy.js'
-import type { SafetyMode } from './safety-mode.js'
+import { runGuarded } from './safety-guard.js'
 
 export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<void> {
   switch (route.command) {
@@ -155,24 +153,6 @@ const NL_RISK_ACTION: Partial<Record<NlpCommand, string>> = {
   'cloud-pull': 'cloud-pull',
 }
 
-/**
- * 자연어로 high-risk 작업을 부를 때 Safety Mode 에 따른 안내 문구.
- * 자연어 채널은 confirm 대신 preview(무엇을 할지 안내) — 에이전트/자연어의 "그냥 실행" 방지.
- * 저위험이면 null.
- */
-export function nlSafetyNotice(command: NlpCommand, mode: SafetyMode): string | null {
-  const action = NL_RISK_ACTION[command]
-  if (!action) return null
-  const guard = resolveGuard(action, mode, 'nl')
-  if (guard === 'warn') {
-    return `⚠️ 위험 작업(${action}) — lite 모드라 경고만 하고 진행합니다.`
-  }
-  if (guard === 'preview') {
-    return `🔎 위험 작업(${action}) 미리보기 — 실행 전 무엇을 할지 확인하세요. (Safety Mode: ${mode})`
-  }
-  return null
-}
-
 export async function runNaturalLanguageRoute(input: string): Promise<void> {
   const route = routeNaturalLanguage(input)
 
@@ -197,11 +177,20 @@ export async function runNaturalLanguageRoute(input: string): Promise<void> {
       return
     }
   }
-  // 자연어로 부른 high-risk 작업은 Safety Mode 에 따라 preview/경고를 먼저 보여준다.
-  const notice = nlSafetyNotice(route.command, readConfig().safetyMode)
-  if (notice) console.log(chalk.yellow(`  ${notice}`))
-
   console.log('')
+
+  // 자연어로 부른 high-risk 작업은 단일 가드(runGuarded) 경유 — 기본 비실행(preview).
+  // 자연어는 명시 승인 수단이 없으므로 high-risk 는 실행되지 않고 안내만 한다.
+  // (이전 nlSafetyNotice 는 preview 만 찍고 dispatch 로 그대로 실행하던 비차단 버그 — 제거.)
+  const riskAction = NL_RISK_ACTION[route.command]
+  if (riskAction) {
+    await runGuarded(
+      riskAction,
+      { channel: 'nl', approved: false, log: (m) => console.log(chalk.yellow(`  ${m}`)) },
+      () => dispatchNlpRoute(route, input),
+    )
+    return
+  }
 
   await dispatchNlpRoute(route, input)
 }

--- a/src/lib/risk-policy.ts
+++ b/src/lib/risk-policy.ts
@@ -1,0 +1,45 @@
+import type { SafetyMode } from './safety-mode.js'
+
+/**
+ * 정책 적용 대상 high-risk 액션 8종 — 되돌리기 어렵거나 외부에 영향 주는 작업.
+ * (undo: 커밋 되돌림 / deploy·publish: 외부 배포 / migrate: 패키지매니저 전환 /
+ *  cloud-pull: 로컬 .vhk 덮어씀 / resume: HARD_STOP 해제 / env-write: 시크릿 파일 변경 / delete: 삭제)
+ */
+export const HIGH_RISK_ACTIONS = [
+  'undo',
+  'deploy',
+  'publish',
+  'migrate',
+  'cloud-pull',
+  'resume',
+  'env-write',
+  'delete',
+] as const
+
+export type HighRiskAction = (typeof HIGH_RISK_ACTIONS)[number]
+
+/** 실행 경로(채널). CLI=대화형 터미널, MCP=에이전트 도구, NL=자연어 라우터. */
+export type Channel = 'cli' | 'mcp' | 'nl'
+
+/** 가드 결정. confirm=y/N 확인, preview=dry-run 출력, warn=경고만, allow=그대로 진행. */
+export type Guard = 'confirm' | 'preview' | 'warn' | 'allow'
+
+/** strict 모드에서 추가로 확인을 요구하는(보통은 저위험) 작업. */
+const STRICT_EXTRA_ACTIONS: ReadonlySet<string> = new Set(['save', 'sync'])
+
+export function isHighRisk(action: string): action is HighRiskAction {
+  return (HIGH_RISK_ACTIONS as readonly string[]).includes(action)
+}
+
+/**
+ * 액션·모드·채널로 가드 결정.
+ * - 저위험(+strict 추가대상 아님) → allow
+ * - lite → 막지 않고 warn(경고만)
+ * - standard/strict → CLI 는 confirm, MCP/자연어는 preview(실행 전 무엇을 할지 출력)
+ */
+export function resolveGuard(action: string, mode: SafetyMode, channel: Channel): Guard {
+  const guarded = isHighRisk(action) || (mode === 'strict' && STRICT_EXTRA_ACTIONS.has(action))
+  if (!guarded) return 'allow'
+  if (mode === 'lite') return 'warn'
+  return channel === 'cli' ? 'confirm' : 'preview'
+}

--- a/src/lib/risk-policy.ts
+++ b/src/lib/risk-policy.ts
@@ -25,7 +25,24 @@ export type Channel = 'cli' | 'mcp' | 'nl'
 export type Guard = 'confirm' | 'preview' | 'warn' | 'allow'
 
 /** strict 모드에서 추가로 확인을 요구하는(보통은 저위험) 작업. */
-const STRICT_EXTRA_ACTIONS: ReadonlySet<string> = new Set(['save', 'sync'])
+export const STRICT_EXTRA_ACTIONS: ReadonlySet<string> = new Set(['save', 'sync'])
+
+/**
+ * 자연어(NlpCommand) → 가드 대상 action 의 **단일 소스**.
+ * 자연어 dispatch 에서 위험/strict-extra 작업을 호출하는 모든 명령을 여기에 등록한다.
+ * (별도 손관리 리스트 금지 — nlp-run 은 import 만. 완전성 가드 테스트가 dispatch 와 교차검증해
+ *  여기 누락 시 FAIL → R1/env 류 드리프트 차단.)
+ */
+export const NL_GUARDED_ACTIONS: Readonly<Record<string, string>> = {
+  undo: 'undo',
+  deploy: 'deploy',
+  publish: 'publish',
+  migrate: 'migrate',
+  'cloud-pull': 'cloud-pull',
+  env: 'env-write',
+  save: 'save',
+  sync: 'sync',
+}
 
 export function isHighRisk(action: string): action is HighRiskAction {
   return (HIGH_RISK_ACTIONS as readonly string[]).includes(action)

--- a/src/lib/safety-guard.ts
+++ b/src/lib/safety-guard.ts
@@ -1,0 +1,76 @@
+import { readConfig } from './config.js'
+import { resolveGuard, type Channel, type Guard } from './risk-policy.js'
+import type { SafetyMode } from './safety-mode.js'
+
+/**
+ * 위험 작업 가드의 **단일 chokepoint**.
+ * CLI 핸들러 · MCP 핸들러 · 자연어 dispatch 세 입구 모두 high-risk "실제 실행" 직전에 이걸 통과시킨다.
+ * 정책 결정(어떤 작업이 위험한가 / 채널·모드별 가드)은 risk-policy 한 곳에서만 정의 → 여기선 결정을 집행만.
+ *
+ * - lite           : 경고만 하고 실행
+ * - CLI(confirm)   : isTTY 면 confirm() y/N, 거부/비대화형 미승인 → 중단. approved=true 면 바로 실행.
+ * - MCP/NL(preview): preview 출력 후 **기본 비실행**. approved=true(명시적 확인 플래그) 일 때만 실행.
+ */
+export interface GuardDeps {
+  channel: Channel
+  /** 미지정 시 .vhk/config.json 에서 읽음 */
+  mode?: SafetyMode
+  /** CLI confirm 가능 여부 (기본 process.stdout.isTTY) */
+  isTTY?: boolean
+  /** CLI 대화형 확인 (y/N) */
+  confirm?: () => Promise<boolean>
+  /** 명시적 승인 플래그 (--yes / confirm:true 등) — 비대화형/preview 채널에서 실행 허용 */
+  approved?: boolean
+  /** 사용자 안내 출력 */
+  log?: (msg: string) => void
+}
+
+export interface GuardedOutcome {
+  ran: boolean
+  guard: Guard
+  reason: string
+}
+
+export async function runGuarded<T>(
+  action: string,
+  deps: GuardDeps,
+  run: () => Promise<T> | T
+): Promise<{ outcome: GuardedOutcome; result?: T }> {
+  const mode: SafetyMode = deps.mode ?? readConfig().safetyMode
+  const log = deps.log ?? (() => {})
+  const guard = resolveGuard(action, mode, deps.channel)
+
+  if (guard === 'allow') {
+    return { outcome: { ran: true, guard, reason: 'low-risk' }, result: await run() }
+  }
+
+  if (guard === 'warn') {
+    // lite — 막지 않고 경고만
+    log(`⚠️ 위험 작업(${action}) — lite 모드: 경고만 하고 진행합니다.`)
+    return { outcome: { ran: true, guard, reason: 'lite-warn' }, result: await run() }
+  }
+
+  if (guard === 'confirm') {
+    // CLI — 명시 승인 우선, 아니면 대화형 확인, 비대화형 미승인은 안전 중단
+    if (deps.approved === true) {
+      return { outcome: { ran: true, guard, reason: 'approved' }, result: await run() }
+    }
+    const tty = deps.isTTY ?? !!process.stdout.isTTY
+    if (tty && deps.confirm) {
+      const ok = await deps.confirm()
+      if (ok) return { outcome: { ran: true, guard, reason: 'confirmed' }, result: await run() }
+      log(`취소됨 — ${action} 을(를) 실행하지 않았습니다.`)
+      return { outcome: { ran: false, guard, reason: 'declined' } }
+    }
+    log(`⚠️ 위험 작업(${action}) — 확인 불가(비대화형). 실행하지 않았습니다. (--yes 로 명시 승인)`)
+    return { outcome: { ran: false, guard, reason: 'no-confirm' } }
+  }
+
+  // preview — MCP / 자연어. 미리보기 후 기본 비실행, 명시 승인 시에만 실행.
+  log(`🔎 위험 작업(${action}) 미리보기 — 실행 전 확인이 필요합니다. (Safety Mode: ${mode})`)
+  if (deps.approved === true) {
+    return { outcome: { ran: true, guard, reason: 'approved' }, result: await run() }
+  }
+  log(`실행하지 않았습니다 — 명시적 확인(승인 플래그) 후 다시 시도하세요.`)
+  return { outcome: { ran: false, guard, reason: 'preview-no-approve' } }
+}

--- a/src/lib/safety-mode.ts
+++ b/src/lib/safety-mode.ts
@@ -1,0 +1,22 @@
+/**
+ * Safety Mode — 위험 작업 가드의 강도.
+ * PRD 프레임: "검증 루프 강제"지 "전문 개발자 대체"가 아니다. 기계 게이트 위에 얹는 레이어.
+ * - lite     : 막지 않고 경고만 (숙련자/빠른 반복)
+ * - standard : 기본 — 위험 작업은 CLI confirm, MCP/자연어는 preview(dry-run)
+ * - strict   : 더 많은 작업(save/sync 등)에도 확인 요구
+ */
+export type SafetyMode = 'lite' | 'standard' | 'strict'
+
+export const SAFETY_MODES: readonly SafetyMode[] = ['lite', 'standard', 'strict']
+
+export const DEFAULT_SAFETY_MODE: SafetyMode = 'standard'
+
+export const SAFETY_MODE_DESC: Record<SafetyMode, string> = {
+  lite: '경고만 — 위험 작업도 막지 않고 경고만 표시 (빠른 반복용)',
+  standard: '기본 — 위험 작업은 CLI 확인·MCP/자연어 미리보기',
+  strict: '엄격 — 더 많은 작업(저장/동기화 등)에도 확인 요구',
+}
+
+export function isSafetyMode(value: unknown): value is SafetyMode {
+  return typeof value === 'string' && (SAFETY_MODES as readonly string[]).includes(value)
+}

--- a/tests/command-registry.test.ts
+++ b/tests/command-registry.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { program } from '../src/index.js'
+import { CONTAINER_SUBCOMMANDS, CONTAINER_ALIASES } from '../src/lib/command-registry.js'
+import { detectNaturalLanguageInput } from '../src/lib/cli-args.js'
+
+// R1 드리프트 가드: commander 정의(index.ts)와 R1 가드의 단일 소스(command-registry)가
+// 따로 놀지 않는지 실제 introspect 로 검증. (주석 grep 이 아니라 코드 구조 검증)
+describe('R1 드리프트 가드 — command-registry 단일 소스', () => {
+  it('commander 의 실제 서브커맨드가 모두 레지스트리에 있음 (누락 = R1 재발 위험)', () => {
+    for (const [container, subs] of Object.entries(CONTAINER_SUBCOMMANDS)) {
+      const cmd = program.commands.find((c) => c.name() === container)
+      if (!cmd) continue // 위치 인자형(mode 등) — commander 서브커맨드 없음
+      const actual = cmd.commands.map((c) => c.name())
+      for (const s of actual) {
+        expect(subs, `${container}.${s} 가 registry 에 없음 → 자연어 라우터가 가로챌 위험`).toContain(s)
+      }
+    }
+  })
+
+  it('레지스트리가 cli-args R1 가드를 실제로 작동시킴', () => {
+    // goal check / mode strict 가 commander 로 가야 함(자연어 라우터 가로채기 금지)
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'goal', 'check'])).toBeNull()
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'mode', 'strict'])).toBeNull()
+  })
+
+  it('모든 한글 별칭이 유효한 영문 컨테이너를 가리킨다', () => {
+    for (const [, canonical] of Object.entries(CONTAINER_ALIASES)) {
+      expect(CONTAINER_SUBCOMMANDS[canonical]).toBeDefined()
+    }
+  })
+})

--- a/tests/command-registry.test.ts
+++ b/tests/command-registry.test.ts
@@ -28,4 +28,15 @@ describe('R1 드리프트 가드 — command-registry 단일 소스', () => {
       expect(CONTAINER_SUBCOMMANDS[canonical]).toBeDefined()
     }
   })
+
+  it('새 컨테이너 명령(서브커맨드 보유)이 registry 에 누락되지 않음', () => {
+    // commander 에서 서브커맨드를 가진 명령 = 컨테이너. registry 에 없으면 R1 가드 누락 → 자연어 가로채기 위험.
+    const containers = program.commands.filter((c) => c.commands.length > 0).map((c) => c.name())
+    for (const name of containers) {
+      expect(
+        CONTAINER_SUBCOMMANDS[name],
+        `새 컨테이너 '${name}' 가 command-registry 에 없음 → R1 가드 누락`
+      ).toBeDefined()
+    }
+  })
 })

--- a/tests/help.test.ts
+++ b/tests/help.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { QUICK_ACTIONS, quickActions } from '../src/commands/help.js'
-import { requiresConfirmation, nlSafetyNotice } from '../src/lib/nlp-run.js'
+import { requiresConfirmation } from '../src/lib/nlp-run.js'
 import type { NlpRoute } from '../src/lib/nlp-router.js'
 
 const route = (command: NlpRoute['command'], confidence: NlpRoute['confidence']): NlpRoute => ({
@@ -39,25 +39,5 @@ describe('requiresConfirmation — 상태변경 명령은 confidence 무관 conf
 
   it('low confidence 는 명령 무관 confirm', () => {
     expect(requiresConfirmation(route('status', 'low'))).toBe(true)
-  })
-})
-
-describe('nlSafetyNotice — 자연어 high-risk 채널 가드(preview/warn)', () => {
-  it('standard: high-risk NL 명령은 preview 안내', () => {
-    const n = nlSafetyNotice('deploy', 'standard')
-    expect(n).toBeTruthy()
-    expect(n).toMatch(/미리보기|preview/i)
-  })
-  it('lite: 막지 않고 경고만', () => {
-    expect(nlSafetyNotice('publish', 'lite')).toMatch(/경고|warn/i)
-  })
-  it('저위험 NL 명령은 안내 없음(null)', () => {
-    expect(nlSafetyNotice('status', 'standard')).toBeNull()
-    expect(nlSafetyNotice('help', 'standard')).toBeNull()
-  })
-  it('migrate/cloud-pull/undo 도 high-risk 로 안내', () => {
-    expect(nlSafetyNotice('migrate', 'standard')).toBeTruthy()
-    expect(nlSafetyNotice('cloud-pull', 'standard')).toBeTruthy()
-    expect(nlSafetyNotice('undo', 'standard')).toBeTruthy()
   })
 })

--- a/tests/help.test.ts
+++ b/tests/help.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { QUICK_ACTIONS, quickActions } from '../src/commands/help.js'
-import { requiresConfirmation } from '../src/lib/nlp-run.js'
+import { requiresConfirmation, nlSafetyNotice } from '../src/lib/nlp-run.js'
 import type { NlpRoute } from '../src/lib/nlp-router.js'
 
 const route = (command: NlpRoute['command'], confidence: NlpRoute['confidence']): NlpRoute => ({
@@ -39,5 +39,25 @@ describe('requiresConfirmation — 상태변경 명령은 confidence 무관 conf
 
   it('low confidence 는 명령 무관 confirm', () => {
     expect(requiresConfirmation(route('status', 'low'))).toBe(true)
+  })
+})
+
+describe('nlSafetyNotice — 자연어 high-risk 채널 가드(preview/warn)', () => {
+  it('standard: high-risk NL 명령은 preview 안내', () => {
+    const n = nlSafetyNotice('deploy', 'standard')
+    expect(n).toBeTruthy()
+    expect(n).toMatch(/미리보기|preview/i)
+  })
+  it('lite: 막지 않고 경고만', () => {
+    expect(nlSafetyNotice('publish', 'lite')).toMatch(/경고|warn/i)
+  })
+  it('저위험 NL 명령은 안내 없음(null)', () => {
+    expect(nlSafetyNotice('status', 'standard')).toBeNull()
+    expect(nlSafetyNotice('help', 'standard')).toBeNull()
+  })
+  it('migrate/cloud-pull/undo 도 high-risk 로 안내', () => {
+    expect(nlSafetyNotice('migrate', 'standard')).toBeTruthy()
+    expect(nlSafetyNotice('cloud-pull', 'standard')).toBeTruthy()
+    expect(nlSafetyNotice('undo', 'standard')).toBeTruthy()
   })
 })

--- a/tests/mode.test.ts
+++ b/tests/mode.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { readConfig } from '../src/lib/config.js'
+import { mode } from '../src/commands/mode.js'
+import { verificationChecklist } from '../src/commands/verify.js'
+
+function tmp(): string {
+  const dir = join(tmpdir(), `vhk-mode-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+describe('vhk mode — 조회/변경', () => {
+  let origCwd: string
+  let dir: string
+  let logs: string[]
+  beforeEach(() => {
+    origCwd = process.cwd()
+    dir = tmp()
+    process.chdir(dir)
+    logs = []
+    vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { logs.push(a.join(' ')) })
+    process.exitCode = 0
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    rmSync(dir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+    process.exitCode = 0
+  })
+
+  it('인자 없으면 현재 모드 출력 (파일 없으면 standard)', async () => {
+    await mode()
+    expect(logs.join('\n')).toContain('standard')
+  })
+
+  it('mode strict → config.json 에 strict 기록', async () => {
+    await mode('strict')
+    expect(readConfig().safetyMode).toBe('strict')
+  })
+
+  it('알 수 없는 모드 → 에러 + 기록 안 함', async () => {
+    await mode('garbage')
+    expect(readConfig().safetyMode).toBe('standard') // 변경 안 됨
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('세 모드 모두 설정 가능', async () => {
+    await mode('lite')
+    expect(readConfig().safetyMode).toBe('lite')
+    await mode('standard')
+    expect(readConfig().safetyMode).toBe('standard')
+  })
+})
+
+describe('vhk verify (lite — 메타러너 자리)', () => {
+  it('검증 묶음 체크리스트에 핵심 게이트 포함', () => {
+    const joined = verificationChecklist().join(' ')
+    expect(joined).toMatch(/tsc|타입/)
+    expect(joined).toMatch(/test|테스트/)
+    expect(joined).toMatch(/build|빌드/)
+  })
+})

--- a/tests/safety-coverage.test.ts
+++ b/tests/safety-coverage.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import {
+  HIGH_RISK_ACTIONS,
+  STRICT_EXTRA_ACTIONS,
+  NL_GUARDED_ACTIONS,
+} from '../src/lib/risk-policy.js'
+
+// 가드가 필요한 action 전체 = high-risk ∪ strict-extra(save/sync).
+const GUARDED = new Set<string>([...HIGH_RISK_ACTIONS, ...STRICT_EXTRA_ACTIONS])
+
+// 가드 대상 핸들러 함수명 → action. dispatch/메뉴에서 이 함수를 호출하면 위험 작업이 실행된다.
+const HANDLER_ACTION: Record<string, string> = {
+  undo: 'undo', deploy: 'deploy', publish: 'publish', migrate: 'migrate',
+  cloudPull: 'cloud-pull', env: 'env-write', save: 'save', sync: 'sync', resume: 'resume',
+}
+
+describe('완전성 가드 — high-risk 무바이패스 (적대리뷰 R2)', () => {
+  it('NL_GUARDED_ACTIONS 의 모든 action 은 가드대상(HIGH_RISK ∪ STRICT_EXTRA)', () => {
+    for (const a of Object.values(NL_GUARDED_ACTIONS)) {
+      expect(GUARDED.has(a), `${a} 가 가드대상 아님`).toBe(true)
+    }
+  })
+
+  it('자연어 dispatch: 가드대상 핸들러 호출 case 는 전부 NL_GUARDED_ACTIONS 등록(caller 가 runGuarded)', () => {
+    const src = readFileSync('src/lib/nlp-run.ts', 'utf-8')
+    const cases = [...src.matchAll(/case\s+'([^']+)':\s*\n?\s*return\s+(\w+)\(/g)]
+    for (const [, cmd, handler] of cases) {
+      const action = HANDLER_ACTION[handler]
+      if (action && GUARDED.has(action)) {
+        expect(Object.keys(NL_GUARDED_ACTIONS), `NL '${cmd}'→${handler}() 가드 미경유`).toContain(cmd)
+      }
+    }
+  })
+
+  it('CLI 등록: 가드대상 + CLI 커맨드 있는 action 은 전부 guardCli 경유 (index.ts)', () => {
+    const idx = readFileSync('src/index.ts', 'utf-8')
+    const CLI_ACTIONS = ['deploy', 'publish', 'migrate', 'env-write', 'cloud-pull', 'undo', 'resume', 'save', 'sync']
+    for (const a of CLI_ACTIONS) {
+      expect(idx.includes(`guardCli('${a}'`), `CLI '${a}' guardCli 미경유`).toBe(true)
+    }
+  })
+
+  it('인라인 메뉴 switch 등: 가드대상 핸들러 직접 호출 없음(전부 guardCli 경유)', () => {
+    const idx = readFileSync('src/index.ts', 'utf-8')
+    const direct = [...idx.matchAll(/return\s+(undo|save|sync|deploy|publish|migrate|env|cloudPull|resume)\(/g)]
+    expect(direct.map((m) => m[1]), '가드 미경유 직접 호출 발견').toEqual([])
+  })
+
+  it('mode 강등은 NL/MCP 로 불가 — 조회전용(NL mode() 무인자 + MCP mode 툴 없음)', () => {
+    const nlp = readFileSync('src/lib/nlp-run.ts', 'utf-8')
+    // 자연어 dispatch 의 mode 는 무인자 호출(조회) — mode('lite') 같은 변경 호출 없음
+    expect(nlp).toMatch(/case 'mode':\s*\n?\s*return mode\(\)/)
+    const server = readFileSync('src/mcp/server.ts', 'utf-8')
+    expect(/registerTool\(\s*['"]mode['"]/.test(server), 'MCP mode 툴 존재 → 강등 가능').toBe(false)
+  })
+
+  it("'delete' 는 진입점 없는 예약 액션(라이브 바이패스 아님)", () => {
+    const idx = readFileSync('src/index.ts', 'utf-8')
+    expect(idx.includes("guardCli('delete'")).toBe(false)
+    expect(idx.includes(".command('delete'")).toBe(false)
+    expect(Object.keys(NL_GUARDED_ACTIONS)).not.toContain('delete')
+  })
+
+  it('high-risk 별도 나열 리스트는 risk-policy 외에 없음(드리프트 소스 감사)', () => {
+    const files = ['src/lib/nlp-run.ts', 'src/index.ts', 'src/mcp/server.ts']
+    const names = ['undo', 'deploy', 'publish', 'migrate', 'cloud-pull', 'resume', 'env-write']
+    for (const f of files) {
+      const src = readFileSync(f, 'utf-8')
+      for (const lit of src.match(/\[[^\]]*\]/g) ?? []) {
+        const hit = names.filter((n) => lit.includes(`'${n}'`))
+        expect(hit.length, `${f} 에 high-risk 별도 나열 의심: ${lit.slice(0, 60)}`).toBeLessThan(3)
+      }
+    }
+  })
+})

--- a/tests/safety-guard.test.ts
+++ b/tests/safety-guard.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { runGuarded } from '../src/lib/safety-guard.js'
+
+function tracker() {
+  let ran = false
+  const run = () => { ran = true; return 'DONE' }
+  return { run, get ran() { return ran } }
+}
+
+describe('runGuarded — 단일 chokepoint', () => {
+  it('저위험(allow) → 그대로 실행', async () => {
+    const t = tracker()
+    const { outcome, result } = await runGuarded('status', { channel: 'cli', mode: 'standard' }, t.run)
+    expect(outcome.ran).toBe(true)
+    expect(result).toBe('DONE')
+    expect(t.ran).toBe(true)
+  })
+
+  it('lite + high-risk → 경고만 하고 실행', async () => {
+    const t = tracker()
+    const logs: string[] = []
+    const { outcome } = await runGuarded('deploy', { channel: 'cli', mode: 'lite', log: (m) => logs.push(m) }, t.run)
+    expect(outcome.ran).toBe(true)
+    expect(t.ran).toBe(true)
+    expect(logs.join(' ')).toMatch(/경고|warn|lite/i)
+  })
+
+  it('CLI standard + confirm 승인 → 실행', async () => {
+    const t = tracker()
+    const { outcome } = await runGuarded('deploy', {
+      channel: 'cli', mode: 'standard', isTTY: true, confirm: async () => true,
+    }, t.run)
+    expect(outcome.ran).toBe(true)
+    expect(t.ran).toBe(true)
+  })
+
+  it('CLI standard + confirm 거부 → 실행 안 함(abort)', async () => {
+    const t = tracker()
+    const { outcome } = await runGuarded('deploy', {
+      channel: 'cli', mode: 'standard', isTTY: true, confirm: async () => false,
+    }, t.run)
+    expect(outcome.ran).toBe(false)
+    expect(t.ran).toBe(false)
+  })
+
+  it('CLI 비대화형(TTY 아님) + 미승인 → 안전하게 중단', async () => {
+    const t = tracker()
+    const { outcome } = await runGuarded('deploy', {
+      channel: 'cli', mode: 'standard', isTTY: false,
+    }, t.run)
+    expect(outcome.ran).toBe(false)
+    expect(t.ran).toBe(false)
+  })
+
+  it('CLI 명시적 승인(approved=true) → 실행', async () => {
+    const t = tracker()
+    const { outcome } = await runGuarded('deploy', {
+      channel: 'cli', mode: 'standard', isTTY: false, approved: true,
+    }, t.run)
+    expect(outcome.ran).toBe(true)
+    expect(t.ran).toBe(true)
+  })
+
+  it('MCP/자연어 standard + 미승인 → preview 만, 기본 비실행', async () => {
+    const t = tracker()
+    const logs: string[] = []
+    const { outcome } = await runGuarded('deploy', {
+      channel: 'nl', mode: 'standard', approved: false, log: (m) => logs.push(m),
+    }, t.run)
+    expect(outcome.ran).toBe(false)
+    expect(t.ran).toBe(false)
+    expect(logs.join(' ')).toMatch(/미리보기|preview/i)
+  })
+
+  it('자연어 + 명시적 승인 → 실행', async () => {
+    const t = tracker()
+    const { outcome } = await runGuarded('deploy', {
+      channel: 'nl', mode: 'standard', approved: true,
+    }, t.run)
+    expect(outcome.ran).toBe(true)
+    expect(t.ran).toBe(true)
+  })
+})
+
+describe('CLI 가드 e2e — standard 모드 high-risk 차단 (행동 검증)', () => {
+  const bin = path.join(process.cwd(), 'dist', 'index.js')
+
+  it('standard(기본) + 확인 없이 vhk deploy → 실행되지 않음', () => {
+    // 빈 temp(설정 없음) = 기본 standard. 비대화형 spawn = 확인 불가 → 가드가 막아야 함.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-guard-'))
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'tp', version: '0.0.0' }), 'utf-8')
+    const r = spawnSync(process.execPath, [bin, 'deploy'], {
+      encoding: 'utf-8', cwd: tmp, env: { ...process.env, NO_COLOR: '1' },
+    })
+    const out = String(r.stdout ?? '') + String(r.stderr ?? '')
+    // 가드 차단 메시지 존재
+    expect(out).toMatch(/위험 작업\(deploy\)/)
+    expect(out).toMatch(/실행하지 않/)
+    // 실제 배포 흐름(플랫폼 선택)으로 진입하지 않음
+    expect(out).not.toMatch(/어떤 플랫폼에 배포/)
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+})

--- a/tests/safety-mode.test.ts
+++ b/tests/safety-mode.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  SAFETY_MODES,
+  DEFAULT_SAFETY_MODE,
+  isSafetyMode,
+} from '../src/lib/safety-mode.js'
+import {
+  HIGH_RISK_ACTIONS,
+  isHighRisk,
+  resolveGuard,
+} from '../src/lib/risk-policy.js'
+import { readConfig, writeConfig, DEFAULT_CONFIG, CONFIG_PATH } from '../src/lib/config.js'
+
+function tmp(label: string): string {
+  const dir = join(tmpdir(), `vhk-safety-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+describe('safety-mode — 모드 정의', () => {
+  it('세 모드 lite/standard/strict', () => {
+    expect(SAFETY_MODES).toEqual(['lite', 'standard', 'strict'])
+  })
+  it('기본 모드는 standard', () => {
+    expect(DEFAULT_SAFETY_MODE).toBe('standard')
+  })
+  it('isSafetyMode 검증', () => {
+    expect(isSafetyMode('strict')).toBe(true)
+    expect(isSafetyMode('nope')).toBe(false)
+    expect(isSafetyMode(undefined)).toBe(false)
+  })
+})
+
+describe('risk-policy — high-risk 8종 + 채널/모드 정책', () => {
+  it('high-risk 8종 포함', () => {
+    for (const a of ['undo', 'deploy', 'publish', 'migrate', 'cloud-pull', 'resume', 'env-write', 'delete']) {
+      expect(HIGH_RISK_ACTIONS).toContain(a)
+    }
+    expect(HIGH_RISK_ACTIONS.length).toBe(8)
+  })
+
+  it('isHighRisk 판정', () => {
+    expect(isHighRisk('deploy')).toBe(true)
+    expect(isHighRisk('status')).toBe(false)
+  })
+
+  it('standard: CLI=confirm, MCP/자연어=preview', () => {
+    expect(resolveGuard('deploy', 'standard', 'cli')).toBe('confirm')
+    expect(resolveGuard('deploy', 'standard', 'mcp')).toBe('preview')
+    expect(resolveGuard('deploy', 'standard', 'nl')).toBe('preview')
+  })
+
+  it('lite: 위험 작업도 막지 않고 경고만(warn)', () => {
+    expect(resolveGuard('deploy', 'lite', 'cli')).toBe('warn')
+    expect(resolveGuard('deploy', 'lite', 'mcp')).toBe('warn')
+  })
+
+  it('strict: 더 많은 작업(save/sync)도 confirm', () => {
+    expect(resolveGuard('save', 'standard', 'cli')).toBe('allow')
+    expect(resolveGuard('save', 'strict', 'cli')).toBe('confirm')
+    expect(resolveGuard('sync', 'strict', 'mcp')).toBe('preview')
+  })
+
+  it('저위험 작업은 allow', () => {
+    expect(resolveGuard('status', 'standard', 'cli')).toBe('allow')
+    expect(resolveGuard('status', 'strict', 'cli')).toBe('allow')
+  })
+})
+
+describe('config — .vhk/config.json 읽기/쓰기', () => {
+  let origCwd: string
+  let dir: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    dir = tmp('config')
+    process.chdir(dir)
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('파일 없으면 기본값(standard)', () => {
+    expect(readConfig()).toEqual(DEFAULT_CONFIG)
+    expect(readConfig().safetyMode).toBe('standard')
+  })
+
+  it('write → read 왕복', () => {
+    writeConfig({ safetyMode: 'strict' })
+    expect(existsSync(CONFIG_PATH)).toBe(true)
+    expect(readConfig().safetyMode).toBe('strict')
+  })
+
+  it('손상된 모드 값은 기본값으로 폴백', () => {
+    mkdirSync('.vhk', { recursive: true })
+    writeFileSync(CONFIG_PATH, JSON.stringify({ safetyMode: 'garbage' }), 'utf-8')
+    expect(readConfig().safetyMode).toBe('standard')
+  })
+
+  it('write 결과는 JSON 파싱 가능', () => {
+    writeConfig({ safetyMode: 'lite' })
+    const parsed = JSON.parse(readFileSync(CONFIG_PATH, 'utf-8'))
+    expect(parsed.safetyMode).toBe('lite')
+  })
+})


### PR DESCRIPTION
## 개요
배치4(goal 6): 위험 작업을 "그냥 실행"하지 못하게 막는 안전 레이어. PRD 프레임 — "검증 루프 강제"지 "전문 개발자 대체"가 아니다(기계 게이트 위에 얹음). roadmap §6 R1 2건 포함.

## 추가/수정 파일
**신규 라이브러리**
- `src/lib/safety-mode.ts` — lite / standard / strict (기본 standard)
- `src/lib/config.ts` — `.vhk/config.json` 읽기/쓰기 (없으면 기본값, 손상 시 폴백)
- `src/lib/risk-policy.ts` — high-risk 8종(undo/deploy/publish/migrate/cloud-pull/resume/env-write/delete) + `resolveGuard(action, mode, channel)` → **CLI=confirm, MCP/자연어=preview, lite=warn**
- `src/lib/command-registry.ts` — 컨테이너→서브커맨드 **단일 소스**(R1)

**신규 커맨드**
- `src/commands/mode.ts` — `vhk mode [lite|standard|strict]` 조회/변경
- `src/commands/verify.ts` — `vhk verify` 검증 묶음 안내(lite, 메타러너 자리)

**연동/수정**
- `nlp-run.ts` — `nlSafetyNotice`: 자연어 high-risk 호출 시 preview/warn 출력(실채널 연동) + mode/verify dispatch
- `index.ts` — mode/verify 등록, `import.meta.url` 메인모듈 체크로 `program` export(드리프트 테스트용)
- `cli-args.ts` — COMMAND_SUBCOMMANDS 를 registry 에서 파생(하드코딩 복제 제거) + mode 토큰

## R1 2건 (roadmap §6)
1. **단일소스화**: `command-registry.ts` 에서 cli-args 가 파생. `tests/command-registry.test.ts` 가 commander `program` 을 introspect 해 registry 와 드리프트 시 실패(주석 grep 아님).
2. **게이트 교체**: `check-goal-5.mjs` R1 검사 = 주석 grep → `isRealSubcommandPath` 정의+호출+레지스트리 코드구조 검증.

## 게이트 결과
- [x] tsc / test:run **483 pass** / build
- [x] scan / audit --moderate
- [x] check-meta / check-goal-0..6 전부 PASS
- e2e: `vhk mode`(조회), `mode strict`(temp 기록), NL "안전 모드 바꿔"→mode 확인

## ⚠️ 남은 위험 (정직 보고 — 거짓완료 방지)
**정책 엔진은 만들었고 자연어 채널엔 연동했으나, 8개 high-risk 커맨드 각각의 CLI confirm / MCP preview 강제는 아직 전면 배선 안 됨.** `resolveGuard`/`nlSafetyNotice` 는 동작하지만, 예: `vhk deploy`(직접 CLI)에 정책 confirm 이 자동 삽입되진 않음(undo 등 일부는 자체 confirm 보유). 전 커맨드/MCP 핸들러 배선은 후속.

## 후속 (이번 범위 아님 — roadmap §6)
sync 미매칭 섹션 누락 / init adopt e2e / MCP fallback exec 테스트 / rules-import 인트로 손실.

🤖 Generated with [Claude Code](https://claude.com/claude-code)