### PR TITLE
fix: HARD_STOP 가드 + 로컬 타임존 날짜 + init→sync 회귀 (v1.6.2)

### DIFF
--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import chalk from 'chalk'
 import { ko } from '../i18n/ko.js'
+import { localDate } from '../lib/date.js'
 import { printNextStep } from '../lib/next-step.js'
 import { safeExecFile } from '../lib/exec.js'
 import {
@@ -266,7 +267,7 @@ export async function goalDone(opts: { id?: string }): Promise<void> {
     return
   }
   const content = readFileSync(target.filePath, 'utf-8')
-  const today = new Date().toISOString().slice(0, 10)
+  const today = localDate() // VHK-019
   const updated = updateFrontmatterStatus(content, 'DONE', { completed: today })
   writeFileSync(target.filePath, updated, 'utf-8')
   console.log(chalk.green(`\n  ✅ Goal ${id} → DONE (completed: ${today})`))

--- a/src/commands/harness.ts
+++ b/src/commands/harness.ts
@@ -5,6 +5,7 @@ import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { safeExecFile } from '../lib/exec.js'
 import { readJsonFile } from '../lib/read-json.js'
+import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
 
 type CheckSpec = { name: string; bin: string; args: string[] }
 
@@ -68,6 +69,7 @@ function detectChecks(): CheckSpec[] {
 }
 
 export async function harness(): Promise<void> {
+  if (!ensureNotHardStopped('harness')) return // VHK-020
   console.log(chalk.bold('\n🔧 ' + t('harness.title')))
   console.log(chalk.gray('─'.repeat(40)))
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,6 +3,7 @@ import type { DistinctQuestion } from 'inquirer'
 import chalk from 'chalk'
 import fs from 'node:fs'
 import path from 'node:path'
+import { localDate } from '../lib/date.js'
 import { CLAUDE_MD_TEMPLATE } from '../templates/claude-md.js'
 import { CURSORRULES_TEMPLATE } from '../templates/cursorrules.js'
 import { RULES_MD_TEMPLATE } from '../templates/rules-md.js'
@@ -237,7 +238,7 @@ export function generateFiles(
     'docs/adr/ADR-000-template.md': ADR_TEMPLATE(),
     'docs/log/.gitkeep': '',
     'docs/troubleshooting/.gitkeep': '',
-    'docs/til.md': `# TIL (Today I Learned)\n\n- [${new Date().toISOString().split('T')[0]}] 프로젝트 시작\n`,
+    'docs/til.md': `# TIL (Today I Learned)\n\n- [${localDate()}] 프로젝트 시작\n`, // VHK-019
     'BACKLOG.md': `# BACKLOG\n\n> v1 OUT 기능은 여기에 기록. 범위 수비 필수.\n\n## v1.1 후보\n\n- \n`,
     // .vhk/ 씨앗 — 규격: docs/spec.md (spec_version 1.0)
     '.vhk/README.md': VHK_README_TEMPLATE(),

--- a/src/commands/recap.ts
+++ b/src/commands/recap.ts
@@ -9,6 +9,7 @@ import { printNextStep } from '../lib/next-step.js'
 import { printSecurityWarnings } from '../lib/check-secure.js'
 import { ensureInteractive } from '../lib/interactive.js'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
+import { localDate } from '../lib/date.js'
 
 export type RecapOptions = {
   since?: string
@@ -32,7 +33,7 @@ export async function recap(options: RecapOptions = {}) {
   printSecurityWarnings()
 
   console.log(chalk.dim(`${ko.recap.analyzing}\n`))
-  const since = options.since || new Date().toISOString().split('T')[0]
+  const since = options.since || localDate()
   const diff = await getSessionDiff(since)
   const commits = await getRecentCommits(10, since)
 
@@ -94,7 +95,7 @@ export async function recap(options: RecapOptions = {}) {
     },
   ])
 
-  const today = new Date().toISOString().split('T')[0]
+  const today = localDate()
   const logDir = path.join(process.cwd(), 'docs', 'log')
   if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true })
 

--- a/src/commands/recap.ts
+++ b/src/commands/recap.ts
@@ -8,12 +8,14 @@ import { ko } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { printSecurityWarnings } from '../lib/check-secure.js'
 import { ensureInteractive } from '../lib/interactive.js'
+import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
 
 export type RecapOptions = {
   since?: string
 }
 
 export async function recap(options: RecapOptions = {}) {
+  if (!ensureNotHardStopped('recap')) return // VHK-020
   console.log(chalk.bold(`\n${ko.recap.title}\n`))
 
   if (!(await isGitRepo())) {

--- a/src/commands/ship.ts
+++ b/src/commands/ship.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { ko } from '../i18n/ko.js'
 import { log } from '../utils/logger.js'
 import { printNextStep } from '../lib/next-step.js'
+import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
 
 const CHECKLIST = [
   { id: 'build', questionKey: 'checkBuild' as const, hintKey: 'hintBuild' as const },
@@ -61,6 +62,7 @@ export function updateChangelogUnreleased(
 }
 
 export async function ship() {
+  if (!ensureNotHardStopped('ship')) return // VHK-020
   console.log(chalk.bold(`\n${ko.ship.title}\n`))
 
   const cwd = process.cwd()

--- a/src/commands/ship.ts
+++ b/src/commands/ship.ts
@@ -6,6 +6,7 @@ import { ko } from '../i18n/ko.js'
 import { log } from '../utils/logger.js'
 import { printNextStep } from '../lib/next-step.js'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
+import { localDate } from '../lib/date.js'
 
 const CHECKLIST = [
   { id: 'build', questionKey: 'checkBuild' as const, hintKey: 'hintBuild' as const },
@@ -128,7 +129,7 @@ export async function ship() {
   const buildLogDir = path.join(cwd, 'docs', 'build-log')
   if (!fs.existsSync(buildLogDir)) fs.mkdirSync(buildLogDir, { recursive: true })
 
-  const today = new Date().toISOString().split('T')[0]
+  const today = localDate() // VHK-019
   const versionSlug = sanitizeVersion(retro.version)
   const fileName = `${today}-v${versionSlug}.md`
   const filePath = path.join(buildLogDir, fileName)

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk'
 import fs from 'node:fs'
 import path from 'node:path'
 import inquirer from 'inquirer'
+import { localDate } from '../lib/date.js'
 import { ko } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { normalizeForCompare } from '../lib/drift.js'
@@ -326,7 +327,7 @@ export function buildSyncPlan(
   const claudeExists = fs.existsSync(claudePath)
   const existingClaude = claudeExists
     ? fs.readFileSync(claudePath, 'utf-8')
-    : `# 기록 규칙 (${projectName})\n\n## 현재 상태\n- **Phase:** **FILL**\n- **블로커:** 없음\n- **다음 액션:** **FILL**\n- **마지막 업데이트:** ${new Date().toISOString().split('T')[0]}`
+    : `# 기록 규칙 (${projectName})\n\n## 현재 상태\n- **Phase:** **FILL**\n- **블로커:** 없음\n- **다음 액션:** **FILL**\n- **마지막 업데이트:** ${localDate()}`
   const claudeNew = toClaudeMd(sections, existingClaude)
   const claudeDrift = claudeExists
     ? normalizeForCompare(existingClaude) !== normalizeForCompare(claudeNew)

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ import { start } from './commands/start.js'
 import { mode } from './commands/mode.js'
 import { verify } from './commands/verify.js'
 import { runGuarded } from './lib/safety-guard.js'
+import { ensureNotHardStopped } from './lib/hard-stop-guard.js'
 import { isPromptAbortError } from './lib/interactive.js'
 
 /**
@@ -50,6 +51,8 @@ async function guardCli(
   approved: boolean,
   run: () => Promise<void> | void,
 ): Promise<void> {
+  // VHK-020: HARD_STOP 활성 시 high-risk CLI 작업(save/deploy/publish/sync/migrate/cloud-pull/env-write) 차단.
+  if (!ensureNotHardStopped(action)) return
   await runGuarded(
     action,
     {

--- a/src/lib/adr.ts
+++ b/src/lib/adr.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import type { SessionDiff } from './git.js'
+import { localDate } from './date.js'
 
 export type AdrCandidate = {
   title: string
@@ -92,7 +93,7 @@ export function createAdrFile(
   if (!fs.existsSync(adrDir)) fs.mkdirSync(adrDir, { recursive: true })
 
   const num = nextAdrNumber(adrDir)
-  const today = new Date().toISOString().split('T')[0]
+  const today = localDate() // VHK-019
   const fileName = `ADR-${String(num).padStart(3, '0')}-${slugify(title)}.md`
   const filePath = path.join(adrDir, fileName)
 

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,13 @@
+/**
+ * VHK-019: 로컬 타임존 기준 `YYYY-MM-DD` 날짜 문자열.
+ *
+ * `new Date().toISOString().slice(0, 10)` 은 **UTC** 기준이라, KST(UTC+9) 자정~오전 9시
+ * 사이에 기록하면 '어제' 날짜가 찍혀 하루 밀린다(블로커/학습/TIL/recap 로그 등 날짜 오기록).
+ * `toLocaleDateString('sv-SE')` 는 로컬 타임존 + ISO 형식(YYYY-MM-DD)을 동시에 만족한다.
+ *
+ * 주의: 시각까지 필요한 머신 타임스탬프(생성시각 푸터·백업 파일명·HARD_STOP ts·memory addedAt)는
+ *      Z(UTC) 표기가 명확하므로 `toISOString()` 을 그대로 둔다. 이 함수는 '날짜 표기' 전용.
+ */
+export function localDate(d: Date = new Date()): string {
+  return d.toLocaleDateString('sv-SE')
+}

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import { simpleGit, type SimpleGit } from 'simple-git'
 import { filterTrackedPaths } from './check-secure.js'
+import { localDate } from './date.js'
 
 const git: SimpleGit = simpleGit()
 
@@ -80,7 +81,7 @@ export function buildSessionDiffFromSummary(diffSummary: {
 const EMPTY_TREE_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
 
 export async function getSessionDiff(since?: string): Promise<SessionDiff> {
-  const sinceDate = since || new Date().toISOString().split('T')[0]
+  const sinceDate = since || localDate() // VHK-019: 기본 since 는 로컬 '오늘'
   try {
     // VHK-015: `git diff --since` 는 무효(--since 는 log 옵션) → 워킹트리만 diff 해 항상 0.
     // since 직전 커밋(boundary)..HEAD 의 커밋 범위를 diff 해 실제 변경 통계를 낸다.

--- a/src/lib/hard-stop-guard.ts
+++ b/src/lib/hard-stop-guard.ts
@@ -1,0 +1,24 @@
+import chalk from 'chalk'
+import { isHardStopActive, readHardStopReason } from './state-files.js'
+
+/**
+ * VHK-020: `.vhk/HARD_STOP` 트립와이어 가드.
+ *
+ * HARD_STOP 이 존재하면 위험/자동화 작업을 즉시 차단한다 — 사유를 출력하고
+ * `process.exitCode = 1` 설정 후 `false` 를 반환하므로, 호출부는 곧바로 `return` 하면 된다.
+ *
+ * 적용처: CLI high-risk chokepoint(guardCli) + harness/recap/ship.
+ * 제외: `resume`(해제 명령) · `blocker`/`learn`(트립와이어를 *생성*하는 쪽) · 읽기전용(status 등).
+ * 해제는 사람이 직접 `vhk resume --confirm` 으로만 — 자동 호출 금지(CLAUDE.md Safety).
+ *
+ * @returns 진행 가능하면 true, HARD_STOP 으로 차단되면 false.
+ */
+export function ensureNotHardStopped(action: string): boolean {
+  if (!isHardStopActive()) return true
+  console.error(chalk.red.bold(`\n🛑 HARD STOP 활성 — '${action}' 을(를) 실행하지 않았습니다.`))
+  const reason = readHardStopReason()
+  if (reason) console.error(chalk.dim(`   사유: ${reason.replace(/\s*\n\s*/g, ' ')}`))
+  console.error(chalk.dim('   해제: vhk resume --confirm (사람이 직접 실행)'))
+  process.exitCode = 1
+  return false
+}

--- a/src/lib/state-files.ts
+++ b/src/lib/state-files.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
+import { localDate } from './date.js'
 
 // docs/state/{next-task,blockers,learnings}.md 와 .vhk/HARD_STOP 의
 // append-only / 카운트 / 트립와이어 동작을 한 곳에 모은 헬퍼.
@@ -23,7 +24,7 @@ function ensureVhkDir(): void {
 }
 
 function isoDate(): string {
-  return new Date().toISOString().slice(0, 10)
+  return localDate() // VHK-019: 로컬 타임존 날짜(UTC slice 는 KST 새벽에 하루 밀림)
 }
 
 // "- [YYYY-MM-DD goal-N] ..." 패턴이지만 ~~strikethrough~~ 로 감싸진 항목은

--- a/src/templates/claude-md.ts
+++ b/src/templates/claude-md.ts
@@ -1,5 +1,7 @@
+import { localDate } from '../lib/date.js'
+
 export function CLAUDE_MD_TEMPLATE(name: string, _stack: string): string {
-  const d = new Date().toISOString().split('T')[0];
+  const d = localDate(); // VHK-019
   const slug = name.toLowerCase().replace(/\s+/g, '-');
   return [
     '---',

--- a/tests/date.test.ts
+++ b/tests/date.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { localDate } from '../src/lib/date.js'
+
+/** Date 의 '로컬' getter 로 YYYY-MM-DD 를 직접 구성(로컬 타임존 기준 참값). */
+function localGetterDate(d: Date): string {
+  const p = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`
+}
+
+describe('localDate (VHK-019)', () => {
+  it('YYYY-MM-DD 형식을 반환한다', () => {
+    expect(localDate(new Date('2026-03-05T12:00:00Z'))).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('UTC 가 아니라 로컬 타임존 날짜를 쓴다(로컬 getter 와 일치)', () => {
+    // 어느 타임존에서 돌려도 로컬 getter 기준값과 같아야 함(toISOString 의 UTC 와 달리).
+    for (const iso of ['2026-05-31T16:00:00Z', '2026-01-01T02:30:00Z', '2026-12-31T23:59:00Z']) {
+      const d = new Date(iso)
+      expect(localDate(d)).toBe(localGetterDate(d))
+    }
+  })
+
+  it('버그 재현: UTC 저녁 시각은 KST 로 다음날 — UTC slice 는 하루 밀린다', () => {
+    // 2026-05-31 16:00Z = 2026-06-01 01:00 KST. 날짜 표기는 KST(로컬) 기준이어야 함.
+    const d = new Date('2026-05-31T16:00:00Z')
+    expect(d.toISOString().slice(0, 10)).toBe('2026-05-31') // 기존 버그: UTC '어제'
+    expect(d.toLocaleDateString('sv-SE', { timeZone: 'Asia/Seoul' })).toBe('2026-06-01') // KST '오늘'
+  })
+})

--- a/tests/hard-stop-guard.test.ts
+++ b/tests/hard-stop-guard.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { ensureNotHardStopped } from '../src/lib/hard-stop-guard.js'
+
+function tmpProject(label: string): string {
+  const dir = join(
+    tmpdir(),
+    `vhk-hardstop-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  )
+  mkdirSync(join(dir, '.vhk'), { recursive: true })
+  return dir
+}
+
+function writeHardStopFixture(dir: string, reason: string): void {
+  writeFileSync(join(dir, '.vhk', 'HARD_STOP'), `2026-05-31T00:00:00.000Z\n${reason}\n`, 'utf-8')
+}
+
+describe('HARD_STOP 가드 (VHK-020)', () => {
+  let origCwd: string
+  let origExitCode: number | string | undefined
+  let dir: string
+  let errSpy: ReturnType<typeof vi.spyOn>
+  let logSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    origCwd = process.cwd()
+    origExitCode = process.exitCode
+    dir = tmpProject('guard')
+    process.chdir(dir)
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    process.exitCode = origExitCode
+    rmSync(dir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  it('HARD_STOP 없으면 통과(true) + exitCode 미설정', () => {
+    expect(ensureNotHardStopped('save')).toBe(true)
+    expect(process.exitCode).not.toBe(1)
+  })
+
+  it('HARD_STOP 활성이면 차단(false) + exitCode 1 + action·사유 출력', () => {
+    writeHardStopFixture(dir, 'auto: 3 active blockers')
+    expect(ensureNotHardStopped('publish')).toBe(false)
+    expect(process.exitCode).toBe(1)
+    const out = errSpy.mock.calls.flat().join(' ')
+    expect(out).toContain('HARD STOP')
+    expect(out).toContain('publish')
+    expect(out).toContain('auto: 3 active blockers')
+  })
+
+  it('harness 는 HARD_STOP 시 본문 진입 전 중단(타이틀 미출력)', async () => {
+    writeHardStopFixture(dir, 'manual stop')
+    const { harness } = await import('../src/commands/harness.js')
+    await harness()
+    expect(process.exitCode).toBe(1)
+    expect(logSpy).not.toHaveBeenCalled() // 본문 첫 console.log(타이틀) 도달 안 함
+  })
+
+  it('recap 은 HARD_STOP 시 본문 진입 전 중단', async () => {
+    writeHardStopFixture(dir, 'manual stop')
+    const { recap } = await import('../src/commands/recap.js')
+    await recap({ since: '2026-05-30' })
+    expect(process.exitCode).toBe(1)
+    expect(logSpy).not.toHaveBeenCalled()
+  })
+
+  it('ship 은 HARD_STOP 시 본문 진입 전 중단', async () => {
+    writeHardStopFixture(dir, 'manual stop')
+    const { ship } = await import('../src/commands/ship.js')
+    await ship()
+    expect(process.exitCode).toBe(1)
+    expect(logSpy).not.toHaveBeenCalled()
+  })
+
+  it('resume 는 가드 제외 — HARD_STOP 활성에서도 실행되어 해제(--confirm)', async () => {
+    writeHardStopFixture(dir, 'manual stop')
+    const { resume } = await import('../src/commands/agent.js')
+    await resume({ confirm: true })
+    // resume 은 ensureNotHardStopped 로 차단되지 않고 정상 실행 → HARD_STOP 제거됨
+    expect(existsSync(join(dir, '.vhk', 'HARD_STOP'))).toBe(false)
+  })
+})

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import {
   parseRulesMd,
   toCursorrules,
@@ -10,7 +13,9 @@ import {
   ANTIGRAVITY_CHAR_LIMIT,
   SYNC_TARGETS,
   findUnmappedSections,
+  syncCore,
 } from '../src/commands/sync.js'
+import { generateFiles } from '../src/commands/init.js'
 
 const SAMPLE_RULES = `# 데모 프로젝트 — Rules
 
@@ -164,5 +169,22 @@ describe('vhk sync — Antigravity 변환 + 12k 절삭', () => {
     // 본문 마지막 줄은 헤딩이거나 완전한 x줄 — 빈 부분 토큰 아님
     const lastLine = body.split('\n').filter(Boolean).pop() ?? ''
     expect(lastLine.startsWith('## ') || lastLine === 'x'.repeat(60)).toBe(true)
+  })
+})
+
+describe('vhk init → sync 연결 (VHK-002 / #61 회귀)', () => {
+  it('init 이 항상 생성하는 RULES.md 를 sync 가 소비해 .cursorrules·CLAUDE.md 를 만든다', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-init-sync-'))
+    // #61: init 이 RULES.md 를 안 만들면 sync 가 그걸 요구하다 깨졌음 → 항상 생성됨을 보장.
+    const files = generateFiles('데모', '한 줄 설명', ['Node.js', 'TypeScript'])
+    expect(files['RULES.md']).toBeDefined()
+    fs.writeFileSync(path.join(dir, 'RULES.md'), files['RULES.md'], 'utf-8')
+
+    const result = await syncCore(dir, {}, async () => true)
+    // sync 가 init 산출 RULES.md 를 읽어 도구 파일을 정상 생성(흐름 단절 없음)
+    expect(result.written).toContain('.cursorrules')
+    expect(result.written).toContain('CLAUDE.md')
+    expect(fs.existsSync(path.join(dir, '.cursorrules'))).toBe(true)
+    fs.rmSync(dir, { recursive: true })
   })
 })


### PR DESCRIPTION
도그푸딩 잔여 이슈 마감 (v1.6.2).

Closes #78
Closes #79

#61 은 회귀테스트만 추가(핵심 수정은 300e81c, 이미 close).

- **#79 (HIGH):** `.vhk/HARD_STOP` 자동화 가드 — guardCli chokepoint + harness/recap/ship. resume/blocker/learn 제외.
- **#78 (MED):** 기록 날짜 UTC→로컬(`localDate()`), KST 하루밀림 제거. 머신 타임스탬프는 UTC 유지.
- **#61 (HIGH):** init→sync RULES.md 연결 회귀테스트.

게이트: tsc clean / 540 pass / build / scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)