### PR TITLE
docs(patterns): 범용 패턴 8건 (v1.6.0~v1.6.2 교훈)

### DIFF
--- a/docs/patterns/build-exec-timeout-etimedout.md
+++ b/docs/patterns/build-exec-timeout-etimedout.md
@@ -1,0 +1,153 @@
+---
+패턴명: 자식 프로세스 timeout 판별은 ETIMEDOUT 단독으로, killed/signal 휴리스틱 금지
+카테고리: build
+출처프로젝트: VHK (vhk-cli)
+태그: [child-process, spawnSync, timeout, ETIMEDOUT, SIGINT, error-handling, nodejs]
+발견일: 2026-05-30
+출처DevLog: docs/log/2026-05-30-v1.6.0-drift-cloud-robustness.md
+---
+
+# 패턴: 자식 프로세스 timeout 판별은 ETIMEDOUT 단독으로
+
+## 증상
+
+CLI/툴이 외부 명령(`build`, `test`, `npm view` 등)을 `child_process` 로 실행하면서 hang 방지용 backstop timeout 을 건다. 그런데 timeout 식별을 `killed && signal` 로 하면, 사용자가 Ctrl+C(SIGINT)로 직접 중단하거나 부모가 SIGTERM 을 보낸 경우까지 "시간 초과"로 잘못 보고한다.
+
+```ts
+// ❌ 오라벨 발생 코드
+function isTimeoutError(e: { killed?: boolean; signal?: string }): boolean {
+  return Boolean(e.killed) && Boolean(e.signal) // SIGINT/SIGTERM 도 여기 걸림
+}
+```
+
+결과적으로 사용자가 의도적으로 끊은 작업에도 다음과 같은 오해 소지 메시지가 뜬다.
+
+```
+명령 시간 초과 (timeout 600000ms): pnpm build
+```
+
+실제로는 timeout 이 발사된 적이 없는데도, "killed 됐고 signal 이 있으니 timeout 이다"라는 휴리스틱이 외부 시그널을 timeout 으로 둔갑시킨다. 사용자/상위 자동화는 잘못된 원인(느린 빌드)에 매달려 디버깅한다.
+
+## 원인
+
+`child_process.spawnSync`(및 이를 쓰는 `execFileSync`)는 **timeout 으로 자식을 죽인 경우에만** `error.code === 'ETIMEDOUT'` 를 크로스플랫폼으로 세팅한다. 반면 `killed`/`signal` 필드는 timeout 종료뿐 아니라 **모든 시그널 종료**(외부 Ctrl+C → SIGINT, 부모의 SIGTERM, OOM killer 등)에서도 채워진다.
+
+- `killed: true` + `signal: 'SIGTERM'` → timeout 일 수도, 외부 종료일 수도 있다 (구별 불가).
+- `code: 'ETIMEDOUT'` → 오직 spawnSync 의 timeout 발사일 때만 존재한다 (명시적 신호).
+
+즉 `killed && signal` 은 timeout 의 **충분조건이 아니라 필요조건의 일부**일 뿐이다. 충분조건이 아닌 것을 판별에 쓰면 거짓 양성(false positive)이 난다.
+
+## 해결
+
+종료 원인은 휴리스틱이 아니라 런타임이 주는 **명시적 code** 로만 판별한다. `ETIMEDOUT` 단독 검사로 바꾸고, timeout 을 애초에 걸지 않은 호출은 검사 자체를 건너뛴다.
+
+`src/lib/exec.ts` 의 판별 함수:
+
+```ts
+// execFileSync(=spawnSync) 가 timeout 으로 죽인 경우 식별.
+// spawnSync 는 timeout 발사 시 err.code='ETIMEDOUT' 를 크로스플랫폼으로 설정한다.
+// killed/signal 로도 판별하면 외부 시그널(Ctrl+C 등)에 의한 종료를 timeout 으로 오라벨할 수
+// 있으므로 ETIMEDOUT 만 신뢰한다.
+function isTimeoutError(e: { code?: string }, timeout?: number): boolean {
+  if (!timeout) return false
+  return e.code === 'ETIMEDOUT'
+}
+```
+
+호출부는 이 판별로만 메시지를 분기한다 (`killed`/`signal` 은 보지 않는다):
+
+```ts
+} catch (err) {
+  const e = err as {
+    stdout?: Buffer | string
+    stderr?: Buffer | string
+    message?: string
+    killed?: boolean
+    signal?: string
+    code?: string
+  }
+  const stdout = e.stdout ? e.stdout.toString() : ''
+  let msg = e.message ?? String(err)
+  if (isTimeoutError(e, timeout)) {
+    msg = `명령 시간 초과 (timeout ${timeout}ms): ${cmd} ${args.join(' ')}`.trim()
+  }
+  return { ok: false, err: msg, out: stdout.trim() }
+}
+```
+
+**timeout 값 정책**도 함께 분리한다 — 정상 작업이 걸리지 않게 종류별로 다른 backstop 을 둔다.
+
+```ts
+// 기본 timeout 정책 — 외부 명령 hang 방지 backstop.
+// 10분: 정상적인 build/test/publish(2FA 제외) 는 절대 안 걸리고, 진짜 hang 만 끊는다.
+export const DEFAULT_EXEC_TIMEOUT_MS = 600_000
+// 네트워크 호출 (npm view 등) 전용 — 레지스트리 장애 시 빠르게 실패.
+export const NETWORK_EXEC_TIMEOUT_MS = 30_000
+```
+
+```ts
+// 적용할 timeout(ms) 계산. undefined 반환 = timeout 미적용.
+function resolveTimeout(timeoutMs: number | undefined, fallback: number): number | undefined {
+  const v = timeoutMs === undefined ? fallback : timeoutMs
+  return v > 0 ? v : undefined
+}
+```
+
+스트리밍/대화형 경로(2FA OTP 입력, `deploy` 실시간 로그 등)는 **timeout 면제**가 기본이다. 사용자 입력 대기가 정상 동작이므로 호출부가 명시할 때만 opt-in 한다.
+
+```ts
+export function safeExecFileStream(
+  cmd: string,
+  args: string[],
+  opts: SafeExecStreamOptions = {}
+): StreamResult {
+  const { bin, argv } = resolveCmd(cmd, args)
+  // stream 은 기본 timeout 없음 (2FA OTP 입력 등 사용자 대기가 정상). opts 로만 opt-in.
+  const timeout = opts.timeoutMs && opts.timeoutMs > 0 ? opts.timeoutMs : undefined
+  ...
+}
+```
+
+정리하면 세 가지 원칙이다.
+1. 종료 원인은 명시적 `code === 'ETIMEDOUT'` 로만 판별, `killed`/`signal` 휴리스틱 금지.
+2. backstop timeout 은 작업 성격별로 차등: 빌드/테스트는 넉넉히(~10분), 네트워크는 짧게(~30초).
+3. 스트리밍/대화형은 timeout 면제(opt-in), 사용자 입력 대기를 hang 으로 오인하지 않게.
+
+## 적용 조건
+
+- ✅ `spawnSync`/`execFileSync`/`execSync` 로 외부 명령을 동기 실행하며 hang 방지 timeout 을 거는 경우
+- ✅ 빌드/테스트/패키지 명령처럼 정상 실행 시간이 길고, 사용자가 Ctrl+C 로 중단할 수 있는 경우
+- ✅ 종료 원인(timeout vs 외부 시그널 vs 일반 실패)에 따라 메시지/재시도/로그를 다르게 처리해야 하는 경우
+- ✅ 네트워크 의존 명령(레지스트리 조회 등)에 별도의 짧은 backstop 을 주고 싶을 때
+- ❌ 비동기 `spawn`/`exec`(콜백·Promise) 의 경우 — 비동기는 `err.signal === 'SIGTERM'` + 직접 건 타이머로 판단하거나 `AbortController` 를 쓰므로 판별 로직이 다르다 (그래도 외부 시그널과의 구별 원칙은 동일하게 유지)
+- ❌ 대화형/스트리밍 명령(OTP 입력, 실시간 로그)에 무조건 timeout 을 거는 것 — 사용자 대기가 정상이므로 면제가 기본, 명시 opt-in 만 허용
+
+## 검증
+
+`tests/exec.test.ts` 가 timeout 발사·면제·정상 완료를 각각 검증한다.
+
+```ts
+it('safeExecFile: timeoutMs 초과 시 ok=false + 시간 초과 메시지', async () => {
+  const { safeExecFile } = await import('../src/lib/exec.js')
+  // setInterval 로 절대 self-exit 안 하는 프로세스 → 느린 머신에서도 timeout 만이 종료 사유 (flaky 제거).
+  const result = safeExecFile('node', ['-e', 'setInterval(() => {}, 1000)'], { timeoutMs: 200 })
+  expect(result.ok).toBe(false)
+  if (!result.ok) {
+    expect(result.err).toMatch(/시간 초과|timeout/i)
+  }
+})
+
+it('safeExecFile: timeoutMs<=0 이면 timeout 비활성 (정상 완료)', async () => {
+  const { safeExecFile } = await import('../src/lib/exec.js')
+  const result = safeExecFile('node', ['--version'], { timeoutMs: 0 })
+  expect(result.ok).toBe(true)
+})
+
+it('exec: 기본 timeout 상수 export 확인', async () => {
+  const { DEFAULT_EXEC_TIMEOUT_MS, NETWORK_EXEC_TIMEOUT_MS } = await import('../src/lib/exec.js')
+  // 네트워크 timeout 은 기본 backstop 보다 짧아야 의미가 있다.
+  expect(NETWORK_EXEC_TIMEOUT_MS).toBeLessThan(DEFAULT_EXEC_TIMEOUT_MS)
+})
+```
+
+테스트가 `setInterval`(절대 self-exit 안 함) 프로세스를 쓰는 이유도 같은 맥락이다 — 종료 사유를 timeout 하나로 고정해 flaky 를 제거하고, `killed`/`signal` 이 아니라 timeout 발사만이 종료 원인이 되도록 조건을 통제한다.

