### PR TITLE
feat(safety): R2 후속 — 완전성 매핑 + no-stray 게이트 + undo/resume guardCliDefer

### DIFF
--- a/scripts/check-goal-6.mjs
+++ b/scripts/check-goal-6.mjs
@@ -29,7 +29,7 @@ must(guard && /confirm/.test(guard) && /approved/.test(guard) && /preview|미리
 const idx = read("src/index.ts") || "";
 // 가드대상(high-risk + strict-extra) CLI 진입점 전체가 guardCli 경유 (5개 아니라 9개)
 const EXECUTING = ["deploy", "publish", "migrate", "env-write", "cloud-pull", "undo", "resume", "save", "sync"];
-must(EXECUTING.every((a) => idx.includes(`guardCli('${a}'`)), "CLI 가드대상 9종 전부 guardCli 경유(undo/resume/save/sync 포함)");
+must(EXECUTING.every((a) => new RegExp(`guardCli(Defer)?\\('${a}'`).test(idx)), "CLI 가드대상 9종 전부 guardCli/guardCliDefer 경유(undo/resume/save/sync 포함)");
 must(/runGuarded/.test(idx), "index.ts guardCli → runGuarded");
 // 인라인 메뉴 switch 등 가드대상 핸들러 직접 호출(바이패스) 없음
 must(![...idx.matchAll(/return\s+(undo|save|sync|deploy|publish|migrate|env|cloudPull|resume)\(/g)].length, "메뉴/직접 호출 가드 미경유 없음");

--- a/scripts/check-no-stray.mjs
+++ b/scripts/check-no-stray.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// 머지 게이트 — src/·tests/ 에 추적 안 된(untracked) 무관 파일이 없는지 검사.
+// (리뷰/에이전트가 Bash 로 만든 PoC stray 파일이 소스 트리에 남는 것을 방지.)
+// .cursor/·.vhk/·dist/ 등 루트/로컬 전용은 대상 아님 — 소스 트리(src/·tests/)만.
+import { execFileSync } from "node:child_process";
+
+let out = "";
+try {
+  out = execFileSync("git", ["status", "--porcelain"], { cwd: process.cwd(), encoding: "utf8" });
+} catch {
+  console.log("[check-no-stray] git 저장소 아님 — 검사 생략");
+  process.exit(0);
+}
+
+const stray = out
+  .split(/\r?\n/)
+  .filter((l) => l.startsWith("?? "))
+  .map((l) => l.slice(3).trim())
+  .filter((p) => /^(src|tests)\//.test(p));
+
+if (stray.length) {
+  console.error("[check-no-stray FAIL] src/·tests/ 에 추적 안 된 무관 파일 발견 — 커밋 또는 삭제 필요:");
+  for (const p of stray) console.error("  ?? " + p);
+  console.error("(의도된 새 파일이면 git add, 리뷰 에이전트 stray 면 삭제)");
+  process.exit(1);
+}
+console.log("[check-no-stray PASS] src/·tests/ untracked 무관 파일 0개");

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,30 @@ async function guardCli(
     run,
   )
 }
+
+/**
+ * undo/resume 처럼 명령이 **자체 확인**(undo: 푸시 커밋 경고·되돌릴 개수, resume: --confirm)을
+ * 하는 high-risk 용 가드. 단일 chokepoint(runGuarded)로 모드 정책만 적용하고
+ * (비대화형 미승인 → 차단, lite → 경고만), 실제 사용자 확인은 명령에 위임해 이중 프롬프트를 막는다.
+ * → 일관성(전부 runGuarded 경유) + 명령별 특화 안전(푸시 경고/--confirm) 둘 다 유지.
+ */
+async function guardCliDefer(
+  action: string,
+  approved: boolean,
+  run: () => Promise<void> | void,
+): Promise<void> {
+  await runGuarded(
+    action,
+    {
+      channel: 'cli',
+      approved,
+      // TTY 면 통과(명령이 자체 확인), 비대화형은 confirm 불가 → 가드가 차단.
+      confirm: async () => !!process.stdout.isTTY,
+      log: (m) => console.log(chalk.yellow(`  ${m}`)),
+    },
+    run,
+  )
+}
 import { cloudPush, cloudPull } from './commands/cloud.js'
 import { goalCheck, goalDone, goalInit, goalList, goalNext } from './commands/goal.js'
 import { blocker, learn, resume } from './commands/agent.js'
@@ -263,7 +287,7 @@ program
   .alias('되돌리기')
   .option('--yes', '확인 없이 실행 (위험 작업 명시 승인)')
   .description('최근 커밋 되돌리기')
-  .action(async (opts: { yes?: boolean }) => { await guardCli('undo', opts?.yes === true, () => undo()) })
+  .action(async (opts: { yes?: boolean }) => { await guardCliDefer('undo', opts?.yes === true, () => undo()) })
 
 program
   .command('restore')
@@ -510,7 +534,7 @@ program
   .alias('재개')
   .option('--confirm', '사람 확인 — 자동 호출 금지 (Forbidden 위반)')
   .description('.vhk/HARD_STOP 해제 (사용자가 사유 확인 후 --confirm 필요)')
-  .action(async (opts: { confirm?: boolean }) => { await guardCli('resume', opts?.confirm === true, () => resume(opts)) })
+  .action(async (opts: { confirm?: boolean }) => { await guardCliDefer('resume', opts?.confirm === true, () => resume(opts)) })
 
 program.on('command:*', async (operands: string[]) => {
   const unknown = operands[0] ?? ''
@@ -562,7 +586,7 @@ program.action(async () => {
     case 'save':
       return guardCli('save', false, () => save())
     case 'undo':
-      return guardCli('undo', false, () => undo())
+      return guardCliDefer('undo', false, () => undo())
     case 'status':
       return status()
     case 'diff':

--- a/tests/safety-coverage.test.ts
+++ b/tests/safety-coverage.test.ts
@@ -33,11 +33,21 @@ describe('완전성 가드 — high-risk 무바이패스 (적대리뷰 R2)', () 
     }
   })
 
-  it('CLI 등록: 가드대상 + CLI 커맨드 있는 action 은 전부 guardCli 경유 (index.ts)', () => {
+  it('CLI 등록: 가드대상 + CLI 커맨드 있는 action 은 전부 guardCli/guardCliDefer 경유 (index.ts)', () => {
     const idx = readFileSync('src/index.ts', 'utf-8')
     const CLI_ACTIONS = ['deploy', 'publish', 'migrate', 'env-write', 'cloud-pull', 'undo', 'resume', 'save', 'sync']
     for (const a of CLI_ACTIONS) {
-      expect(idx.includes(`guardCli('${a}'`), `CLI '${a}' guardCli 미경유`).toBe(true)
+      // undo/resume 는 guardCliDefer(명령 자체확인 위임), 나머지는 guardCli
+      expect(new RegExp(`guardCli(Defer)?\\('${a}'`).test(idx), `CLI '${a}' 가드 미경유`).toBe(true)
+    }
+  })
+
+  it('가드대상 action(예약 delete 제외)은 전부 HANDLER_ACTION 에 핸들러 매핑됨 (완전성 매핑 누락 방지)', () => {
+    // 새 high-risk action 이 risk-policy 에 추가되면 HANDLER_ACTION 도 갱신해야 dispatch/직접호출 검사가 동작.
+    const mapped = new Set(Object.values(HANDLER_ACTION))
+    for (const a of GUARDED) {
+      if (a === 'delete') continue // 진입점 없는 예약 액션
+      expect(mapped.has(a), `action '${a}' 핸들러 매핑 없음 → 완전성 검사 누락(드리프트)`).toBe(true)
     }
   })
 


### PR DESCRIPTION
roadmap §6 R2 후속 MED 3건 구현.

## ⑦ 완전성 매핑 누락 방지
`tests/safety-coverage.test.ts`: 가드대상 action(예약 `delete` 제외) 전부 `HANDLER_ACTION` 에 핸들러 매핑 존재 검증. risk-policy 에 새 high-risk 추가 시 매핑 누락이면 FAIL → 완전성 검사 드리프트 차단.

## ⑧ no-stray 머지 게이트
`scripts/check-no-stray.mjs`: `src/`·`tests/` 에 untracked 무관 파일(리뷰 에이전트 stray PoC) 0개 검사. 재발 방지.

## ⑨ undo/resume → guardCliDefer
단일 chokepoint `runGuarded` 경유(모드정책: 비대화형 차단·lite 경고)하되 실제 확인은 명령 자체검사에 위임:
- undo: 푸시 커밋 경고 + 되돌릴 개수(명령 고유 안전) 보존
- resume: `--confirm`(HARD_STOP 해제용 의도적 강가드, mode 무관) 보존
→ 이중 프롬프트 제거 + 일관성(전부 runGuarded) + 명령별 특화 안전 유지.

## 게이트
tsc / test:run **497 pass** / build / scan / audit / check-goal-0..6 / no-stray. e2e: undo(standard 비대화형) 차단.

남은 위험: ⑦의 핸들러명 매핑은 여전히 테스트-로컬 선언 — 핸들러 함수 *이름 변경*은 못 잡음(보장 아님, 액션 추가는 잡음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)