### PR TITLE
docs: 2026-05-31 세션로그 + CLAUDE.md 역전파 (v1.6.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,17 +13,17 @@ tags: [process, documentation]
 
 - **레포:** <https://github.com/byh3071-cpu/vhk> (public)
 - **npm:** @byh3071/vhk (public, scoped)
-- **버전:** v1.4.0 (package.json + MCP SERVER_VERSION 정합)
+- **버전:** v1.6.2 (package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
 - **MCP tool:** 24/24 (Goal 0 DONE)
-- **테스트:** 356 pass (vitest)
+- **테스트:** 540 pass (vitest)
 - **패키지 매니저:** pnpm
 
 ## 현재 상태
 
-- **Phase:** Phase 5 종료 — Goal 0/1/2 모두 DONE. v1.4.0 릴리즈 prep.
+- **Phase:** Phase 5 이후 — 도그푸딩 20건 정정 + v1.6.2 출시 완료.
 - **블로커:** 없음
-- **다음 액션:** v1.4.0 npm publish → Goal 3 또는 Phase 6 (Product Hunt) 분기점
-- **마지막 업데이트:** 2026-05-30
+- **다음 액션:** v1.6.3 — #82(.vhk/cloud.json gitignore, 보안성) + #80(goal 스키마 문서화)
+- **마지막 업데이트:** 2026-05-31
 
 ## 코딩 컨벤션
 

--- a/docs/log/2026-05-31-v1.6.2-dogfooding-release.md
+++ b/docs/log/2026-05-31-v1.6.2-dogfooding-release.md
@@ -1,0 +1,84 @@
+---
+date: 2026-05-31
+project: VHK
+version: 1.6.1 → 1.6.2
+type: 세션로그
+---
+
+# 2026-05-31 — 도그푸딩 20건 정정 + HARD_STOP 가드/로컬TZ → v1.6.2 출시
+
+## 요약
+
+자가 사용(도그푸딩) 워크플로로 발견한 결함 **20건**을 클러스터 단위로 정정하고
+`@byh3071/vhk@1.6.2` 출시. 핵심은 **거짓 안심·오보 제거**(check 거짓 '통과', goal 빈상태 오보,
+recap 변경통계 0, status 커밋 카운트 불일치)와 **안전장치 활성화**(HARD_STOP 가드).
+테스트 356 계열 → **540 pass**, tsc/build/scan 클린, PR #81·#83 머지.
+
+## 무엇을 했나
+
+### 도그푸딩 배치 17건 (PR #81)
+
+- **#73 (HIGH) 대화형 크래시** — design/design-palette/recap 이 비-TTY/EOF stdin 에서
+  `ERR_USE_AFTER_CLOSE`(exit 13) + unsettled top-level await. `ensureInteractive()` 진입 가드 +
+  index.ts `parseAsync().catch(isPromptAbortError)` → friendly exit 1.
+- **#60 (HIGH) 스택 오인식** — init 이 `--type` 프리셋만 박고 실제 deps 무시 →
+  `detectProjectStack(package.json deps)` 로 실제 스택 감지(Vite/React/Anthropic 등),
+  greenfield 면 프리셋 폴백. **#77** Tailwind v4 CSS-first(@theme/@custom-variant) 인지.
+- **#70/#71 (HIGH) parseRules 오탐 + 거짓 통과** — 지침/메타 섹션 불릿 추출 제외,
+  구조(필수 디렉터리) 규칙은 아키텍처 섹션만(행동지침 경로가 severity=error 로 CI 깨뜨리던 지뢰 제거),
+  '금지'는 인접 백틱 코드 토큰만(github URL 금지패턴 오탐 제거). '모든 규칙 통과' 거짓안심 →
+  '자동 검증 N개 통과, 나머지 수동' 정직 보고.
+- **#64/#68 (보안) 민감파일 오탐** — `.env.example/.sample` 템플릿 제외,
+  `.env.local`·`.env.*.local` 인지(env-check·doctor·secure).
+- **#69/#75 (exit) 종료코드** — env-check·harness 실패 시 `process.exitCode=1`,
+  memory add 저장실패 exit≠0 + 자연어 흡수 회귀가드.
+- **LOW 배치 8건 (#62·63·65·66·67·72·74·76)** — 마크다운 정합(MD040 ```` ```text ````,
+  MD050 `__FILL__`→`**FILL**`), brief 가 RULES.md/CLAUDE.md 식별자 우선,
+  .vhk/README.md 의 없는 docs/spec.md → 외부 URL, CLAUDE.md AGENTS.md 참조 주석,
+  COMMANDS.md test 스크립트 감지 분기, check rule id 행번호(L<n>)+검사패턴 표기,
+  status 커밋 카운트 실제 length, recap diff boundary..HEAD, goal next 빈상태 분기.
+
+### v1.6.2 릴리즈 작업 (PR #83)
+
+- **#79 (HIGH) HARD_STOP 무효** — `.vhk/HARD_STOP` 이 존재해도 어떤 자동화도 안 막았음(안전장치 무효).
+  `ensureNotHardStopped(action)` 헬퍼 신설 → 활성 시 사유 출력 + exit 1 후 false. CLI high-risk
+  chokepoint(guardCli)에 배선해 save/deploy/publish/sync/migrate/cloud-pull/env-write 자동 커버,
+  harness/recap/ship 은 함수 진입부 직접 가드. **제외:** resume(해제 명령)·blocker/learn(트립와이어 생성측)·읽기전용.
+- **#78 (MED) UTC 날짜 하루밀림** — `toISOString().slice(0,10)` 이 UTC 라 KST 자정~09시엔 '어제'.
+  `localDate()`(`toLocaleDateString('sv-SE')`) 헬퍼로 날짜 표기 10곳 통일. 머신 타임스탬프(생성시각·백업·HARD_STOP ts·addedAt)는 UTC 유지.
+- **#61 (HIGH) init↔sync 단절** — 이미 300e81c(#52)에서 init 이 RULES.md 항상 생성하도록 수정됨.
+  코드 변경 없이 generateFiles→RULES.md→syncCore 회귀테스트 추가 + 정확한 커밋 인용 코멘트 후 close.
+
+### 릴리즈 게이트 + 출시
+
+- tsc --noEmit clean / 540 pass / tsup build / `secure scan` clean.
+- `npm version patch` → v1.6.2 commit+tag, main push(--follow-tags), `npm publish --access public`(2FA OTP).
+- SERVER_VERSION 은 `getVhkVersion()` 동적 → package.json 범프만으로 정합.
+
+## 교훈
+
+1. **"에러 없음" ≠ "정확함".** `git diff --since` 는 무효 옵션(--since 는 log 전용)이라 워킹트리만 diff 해
+   조용히 항상 0. 플래그가 그 서브커맨드 소속인지 확인하고, 출력이 '그럴듯한 0'인지 의심.
+2. **거짓 안심 금지.** 휴리스틱이 일부만 검사하면서 "모든 규칙 통과"라 하면 사용자는 안 한 검증을 했다고 오인.
+   자동 검증 가능 범위를 명시하고 나머지는 수동이라 밝혀라.
+3. **안전장치는 chokepoint 에서 집행돼야 장식이 아니다.** HARD_STOP 파일이 있어도 호출하는 가드가 없으면 무효.
+   단일 chokepoint(guardCli)에 가드 호출을 박고, 우회 경로(harness/recap/ship)는 진입부에 직접.
+4. **사실은 신호에서 도출, 프리셋에서 박지 마라.** init 이 deps 무시하고 정적 스택을 박아 SoT 문서에 틀린 스택 →
+   AI 가 틀린 스택 코드 제안 위험. package.json 같은 실제 신호로 감지, 실패 시 추측 대신 placeholder.
+5. **날짜는 로컬, 타임스탬프는 UTC.** 사람이 읽는 날짜 표기는 로컬 타임존(toLocaleDateString 'sv-SE'),
+   머신용 시각은 Z(UTC) 명시. 섞으면 KST 새벽에 하루 밀림.
+6. **파이프가 exit code 를 가린다.** `pnpm test:run | tail` 이 실패(exit 1)를 가려 깨진 커밋이 통과.
+   게이트 명령은 종료코드를 가리지 않게 실행하고 실제 코드를 확인.
+
+## 결과
+
+- npm: `@byh3071/vhk@1.6.2` (latest), git tag `v1.6.2`, main 머지 완료.
+- 닫힌 이슈 20건: #60 #62 #63 #64 #65 #66 #67 #68 #69 #70 #71 #72 #73 #74 #75 #76 #77 #78 #79 #61.
+- 테스트 540 pass(신규: hard-stop-guard 7 + date 3 + stack-detect 4 + rules-parser/interactive/sync 회귀 등).
+- 신규 모듈: `src/lib/hard-stop-guard.ts`, `src/lib/date.ts`, `src/lib/stack-detect.ts`, `src/lib/interactive.ts`.
+
+## 남은 것 (1.6.3 후보)
+
+- **#80 (MED)** goal 파일 스키마(type:goal, id 숫자) 미문서화 → 잘못 쓰면 silent skip. (계획상 연기)
+- **#82 (MED, 보안성)** `vhk cloud push` 의 `.vhk/cloud.json`(secret gist 포인터)이 gitignore 안 됨. 신규 발견 — 우선 처리 권장.
+- **역전파 TODO:** 프로젝트 CLAUDE.md '현재 상태'가 v1.4.0/356테스트로 stale → v1.6.2/540 으로 갱신 필요.


### PR DESCRIPTION
## 내용
- **세션로그:** `docs/log/2026-05-31-v1.6.2-dogfooding-release.md` — 도그푸딩 20건(#60·62~79·61) 정정 + HARD_STOP 가드/로컬TZ → v1.6.2 출시 기록. 교훈 6개 포함.
- **역전파:** CLAUDE.md '프로젝트 정보/현재 상태' 를 v1.4.0·356테스트(stale) → **v1.6.2·540테스트** 로 갱신, 다음 액션을 1.6.3(#82·#80)으로 교정.

코드 변경 없음(문서만). Notion Dev Log DB 에도 동일 세션로그 적재됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)