--- a/docs/patterns/env-windows-filename-sanitize.md
+++ b/docs/patterns/env-windows-filename-sanitize.md
@@ -1,0 +1,158 @@
+---
+패턴명: ISO 타임스탬프를 파일명에 쓰기 전 Windows 금지문자(:·.)를 sanitize 한다
+카테고리: env
+출처프로젝트: VHK (vhk-cli)
+태그: [windows, filename, cross-platform, iso-timestamp, sanitize, fs, ring-buffer, idempotency, sort-stability]
+발견일: 2026-05-31
+출처DevLog: docs/log/2026-05-31-safety-batches.md
+---
+
+# 패턴: 크로스플랫폼 파일명은 OS 금지문자를 sanitize 한 뒤 쓴다
+
+## 증상
+
+타임스탬프 기반으로 백업/로그/스냅샷 디렉터리·파일을 만들 때, `Date#toISOString()` 결과를 그대로 이름으로 사용하면 Windows(NTFS/exFAT)에서 쓰기가 실패한다.
+
+```ts
+const id = new Date().toISOString()        // "2026-05-31T12:34:56.789Z"
+fs.mkdirSync(path.join(root, id))          // ❌ Windows
+```
+
+```
+Error: ENOENT: no such file or directory, mkdir '...\2026-05-31T12:34:56.789Z'
+// 또는 EINVAL — 파일명에 ':' 사용 불가
+```
+
+- `:` 는 Windows 에서 파일명 금지문자(드라이브 문자/ADS 구분자로 예약). POSIX 에서는 통과하므로 macOS/Linux CI 에서만 녹색, Windows 사용자 환경에서만 깨지는 "내 머신에선 됐는데" 버그가 된다.
+- `.` 는 금지문자는 아니지만 확장자 경계로 오인되어, 같은 타임스탬프를 폴더명/파일명으로 재사용할 때 도구가 잘못 자르거나 혼동할 수 있다.
+
+여기에 더해, 타임스탬프 이름을 쓰는 ring buffer(최근 N개 보존) 구조에서 두 가지 2차 결함이 따라온다.
+
+1. **동일-ms 충돌로 인한 데이터 유실** — 같은 밀리초 안에 두 번 저장하면 디렉터리명이 충돌해 첫 백업이 두 번째에 덮여 영구 소실된다.
+2. **비멱등 정렬 churn 으로 인한 잘못된 evict** — 충돌 회피 suffix(`-1`, `-2`, …)를 단순 문자열로 정렬하면 `base-1000 < base-999`(렉시컬 뒤틀림)가 되어, 보존 정책이 "오래된 것"으로 오판하고 진짜 최신 백업을 지운다.
+
+## 원인
+
+- 파일시스템마다 파일명 금지문자 집합이 다르다. Windows 예약 문자: `< > : " / \ | ? *`. ISO 8601 타임스탬프는 시:분:초를 `:` 로, 밀리초를 `.` 로 구분하므로 Windows 금지문자를 항상 포함한다.
+- 단순 문자열 정렬(`localeCompare`/`<`)은 숫자를 자릿수가 아니라 문자 단위로 비교한다. 그래서 `"-1000" < "-999"`(첫 글자 `1` vs `9`) 가 되어, 1000회 이상 충돌하거나 zero-pad 자릿수를 넘기는 순간 시간순이 무너진다.
+- ring buffer 의 `prune` 는 "정렬된 목록의 앞 N개만 남긴다"는 가정에 의존한다. 정렬이 한 번이라도 비멱등하게 뒤틀리면 prune 은 멀쩡한 데이터를 evict 한다.
+
+## 해결
+
+핵심은 **이름을 짓는 순간 OS 금지문자를 정규화**하는 단일 헬퍼를 두고, 모든 경로 생성이 이를 거치게 하는 것. vhk 의 실제 구현(`src/lib/backup.ts`):
+
+```ts
+/**
+ * 파일시스템 안전 타임스탬프 — ISO 의 ':' '.' 를 '-' 로 치환.
+ * ⚠️ Windows 는 파일명에 ':' 를 허용하지 않으므로 raw ISO 를 디렉터리명으로 쓰면 실패한다.
+ * 예: 2026-05-30T09:19:17.358Z → 2026-05-30T09-19-17-358Z
+ */
+export function fsSafeStamp(d: Date): string {
+  return d.toISOString().replace(/[:.]/g, '-')
+}
+```
+
+`-` 로 치환하면 (1) 금지문자가 사라지고 (2) `Z` 로 끝나는 ISO 자릿수 고정 포맷이 유지되어 **렉시컬 정렬 == 시간순**이 보존된다.
+
+**동일-ms 충돌 방지** — 디렉터리가 이미 있으면 zero-pad suffix 로 유니크화:
+
+```ts
+export function saveBackup(files: string[], rootDir: string, stamp?: string): BackupInfo {
+  // 충돌 방지: 같은 ms(또는 같은 명시 stamp)로 재호출 시 기존 백업을 덮어쓰면 직전 원본이
+  // 영구 유실된다. 디렉터리가 이미 있으면 suffix 를 붙여 유니크화(시간순 정렬도 보존).
+  const baseId = stamp ?? fsSafeStamp(new Date())
+  let id = baseId
+  let n = 1
+  while (fs.existsSync(path.join(rootDir, BACKUPS_REL, id))) {
+    id = `${baseId}-${String(n++).padStart(3, '0')}`
+  }
+  // ... backupDir 생성 후 존재하는 파일만 구조 보존 복사
+}
+```
+
+**비멱등 정렬 churn 차단** — suffix 를 문자열이 아니라 숫자로 비교해, zero-pad 자릿수를 넘겨도 시간순을 보장:
+
+```ts
+/**
+ * 백업 id 정렬 키 — baseId(시간순 ISO 문자열, 'Z' 종료) + 숫자 suffix.
+ * 단순 문자열 정렬은 충돌 suffix 에서 base-1000 < base-999 처럼 렉시컬 뒤틀림이 생긴다
+ * (zero-pad 도 자릿수 넘으면 재발). 숫자로 비교해 어떤 suffix 폭에서도 시간순을 보장.
+ */
+function backupOrderKey(id: string): [string, number] {
+  const m = /^(.*Z)(?:-(\d+))?$/.exec(id)
+  return m ? [m[1], m[2] ? parseInt(m[2], 10) : 0] : [id, 0]
+}
+
+export function listBackups(rootDir: string): BackupInfo[] {
+  // ...
+  return fs.readdirSync(root)
+    .filter((e) => fs.statSync(path.join(root, e)).isDirectory())
+    .sort((a, b) => {
+      const [ba, na] = backupOrderKey(a)
+      const [bb, nb] = backupOrderKey(b)
+      if (ba !== bb) return ba < bb ? 1 : -1 // base 시간 역순(최신 먼저)
+      return nb - na                          // 같은 base 면 suffix 큰(나중) 것 먼저
+    })
+    .map(/* ... */)
+}
+```
+
+보존 정책은 이 안정 정렬에만 의존하므로 단순하게 유지된다:
+
+```ts
+/** 보존 정책 — 최근 keepN 개만 남기고 오래된 백업 삭제. 삭제한 id 목록 반환. */
+export function pruneBackups(keepN: number, rootDir: string): string[] {
+  const all = listBackups(rootDir) // 최신순
+  const toDelete = all.slice(Math.max(0, keepN))
+  for (const b of toDelete) fs.rmSync(b.dir, { recursive: true, force: true })
+  return toDelete.map((b) => b.id)
+}
+```
+
+일반화 규칙:
+1. 외부 입력(타임스탬프, 사용자 라벨, 브랜치명 등)을 파일명으로 쓰기 전 **항상 OS 금지문자를 sanitize** 하는 단일 함수를 통과시킨다.
+2. 치환 문자는 **정렬 안정성을 깨지 않는 것**(자릿수 고정 포맷이면 `-`)을 고른다.
+3. 동일 키 충돌 가능성이 있으면 **유니크 suffix** 로 덮어쓰기를 막는다.
+4. suffix 정렬은 **문자열이 아니라 숫자**로 비교한다.
+
+## 적용 조건
+
+- ✅ 타임스탬프/사용자 입력으로 파일·디렉터리 이름을 만들고, Windows를 포함한 다중 OS를 지원할 때
+- ✅ 최근 N개만 남기는 ring buffer / 보존 정책이 "정렬 후 앞 N개" 가정에 의존할 때
+- ✅ 동일 시각(ms)에 두 번 이상 같은 작업이 일어날 수 있을 때(루프, 배치, 빠른 연속 호출)
+- ❌ POSIX 전용 환경이 보장되고 이름이 항상 유일하며 정렬에 의존하지 않을 때(과한 방어)
+- ❌ 이름이 라이브러리/OS가 생성하는 안전한 식별자(UUID 등)이고 금지문자가 원천적으로 없을 때
+
+## 검증
+
+vitest 회귀 테스트(`tests/backup.test.ts`)가 sanitize·충돌·정렬 churn 세 결함을 모두 고정한다.
+
+```ts
+describe('fsSafeStamp', () => {
+  it('콜론·점 제거 — Windows 파일명 금지문자 안전', () => {
+    const s = fsSafeStamp(new Date('2026-05-30T09:19:17.358Z'))
+    expect(s).not.toMatch(/[:.]/)
+    expect(s).toBe('2026-05-30T09-19-17-358Z')
+  })
+})
+
+// 회귀: 같은 ms 타임스탬프로 연속 백업 시 디렉터리 충돌로 첫 백업이 덮여 영구 유실되면 안 됨.
+it('같은 stamp 재호출 → 유니크 디렉터리 (첫 백업 덮어쓰기 방지)', () => {
+  write('.cursorrules', 'FIRST')
+  const a = saveBackup(['.cursorrules'], dir, '2026-09-09T00-00-00-000Z')
+  write('.cursorrules', 'SECOND')
+  const b = saveBackup(['.cursorrules'], dir, '2026-09-09T00-00-00-000Z')
+  expect(a.id).not.toBe(b.id)
+  expect(fs.readFileSync(path.join(a.dir, '.cursorrules'), 'utf-8')).toBe('FIRST')
+  expect(fs.readFileSync(path.join(b.dir, '.cursorrules'), 'utf-8')).toBe('SECOND')
+})
+
+// 회귀: 문자열 정렬이면 'base-999' > 'base-1001' 로 뒤틀려 pruneBackups 가 진짜 최신을 evict.
+it('suffix 4자리 경계도 숫자 정렬 (base-1001 > base-1000 > base-999)', () => {
+  const base = '2026-09-09T00-00-00-000Z'
+  // base-999 / base-1000 / base-1001 디렉터리 생성 후
+  expect(listBackups(dir).map((b) => b.id)).toEqual([
+    `${base}-1001`, `${base}-1000`, `${base}-999`,
+  ])
+})
+```

