### PR TITLE
fix(cleanup): roadmap §6 후속 ③④⑤⑥ 청산

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -16,6 +16,18 @@ const CURSORRULES_KEYS = ['코딩 규칙', '기술 스택', '아키텍처', '디
 const CLAUDE_MD_KEYS = ['기록', '로그', 'ADR', '트러블슈팅', 'TIL', '/done', '체크리스트']
 
 /**
+ * RULES.md 섹션 중 어느 sync 타깃 키(CURSORRULES_KEYS ∪ CLAUDE_MD_KEYS)에도
+ * 매핑되지 않는 섹션 제목. 이 섹션들은 모든 산출물에서 빠지므로(예: `## 프로젝트 정체성`)
+ * sync 가 **조용히 버리지 않고 경고**하도록 sync() 가 이걸로 사용자에게 알린다.
+ */
+export function findUnmappedSections(sections: RulesSection[]): string[] {
+  const allKeys = [...CURSORRULES_KEYS, ...CLAUDE_MD_KEYS]
+  return sections
+    .filter((s) => !allKeys.some((k) => s.title.includes(k)))
+    .map((s) => s.title)
+}
+
+/**
  * RULES.md를 ## 기준으로 섹션 파싱
  */
 export function parseRulesMd(content: string): RulesSection[] {
@@ -420,6 +432,17 @@ export async function sync(opts: SyncOptions = {}): Promise<void> {
 
   const sections = parseRulesMd(fs.readFileSync(rulesPath, 'utf-8'))
   console.log(chalk.dim(`  📄 RULES.md 파싱 완료 — ${sections.length}개 섹션`))
+
+  // ③ 미매칭 섹션은 어느 산출물에도 안 실려 조용히 사라진다 → 경고(stderr)로 알린다.
+  const unmapped = findUnmappedSections(sections)
+  if (unmapped.length) {
+    console.error(
+      chalk.yellow(
+        `  ⚠️  ${unmapped.length}개 섹션이 어느 타깃에도 매핑 안 돼 산출물에서 제외됨: ${unmapped.join(', ')}` +
+          `\n     (코딩 규칙/기술 스택/커밋/기록 등 표준 제목을 쓰거나, 이 섹션은 RULES.md 에만 보존됩니다.)`
+      )
+    )
+  }
 
   // 비대화형(CI/MCP subprocess: isTTY=false)·--yes → 자동 덮어쓰기(멈춤 금지).
   // TTY → drift 시 inquirer 확인(기본 거부). 어느 쪽이든 백업이 먼저라 손실 0.

--- a/src/lib/rules-import.ts
+++ b/src/lib/rules-import.ts
@@ -52,16 +52,24 @@ function splitSections(content: string): ParsedSection[] {
   const sections: ParsedSection[] = []
   let title = ''
   let buf: string[] = []
+  const preamble: string[] = []
+  let sawHeading = false
   for (const line of content.split('\n')) {
     if (line.startsWith('## ')) {
+      sawHeading = true
       if (title) sections.push({ title, content: buf.join('\n').trim() })
       title = line.replace('## ', '').trim()
       buf = []
     } else if (title) {
       buf.push(line)
+    } else if (!sawHeading) {
+      // ⑥ 첫 ## 이전 본문(인트로)은 버리지 않고 '서문'으로 보존.
+      preamble.push(line)
     }
   }
   if (title) sections.push({ title, content: buf.join('\n').trim() })
+  const pre = preamble.join('\n').trim()
+  if (pre) sections.unshift({ title: '서문', content: pre })
   return sections
 }
 
@@ -101,10 +109,13 @@ export function buildAdoptedRules(files: DetectedRuleFile[], projectName: string
 
   for (const title of order) {
     const merged = byTitle.get(title)!
+    // ⑥ 빈 섹션 생성 금지 — 본문 있는 출처만. 전부 비면 제목 자체를 생략.
+    const nonEmpty = merged.parts.filter((p) => p.content.trim())
+    if (!nonEmpty.length) continue
     lines.push(`## ${title}`)
-    for (const part of merged.parts) {
+    for (const part of nonEmpty) {
       lines.push(`<!-- 출처: ${part.source} -->`)
-      if (part.content) lines.push(part.content)
+      lines.push(part.content)
     }
     lines.push('')
   }

--- a/src/mcp/cli-path.ts
+++ b/src/mcp/cli-path.ts
@@ -32,6 +32,17 @@ export function pickCliInvocation(
   return { bin: 'vhk', prefixArgs: [], fallback: false }
 }
 
+/**
+ * resolve 결과(VhkCliInvocation) + 호출 인자 → 실제 실행할 `{ bin, args }`.
+ * (runVhkCli 가 쓰는 인자 합성 — 순수 함수라 fallback(node dist/index.js) 합성을 단위테스트 가능.)
+ */
+export function composeInvocation(
+  cli: VhkCliInvocation,
+  args: string[]
+): { bin: string; args: string[] } {
+  return { bin: cli.bin, args: [...cli.prefixArgs, ...args] }
+}
+
 /** dist/mcp/cli-path.js 기준 로컬 CLI(dist/index.js) 절대경로. */
 export function localCliPath(): string {
   const here = dirname(fileURLToPath(import.meta.url))

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,7 +10,7 @@ import { detectCurrentPM, parseAuditOutput, runAuditJson } from '../commands/aud
 import { readJsonFile } from '../lib/read-json.js'
 import { filterSevereFindings, scanProjectForSecrets } from '../lib/scan-secrets.js'
 import { getVhkVersion } from '../lib/version.js'
-import { resolveVhkCliInvocation, type VhkCliInvocation } from './cli-path.js'
+import { resolveVhkCliInvocation, composeInvocation, type VhkCliInvocation } from './cli-path.js'
 
 // package.json 의 version 을 런타임에 읽음 (lib/version 재사용) — drift 방지.
 // dist/index.js 와 dist/mcp/index.js 둘 다 lib/version 의 candidate 경로로 해석됨.
@@ -42,8 +42,8 @@ function runVhkCli(
   args: string[],
   headline: string
 ): { content: [{ type: 'text'; text: string }] } {
-  const cli = getVhkCli()
-  const result = safeExecFile(cli.bin, [...cli.prefixArgs, ...args], {
+  const { bin, args: fullArgs } = composeInvocation(getVhkCli(), args)
+  const result = safeExecFile(bin, fullArgs, {
     env: { FORCE_COLOR: '0', NO_COLOR: '1' },
   })
   const body = stripAnsi(result.out || (result.ok ? '' : `(stdout 없음)\n${result.err}`))

--- a/tests/init-adopt.test.ts
+++ b/tests/init-adopt.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+// ④ 대화형 adopt 분기 e2e — inquirer 를 모킹해 실제 init() 흐름(감지→adopt→RULES.md 채택)을 돈다.
+// (지금까지 순수함수(detectExistingRuleFiles/buildAdoptedRules)만 단위테스트 → 통합 경로 무검증이었음.)
+vi.mock('inquirer', () => ({
+  default: {
+    prompt: vi.fn(async (qs: unknown) => {
+      const q = (Array.isArray(qs) ? qs[0] : qs) as { name?: string }
+      if (q?.name === 'confirmStack') return { confirmStack: true }
+      if (q?.name === 'adopt') return { adopt: true }
+      if (q?.name === 'overwrite') return { overwrite: true }
+      return {}
+    }),
+  },
+}))
+
+describe('vhk init — ④ adopt 대화형 분기 e2e', () => {
+  let origCwd: string
+  let dir: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-adopt-e2e-'))
+    process.chdir(dir)
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    fs.rmSync(dir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  it('기존 .cursorrules 감지 → adopt 채택 → RULES.md 가 채택본(출처주석 포함)', async () => {
+    fs.writeFileSync('.cursorrules', '# 기존 프로젝트\n\n## 코딩 규칙\n- 채택될 규칙 XYZ\n', 'utf-8')
+
+    const { init } = await import('../src/commands/init.js')
+    await init({ name: 'my-app', description: '설명', type: 'cli' })
+
+    const rules = fs.readFileSync(path.join(dir, 'RULES.md'), 'utf-8')
+    expect(rules).toContain('채택될 규칙 XYZ') // 기존 규칙이 RULES.md 로 채택됨
+    expect(rules).toContain('.cursorrules') // 출처 주석
+  })
+})

--- a/tests/mcp-cli-path.test.ts
+++ b/tests/mcp-cli-path.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { pickCliInvocation } from '../src/mcp/cli-path.js'
+import { pickCliInvocation, composeInvocation } from '../src/mcp/cli-path.js'
 
 describe('MCP CLI 경로 resolve fallback (배치3 §5)', () => {
   it('전역 vhk 가 있으면 vhk 를 그대로 쓴다', () => {
@@ -20,5 +20,22 @@ describe('MCP CLI 경로 resolve fallback (배치3 §5)', () => {
     const r = pickCliInvocation(false, '/x/dist/index.js', false)
     expect(r.bin).toBe('vhk')
     expect(r.fallback).toBe(false)
+  })
+})
+
+describe('composeInvocation — ⑤ fallback 인자 합성 (실행 경로)', () => {
+  it('전역 vhk: prefixArgs 없이 args 그대로', () => {
+    expect(
+      composeInvocation({ bin: 'vhk', prefixArgs: [], fallback: false }, ['sync'])
+    ).toEqual({ bin: 'vhk', args: ['sync'] })
+  })
+
+  it('fallback: node + 로컬 dist/index.js + args 순서대로', () => {
+    expect(
+      composeInvocation(
+        { bin: process.execPath, prefixArgs: ['/x/dist/index.js'], fallback: true },
+        ['secure', 'scan']
+      )
+    ).toEqual({ bin: process.execPath, args: ['/x/dist/index.js', 'secure', 'scan'] })
   })
 })

--- a/tests/rules-import.test.ts
+++ b/tests/rules-import.test.ts
@@ -91,3 +91,18 @@ describe('rules-import — RULES.md 표준 섹션 병합', () => {
     expect(out).toContain('Node.js')
   })
 })
+
+describe('rules-import — ⑥ 인트로 보존 + 빈 섹션 0 (회귀)', () => {
+  it('첫 ## 이전 인트로를 서문으로 보존한다 (버리지 않음 → 잃으면 FAIL)', () => {
+    const files = [{ path: '.cursorrules', content: '# C\n\n중요한 인트로 메모입니다\n\n## 코딩 규칙\n- a\n' }]
+    const out = buildAdoptedRules(files, 'P')
+    expect(out).toContain('중요한 인트로 메모입니다')
+  })
+
+  it('본문 없는 빈 섹션은 제목/출처주석을 만들지 않는다 (오염 0)', () => {
+    const files = [{ path: '.cursorrules', content: '## 빈섹션\n\n## 코딩 규칙\n- a\n' }]
+    const out = buildAdoptedRules(files, 'P')
+    expect(out).not.toContain('## 빈섹션')
+    expect(out).toContain('## 코딩 규칙')
+  })
+})

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -9,6 +9,7 @@ import {
   truncateForAntigravity,
   ANTIGRAVITY_CHAR_LIMIT,
   SYNC_TARGETS,
+  findUnmappedSections,
 } from '../src/commands/sync.js'
 
 const SAMPLE_RULES = `# 데모 프로젝트 — Rules
@@ -79,6 +80,18 @@ describe('vhk sync — GitHub Copilot 변환', () => {
     expect(out.split('\n').slice(0, 5).join('\n')).toContain('자동 생성됨 (vhk sync). 직접 수정 금지')
     expect(out).toContain('execSync 금지')
     expect(out).not.toContain('docs/log/ 작성')
+  })
+})
+
+describe('vhk sync — ③ 미매칭 섹션 silent drop 방지 (회귀)', () => {
+  it('어느 타깃 키에도 안 맞는 섹션(프로젝트 정체성)을 잡는다 — 조용히 누락하면 FAIL', () => {
+    const sections = parseRulesMd('# P — Rules\n\n## 프로젝트 정체성\n- 한 줄: x\n\n## 코딩 규칙\n- a\n')
+    expect(findUnmappedSections(sections)).toContain('프로젝트 정체성')
+  })
+
+  it('매핑되는 섹션만 있으면 unmapped 0개', () => {
+    const sections = parseRulesMd('## 코딩 규칙\n- a\n\n## 기록 규칙\n- b\n')
+    expect(findUnmappedSections(sections)).toEqual([])
   })
 })
 


### PR DESCRIPTION
§6 PR#52 시절 잔여 MED 4건을 한 PR로 청산. 새 goal/check-goal 추가 없음(버그·테스트 빚).

| # | 수정 | 파일 |
|---|------|------|
| ③ | sync 미매칭 섹션 **silent drop** → `findUnmappedSections()` + sync() stderr 경고(조용히 안 버림) | `src/commands/sync.ts` |
| ⑥ | rules-import 인트로 손실 → 첫 `##` 이전 본문 **서문 보존** + 빈 섹션 0 | `src/lib/rules-import.ts` |
| ④ | init adopt 대화형 **e2e**(inquirer mock — 감지→adopt→RULES.md 채택) | `tests/init-adopt.test.ts` |
| ⑤ | MCP fallback **실행 경로** → `composeInvocation()` 추출 + 단위테스트 | `src/mcp/cli-path.ts` |

③⑥ 회귀테스트는 "조용히 누락하면 FAIL"로 작성.

게이트: tsc / test:run **504 pass** / build / scan / audit / check-meta / check-goal-0..6 / no-stray.

남은 위험: ③ 경고는 stderr 출력(미매칭 섹션 보존 아님 — 사용자가 표준 제목 쓰도록 유도). ⑤ MCP 전체 fallback exec e2e(전역 vhk 부재 시뮬)는 비현실적 → composeInvocation 순수 단위테스트로 대체.

🤖 Generated with [Claude Code](https://claude.com/claude-code)