--- a/docs/patterns/git-crlf-normalize-before-compare.md
+++ b/docs/patterns/git-crlf-normalize-before-compare.md
@@ -1,0 +1,115 @@
+---
+패턴명: 콘텐츠 동등성 비교 전 CRLF→LF 정규화로 거짓 드리프트 차단
+카테고리: git
+출처프로젝트: VHK (vhk-cli)
+태그: [crlf, lf, line-ending, autocrlf, gitattributes, normalization, drift-detection, content-comparison]
+발견일: 2026-05-30
+출처DevLog: docs/log/2026-05-30-v1.6.0-drift-cloud-robustness.md
+---
+
+# 패턴: 콘텐츠 동등성 비교 전 줄바꿈(CRLF→LF) 정규화로 거짓 드리프트 차단
+
+## 증상
+
+디스크에 저장된 파일과 "기대값(재생성/스냅샷/템플릿 출력)"을 문자열로 직접 비교하는 검증 로직이, 내용은 완전히 동일한데도 계속 "변경됨 / 불일치 / 드리프트"로 판정한다.
+
+- Windows 개발자만 실패하고 macOS/Linux 동료는 통과하거나, CI는 통과하는데 로컬만 실패한다.
+- diff 를 떠 보면 줄 내용은 같고 줄바꿈만 다르다. 눈으로는 차이가 안 보인다.
+
+```text
+# "갓 생성한 직후"인데도 불일치로 뜸
+expected (재생성, LF):  "rule a\nrule b\n"
+actual   (디스크, CRLF): "rule a\r\nb\r\n"   ← \r 때문에 === 가 false
+```
+
+```ts
+// 흔한 버그 패턴: 줄바꿈을 그대로 둔 채 === 로 비교
+const expected = template.generate(...)            // 코드가 만든 문자열 → LF
+const actual = fs.readFileSync(fullPath, 'utf-8')  // 디스크 파일 → CRLF
+const drifted = expected !== actual                // 항상 true (거짓 드리프트)
+```
+
+## 원인
+
+`core.autocrlf=true`(Windows Git 기본값에 가까움) 환경에서 레포에 `.gitattributes` 가 없으면, Git 은 체크아웃 시 텍스트 파일의 LF 를 CRLF 로 변환해서 디스크에 쓴다. 반면 코드가 런타임에 만들어내는 "기대 문자열"(템플릿 렌더링, 직렬화, 재생성 결과)은 거의 항상 LF 다.
+
+따라서 같은 논리적 내용이라도 디스크본은 `\r\n`, 기대본은 `\n` 이 되어 바이트 단위 `===` 가 어긋난다. 추가로 에디터/툴마다 다른 trailing whitespace, 파일 끝 빈 줄 개수, BOM(`﻿`) 도 같은 종류의 "내용은 같은데 바이트는 다른" 거짓 불일치를 만든다.
+
+핵심: **콘텐츠 동등성**(내용이 같은가)을 묻고 싶은데 **바이트 동등성**(인코딩 표현까지 같은가)으로 비교하면, 플랫폼/도구 차이가 그대로 거짓 양성으로 새어 나온다.
+
+## 해결
+
+비교 직전에 **양쪽 문자열 모두**를 같은 규칙으로 정규화한 뒤 비교한다. 줄 내부 내용은 절대 건드리지 않고, 표현 차이(줄바꿈/끝 공백/끝 빈 줄)만 제거한다.
+
+vhk-cli 의 실제 구현 (`src/lib/drift.ts`):
+
+```ts
+/**
+ * 비교용 정규화 — CRLF→LF + 끝 공백/빈줄 제거.
+ * `.gitattributes` 없고 core.autocrlf=true 인 환경에서 디스크 파일이 CRLF 로 체크아웃되어
+ * LF 재생성본과 매번 어긋나는 **거짓 드리프트**를 막는다. (줄 내용은 안 건드림.)
+ */
+export function normalizeForCompare(s: string): string {
+  return s.replace(/\r\n/g, '\n').replace(/[ \t]+$/gm, '').replace(/\n+$/, '\n')
+}
+```
+
+세 단계의 의미:
+
+- `.replace(/\r\n/g, '\n')` — CRLF→LF 통일 (autocrlf 거짓 드리프트의 주원인 제거)
+- `.replace(/[ \t]+$/gm, '')` — 각 줄 끝의 공백/탭 제거 (`m` 플래그로 모든 줄에 적용)
+- `.replace(/\n+$/, '\n')` — 파일 끝 빈 줄을 하나로 정규화
+
+비교하는 쪽은 **반드시 양쪽 다** 정규화해야 한다. 한쪽만 정규화하면 거짓 불일치가 남는다 (`src/lib/drift.ts` 의 `checkRuleDrift`):
+
+```ts
+const expected = normalizeForCompare(target.generate(sections, projectName))
+const actual = normalizeForCompare(fs.readFileSync(fullPath, 'utf-8'))
+results.push({ path: target.path, status: expected === actual ? 'ok' : 'drifted' })
+```
+
+BOM 까지 방어해야 한다면 선두 `﻿` 제거를 한 단계 더 붙인다 (`.replace(/^﻿/, '')`).
+
+근본 예방책으로 레포에 `.gitattributes` 를 두어 텍스트 파일의 줄바꿈을 고정하는 것도 권장된다 (예: `* text=auto eol=lf`). 다만 이건 새 체크아웃에만 적용되고 이미 받은 작업트리에는 소급되지 않으므로, **비교 로직 자체의 정규화가 1차 방어선**이다.
+
+## 적용 조건
+
+- ✅ 디스크 파일 vs 코드가 만든 기대 문자열(템플릿/재생성/스냅샷)을 동등성 비교할 때
+- ✅ 멀티 플랫폼(Windows + macOS/Linux) 협업으로 줄바꿈이 섞일 수 있는 레포
+- ✅ `.gitattributes` 가 없거나 `core.autocrlf` 설정이 개발자마다 제각각인 환경
+- ✅ "변경 감지 / 드리프트 / 동기화 필요" 류의 읽기 전용 판정 로직
+- ❌ 바이트 단위 정확성이 본질인 경우 (체크섬 검증, 서명 대상 원문, 바이너리 파일) — 이때는 정규화하면 안 됨
+- ❌ 줄바꿈 스타일 자체를 검사·강제하는 린터/포매터 (CRLF 존재 여부가 판정 대상이므로 지우면 안 됨)
+- ❌ 정규화 규칙을 한쪽 비교 대상에만 적용 (양쪽 동일 적용이 아니면 효과 없음)
+
+## 검증
+
+`tests/drift.test.ts` 가 정규화 자체와 실제 드리프트 판정에서의 동작을 모두 검증한다.
+
+```ts
+describe('normalizeForCompare', () => {
+  it('CRLF→LF 통일 — autocrlf 거짓 드리프트 방지', () => {
+    expect(normalizeForCompare('a\r\nb\r\n')).toBe(normalizeForCompare('a\nb\n'))
+  })
+  it('끝 공백/빈줄 차이 무시', () => {
+    expect(normalizeForCompare('a\nb   \n\n\n')).toBe(normalizeForCompare('a\nb\n'))
+  })
+  it('내용 차이는 유지', () => {
+    expect(normalizeForCompare('a\nb')).not.toBe(normalizeForCompare('a\nc'))
+  })
+})
+```
+
+실제 파일을 CRLF 로 다시 써도 드리프트로 오탐하지 않음을 확인하는 통합 테스트:
+
+```ts
+it('CRLF 로 체크아웃돼도 ok (정규화)', () => {
+  const cursor = path.join(dir, '.cursorrules')
+  const crlf = fs.readFileSync(cursor, 'utf-8').replace(/\n/g, '\r\n')
+  fs.writeFileSync(cursor, crlf, 'utf-8')
+  const r = checkRuleDrift(dir)
+  expect(r.results.find(x => x.path === '.cursorrules')?.status).toBe('ok')
+})
+```
+
+마지막 "내용 차이는 유지" 케이스가 핵심 안전망이다 — 정규화가 줄바꿈/공백만 지우고 **진짜 내용 차이는 보존**함을 보장하여, 거짓 양성을 없애면서 진짜 드리프트를 놓치지 않는다.

--- a/docs/patterns/git-diff-since-no-op.md
+++ b/docs/patterns/git-diff-since-no-op.md
@@ -1,0 +1,126 @@
+---
+패턴명: git diff 에 --since 를 쓰면 무시되어 변경 통계가 항상 0
+카테고리: git
+출처프로젝트: VHK (vhk-cli)
+태그: [git, git-diff, git-log, git-rev-list, cli-flags, no-op, date-range, silent-failure]
+발견일: 2026-05-31
+출처DevLog: docs/log/2026-05-31-v1.6.2-dogfooding-release.md
+---
+
+# 패턴: `git diff --since=<date>` 는 무효 — 워킹트리만 비교되어 변경 통계가 항상 0
+
+## 증상
+
+특정 날짜 이후의 변경 통계(파일 수/추가·삭제 라인)를 내려고 `git diff` 에 `--since` 를 붙였는데,
+에러는 전혀 나지 않으면서 **결과가 항상 0** 으로 나온다.
+
+```bash
+# 의도: "2026-05-01 이후 변경" 통계
+git diff --since=2026-05-01 --stat
+# → 에러 없음. 그러나 출력은 날짜와 무관하게
+#   "현재 워킹트리 vs HEAD" 의 차이(보통 0)만 나옴
+```
+
+코드로 옮기면 다음과 같이 항상 빈/0 결과가 돌아온다.
+
+```ts
+// ❌ 잘못된 구현 — diff 가 --since 를 조용히 무시한다
+const diff = await git.diffSummary(['--since', since])
+// diff.insertions === 0, diff.deletions === 0, diff.files === []  (날짜와 무관)
+```
+
+`--since` 는 `git log` 의 리비전-셀렉션 옵션이지 `git diff` 의 옵션이 아니다.
+`git diff` 는 모르는 인자를 (대부분) 무시하고 기본 동작(인덱스/워킹트리 비교)을 수행한다.
+즉 **"에러 없는 0"** 이라 정상 통과처럼 보이지만 실제로는 옵션이 통째로 버려진 상태다.
+
+## 원인
+
+CLI 서브커맨드마다 받아들이는 플래그가 다른데, 이를 혼동한 것이 근본 원인이다.
+
+- `--since` / `--until` / `--after` / `--before` 는 **`git log` (리비전 워크) 전용** 날짜 필터다.
+  커밋 그래프를 시간으로 잘라 어떤 커밋을 보여줄지 고르는 옵션이다.
+- `git diff` 는 **두 트리(커밋/인덱스/워킹트리)의 스냅샷 비교** 도구라 날짜 개념 자체가 없다.
+  비교 대상은 "리비전 또는 범위"로 지정해야 하며, 날짜로는 지정할 수 없다.
+
+`git diff` 에 `--since` 를 넘기면 알 수 없는 옵션으로 취급되어 효과 없이 무시되고,
+인자 없는 `git diff`(= 워킹트리 vs 스테이징/HEAD)로 동작한다.
+깨끗한 트리에서는 그 차이가 0이므로 "조용한 실패(silent no-op)"가 된다.
+
+## 해결
+
+**날짜를 직접 diff 에 넘기지 말고, 날짜를 경계 커밋 SHA 로 먼저 변환한 뒤 커밋 범위(`<boundary>..HEAD`)를 diff 한다.**
+
+1. `git rev-list -1 --before=<date> HEAD` 로 그 날짜 **직전 커밋(boundary)** 의 SHA 를 구한다.
+   (`rev-list` 는 `log` 계열이라 `--before` 날짜 필터가 유효하다.)
+2. 그 boundary 에서 `HEAD` 까지의 **커밋 범위**를 diff 한다.
+3. boundary 가 없으면(= 해당 날짜 이전 커밋이 하나도 없음, 전체 히스토리가 대상)
+   **빈 트리 SHA** 를 기준점으로 써서 "최초부터 지금까지"를 비교한다.
+
+실제 vhk 구현 (`src/lib/git.ts`):
+
+```ts
+/** 빈 트리 SHA — since 가 전체 히스토리를 포함할 때(boundary 없음) diff 기준점. */
+const EMPTY_TREE_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+
+export async function getSessionDiff(since?: string): Promise<SessionDiff> {
+  const sinceDate = since || localDate() // 기본 since 는 로컬 '오늘'
+  try {
+    // `git diff --since` 는 무효(--since 는 log 옵션) → 워킹트리만 diff 해 항상 0.
+    // since 직전 커밋(boundary)..HEAD 의 커밋 범위를 diff 해 실제 변경 통계를 낸다.
+    const boundary = (await git.raw(['rev-list', '-1', `--before=${sinceDate}`, 'HEAD'])).trim()
+    const base = boundary || EMPTY_TREE_SHA
+    const diffSummary = await git.diffSummary([`${base}..HEAD`])
+    // ... diffSummary.insertions / deletions / files 로 통계 구성
+  } catch {
+    return { filesChanged: 0, insertions: 0, deletions: 0, files: [] }
+  }
+}
+```
+
+핵심 변환은 두 줄이다.
+
+```ts
+const boundary = (await git.raw(['rev-list', '-1', `--before=${sinceDate}`, 'HEAD'])).trim()
+const base = boundary || EMPTY_TREE_SHA
+const diffSummary = await git.diffSummary([`${base}..HEAD`])
+```
+
+`git.diffSummary` 에는 날짜가 아니라 **리비전 범위 문자열(`base..HEAD`)** 하나만 넘어간다.
+또한 커밋이 0개인 신규 레포에서는 `rev-list`/`diff` 가 throw 하므로 `try/catch` 로 흡수해 빈 결과를 반환한다.
+
+> 교훈: **CLI 플래그가 그 서브커맨드 소속인지 먼저 확인하라.**
+> 어떤 옵션이 `log` 전용인데 `diff` 에 붙이면 에러가 아니라 "무시"로 끝난다.
+> **"에러 없이 0" 은 정상이 아니라 옵션 무시일 수 있다** — 0/빈 결과가 나올 때
+> "정말 0인지" vs "필터가 먹지 않은 것인지"를 의심하라.
+
+## 적용 조건
+
+- ✅ "특정 날짜/시점 이후의 변경"을 diff 통계(파일 수·추가/삭제 라인)로 내야 할 때
+- ✅ `git log` 계열 날짜 플래그(`--since`/`--before`/`--after`/`--until`)를 `git diff` 에 잘못 넘기고 있을 때
+- ✅ simple-git 등 래퍼로 diff 를 호출하는데 결과가 항상 0/빈 배열로 나올 때
+- ✅ 날짜 → 커밋 SHA 변환이 가능한 환경(로컬 git 히스토리 존재)일 때
+- ❌ "커밋이 아니라 워킹트리/스테이징의 현재 미커밋 변경"을 보고 싶을 때 (이때는 인자 없는 `git diff` 가 맞다)
+- ❌ "어떤 커밋을 보여줄지" 목록만 필요할 때 — 그건 원래 `git log --since` 로 충분하다(이 경우 `--since` 는 유효)
+- ❌ 빈 트리 SHA 미지원/비표준 git 호환 도구 — `EMPTY_TREE_SHA` 폴백이 통하지 않을 수 있음
+
+## 검증
+
+`getSessionDiff` 의 boundary→범위 변환 로직을 직접 검증하는 단위 테스트는 없다.
+상위 소비자 테스트(`tests/recap.test.ts`)는 `getSessionDiff` 를 모킹해 호출부만 검증한다.
+
+```ts
+// tests/recap.test.ts
+vi.mock('../src/lib/git.js', () => ({
+  getSessionDiff: (...a: unknown[]) => mockGetSessionDiff(...a),
+  getRecentCommits: (...a: unknown[]) => mockGetRecentCommits(...a),
+}))
+```
+
+수동 검증 절차:
+
+```bash
+# boundary 가 잡히는지 먼저 확인 (비어 있으면 EMPTY_TREE_SHA 로 폴백됨)
+git rev-list -1 --before=2026-05-01 HEAD
+# 그 범위의 실제 통계가 0 이 아닌 값으로 나오는지 확인
+git diff --stat <boundary>..HEAD
+```

--- a/docs/patterns/state-single-chokepoint-guard.md
+++ b/docs/patterns/state-single-chokepoint-guard.md
@@ -1,0 +1,233 @@
+---
+패턴명: 위험 작업 가드는 단일 통제점 + 완전성 게이트로 집행한다
+카테고리: state
+출처프로젝트: VHK (vhk-cli)
+태그: [safety, guard, chokepoint, security, completeness-test, drift-detection, policy-as-data]
+발견일: 2026-05-31
+출처DevLog: docs/log/2026-05-31-safety-batches.md
+---
+
+# 패턴: 위험/파괴적 작업 가드 — 분산 if 배선 대신 단일 chokepoint + 완전성 매핑 테스트
+
+## 증상
+
+되돌리기 어렵거나 외부에 영향을 주는 작업(배포·삭제·되돌리기·시크릿 파일 쓰기 등)에 "확인 가드"를 호출부마다 손으로 `if` 배선했더니, 일부 진입 경로가 가드를 안 거치는 바이패스가 생긴다.
+
+- 같은 위험 작업이 여러 입구(대화형 CLI / 에이전트 도구 / 자연어 라우터 / 인라인 메뉴 switch)에서 호출되는데, 새 입구를 추가할 때 가드 한 줄을 빠뜨림.
+- 자연어 라우터가 핸들러를 **직접** 호출해 확인 단계를 건너뜀:
+
+```ts
+// 위험: dispatch 가 가드 없이 핸들러 직호출
+case 'deploy': return deploy()   // ← 확인 절차 우회
+```
+
+- 또 다른 함정: 안전장치 "파일"(예: `.vhk/HARD_STOP` 같은 트립와이어)을 만들어 두었지만, 그 파일을 **읽고 차단하는 가드 호출이 어디에도 없으면** 파일은 장식일 뿐 아무것도 막지 못한다.
+- 비대화형(TTY 아님) 환경에서 확인 프롬프트가 그냥 통과되어 위험 작업이 무인 실행되는 경우도 발생.
+
+## 원인
+
+- **정책과 집행의 분산.** "무엇이 위험한가"의 판단과 "어떻게 막을까"의 코드가 호출부마다 흩어지면, 입구가 N개일 때 가드도 N군데에 중복 배선해야 하고 한 곳만 누락돼도 구멍이 생긴다. (드리프트)
+- **별도 손관리 리스트.** 위험 작업 목록을 여러 파일에 각자 하드코딩하면 동기화가 깨진다.
+- **트립와이어 ≠ 가드.** 신호 파일의 *존재*와 그 신호를 *집행*하는 코드는 별개다. 집행 호출이 없으면 신호는 무효.
+- **완전성 검증 부재.** "모든 위험 작업이 빠짐없이 가드를 거치는가"를 검사하는 테스트가 없으면, 신규 작업 추가 시 누락이 조용히 통과한다.
+
+## 해결
+
+핵심 3원칙: ① 정책은 데이터 한 곳에, ② 집행은 단일 chokepoint 하나로, ③ 누락은 완전성 테스트가 FAIL.
+
+### 1) 정책을 단일 소스(데이터)로 — `src/lib/risk-policy.ts`
+
+위험 작업 목록과 채널·모드별 가드 결정을 한 파일에만 둔다. 다른 곳에 같은 리스트를 나열하지 않는다.
+
+```ts
+/** 정책 적용 대상 high-risk 액션 — 되돌리기 어렵거나 외부에 영향 주는 작업. */
+export const HIGH_RISK_ACTIONS = [
+  'undo', 'deploy', 'publish', 'migrate',
+  'cloud-pull', 'resume', 'env-write', 'delete',
+] as const
+
+export type Channel = 'cli' | 'mcp' | 'nl'
+export type Guard = 'confirm' | 'preview' | 'warn' | 'allow'
+
+export function isHighRisk(action: string): action is HighRiskAction {
+  return (HIGH_RISK_ACTIONS as readonly string[]).includes(action)
+}
+
+/** 액션·모드·채널 → 가드 결정 (정책은 여기서만 내린다) */
+export function resolveGuard(action: string, mode: SafetyMode, channel: Channel): Guard {
+  const guarded = isHighRisk(action) || (mode === 'strict' && STRICT_EXTRA_ACTIONS.has(action))
+  if (!guarded) return 'allow'
+  if (mode === 'lite') return 'warn'                 // 막지 않고 경고만
+  return channel === 'cli' ? 'confirm' : 'preview'   // CLI=y/N, 에이전트/자연어=미리보기
+}
+```
+
+자연어 라우터가 가드를 거쳐야 하는 명령도 이 파일에 **단일 매핑**으로 등록한다(별도 손관리 리스트 금지):
+
+```ts
+export const NL_GUARDED_ACTIONS: Readonly<Record<string, string>> = {
+  undo: 'undo', deploy: 'deploy', publish: 'publish', migrate: 'migrate',
+  'cloud-pull': 'cloud-pull', env: 'env-write', save: 'save', sync: 'sync',
+}
+```
+
+### 2) 모든 high-risk 실행을 단일 chokepoint로 통과 — `src/lib/safety-guard.ts`
+
+CLI·에이전트·자연어 세 입구 모두 "실제 실행" 직전에 이 함수 **하나**를 통과시킨다. 정책 결정은 `resolveGuard` 에 위임하고, 여기선 결정을 집행만 한다.
+
+```ts
+export async function runGuarded<T>(
+  action: string,
+  deps: GuardDeps,
+  run: () => Promise<T> | T
+): Promise<{ outcome: GuardedOutcome; result?: T }> {
+  const mode: SafetyMode = deps.mode ?? readConfig().safetyMode
+  const log = deps.log ?? (() => {})
+  const guard = resolveGuard(action, mode, deps.channel)
+
+  if (guard === 'allow') {
+    return { outcome: { ran: true, guard, reason: 'low-risk' }, result: await run() }
+  }
+  if (guard === 'warn') {                  // lite — 막지 않고 경고만
+    log(`⚠️ 위험 작업(${action}) — lite 모드: 경고만 하고 진행합니다.`)
+    return { outcome: { ran: true, guard, reason: 'lite-warn' }, result: await run() }
+  }
+  if (guard === 'confirm') {               // CLI — 명시 승인 > 대화형 확인 > 비대화형은 안전 중단
+    if (deps.approved === true) {
+      return { outcome: { ran: true, guard, reason: 'approved' }, result: await run() }
+    }
+    const tty = deps.isTTY ?? !!process.stdout.isTTY
+    if (tty && deps.confirm) {
+      const ok = await deps.confirm()
+      if (ok) return { outcome: { ran: true, guard, reason: 'confirmed' }, result: await run() }
+      log(`취소됨 — ${action} 을(를) 실행하지 않았습니다.`)
+      return { outcome: { ran: false, guard, reason: 'declined' } }
+    }
+    log(`⚠️ 위험 작업(${action}) — 확인 불가(비대화형). 실행하지 않았습니다. (--yes 로 명시 승인)`)
+    return { outcome: { ran: false, guard, reason: 'no-confirm' } }
+  }
+
+  // preview — 에이전트/자연어. 미리보기 후 기본 비실행, 명시 승인 시에만 실행.
+  log(`🔎 위험 작업(${action}) 미리보기 — 실행 전 확인이 필요합니다. (Safety Mode: ${mode})`)
+  if (deps.approved === true) {
+    return { outcome: { ran: true, guard, reason: 'approved' }, result: await run() }
+  }
+  log(`실행하지 않았습니다 — 명시적 확인(승인 플래그) 후 다시 시도하세요.`)
+  return { outcome: { ran: false, guard, reason: 'preview-no-approve' } }
+}
+```
+
+설계 포인트:
+- **fail-safe 기본값.** 비대화형(TTY 아님) + 미승인 → `ran: false` 로 **차단**이 기본. "막지 못하면 실행"이 아니라 "확신 없으면 비실행".
+- **채널별 표현만 다르고 결정은 하나.** CLI는 y/N, 에이전트/자연어는 dry-run preview. 무엇이 위험한지의 판단은 단일 `resolveGuard`.
+
+### 3) 트립와이어는 "집행 호출"까지 짝지어야 유효 — `src/lib/hard-stop-guard.ts`
+
+신호 파일(`.vhk/HARD_STOP`)을 읽어 차단하는 가드를 만들고, **모든 자동화/위험 작업 진입부에서 이 함수를 실제로 호출**한다. 함수는 차단 시 `false` 를 반환하므로 호출부는 곧바로 `return` 하면 된다.
+
+```ts
+export function ensureNotHardStopped(action: string): boolean {
+  if (!isHardStopActive()) return true
+  console.error(chalk.red.bold(`\n🛑 HARD STOP 활성 — '${action}' 을(를) 실행하지 않았습니다.`))
+  const reason = readHardStopReason()
+  if (reason) console.error(chalk.dim(`   사유: ${reason.replace(/\s*\n\s*/g, ' ')}`))
+  console.error(chalk.dim('   해제: vhk resume --confirm (사람이 직접 실행)'))
+  process.exitCode = 1
+  return false
+}
+```
+
+해제 명령(`resume`)과 트립와이어를 *생성*하는 쪽은 의도적으로 가드 제외 — 그래야 잠긴 상태에서도 풀 수 있다(데드락 방지). 해제는 사람이 직접 명시 플래그로만.
+
+### 4) 완전성 매핑 테스트로 누락을 FAIL 처리 — `tests/safety-coverage.test.ts`
+
+"가드 대상 ↔ 핸들러" 매핑을 소스에서 정적으로 읽어 교차검증한다. 신규 위험 작업을 추가했는데 어느 입구가 가드를 안 거치면 테스트가 깨진다.
+
+```ts
+const GUARDED = new Set<string>([...HIGH_RISK_ACTIONS, ...STRICT_EXTRA_ACTIONS])
+
+it('자연어 dispatch: 가드대상 핸들러 호출 case 는 전부 등록(caller 가 runGuarded)', () => {
+  const src = readFileSync('src/lib/nlp-run.ts', 'utf-8')
+  const cases = [...src.matchAll(/case\s+'([^']+)':\s*\n?\s*return\s+(\w+)\(/g)]
+  for (const [, cmd, handler] of cases) {
+    const action = HANDLER_ACTION[handler]
+    if (action && GUARDED.has(action)) {
+      expect(Object.keys(NL_GUARDED_ACTIONS), `NL '${cmd}'→${handler}() 가드 미경유`).toContain(cmd)
+    }
+  }
+})
+
+it('인라인 메뉴 switch 등: 가드대상 핸들러 직접 호출 없음(전부 chokepoint 경유)', () => {
+  const idx = readFileSync('src/index.ts', 'utf-8')
+  const direct = [...idx.matchAll(/return\s+(undo|save|sync|deploy|publish|migrate|env|cloudPull|resume)\(/g)]
+  expect(direct.map((m) => m[1]), '가드 미경유 직접 호출 발견').toEqual([])
+})
+
+it('가드대상 action 은 전부 핸들러 매핑됨 (완전성 매핑 누락 방지)', () => {
+  const mapped = new Set(Object.values(HANDLER_ACTION))
+  for (const a of GUARDED) {
+    if (a === 'delete') continue                  // 진입점 없는 예약 액션
+    expect(mapped.has(a), `action '${a}' 핸들러 매핑 없음 → 드리프트`).toBe(true)
+  }
+})
+
+it('high-risk 별도 나열 리스트는 정책 파일 외에 없음(드리프트 소스 감사)', () => {
+  const files = ['src/lib/nlp-run.ts', 'src/index.ts', 'src/mcp/server.ts']
+  const names = ['undo', 'deploy', 'publish', 'migrate', 'cloud-pull', 'resume', 'env-write']
+  for (const f of files) {
+    const src = readFileSync(f, 'utf-8')
+    for (const lit of src.match(/\[[^\]]*\]/g) ?? []) {
+      const hit = names.filter((n) => lit.includes(`'${n}'`))
+      expect(hit.length, `${f} 에 별도 나열 의심: ${lit.slice(0, 60)}`).toBeLessThan(3)
+    }
+  }
+})
+```
+
+이 테스트군이 핵심 게이트다: 정책 파일에 위험 작업을 추가하면, 모든 입구가 chokepoint를 경유하도록 강제되고, 별도 나열 리스트(드리프트 소스)도 차단된다.
+
+## 적용 조건
+
+- ✅ 같은 위험/파괴적 작업이 **2개 이상의 진입 경로**(CLI, API/에이전트 도구, 자연어/메뉴 등)에서 호출될 때.
+- ✅ 작업이 되돌리기 어렵거나 외부 영향(배포·결제·삭제·시크릿/설정 파일 변경·외부 호출)을 줄 때.
+- ✅ 비대화형/자동화(에이전트, CI, cron)에서도 호출 가능해 "프롬프트 우회 → 무인 실행" 위험이 있을 때.
+- ✅ 안전장치 신호 파일/플래그(킬스위치·트립와이어)를 도입할 때 — 반드시 집행 호출과 짝으로.
+- ❌ 단일 입구만 있고 영원히 그럴 것이 확실한 일회성 스크립트(과설계).
+- ❌ 읽기 전용/부수효과 없는 조회 작업(`status` 류) — 가드 자체가 불필요(`allow`).
+- ❌ 가드 자체를 해제하는 명령이나 트립와이어를 *생성*하는 쪽 — 의도적으로 chokepoint에서 제외해야 데드락을 피함.
+
+## 검증
+
+`tests/safety-coverage.test.ts` 가 핵심 완전성 게이트(정적 소스 교차검증). 그 외 동작 검증:
+
+- `tests/safety-guard.test.ts` — chokepoint 동작 전 케이스. 특히 fail-safe 기본값:
+
+```ts
+it('CLI 비대화형(TTY 아님) + 미승인 → 안전하게 중단', async () => {
+  const t = tracker()
+  const { outcome } = await runGuarded('deploy', {
+    channel: 'cli', mode: 'standard', isTTY: false,
+  }, t.run)
+  expect(outcome.ran).toBe(false)   // 막지 못하면 실행이 아니라, 확신 없으면 비실행
+  expect(t.ran).toBe(false)
+})
+```
+
+  또한 빌드 산출물을 비대화형 spawn 으로 실행해 실제 CLI가 위험 작업을 진짜로 막는지 e2e 검증(`vhk deploy` → 가드 차단 메시지 출력 + 배포 흐름 미진입).
+
+- `tests/hard-stop-guard.test.ts` — 트립와이어가 장식이 아님을 보장. 신호 파일이 활성이면 자동화 진입부(예: harness/recap/ship)가 본문 진입 전 중단되고, 해제 명령만 예외로 통과:
+
+```ts
+it('HARD_STOP 활성이면 차단(false) + exitCode 1 + action·사유 출력', () => {
+  writeHardStopFixture(dir, 'auto: 3 active blockers')
+  expect(ensureNotHardStopped('publish')).toBe(false)
+  expect(process.exitCode).toBe(1)
+})
+
+it('resume 는 가드 제외 — HARD_STOP 활성에서도 실행되어 해제', async () => {
+  writeHardStopFixture(dir, 'manual stop')
+  const { resume } = await import('../src/commands/agent.js')
+  await resume({ confirm: true })
+  expect(existsSync(join(dir, '.vhk', 'HARD_STOP'))).toBe(false)  // 데드락 방지
+})
+```

--- a/docs/patterns/test-gate-derive-not-hardcode.md
+++ b/docs/patterns/test-gate-derive-not-hardcode.md
@@ -1,0 +1,181 @@
+---
+패턴명: 하드코딩 복제는 코드가 아니라 게이트(드리프트·완전성 테스트)로 막아라
+카테고리: test
+출처프로젝트: VHK (vhk-cli)
+태그: [drift-guard, single-source-of-truth, introspection, completeness-test, registry, ci-gate]
+발견일: 2026-05-31
+출처DevLog: docs/log/2026-05-31-safety-batches.md
+---
+
+# 패턴: 명령/정책 목록을 손으로 복제하지 말고, 단일 소스에서 파생 + 드리프트 게이트로 강제하라
+
+## 증상
+
+같은 "목록"(명령 서브커맨드, 위험 작업 목록, 가드 대상 핸들러 등)이 여러 파일에 하드코딩으로 복제되어 있고, 한쪽만 수정되면서 서로 어긋나는 드리프트가 발생한다.
+
+- 라우터/디스패처에 새 명령을 추가했지만 다른 곳의 하드코딩 목록에 등록하지 않아, 런타임에 명령이 엉뚱한 경로(예: 자연어 라우터)로 가로채진다.
+- "위험 작업(high-risk)" 목록이 A 파일과 B 파일에 따로 나열되어, B 에만 새 작업을 추가하는 바람에 한 경로에서 가드(확인 프롬프트)를 우회한다.
+
+```
+# 흔한 잘못된 "게이트": 주석/문자열 grep
+grep -q "// 새 명령 추가 시 여기도 추가" src/router.ts || echo "FAIL"
+```
+
+이런 grep 게이트는 주석이 그대로 있는 한 통과하므로, 실제로 목록이 어긋나도(드리프트) 아무것도 잡지 못한다. "통과"라는 거짓 신호만 준다.
+
+## 원인
+
+- **진실의 출처가 둘 이상이다.** 동일 정보를 사람이 두 군데 이상에 손으로 적으면, 한쪽 수정 시 다른 쪽 갱신은 "기억"에 의존한다 → 결국 빠진다.
+- **게이트가 행동이 아니라 텍스트를 검사한다.** 주석·식별자 이름·문자열 존재 여부 grep 은 코드의 실제 구조나 런타임 동작과 무관하다. 복제본이 어긋나도 grep 은 초록불을 준다.
+- **추가는 막지만 누락은 막지 못한다.** 단순 "존재 검사"는 "있어야 할 게 없는" 누락(완전성 위반)을 잡지 못한다.
+
+## 해결
+
+### 1) 목록을 단일 소스로 추출하고, 모든 소비자는 import 만 한다
+
+복제 가능한 목록을 한 모듈에 정의하고 주석으로 그 계약을 못 박는다. (vhk: `src/lib/command-registry.ts`)
+
+```ts
+/**
+ * 컨테이너 명령 → 서브커맨드의 **단일 소스**.
+ * R1 가드(cli-args.ts)와 드리프트 가드 테스트가 같은 출처를 본다 —
+ * commander 정의와 따로 노는 하드코딩 복제를 제거하기 위함.
+ */
+export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
+  goal: ['list', 'next', 'check', 'init', 'done'],
+  ref: ['add', 'list', 'open'],
+  memory: ['add', 'list', 'remove'],
+  // ...
+}
+```
+
+위험 정책도 동일하게 단일 소스로. (vhk: `src/lib/risk-policy.ts`)
+
+```ts
+export const HIGH_RISK_ACTIONS = [
+  'undo', 'deploy', 'publish', 'migrate',
+  'cloud-pull', 'resume', 'env-write', 'delete',
+] as const
+
+/**
+ * 자연어 → 가드 대상 action 의 **단일 소스**.
+ * (별도 손관리 리스트 금지 — 소비자는 import 만. 완전성 가드 테스트가
+ *  실제 dispatch 와 교차검증해 여기 누락 시 FAIL.)
+ */
+export const NL_GUARDED_ACTIONS: Readonly<Record<string, string>> = {
+  undo: 'undo', deploy: 'deploy', publish: 'publish', /* ... */ sync: 'sync',
+}
+```
+
+### 2) introspect 드리프트 테스트 — "실제 구조" vs "선언"을 코드로 대조
+
+주석 grep 이 아니라, 프레임워크가 실제로 등록한 구조를 introspect 해 단일 소스와 비교한다. (vhk: `tests/command-registry.test.ts`)
+
+```ts
+import { program } from '../src/index.js'
+import { CONTAINER_SUBCOMMANDS } from '../src/lib/command-registry.js'
+
+it('commander 의 실제 서브커맨드가 모두 레지스트리에 있음 (누락 = 재발 위험)', () => {
+  for (const [container, subs] of Object.entries(CONTAINER_SUBCOMMANDS)) {
+    const cmd = program.commands.find((c) => c.name() === container)
+    if (!cmd) continue
+    const actual = cmd.commands.map((c) => c.name())  // 실제 등록된 구조
+    for (const s of actual) {
+      expect(subs, `${container}.${s} 가 registry 에 없음`).toContain(s)
+    }
+  }
+})
+
+it('새 컨테이너 명령(서브커맨드 보유)이 registry 에 누락되지 않음', () => {
+  const containers = program.commands
+    .filter((c) => c.commands.length > 0).map((c) => c.name())
+  for (const name of containers) {
+    expect(CONTAINER_SUBCOMMANDS[name], `새 컨테이너 '${name}' 누락`).toBeDefined()
+  }
+})
+```
+
+→ 새 명령을 프레임워크에 추가하고 레지스트리에 등록을 빠뜨리면, "실제 구조에는 있는데 선언에는 없음"으로 테스트가 **FAIL** 한다.
+
+### 3) 완전성 매핑 테스트 — "추가했는데 매핑 누락" 자동 FAIL
+
+단일 소스의 모든 원소가 소비 측(핸들러 매핑·가드 경유)에 빠짐없이 연결됐는지 검사한다. (vhk: `tests/safety-coverage.test.ts`)
+
+```ts
+const GUARDED = new Set<string>([...HIGH_RISK_ACTIONS, ...STRICT_EXTRA_ACTIONS])
+
+// 단일 소스의 모든 위험 action 이 핸들러 매핑에 존재해야 한다
+it('가드대상 action 은 전부 HANDLER_ACTION 에 매핑됨 (완전성 매핑 누락 방지)', () => {
+  const mapped = new Set(Object.values(HANDLER_ACTION))
+  for (const a of GUARDED) {
+    if (a === 'delete') continue // 진입점 없는 예약 액션
+    expect(mapped.has(a), `action '${a}' 핸들러 매핑 없음 → 완전성 누락(드리프트)`).toBe(true)
+  }
+})
+```
+
+### 4) 게이트는 행동/구조 검증으로 — 디스패치 실제 케이스를 파싱해 교차검증
+
+가드 우회 같은 동작 보장은, 실제 dispatch 소스를 파싱해 "위험 핸들러를 호출하는 케이스가 전부 가드 목록에 등록됐는지"까지 검사한다. (vhk: `tests/safety-coverage.test.ts`)
+
+```ts
+it('자연어 dispatch: 가드대상 핸들러 호출 case 는 전부 가드 목록 등록', () => {
+  const src = readFileSync('src/lib/nlp-run.ts', 'utf-8')
+  const cases = [...src.matchAll(/case\s+'([^']+)':\s*\n?\s*return\s+(\w+)\(/g)]
+  for (const [, cmd, handler] of cases) {
+    const action = HANDLER_ACTION[handler]
+    if (action && GUARDED.has(action)) {
+      expect(Object.keys(NL_GUARDED_ACTIONS), `'${cmd}'→${handler}() 가드 미경유`)
+        .toContain(cmd)
+    }
+  }
+})
+
+// 드리프트 소스 감사: 단일 소스 밖에 위험 목록을 또 나열했는지 탐지
+it('high-risk 별도 나열 리스트는 정책 모듈 외에 없음', () => {
+  for (const f of ['src/lib/nlp-run.ts', 'src/index.ts', 'src/mcp/server.ts']) {
+    const src = readFileSync(f, 'utf-8')
+    for (const lit of src.match(/\[[^\]]*\]/g) ?? []) {
+      const hit = names.filter((n) => lit.includes(`'${n}'`))
+      expect(hit.length, `${f} 에 high-risk 별도 나열 의심`).toBeLessThan(3)
+    }
+  }
+})
+```
+
+### 핵심 교훈
+
+> 중복을 코드로(주석으로 "여기도 추가하세요") 막지 말고, **게이트로** 막아라.
+> 단일 소스에서 파생 + introspect 드리프트 테스트 + 완전성 매핑 테스트 →
+> "추가했는데 등록 누락하면 FAIL" 을 자동화하라. 게이트는 주석 grep 이 아니라
+> 실제 구조·동작 검증이어야 한다.
+
+## 적용 조건
+
+- ✅ 같은 목록(명령·라우트·권한·위험 작업·기능 플래그)이 2곳 이상에서 참조되어 어긋날 수 있을 때
+- ✅ 프레임워크가 등록 구조를 introspect 할 수 있을 때(commander `program.commands`, 라우트 테이블, DI 컨테이너 등)
+- ✅ "X 를 추가하면 Y 에도 반드시 등록" 같은 사람 기억 의존 계약이 존재할 때
+- ✅ 누락이 보안/안전(가드 우회) 또는 라우팅 오작동으로 직결될 때
+- ❌ 목록이 진짜 1곳에서만 쓰이고 복제본이 없을 때(과도한 테스트)
+- ❌ 런타임/소스 introspect 가 불가능해 검증이 추측에 그칠 때 — 그땐 단일 소스 추출(해결 1)만으로 충분
+- ❌ "주석/문자열 존재"만 확인하는 grep 게이트로 대체하려 할 때(거짓 통과 유발 — 안티패턴)
+
+## 검증
+
+vhk 의 게이트 구성을 그대로 일반 템플릿으로 쓸 수 있다.
+
+1. **introspect 드리프트 테스트** (`tests/command-registry.test.ts`): 프레임워크가 실제 등록한 구조 ↔ 단일 소스 선언을 대조. 새 컨테이너/서브커맨드 누락 시 FAIL.
+2. **완전성 매핑 테스트** (`tests/safety-coverage.test.ts`): 위험 action 단일 소스의 모든 원소가 핸들러 매핑·가드 경유에 연결됐는지 확인. dispatch 소스를 파싱해 가드 미경유 케이스를 FAIL 처리.
+3. **stray/구조 머지 게이트** (`scripts/check-no-stray.mjs`): grep 이 아니라 `git status --porcelain` 출력을 파싱해 소스 트리에 추적 안 된 무관 파일이 남았는지 행동 기반으로 검사.
+
+```js
+// scripts/check-no-stray.mjs — 텍스트 패턴이 아니라 VCS 실제 상태를 검증
+const stray = out
+  .split(/\r?\n/)
+  .filter((l) => l.startsWith("?? "))
+  .map((l) => l.slice(3).trim())
+  .filter((p) => /^(src|tests)\//.test(p));
+if (stray.length) process.exit(1);
+```
+
+세 게이트를 CI 의 `build && test` 단계에 묶으면, 복제·드리프트·잔여물을 사람 리뷰 이전에 자동 차단할 수 있다.

--- a/docs/patterns/ux-local-date-vs-utc-timestamp.md
+++ b/docs/patterns/ux-local-date-vs-utc-timestamp.md
@@ -1,0 +1,100 @@
+---
+패턴명: 사람이 읽는 날짜는 로컬, 머신 타임스탬프는 UTC — 섞으면 하루 밀린다
+카테고리: ux
+출처프로젝트: VHK (vhk-cli)
+태그: [date, timezone, utc, kst, iso8601, toISOString, toLocaleDateString, logging]
+발견일: 2026-05-31
+출처DevLog: docs/log/2026-05-31-v1.6.2-dogfooding-release.md
+---
+
+# 패턴: 로컬 날짜 표기 vs UTC 타임스탬프 — `toISOString().slice(0,10)` 의 하루 밀림
+
+## 증상
+
+로그/문서/파일명에 "오늘 날짜"를 찍었는데, 실제 작성 시점과 하루가 어긋난다.
+UTC+9(KST) 환경에서 자정~오전 9시 사이에 기록하면 항상 **어제** 날짜가 박힌다.
+
+흔한 구현:
+
+```ts
+const today = new Date().toISOString().slice(0, 10) // ❌ UTC 기준
+// docs/log/{today}-... , "발견일: {today}", blocker/TIL/recap 날짜 등
+```
+
+재현 케이스 (KST 기준 오늘인데 UTC 로는 어제로 찍힘):
+
+```ts
+const d = new Date('2026-05-31T16:00:00Z') // = 2026-06-01 01:00 KST
+d.toISOString().slice(0, 10)               // → '2026-05-31' (UTC '어제') ❌
+d.toLocaleDateString('sv-SE', { timeZone: 'Asia/Seoul' }) // → '2026-06-01' (KST '오늘') ✅
+```
+
+결과적으로 작업 로그 파일명, 발견일/기록일 필드, 일일 recap 등이 하루 밀려 기록된다.
+
+## 원인
+
+`Date#toISOString()` 은 **항상 UTC** 로 직렬화한다(`...Z` 접미사). 거기서 `.slice(0, 10)`
+으로 날짜 부분만 잘라내면 "UTC 기준 날짜"가 된다.
+
+UTC+9 처럼 양의 오프셋을 가진 타임존에서는 **로컬 자정 ~ 오전 9시**(= UTC 전날 15:00~24:00)
+구간 동안 UTC 날짜가 로컬 날짜보다 하루 작다. 그래서 이 시간대에 "오늘"을 찍으면 어제가 나온다.
+(음의 오프셋 타임존에서는 반대로 저녁 시간대에 +1 밀림이 발생할 수 있다.)
+
+핵심은 "사람이 읽는 날짜"와 "정밀 타임스탬프"의 기준 타임존을 구분하지 않고 하나로 섞어 쓴 것.
+
+## 해결
+
+날짜만 필요한 곳은 로컬 타임존 기준으로 직렬화하는 전용 헬퍼를 둔다.
+`toLocaleDateString('sv-SE')` 는 스웨덴 로캘이 ISO 형식(`YYYY-MM-DD`)을 쓰기 때문에,
+**로컬 타임존 + ISO 포맷**을 한 번에 만족한다(별도 zero-padding 불필요).
+
+실제 vhk 구현 (`src/lib/date.ts`):
+
+```ts
+/**
+ * VHK-019: 로컬 타임존 기준 `YYYY-MM-DD` 날짜 문자열.
+ *
+ * `new Date().toISOString().slice(0, 10)` 은 **UTC** 기준이라, KST(UTC+9) 자정~오전 9시
+ * 사이에 기록하면 '어제' 날짜가 찍혀 하루 밀린다(블로커/학습/TIL/recap 로그 등 날짜 오기록).
+ * `toLocaleDateString('sv-SE')` 는 로컬 타임존 + ISO 형식(YYYY-MM-DD)을 동시에 만족한다.
+ *
+ * 주의: 시각까지 필요한 머신 타임스탬프(생성시각 푸터·백업 파일명·HARD_STOP ts·memory addedAt)는
+ *      Z(UTC) 표기가 명확하므로 `toISOString()` 을 그대로 둔다. 이 함수는 '날짜 표기' 전용.
+ */
+export function localDate(d: Date = new Date()): string {
+  return d.toLocaleDateString('sv-SE')
+}
+```
+
+운영 규칙:
+
+- **사람이 읽는 날짜**(로그 파일명, 발견일/기록일, recap 헤더) → `localDate()` (로컬 타임존).
+- **머신 타임스탬프**(생성시각 푸터, 백업 파일명, 정지 신호 ts, 메모리 addedAt 등 정밀 시각) → `toISOString()` 그대로 유지. UTC + `Z` 표기가 명확해 머신 비교/정렬에 안전하다.
+
+즉 **둘을 한 함수/한 포맷으로 섞지 말 것.** 날짜 표기는 로컬, 정밀 타임스탬프는 UTC.
+
+## 적용 조건
+
+- ✅ 로그/문서/리포트에 "사람이 보는 날짜(YYYY-MM-DD)"를 찍을 때
+- ✅ 날짜로 파일명을 만들 때 (`YYYY-MM-DD-작업명.md` 등) — 로컬 날짜로 폴더가 깔끔히 묶임
+- ✅ UTC 가 아닌 타임존(특히 KST 등 양의 오프셋)에서 동작하는 CLI/로컬 도구
+- ❌ 머신용 정밀 타임스탬프(정렬·비교·만료 계산·이벤트 시각) — 이때는 `toISOString()`(UTC, `Z` 명시)을 유지
+- ❌ 여러 타임존 사용자가 공유하는 서버 저장값 — 저장은 UTC 로 통일하고 표시 단계에서만 로컬 변환
+- ❌ 사용자/서버 타임존을 명시적으로 고정해야 하는 경우 — 그땐 `{ timeZone: 'Asia/Seoul' }` 처럼 옵션을 박아 의도를 못박을 것
+
+## 검증
+
+`tests/date.test.ts` 가 버그 재현과 로컬 기준 정합을 함께 검증한다.
+
+```ts
+it('버그 재현: UTC 저녁 시각은 KST 로 다음날 — UTC slice 는 하루 밀린다', () => {
+  // 2026-05-31 16:00Z = 2026-06-01 01:00 KST. 날짜 표기는 KST(로컬) 기준이어야 함.
+  const d = new Date('2026-05-31T16:00:00Z')
+  expect(d.toISOString().slice(0, 10)).toBe('2026-05-31') // 기존 버그: UTC '어제'
+  expect(d.toLocaleDateString('sv-SE', { timeZone: 'Asia/Seoul' })).toBe('2026-06-01') // KST '오늘'
+})
+```
+
+또한 "UTC 가 아니라 로컬 타임존 날짜를 쓴다" 테스트는 여러 ISO 입력에 대해
+`localDate(d)` 가 로컬 getter(`getFullYear`/`getMonth`/`getDate`)로 직접 조립한 값과
+일치함을 보장한다 — 즉 결과가 실행 타임존을 따른다는 것을 회귀 방지로 못박는다.

--- a/docs/patterns/ux-nontty-interactive-guard.md
+++ b/docs/patterns/ux-nontty-interactive-guard.md
@@ -1,0 +1,171 @@
+---
+패턴명: 비-TTY 진입을 가정한 대화형 프롬프트 가드 + 전역 EOF catch
+카테고리: ux
+출처프로젝트: VHK (vhk-cli)
+태그: [cli, tty, stdin, inquirer, readline, eof, ci, error-handling, nodejs]
+발견일: 2026-05-31
+출처DevLog: docs/log/2026-05-31-v1.6.2-dogfooding-release.md
+---
+
+# 패턴: 비-TTY 진입을 가정한 대화형 프롬프트 가드 + 전역 EOF catch
+
+## 증상
+
+대화형 프롬프트(`inquirer`, `readline`, `prompts` 등)를 호출하는 CLI 명령을 비-TTY stdin 환경에서 실행하면 readline 이 즉시 닫힌 상태로 프롬프트가 열려 크래시한다.
+
+재현 경로(모두 stdin 이 TTY 가 아님):
+
+```bash
+echo "" | mycli recap          # 파이프
+mycli recap < /dev/null        # EOF 리다이렉트
+mycli recap                    # CI 러너 / Docker / 백그라운드 잡
+```
+
+에러 출력:
+
+```
+Error [ERR_USE_AFTER_CLOSE]: readline was closed
+    at Interface.[kError] (node:internal/readline/interface)
+    ...
+node:internal/process/promises: Unsettled top-level await ...
+```
+
+- 종료 코드 13(`ERR_USE_AFTER_CLOSE` unhandled rejection) 으로 비정상 종료.
+- top-level `await` 를 try/catch 없이 쓴 진입부에서는 `Unsettled top-level await` 경고까지 동반.
+- 사용자에게 노출되는 건 스택 트레이스뿐 — "왜 안 되는지" 안내가 전혀 없다.
+
+## 원인
+
+대화형 라이브러리는 `process.stdin` 에 readline 인터페이스를 붙여 한 줄씩 입력을 기다린다. stdin 이 TTY 가 아니면(파이프/리다이렉트/CI):
+
+1. stdin 이 데이터 없이 곧바로 `end`(EOF) 를 발생 → readline 이 닫힘.
+2. 프롬프트는 닫힌 readline 에 다시 쓰려다 `ERR_USE_AFTER_CLOSE` 를 던진다.
+3. 이 에러가 `parseAsync()`(또는 핸들러)의 Promise rejection 으로 전파되는데, top-level `await` 를 try/catch 없이 호출했다면 잡히지 않고 프로세스가 비정상 종료한다.
+
+즉 "사용자가 항상 키보드 앞에 있다"는 암묵 가정이 깨지는 지점이다. CI·파이프라인·스크립트·다른 도구의 자식 프로세스로 호출되는 순간 모든 대화형 경로는 비-TTY 진입을 받는다.
+
+## 해결
+
+두 겹의 방어선을 둔다. (1) 각 대화형 명령 **진입부**에서 TTY 여부를 먼저 검사해 friendly 안내 후 우아하게 빠진다. (2) 그래도 새어나오는 EOF/강제종료 류 에러를 **전역 catch** 에서 잡아 스택 트레이스 대신 안내 메시지로 종료한다.
+
+### 1. 공용 가드 헬퍼 (`src/lib/interactive.ts`)
+
+```ts
+import chalk from 'chalk'
+
+/**
+ * 대화형 명령 진입 가드 — 비-TTY(파이프/CI/EOF stdin)면 inquirer 프롬프트가
+ * `ERR_USE_AFTER_CLOSE` 로 크래시하므로, 진입부에서 friendly 안내 + 비-0 종료 신호 후 중단한다.
+ * 반환 true = 대화형 진행 가능.
+ */
+export function ensureInteractive(hint = ''): boolean {
+  if (process.stdin.isTTY) return true
+  console.error(chalk.yellow('  ⚠️  이 명령은 대화형 입력이 필요합니다 — 비-TTY/파이프 환경에서는 실행할 수 없어요.'))
+  if (hint) console.error(chalk.dim(`     ${hint}`))
+  process.exitCode = 1
+  return false
+}
+
+/** 프롬프트 강제 종료/EOF 류 에러인지 — 전역 catch 에서 friendly 처리용. */
+export function isPromptAbortError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err)
+  return /ERR_USE_AFTER_CLOSE|force closed|ExitPromptError|readline was closed|User force closed/i.test(msg)
+}
+```
+
+### 2. 대화형 명령 진입부에서 가드 호출 (`src/commands/recap.ts`)
+
+```ts
+import { ensureInteractive } from '../lib/interactive.js'
+
+// ... 비대화형으로 보여줄 정보(분석 결과 등)는 먼저 출력한 뒤 ...
+console.log('')
+// 비-TTY 면 프롬프트 크래시 대신 friendly 안내 + exit 1.
+if (!ensureInteractive('회고 입력은 대화형으로만 가능합니다.')) return
+
+const answers = await inquirer.prompt([
+  { type: 'input', name: 'summary', message: ko.recap.summary },
+  // ...
+])
+```
+
+`return` 으로 빠지므로 프롬프트가 아예 열리지 않는다. `process.exitCode = 1` 을 세팅해 호출 측(스크립트/CI)이 "실행 불가"를 종료 코드로 감지할 수 있다 — `throw`/`process.exit()` 대신 `exitCode` 만 세팅하면 이미 출력한 정보가 끊기지 않는다.
+
+### 3. 진입부를 try/catch 로 감싸고 전역 catch 에서 분류 (`src/index.ts`)
+
+```ts
+import { isPromptAbortError } from './lib/interactive.js'
+
+if (isMainModule) {
+  // parseAsync 를 try/catch 로 감싸 unsettled top-level await 경고 제거 +
+  // 비-TTY/EOF 프롬프트 크래시(ERR_USE_AFTER_CLOSE)를 friendly 종료로 처리.
+  try {
+    const nlInput = detectNaturalLanguageInput(process.argv)
+    if (nlInput !== null) {
+      await runNaturalLanguageRoute(nlInput)
+    } else {
+      await program.parseAsync(process.argv)
+    }
+  } catch (err) {
+    if (isPromptAbortError(err)) {
+      console.error(chalk.yellow('\n  ⚠️  대화형 입력이 취소/종료됐습니다. (비대화형 환경에서는 해당 명령을 쓸 수 없어요)'))
+    } else {
+      console.error(chalk.red(`\n❌ ${err instanceof Error ? err.message : String(err)}`))
+    }
+    process.exitCode = 1
+  }
+}
+```
+
+핵심:
+
+- top-level `await` 를 **반드시** `try/catch` 로 감싼다 → `Unsettled top-level await` 경고 제거.
+- `isPromptAbortError()` 로 EOF/강제종료(Ctrl+C 의 `ExitPromptError` 포함) 류만 구분해 friendly 메시지로, 그 외 진짜 에러는 빨간 메시지로 분기.
+- 둘 다 `process.exitCode = 1` → 비정상 종료를 종료 코드로 정직하게 전달하되 크래시 스택은 숨긴다.
+
+## 적용 조건
+
+- ✅ 사용자 입력을 기다리는 대화형 프롬프트(inquirer / prompts / readline / Ink 입력 등)를 호출하는 모든 CLI 명령.
+- ✅ CI·파이프·`< /dev/null`·다른 도구의 자식 프로세스 등 비-TTY 호출 가능성이 있는 도구(= 사실상 모든 CLI).
+- ✅ top-level `await` 또는 async 진입부를 가진 ESM CLI 엔트리(전역 try/catch 가 없으면 unsettled await 경고까지 동반).
+- ✅ Ctrl+C 로 프롬프트를 강제 종료(`ExitPromptError`) 했을 때도 스택 대신 깔끔히 끝내고 싶을 때.
+- ❌ 대화형 입력이 전혀 없는 순수 배치/비대화형 명령(가드 불필요).
+- ❌ `--yes`/`--non-interactive` 같은 플래그로 입력값을 모두 인자로 받도록 설계된 경로 — 이 경우 프롬프트를 호출하지 않으므로 가드 대신 플래그 분기로 처리한다.
+- ❌ TTY 를 직접 다루는 풀스크린 TUI(별도 입력 모델) — 동일 정규식이 안 맞을 수 있으니 라이브러리별 에러 식별자를 확인할 것.
+
+## 검증
+
+`tests/interactive.test.ts` — `process.stdin.isTTY` 를 `Object.defineProperty` 로 모사해 양쪽 분기를 검증한다.
+
+```ts
+function setTTY(value: boolean | undefined): boolean | undefined {
+  const orig = process.stdin.isTTY
+  Object.defineProperty(process.stdin, 'isTTY', { value, configurable: true })
+  return orig
+}
+
+it('비-TTY 면 false 반환 + exitCode 1 (크래시 대신 friendly 중단)', () => {
+  const orig = setTTY(false)
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  expect(ensureInteractive('hint')).toBe(false)
+  expect(process.exitCode).toBe(1)
+  vi.restoreAllMocks()
+  setTTY(orig)
+})
+
+it('TTY 면 true 반환', () => {
+  const orig = setTTY(true)
+  expect(ensureInteractive()).toBe(true)
+  expect(process.exitCode).toBe(0)
+  setTTY(orig)
+})
+
+it('isPromptAbortError — EOF/강제종료 류만 true', () => {
+  expect(isPromptAbortError(new Error('Error [ERR_USE_AFTER_CLOSE]: readline was closed'))).toBe(true)
+  expect(isPromptAbortError(new Error('User force closed the prompt'))).toBe(true)
+  expect(isPromptAbortError(new Error('ExitPromptError'))).toBe(true)
+  expect(isPromptAbortError(new Error('일반 에러'))).toBe(false)
+})
+```
+
+`isTTY` 를 직접 모사할 수 있다는 점이 핵심 — 실제 파이프/EOF 를 띄우지 않고도 비-TTY 진입을 단위 테스트로 재현한다. 대화형 명령 테스트(`tests/design.test.ts`)도 `beforeEach` 에서 `isTTY` 를 `true` 로 강제해 가드를 통과시킨 뒤 프롬프트 로직을 검증한다.


### PR DESCRIPTION
v1.6.0/v1.6.1/Safety/도그푸딩 dev log 교훈에서 **프로젝트 무관 범용 패턴 8건** 추출. 각 패턴 실제 vhk 소스 근거 코드 인용.

| 파일 | 카테고리 | 패턴 |
|------|------|------|
| git-diff-since-no-op | git | `git diff --since` 무효 → boundary..HEAD |
| git-crlf-normalize-before-compare | git | 비교 전 CRLF→LF 정규화 |
| ux-local-date-vs-utc-timestamp | ux | 날짜=로컬, 타임스탬프=UTC |
| ux-nontty-interactive-guard | ux | 비-TTY 대화형 가드 + friendly exit |
| state-single-chokepoint-guard | state | 위험작업 단일 chokepoint + 완전성 게이트 |
| test-gate-derive-not-hardcode | test | 단일소스 파생 + introspect/완전성 게이트 |
| build-exec-timeout-etimedout | build | timeout 식별 ETIMEDOUT 단독 |
| env-windows-filename-sanitize | env | Windows 파일명 콜론 sanitize |

기존 docs/patterns 4건과 중복 없음. Notion 패턴사전 DB 직접 주입 안 함(자동화 도우미 등록). 문서만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)