### PR TITLE
Goal 11 — 대화형/비대화형 통합 가드 (MCP·CI 안전, #14)

### DIFF
--- a/docs/superpowers/plans/2026-06-01-noninteractive-guard.md
+++ b/docs/superpowers/plans/2026-06-01-noninteractive-guard.md
@@ -1,0 +1,421 @@
+# 대화형/비대화형 통합 가드 (Goal 11) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** inquirer 쓰는 명령을 비-TTY(CI·파이프·MCP stdio)에서 안전하게 — 절대 안 멈춤 + 위험작업 무단실행 0 + MCP면 stdin 미접근 — 단일 계약으로 통합.
+
+**Architecture:** 감지 단일출처 `isInteractive()` + 3버킷(auto-default=`promptOrDefault` / essential=`ensureInteractive` / destructive=기존 `runGuarded`). 새 분류 안 만들고 `risk-policy`/`safety-guard` 재사용.
+
+**Tech Stack:** TypeScript, Node, commander, inquirer, vitest, tsup.
+
+**설계 정본:** `docs/superpowers/specs/2026-06-01-mcp-noninteractive-guard-design.md`
+
+---
+
+### Task 1: `isInteractive` + `promptOrDefault` (감지 SoT)
+
+**Files:**
+- Modify: `src/lib/interactive.ts`
+- Test: `tests/interactive.test.ts`
+
+- [ ] **Step 1: 실패 테스트 작성** — `tests/interactive.test.ts` 에 추가
+
+```ts
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { isInteractive, promptOrDefault } from '../src/lib/interactive.js'
+
+describe('isInteractive (감지 SoT)', () => {
+  const origTTY = process.stdin.isTTY
+  const origEnv = process.env.VHK_FORCE_INTERACTIVE
+  afterEach(() => { process.stdin.isTTY = origTTY; process.env.VHK_FORCE_INTERACTIVE = origEnv })
+
+  it('stdin TTY 면 true', () => { process.stdin.isTTY = true; expect(isInteractive()).toBe(true) })
+  it('비-TTY 면 false', () => { process.stdin.isTTY = undefined as never; expect(isInteractive()).toBe(false) })
+  it('--yes 면 TTY 라도 false', () => { process.stdin.isTTY = true; expect(isInteractive({ yes: true })).toBe(false) })
+  it('VHK_FORCE_INTERACTIVE=1 면 비-TTY 라도 true (Git Bash 탈출구)', () => {
+    process.stdin.isTTY = undefined as never; process.env.VHK_FORCE_INTERACTIVE = '1'
+    expect(isInteractive()).toBe(true)
+  })
+})
+
+describe('promptOrDefault', () => {
+  const origTTY = process.stdin.isTTY
+  afterEach(() => { process.stdin.isTTY = origTTY })
+
+  it('대화형 → ask 결과', async () => {
+    process.stdin.isTTY = true
+    expect(await promptOrDefault(async () => 'asked', 'fb')).toBe('asked')
+  })
+  it('비대화형 → ask 미호출 + fallback (MCP 불변식)', async () => {
+    process.stdin.isTTY = undefined as never
+    const ask = vi.fn(async () => 'asked')
+    expect(await promptOrDefault(ask, 'fb')).toBe('fb')
+    expect(ask).not.toHaveBeenCalled()
+  })
+  it('ask 가 abort 던지면 fallback', async () => {
+    process.stdin.isTTY = true
+    const ask = async () => { throw new Error('User force closed the prompt') }
+    expect(await promptOrDefault(ask, 'fb')).toBe('fb')
+  })
+  it('ask 가 비-abort 에러면 rethrow', async () => {
+    process.stdin.isTTY = true
+    const ask = async () => { throw new Error('boom') }
+    await expect(promptOrDefault(ask, 'fb')).rejects.toThrow('boom')
+  })
+})
+```
+
+- [ ] **Step 2: 실패 확인** — Run: `pnpm exec vitest --run tests/interactive.test.ts` → FAIL ("isInteractive is not a function").
+
+- [ ] **Step 3: 구현** — `src/lib/interactive.ts` 상단(ensureInteractive 위)에 추가 + ensureInteractive 재배선
+
+```ts
+// 프롬프트 가능 여부 단일출처. stdin TTY + --yes 아님.
+// VHK_FORCE_INTERACTIVE=1 = Git Bash/MinTTY 탈출구(E3). 비-TTY 는 undefined → !! (E1).
+export function isInteractive(opts?: { yes?: boolean }): boolean {
+  if (opts?.yes) return false
+  if (process.env.VHK_FORCE_INTERACTIVE === '1') return true
+  return !!process.stdin.isTTY
+}
+
+// benign 프롬프트: 비대화형이면 ask 호출 없이 fallback (stdin 미접근 = MCP 안전, E5).
+export async function promptOrDefault<T>(
+  ask: () => Promise<T>,
+  fallback: T,
+  opts?: { yes?: boolean }
+): Promise<T> {
+  if (!isInteractive(opts)) return fallback
+  try {
+    return await ask()
+  } catch (err) {
+    if (isPromptAbortError(err)) return fallback
+    throw err
+  }
+}
+```
+
+그리고 기존 `ensureInteractive` 의 `if (process.stdin.isTTY) return true` 를 `if (isInteractive()) return true` 로 교체(축 통일).
+
+- [ ] **Step 4: 통과 확인** — Run: `pnpm exec vitest --run tests/interactive.test.ts` → PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/lib/interactive.ts tests/interactive.test.ts
+git commit -m "feat(interactive): isInteractive/promptOrDefault 감지 SoT (#14)"
+```
+
+---
+
+### Task 2: `restore` 를 HIGH_RISK_ACTIONS 에 추가 (R3)
+
+**Files:**
+- Modify: `src/lib/risk-policy.ts:8-17`
+- Test: `tests/safety-coverage.test.ts` (또는 risk-policy 테스트 파일)
+
+- [ ] **Step 1: 실패 테스트** — risk-policy 테스트에 추가
+
+```ts
+import { isHighRisk } from '../src/lib/risk-policy.js'
+it('restore 는 high-risk (백업 덮어쓰기)', () => { expect(isHighRisk('restore')).toBe(true) })
+```
+
+- [ ] **Step 2: 실패 확인** — Run: `pnpm exec vitest --run tests/safety-coverage.test.ts` → FAIL.
+
+- [ ] **Step 3: 구현** — `HIGH_RISK_ACTIONS` 배열 끝에 `'restore'` 추가 + 주석에 restore 설명.
+
+```ts
+export const HIGH_RISK_ACTIONS = [
+  'undo', 'deploy', 'publish', 'migrate', 'cloud-pull', 'resume', 'env-write', 'delete', 'restore',
+] as const
+```
+
+- [ ] **Step 4: 통과 확인** — Run: `pnpm exec vitest --run tests/safety-coverage.test.ts` → PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/lib/risk-policy.ts tests/safety-coverage.test.ts
+git commit -m "fix(safety): restore 를 HIGH_RISK_ACTIONS 에 추가 (R3)"
+```
+
+---
+
+### Task 3: runGuarded lite 분기 — 비대화형 destructive 중단 (R13/E8)
+
+**Files:**
+- Modify: `src/lib/safety-guard.ts:47-67`
+- Test: `tests/safety-guard.test.ts` (없으면 생성)
+
+- [ ] **Step 1: 실패 테스트**
+
+```ts
+import { describe, it, expect, vi } from 'vitest'
+import { runGuarded } from '../src/lib/safety-guard.js'
+
+describe('runGuarded — lite 비대화형 destructive 중단 (R13)', () => {
+  it('lite + 비대화형(isTTY:false) + 미승인 → 실행 안 함', async () => {
+    const run = vi.fn(async () => 'ran')
+    const { outcome } = await runGuarded('undo',
+      { channel: 'cli', mode: 'lite', isTTY: false, approved: false }, run)
+    expect(run).not.toHaveBeenCalled()
+    expect(outcome.ran).toBe(false)
+  })
+  it('lite + 대화형(isTTY:true) → 경고 후 실행', async () => {
+    const run = vi.fn(async () => 'ran')
+    const { outcome } = await runGuarded('undo',
+      { channel: 'cli', mode: 'lite', isTTY: true }, run)
+    expect(outcome.ran).toBe(true)
+  })
+  it('lite + 비대화형 + --yes 승인 → 실행', async () => {
+    const run = vi.fn(async () => 'ran')
+    const { outcome } = await runGuarded('undo',
+      { channel: 'cli', mode: 'lite', isTTY: false, approved: true }, run)
+    expect(outcome.ran).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: 실패 확인** — Run: `pnpm exec vitest --run tests/safety-guard.test.ts` → 첫 테스트 FAIL (현재 lite 는 항상 실행).
+
+- [ ] **Step 3: 구현** — 'warn' 분기 교체 + confirm 분기 축 stdin 통일(E8)
+
+```ts
+if (guard === 'warn') {
+  // R13/E8: lite 여도 비대화형(stdin 비-TTY)+미승인이면 destructive 중단 — 경고 볼 사람 없음.
+  const canConfirm = deps.isTTY ?? !!process.stdin.isTTY
+  if (!deps.approved && !canConfirm) {
+    log(`⚠️ 위험 작업(${action}) — lite 지만 비대화형+미승인 → 중단. (--yes 로 승인)`)
+    return { outcome: { ran: false, guard, reason: 'lite-noninteractive-block' } }
+  }
+  log(`⚠️ 위험 작업(${action}) — lite 모드: 경고만 하고 진행합니다.`)
+  return { outcome: { ran: true, guard, reason: 'lite-warn' }, result: await run() }
+}
+```
+
+그리고 confirm 분기의 `const tty = deps.isTTY ?? !!process.stdout.isTTY` → `?? !!process.stdin.isTTY` (E8 축 통일).
+
+- [ ] **Step 4: 통과 확인** — Run: `pnpm exec vitest --run tests/safety-guard.test.ts` → PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/lib/safety-guard.ts tests/safety-guard.test.ts
+git commit -m "fix(safety): lite 여도 비대화형+미승인 destructive 중단 (R13, stdin 축 E8)"
+```
+
+---
+
+### Task 4: restore CLI 를 guardCli 로 래핑 + `--yes` (R3)
+
+**Files:**
+- Modify: `src/index.ts` (restore `.command()` 블록)
+
+- [ ] **Step 1: 현재 restore 등록 확인** — Run: `rg -n "command\('restore'\)" src/index.ts` 로 블록 위치 찾기. 기존 형태:
+`.command('restore').alias('복원')…​.action(async (…) => { await restore(…) })`
+
+- [ ] **Step 2: 구현** — save(line 287) 패턴 그대로 적용. `--yes` 옵션 추가 + action 을 guardCli 경유:
+
+```ts
+  .option('--yes', '확인 없이 실행 (위험 작업 명시 승인)')
+  .action(async (/* 기존 인자 */ opts: { yes?: boolean }) => {
+    await guardCli('restore', opts?.yes === true, () => restore(/* 기존 인자 */))
+  })
+```
+
+- [ ] **Step 3: 빌드 + 수동 확인**
+
+Run: `pnpm build` → success.
+Run: `echo "" | node dist/index.js restore` → "위험 작업(restore) … 확인 불가(비대화형). 실행하지 않았습니다." (크래시·실행 없음)
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/index.ts
+git commit -m "fix(restore): guardCli 래핑 + --yes — 비대화형 무가드 덮어쓰기 차단 (R3)"
+```
+
+---
+
+### Task 5: init.ts 감지 SoT 통일 + check-goal-8 갱신 (R1/S2)
+
+**Files:**
+- Modify: `src/commands/init.ts` (isNonInteractive 제거 → isInteractive import)
+- Modify: `scripts/check-goal-8.mjs` (assertion 갱신)
+- Test: 기존 `tests/init-yes.test.ts`, `tests/init-adopt.test.ts` 회귀 확인
+
+- [ ] **Step 1: 구현** — init.ts 상단 로컬 `function isNonInteractive(options)` 삭제, `import { isInteractive } from '../lib/interactive.js'` 추가. 모든 `isNonInteractive(options)` 호출 → `!isInteractive(options)` 로 교체 (collectAnswers, overwrite 가드 2곳, writeInitExtras 인자).
+
+- [ ] **Step 2: check-goal-8 assertion 갱신** — init 에서 stdin/stdout 직접 참조가 사라지므로 SoT 기준으로 변경:
+
+```js
+// (구) must(/process.stdin.isTTY/.test(initSrc) && /process.stdout.isTTY/.test(initSrc), ...)
+// (신)
+const itSrc = read('src/lib/interactive.ts') ?? ''
+must(/export function isInteractive/.test(itSrc) && /process\.stdin\.isTTY/.test(itSrc), 'isInteractive SoT (stdin 축)')
+must(/from '\.\.\/lib\/interactive\.js'/.test(initSrc) && /isInteractive\(options\)/.test(initSrc), 'init 이 isInteractive SoT 사용')
+```
+
+- [ ] **Step 3: 회귀 테스트** — Run: `pnpm build && pnpm exec vitest --run tests/init-yes.test.ts tests/init-adopt.test.ts` → 모두 PASS.
+
+- [ ] **Step 4: 수동 확인** — Run: `node dist/index.js init -y` (빈 임시폴더) → 안 멈추고 생성. `node dist/index.js goal check --id 8`(VHK_GATES_SKIP_DEEP=1) → 게이트 통과.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/commands/init.ts scripts/check-goal-8.mjs
+git commit -m "refactor(init): 로컬 isNonInteractive → isInteractive SoT (stdin 축, R1/S2)"
+```
+
+---
+
+### Task 6: gate.ts — essential 진입 가드 (R2)
+
+**Files:**
+- Modify: `src/commands/gate.ts:41`
+
+- [ ] **Step 1: 구현** — `import { ensureInteractive } from '../lib/interactive.js'` 추가. `export async function gate() {` 직후 첫 줄:
+
+```ts
+  if (!ensureInteractive('아이디어 검증은 대화형 질문이 필요합니다. 터미널(PowerShell 등)에서 직접 실행하거나, Git Bash 면 VHK_FORCE_INTERACTIVE=1 설정.')) return
+```
+
+- [ ] **Step 2: 빌드 + 실파이프 확인**
+
+Run: `pnpm build`
+Run: `echo "" | node dist/index.js gate` → "대화형 입력이 필요합니다…" 안내 후 깔끔히 종료(멈춤·크래시 없음). exitCode 1.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/commands/gate.ts
+git commit -m "fix(gate): 비-TTY 진입 거부 (essential 버킷, R2)"
+```
+
+---
+
+### Task 7: save.ts — 커밋메시지 기본값 + secrets 안전중단 (S1)
+
+**Files:**
+- Modify: `src/commands/save.ts:59-63` (secretsConfirm), `:84-88` (commit message)
+
+- [ ] **Step 1: 구현 (커밋메시지)** — line 84 prompt 를 promptOrDefault 로 감쌈:
+
+```ts
+import { promptOrDefault } from '../lib/interactive.js'
+// ...
+const message = await promptOrDefault(
+  async () => (await inquirer.prompt<{ message: string }>([{
+    type: 'input', name: 'message', message: t('save.commitMessage'),
+  }])).message,
+  'chore: vhk save',
+)
+```
+
+- [ ] **Step 2: 구현 (secretsConfirm — 안전중단)** — line 59 prompt 는 "시크릿 발견, 진행?" → 비대화형이면 **중단**(default false), 자동 진행 금지:
+
+```ts
+const proceed = await promptOrDefault(
+  async () => (await inquirer.prompt<{ proceed: boolean }>([{
+    type: 'confirm', name: 'proceed', message: t('save.secretsConfirm'), default: false,
+  }])).proceed,
+  false,   // 비대화형 = 시크릿 커밋 안 함 (안전)
+)
+```
+
+- [ ] **Step 3: 빌드 + 수동 확인**
+
+Run: `pnpm build`
+Run: 변경 있는 임시 repo 에서 `echo "" | node dist/index.js save` → 멈춤 없이 `chore: vhk save` 메시지로 커밋(시크릿 없을 때). 크래시 없음.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/commands/save.ts
+git commit -m "fix(save): 비대화형 커밋메시지 기본값 + secrets 안전중단 (S1)"
+```
+
+---
+
+### Task 8: 완전성 가드 + MCP 불변식 테스트
+
+**Files:**
+- Test: `tests/safety-coverage.test.ts` (확장)
+
+- [ ] **Step 1: 완전성 테스트** — HIGH_RISK 전 액션이 index.ts 에서 guard 경유하는지 교차검증
+
+```ts
+import { readFileSync } from 'node:fs'
+import { HIGH_RISK_ACTIONS } from '../src/lib/risk-policy.js'
+it('HIGH_RISK 전 액션이 index.ts 에서 guardCli/guardCliDefer 경유', () => {
+  const idx = readFileSync('src/index.ts', 'utf-8')
+  for (const a of HIGH_RISK_ACTIONS) {
+    expect(new RegExp(`guardCli(Defer)?\\('${a}'`).test(idx), `${a} unguarded`).toBe(true)
+  }
+})
+```
+주의: `env-write`/`delete` 는 매핑명(env-write↔env, delete↔?)이 다르면 매핑 테이블로 검증. 현재 env 는 `guardCli('env-write', …)` 로 등록됨. delete 가 미사용이면 HIGH_RISK 에서 제외하거나 예외목록 명시.
+
+- [ ] **Step 2: MCP 불변식 테스트** (이미 Task 1 에 포함 — ask 미호출). 추가로 명시 주석.
+
+- [ ] **Step 3: 통과 확인** — Run: `pnpm exec vitest --run tests/safety-coverage.test.ts` → PASS. (FAIL 시 누락 액션 guard 보강.)
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add tests/safety-coverage.test.ts
+git commit -m "test(safety): HIGH_RISK guard 완전성 + MCP stdin 불변식"
+```
+
+---
+
+### Task 9: 전체 게이트 + 4환경 스파이크 + Goal 11 done
+
+**Files:**
+- Create: `scripts/check-goal-11.mjs` (via `vhk goal sync`, 후 goal-11 assertion 손추가)
+- Create: `docs/troubleshooting/` 또는 spec 부록에 스파이크 결과 기록
+
+- [ ] **Step 1: 빌드 + 전체 테스트** — Run: `pnpm build && pnpm exec vitest --run` → 전부 PASS (회귀 0).
+
+- [ ] **Step 2: 게이트 스크립트 생성** — Run: `node dist/index.js goal sync` → `scripts/check-goal-11.mjs` 생성. 거기에 goal-11 고유 assertion 추가:
+
+```js
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+const it = read('src/lib/interactive.ts') ?? ''
+must(/export function isInteractive/.test(it) && /export async function promptOrDefault/.test(it), 'isInteractive/promptOrDefault SoT')
+must(/'restore'/.test(read('src/lib/risk-policy.ts') ?? ''), 'restore HIGH_RISK')
+must(/lite-noninteractive-block/.test(read('src/lib/safety-guard.ts') ?? ''), 'lite 비대화형 destructive 중단 (R13)')
+must(/ensureInteractive\(/.test(read('src/commands/gate.ts') ?? ''), 'gate essential 가드')
+must(/guardCli\('restore'/.test(read('src/index.ts') ?? ''), 'restore guardCli 래핑')
+```
+
+- [ ] **Step 3: 4환경 실측 스파이크** — 각 환경서 실행, 결과 기록:
+
+| 환경 | 명령 | 기대 |
+| --- | --- | --- |
+| PowerShell (TTY) | `vhk gate` | 정상 프롬프트 |
+| Git Bash | `vhk gate` | 거부+힌트 / `VHK_FORCE_INTERACTIVE=1 vhk gate` → 프롬프트 |
+| 파이프 | `echo "" | vhk gate` / `... undo` | gate 거부, undo 중단 (멈춤 없음) |
+| MCP stdio | MCP tool 로 read-only 호출 | RPC 파이프 정상 (stdin 미접근) |
+
+결과를 spec §6 또는 troubleshooting 에 한 줄씩 기록.
+
+- [ ] **Step 4: Goal 11 done**
+
+Run: `node dist/index.js goal done --id 11` → 풀게이트(typecheck+test+build+assertion) 통과 → status DONE.
+
+- [ ] **Step 5: 커밋 + PR**
+
+```bash
+git add scripts/check-goal-11.mjs goals/11-noninteractive-guard.md docs/
+git commit -m "feat(safety): 대화형/비대화형 통합 가드 P1 완료 (Goal 11, #14)"
+```
+브랜치 push → PR (base main) → merge.
+
+---
+
+## Self-Review (작성자 체크 — 완료)
+
+- **스펙 커버리지:** §3 SoT→T1, §4 restore→T2/T4, R13→T3, init→T5, gate→T6, save S1→T7, 완전성/불변식→T8, 스파이크/게이트→T9. ✅ (P2 항목은 Goal 12 — 의도적 제외)
+- **Placeholder:** Task 4 의 "기존 인자"는 실행 시 restore 시그니처 확인 필요 — Step 1 에서 rg 로 확정하도록 명시함(허용). 나머지 코드 완비.
+- **타입 일관:** `isInteractive(opts?: {yes?})`, `promptOrDefault<T>(ask, fallback, opts?)`, `lite-noninteractive-block` reason 문자열 — T1/T3/T9 일관.

--- a/docs/superpowers/specs/2026-06-01-mcp-noninteractive-guard-design.md
+++ b/docs/superpowers/specs/2026-06-01-mcp-noninteractive-guard-design.md
@@ -1,0 +1,124 @@
+# 설계 — 대화형/비대화형 통합 가드 (MCP·CI 안전, #14)
+
+- **날짜:** 2026-06-01
+- **이슈:** #14 (vhk start: MCP stdio inquirer stdin 점유)
+- **상태:** 설계 확정 → 구현 대기 (Goal 11 = P1, Goal 12 = P2)
+
+## 1. 문제
+
+VHK 의 여러 명령이 `inquirer.prompt` 로 사용자 입력을 받는다(15 파일, 39회). 비-TTY(CI·파이프·MCP stdio) 에서 프롬프트가 뜨면:
+
+- 멈춤(hang) 또는 `ERR_USE_AFTER_CLOSE` 크래시
+- **MCP stdio 모드**: inquirer 가 stdin(=JSON-RPC 파이프)을 읽으면 RPC 바이트를 훔쳐 파이프가 깨진다 (#14 의 원래 공포)
+
+현재 상태는 **부분적으로만** 안전:
+- 대화형 명령(gate/init/design palette/theme)은 MCP tool 에서 제외 → stdio 직접 호출 불가
+- `init` 은 자체 `isNonInteractive` 보유 (v1.6.3)
+- `interactive.ts ensureInteractive()` 는 stdin TTY 체크 후 거부
+- high-risk CLI 는 `index.ts guardCli/guardCliDefer` → `runGuarded` 경유
+
+문제: **감지·동작이 명령마다 제각각** (init=defaults / recap·design=refuse / high-risk=runGuarded / 나머지 gate·theme·ship·restore=무가드). MCP 사용이 늘어나는 미래에 일관된 계약이 필요.
+
+## 2. 철학 (핵심)
+
+목표는 "항상 진행"이 아니라:
+
+1. **절대 안 멈춤 (never hang)** — 비-TTY 어디서든 깔끔히 종료(기본값 진행 / 명확 거부 / 안전 중단).
+2. **위험 작업 무단실행 0** — 되돌리기 어려운 작업은 비대화형·미승인이면 실행 안 함.
+3. **MCP 파이프 불변식** — 비-TTY 면 stdin 을 **절대 읽지 않는다** (RPC 바이트 보호). ← 載荷(load-bearing) 불변식.
+4. **단일 출처 재사용** — 새 위험 분류/특수케이스 금지. 기존 `risk-policy` + `safety-guard` 재사용.
+
+## 3. 아키텍처 — 3버킷 + 감지 SoT
+
+```
+입력 필요? → isInteractive() 판단
+   ├─ ① auto-default (benign)   : 비대화형 → promptOrDefault() = 기본값
+   ├─ ② refuse-essential        : 비대화형 → ensureInteractive() = 깔끔히 거부(exit 1)
+   └─ ③ destructive-guarded     : runGuarded() = 비대화형·미승인 중단, --yes 로만
+```
+
+### 감지 단일출처 (`src/lib/interactive.ts`)
+
+```ts
+// 프롬프트 가능 여부 — stdin TTY + --yes 아님. (stdout 무관: R1)
+// VHK_FORCE_INTERACTIVE=1 = Git Bash/MinTTY 탈출구(E3).
+export function isInteractive(opts?: { yes?: boolean }): boolean {
+  if (opts?.yes) return false
+  if (process.env.VHK_FORCE_INTERACTIVE === '1') return true
+  return !!process.stdin.isTTY   // 비-TTY 는 undefined → !! 로 false (E1)
+}
+
+// benign: 비대화형 → fallback. (비-TTY 면 stdin 미접근 = MCP 안전, E5)
+export async function promptOrDefault<T>(
+  ask: () => Promise<T>, fallback: T, opts?: { yes?: boolean }
+): Promise<T> {
+  if (!isInteractive(opts)) return fallback
+  try { return await ask() } catch (e) { if (isPromptAbortError(e)) return fallback; throw e }
+}
+
+// essential: 비대화형 → 거부. isInteractive 로 재배선(축 통일).
+export function ensureInteractive(hint = ''): boolean { /* !isInteractive() → refuse + exit 1 */ }
+```
+
+`init` 의 로컬 `isNonInteractive` 는 이 SoT 로 교체.
+
+## 4. 컴포넌트 변경
+
+| 파일 | 변경 |
+| --- | --- |
+| `src/lib/interactive.ts` | `isInteractive`, `promptOrDefault` 추가, `ensureInteractive` 재배선 |
+| `src/lib/risk-policy.ts` | `HIGH_RISK_ACTIONS` 에 **`restore`** 추가 (R3) |
+| `src/lib/safety-guard.ts` | `runGuarded` 'warn'(lite) 분기: destructive + 미승인 + **비대화형(stdin)** 이면 lite 여도 중단 (R13, 축은 stdin = E8) |
+| `src/commands/init.ts` | 로컬 isNonInteractive → SoT, stdout 축 제거 |
+| `src/index.ts` | `restore` action 을 `guardCli('restore', opts.yes, …)` 래핑 + `--yes` 옵션 (R3) |
+| `src/commands/gate.ts` | 진입부 `ensureInteractive()` (② essential) |
+| `scripts/check-goal-8.mjs` | init 의 stdout 축 제거에 맞춰 assertion 갱신 (S2 — self-consistency) |
+
+## 5. 명령 분류 (3버킷)
+
+| 버킷 | 명령 | 비대화형 동작 |
+| --- | --- | --- |
+| ① auto-default | init✅, sync(confirm), theme, design-palette, save(**커밋메시지**) | 기본값. save 메시지 기본 = `"chore: vhk save"` (S1) |
+| ② refuse-essential | **gate**(13문), recap✅, design✅ | 거부 |
+| ③ destructive-guarded | undo, deploy, publish, migrate, cloud-pull, resume, env-write, **restore**(신규), save/sync(strict) | 미승인 중단 |
+
+- `--yes` 는 ①③ 전용. ② essential 엔 무의미(13문 자동답 불가) → 안 붙임 (S3).
+- `sync`(①) 비-TTY 자동진행 = 파생파일 자동 재생성. RULES.md(SoT) 보존·멱등이라 허용 (S4, 문서화).
+
+## 6. 환경 의존 (E)
+
+- **E3 (Git Bash/MinTTY)**: Windows Git Bash 서 `stdin.isTTY` 가 대화형인데도 `undefined` → essential 오거부. 완화: 거부 시 "PowerShell 또는 `winpty …`" 힌트 + `VHK_FORCE_INTERACTIVE=1` 탈출구.
+- **E5 (MCP 불변식)**: 비-TTY → stdin 미접근. 전용 테스트로 못박음.
+- **E1**: `isTTY` 는 비-TTY 시 `undefined` → `!!` 필수.
+- **E11**: `yes | vhk undo` 는 이제 중단(비-TTY+미승인). 동작 변경 — 문서화.
+
+## 7. 에러/엣지
+
+- 전역 `catch(isPromptAbortError)`(index.ts) 최후방어 유지. promptOrDefault 로컬 catch = 2중.
+- `readConfig` 절대 throw 안 함 → 손상/없음/타 cwd = standard 폴백 (R20, 안전쪽).
+
+## 8. 테스트
+
+- 단위: `isInteractive`(stdin.isTTY mock + VHK_FORCE_INTERACTIVE), `promptOrDefault`(TTY/비-TTY/abort→fallback), `runGuarded`(lite+비-TTY+미승인→중단).
+- **완전성 가드**: HIGH_RISK 전 액션이 `index.ts` 에서 guard 경유 — 교차검증(restore 누락 재발 방지).
+- **MCP 불변식 테스트**: 비-TTY 면 promptOrDefault 가 stdin 미접근.
+- **실파이프 e2e**: `echo "" | node dist/index.js gate` → 안 멈추고 거부. `init -y` → 안 멈춤.
+- **4환경 실측 스파이크** (분석 대체): PowerShell / Git Bash / `echo|` 파이프 / MCP stdio — 실제 거동 확정.
+
+## 9. 스코프 / 단계
+
+**Goal 11 (P1 — 이번):** interactive.ts SoT + init 마이그 + R3(restore) + R13/E8(lite-block, stdin 축) + gate essential + S1(save 기본메시지) + S2(게이트 갱신) + E3 탈출구 + 테스트 + 4환경 스파이크.
+
+**Goal 12 (P2 — 백로그):** 남은 benign/essential 마이그(theme/design-palette/sync-confirm/ship) + S5(save push 비대화형 검토).
+
+## 10. 확정된 결정 (의사결정 기록)
+
+- **R19**: piped-answer(`echo y | cmd`) 지원 **포기**. 비-TTY → stdin 미접근(MCP 안전 우선). 답 주입은 `--yes`/플래그.
+- **R13**: 비대화형 + 미승인 destructive 는 **모드 무관 중단**(lite 여도). 비대화형 = 경고 볼 사람 없음.
+- **E8**: lite-block 판정 축 = **stdin.isTTY** (confirm 가능성), stdout 아님.
+- **VHK_MCP_MODE env**: P1 제외 (YAGNI — 비-TTY 가 이미 MCP 감지 커버, channel='mcp' preview UX 는 P2).
+
+## 11. 위험 / 미해결
+
+- 환경 거동(특히 Git Bash)은 **실측 스파이크**로 확정 — 선분석 한계 인정. 우아한 degradation(never-hang + no-unauthorized-destructive)으로 오판 시에도 비치명.
+- 명령 마이그레이션 시 기존 테스트 비-TTY 경로 충돌 가능 (E12) → P1 회귀범위.

--- a/goals/11-noninteractive-guard.md
+++ b/goals/11-noninteractive-guard.md
@@ -3,8 +3,9 @@ vhk_format: 1
 type: goal
 id: 11
 title: 대화형/비대화형 통합 가드 (MCP·CI 안전) — P1
-status: NOT_STARTED
+status: DONE
 priority: P1
+completed: 2026-06-02
 ---
 
 # Goal 11: 대화형/비대화형 통합 가드 P1 (#14)

--- a/goals/11-noninteractive-guard.md
+++ b/goals/11-noninteractive-guard.md
@@ -1,0 +1,50 @@
+---
+vhk_format: 1
+type: goal
+id: 11
+title: 대화형/비대화형 통합 가드 (MCP·CI 안전) — P1
+status: NOT_STARTED
+priority: P1
+---
+
+# Goal 11: 대화형/비대화형 통합 가드 P1 (#14)
+
+> 설계 전문: `docs/superpowers/specs/2026-06-01-mcp-noninteractive-guard-design.md`
+> 출처: 이슈 #14 (MCP stdio inquirer stdin 점유) + MCP-first 미래 대비.
+
+## 배경
+inquirer 쓰는 명령(15개)이 비-TTY(CI·파이프·MCP stdio)서 멈춤/크래시/RPC파이프 훼손.
+감지·동작이 명령마다 제각각(init=defaults / recap·design=refuse / high-risk=runGuarded /
+gate·theme·ship·restore=무가드). 단일 계약 필요.
+
+## 철학
+① 절대 안 멈춤 ② 위험작업 무단실행 0 ③ 비-TTY면 stdin 미접근(MCP 불변식)
+④ 기존 risk-policy/safety-guard 재사용(새 분류 금지).
+
+## 동작 (3버킷 + 감지 SoT)
+- `src/lib/interactive.ts`: `isInteractive(opts)` (stdin.isTTY + !yes + VHK_FORCE_INTERACTIVE 탈출구),
+  `promptOrDefault(ask, fallback, opts)` (비대화형→fallback, 시도시 abort catch), `ensureInteractive` 재배선.
+- `risk-policy.ts`: HIGH_RISK_ACTIONS 에 `restore` 추가.
+- `safety-guard.ts`: lite 분기 — destructive+미승인+비대화형(stdin)이면 lite여도 중단.
+- `index.ts`: restore → guardCli + `--yes`.
+- `init.ts`: 로컬 isNonInteractive → SoT (stdout 축 제거).
+- `gate.ts`: 진입부 ensureInteractive (essential).
+- `save`: 비대화형 커밋메시지 기본값 = `"chore: vhk save"`.
+- `scripts/check-goal-8.mjs`: init stdout 축 제거에 맞춰 assertion 갱신.
+
+## Completion Check
+- [ ] isInteractive/promptOrDefault/ensureInteractive 단일 SoT + 단위테스트
+- [ ] restore HIGH_RISK + guardCli 래핑 + --yes
+- [ ] lite여도 비대화형+미승인 destructive 중단 (runGuarded, stdin 축)
+- [ ] gate 비-TTY 거부(essential), init 비대화형 SoT 통일
+- [ ] HIGH_RISK 전 액션 guard 경유 완전성 가드 테스트 + MCP 불변식 테스트
+- [ ] check-goal-8 assertion 갱신(회귀 없음)
+- [ ] 4환경 실측 스파이크: PowerShell / Git Bash / `echo|` / MCP stdio
+- [ ] 공통 게이트 통과 (typecheck + test + build)
+
+## Mandatory Reading
+- `docs/superpowers/specs/2026-06-01-mcp-noninteractive-guard-design.md` (설계 정본)
+- `src/lib/interactive.ts`, `src/lib/safety-guard.ts`, `src/lib/risk-policy.ts`, `src/index.ts`(guardCli)
+
+## When Stuck
+환경 거동 불확실하면 선분석 말고 실측 스파이크 먼저. 우아한 degradation(never-hang)이 안전망.

--- a/goals/12-noninteractive-guard-p2.md
+++ b/goals/12-noninteractive-guard-p2.md
@@ -1,0 +1,34 @@
+---
+vhk_format: 1
+type: goal
+id: 12
+title: 비대화형 가드 P2 — 잔여 명령 마이그 + save push 검토
+status: NOT_STARTED
+priority: P2
+---
+
+# Goal 12: 비대화형 가드 P2 (#14 후속)
+
+> 설계 전문: `docs/superpowers/specs/2026-06-01-mcp-noninteractive-guard-design.md`
+> Goal 11(P1) 완료 후 진행. 백로그.
+
+## 배경
+P1 이 안전핵심(감지 SoT + restore + lite-block + gate)을 처리. P2 는 나머지 대화형
+명령을 3버킷 계약으로 기회주의적 마이그 + 걸친 케이스(save push) 정책 결정.
+
+## 동작
+- 잔여 benign/essential 마이그: theme, design-palette, sync(confirm), ship.
+- `promptOrDefault`/`ensureInteractive` 일괄 적용 → 비-TTY 일관 동작.
+- S5: `save` 의 push 가 standard 모드서 비대화형 자동실행되는 문제 — 비대화형 미승인이면
+  push 막을지(외부영향) 결정. high-risk 승격 vs strict-extra 유지.
+- (선택) `VHK_MCP_MODE` env → channel='mcp' preview UX (P1 에서 YAGNI 로 제외했던 것).
+
+## Completion Check
+- [ ] theme/design-palette/sync/ship 비-TTY 일관 동작 + 테스트
+- [ ] save push 비대화형 정책 결정·구현
+- [ ] 회귀 없음 (P1 동작 보존)
+- [ ] 공통 게이트 통과
+
+## Mandatory Reading
+- `docs/superpowers/specs/2026-06-01-mcp-noninteractive-guard-design.md` §9 (스코프 P2)
+- Goal 11 구현 결과

--- a/scripts/check-goal-11.mjs
+++ b/scripts/check-goal-11.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// scripts/check-goal-11.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 11 gate.')
+  process.exit(1)
+}
+
+const pkg = existsSync('package.json') ? JSON.parse(readFileSync('package.json', 'utf-8')) : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 11] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 11 고유 검증 (대화형/비대화형 통합 가드) ──────────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+const it = read('src/lib/interactive.ts') ?? ''
+must(/export function isInteractive/.test(it) && /export async function promptOrDefault/.test(it), 'isInteractive/promptOrDefault SoT')
+must(/process\.stdin\.isTTY/.test(it) && /VHK_FORCE_INTERACTIVE/.test(it), 'stdin 축 + Git Bash 탈출구(E3)')
+must(/'restore'/.test(read('src/lib/risk-policy.ts') ?? ''), 'restore HIGH_RISK (R3)')
+must(/lite-noninteractive-block/.test(read('src/lib/safety-guard.ts') ?? ''), 'lite여도 비대화형 destructive 중단 (R13)')
+must(/guardCli\('restore'/.test(read('src/index.ts') ?? ''), 'restore guardCli 래핑')
+const initSrc = read('src/commands/init.ts') ?? ''
+must(/isInteractive\(options\)/.test(initSrc) && !/function isNonInteractive/.test(initSrc), 'init 이 isInteractive SoT 사용(로컬 헬퍼 제거)')
+must(/ensureInteractive\(/.test(read('src/commands/gate.ts') ?? ''), 'gate essential 진입거부 (R2)')
+must(/promptOrDefault/.test(read('src/commands/save.ts') ?? ''), 'save 비대화형 기본값/안전중단 (S1)')
+
+if (pass) { console.log('✅ goal 11 gate passes'); process.exit(0) }
+console.log('❌ goal 11 gate failed'); process.exit(1)

--- a/scripts/check-goal-12.mjs
+++ b/scripts/check-goal-12.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// scripts/check-goal-12.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 12 gate.')
+  process.exit(1)
+}
+
+const pkg = existsSync('package.json') ? JSON.parse(readFileSync('package.json', 'utf-8')) : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 12] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 12 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 12 gate passes'); process.exit(0) }
+console.log('❌ goal 12 gate failed'); process.exit(1)

--- a/scripts/check-goal-8.mjs
+++ b/scripts/check-goal-8.mjs
@@ -52,15 +52,17 @@ if (!skipDeep) {
 // ─── goal 8 고유 검증 (init -y 완전 비대화형) ───────────────────────
 const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
 const initSrc = read('src/commands/init.ts') ?? ''
-must(/function isNonInteractive/.test(initSrc), 'isNonInteractive 헬퍼 존재')
-must(/options\.yes/.test(initSrc) && /process\.stdin\.isTTY/.test(initSrc) && /process\.stdout\.isTTY/.test(initSrc), '-y(yes) + stdin/stdout 비-TTY 감지')
+// SoT = src/lib/interactive.ts 의 isInteractive (stdin 축). init 은 로컬 헬퍼 대신 이 SoT 를 쓴다.
+const itSrc = read('src/lib/interactive.ts') ?? ''
+must(/export function isInteractive/.test(itSrc) && /process\.stdin\.isTTY/.test(itSrc), 'isInteractive SoT (stdin 축)')
+must(/from '\.\.\/lib\/interactive\.js'/.test(initSrc) && /isInteractive\(options\)/.test(initSrc), 'init 이 isInteractive SoT 사용')
 must(/if\s*\(!noninteractive\)/.test(initSrc), 'collectAnswers 가 비대화형이면 프롬프트 skip')
 must(/DEFAULT_TYPE\s*=\s*PROJECT_TYPES\[0\]\.value/.test(initSrc), '타입 미지정 시 기본 타입(webapp) 폴백')
 // overwrite 프롬프트도 비대화형 가드.
-must((initSrc.match(/isNonInteractive\(options\)\s*\n?\s*\?\s*false/g) ?? []).length >= 1 || /noninteractive\s*\n?\s*\?\s*false/.test(initSrc), 'overwrite 프롬프트 비대화형 가드')
+must((initSrc.match(/!isInteractive\(options\)\s*\n?\s*\?\s*false/g) ?? []).length >= 1 || /noninteractive\s*\n?\s*\?\s*false/.test(initSrc), 'overwrite 프롬프트 비대화형 가드')
 // Codex #3: confirmStack/adopt 도 비대화형 가드(!options.yes 단독 금지 — 비-TTY 멈춤 방지).
-must(/if\s*\(!isNonInteractive\(options\)\)\s*\{[\s\S]{0,80}confirmStack/.test(initSrc), 'confirmStack 가 isNonInteractive 가드')
-must(/!isNonInteractive\(options\)\s*&&\s*!options\.fromNotion/.test(initSrc), 'adopt 가 isNonInteractive 가드')
+must(/if\s*\(isInteractive\(options\)\)\s*\{[\s\S]{0,80}confirmStack/.test(initSrc), 'confirmStack 가 isInteractive 가드')
+must(/isInteractive\(options\)\s*&&\s*!options\.fromNotion/.test(initSrc), 'adopt 가 isInteractive 가드')
 must(!/if\s*\(!options\.yes\)\s*\{[\s\S]{0,80}confirmStack/.test(initSrc), 'confirmStack 에서 옛 !options.yes 단독 가드 제거됨')
 
 if (pass) { console.log('✅ goal 8 gate passes'); process.exit(0) }

--- a/src/commands/gate.ts
+++ b/src/commands/gate.ts
@@ -2,6 +2,7 @@ import inquirer from 'inquirer'
 import chalk from 'chalk'
 import { ko } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
+import { ensureInteractive } from '../lib/interactive.js'
 
 export type GateMode = 'full' | 'quick' | 'skip'
 export type GateStatus = 'pass' | 'hold' | 'fail'
@@ -39,6 +40,8 @@ export function judgeGate(failCount: number, holdCount: number): GateVerdict {
 }
 
 export async function gate() {
+  if (!ensureInteractive('아이디어 검증은 대화형 질문이 필요합니다. 터미널(PowerShell 등)에서 직접 실행하세요. Git Bash 면 VHK_FORCE_INTERACTIVE=1.')) return
+
   console.log(chalk.bold(`\n${ko.gate.title}\n`))
 
   const { mode } = await inquirer.prompt<{ mode: GateMode }>([{

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -22,6 +22,7 @@ import type { PrdContent } from '../types/prd.js'
 import { readJsonFile } from '../lib/read-json.js'
 import { detectExistingRuleFiles, buildAdoptedRules } from '../lib/rules-import.js'
 import { detectProjectStack } from '../lib/stack-detect.js'
+import { isInteractive } from '../lib/interactive.js'
 
 const PROJECT_TYPES = [
   { name: '🌐 웹 앱 (Next.js + Supabase + Vercel)', value: 'webapp' },
@@ -64,20 +65,16 @@ function resolveType(type?: string): string | undefined {
   return type
 }
 
-// VHK-021/Goal 8: -y(--yes) 또는 비-TTY(CI/파이프) 면 비대화형 — 프롬프트 0개.
-// inquirer 는 stdin 을 읽으므로 stdin 비-TTY 면 프롬프트 불가(EOF 크래시) → stdin 우선.
-// stdout 비-TTY(출력 파이프=자동화)도 비대화형 취급. 둘 중 하나라도 비-TTY 면 skip.
-function isNonInteractive(options: InitOptions): boolean {
-  return Boolean(options.yes) || !process.stdin.isTTY || !process.stdout.isTTY
-}
-
+// VHK-021/Goal 8: -y(--yes) 또는 비대화형(비-TTY stdin/CI/파이프) 면 프롬프트 0개.
+// 비대화형 판정 SoT = isInteractive(opts) (src/lib/interactive.ts) — stdin 축만 본다.
+// (stdout 파이프는 더 이상 프롬프트를 막지 않음 — 자동화 출력 리다이렉트 허용.)
 const DEFAULT_TYPE = PROJECT_TYPES[0].value // 'webapp'
 
 async function collectAnswers(
   options: InitOptions,
   defaults: Partial<ProjectAnswers> = {}
 ): Promise<ProjectAnswers> {
-  const noninteractive = isNonInteractive(options)
+  const noninteractive = !isInteractive(options)
   const prompts: DistinctQuestion[] = []
 
   // 비대화형이면 프롬프트를 만들지 않는다 → inquirer 호출 0회 → 멈춤/EOF 크래시 없음.
@@ -151,7 +148,7 @@ export async function init(options: InitOptions = {}) {
 
   // 비대화형(yes/비-TTY)이면 confirmStack 프롬프트 skip — default(진행)로 자동 진행.
   // (이전엔 !options.yes 만 봐서 비-TTY+무-yes 에서 EOF 멈춤 — Goal 8 비대화형 계약 위반.)
-  if (!isNonInteractive(options)) {
+  if (isInteractive(options)) {
     const { confirmStack } = await inquirer.prompt([{
       type: 'confirm', name: 'confirmStack',
       message: ko.init.confirmStack, default: true,
@@ -168,7 +165,7 @@ export async function init(options: InitOptions = {}) {
   // adopt 모드(브라운필드) — 기존 도구별 규칙 파일을 RULES.md(SoT)로 가져오기 제안.
   // 비대화형(yes/비-TTY/notion)은 건너뛰고 greenfield 템플릿 RULES.md 를 그대로 쓴다.
   let adoptedRules: string | null = null
-  if (!isNonInteractive(options) && !options.fromNotion) {
+  if (isInteractive(options) && !options.fromNotion) {
     const existingRules = detectExistingRuleFiles(cwd)
     if (existingRules.length > 0) {
       const { adopt } = await inquirer.prompt([{
@@ -197,7 +194,7 @@ export async function init(options: InitOptions = {}) {
 
     if (fileExists(fullPath)) {
       // 비대화형이면 프롬프트 default(=false, 보존) 자동 적용 — 기존 파일 클로버 금지.
-      const overwrite = isNonInteractive(options)
+      const overwrite = !isInteractive(options)
         ? false
         : (await inquirer.prompt([{
             type: 'confirm', name: 'overwrite',
@@ -214,7 +211,7 @@ export async function init(options: InitOptions = {}) {
     log.success(filePath)
   }
 
-  await writeInitExtras(cwd, isNonInteractive(options))
+  await writeInitExtras(cwd, !isInteractive(options))
 
   console.log(chalk.bold.green(`\n${ko.init.done}`))
   console.log(chalk.dim(`\n${ko.init.nextSteps}`))

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -13,6 +13,7 @@ import {
 } from '../lib/git-repo.js'
 import { filterSevereFindings, scanProjectForSecrets } from '../lib/scan-secrets.js'
 import { printNextStep } from '../lib/next-step.js'
+import { promptOrDefault } from '../lib/interactive.js'
 import { t } from '../i18n/ko.js'
 
 export function formatDefaultCommitMessage(date = new Date()): string {
@@ -56,12 +57,15 @@ export async function save(): Promise<void> {
     if (severe.length > 5) {
       console.log(chalk.dim(`   ... 외 ${severe.length - 5}건 (vhk 보안 scan)`))
     }
-    const { proceed } = await inquirer.prompt<{ proceed: boolean }>([{
-      type: 'confirm',
-      name: 'proceed',
-      message: t('save.secretsConfirm'),
-      default: false,
-    }])
+    const proceed = await promptOrDefault(
+      async () => (await inquirer.prompt<{ proceed: boolean }>([{
+        type: 'confirm',
+        name: 'proceed',
+        message: t('save.secretsConfirm'),
+        default: false,
+      }])).proceed,
+      false,   // 비대화형 = 시크릿 커밋 안 함 (안전)
+    )
     if (!proceed) {
       console.log(chalk.gray(t('save.cancelled')))
       return
@@ -81,12 +85,15 @@ export async function save(): Promise<void> {
     console.log(`   ${statusIcon(code)} ${name}`)
   })
 
-  const { message } = await inquirer.prompt<{ message: string }>([{
-    type: 'input',
-    name: 'message',
-    message: t('save.commitMessage'),
-    default: formatDefaultCommitMessage(),
-  }])
+  const message = await promptOrDefault(
+    async () => (await inquirer.prompt<{ message: string }>([{
+      type: 'input',
+      name: 'message',
+      message: t('save.commitMessage'),
+      default: formatDefaultCommitMessage(),
+    }])).message,
+    'chore: vhk save',
+  )
 
   const spinner = ora(t('save.saving')).start()
   let didAdd = false

--- a/src/index.ts
+++ b/src/index.ts
@@ -297,8 +297,9 @@ program
   .command('restore')
   .alias('복원')
   .argument('[id]', '복원할 백업 id (생략 시 목록에서 선택)')
+  .option('--yes', '확인 없이 실행 (위험 작업 명시 승인)')
   .description('sync 백업 복원 (.vhk/backups/ — 언커밋 덮어쓰기 복구)')
-  .action(async (id?: string) => { await restore(id) })
+  .action(async (id: string | undefined, opts: { yes?: boolean }) => { await guardCli('restore', opts?.yes === true, () => restore(id)) })
 
 program
   .command('status')

--- a/src/lib/goal-frontmatter.ts
+++ b/src/lib/goal-frontmatter.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
+import { stripBom } from './read-json.js'
 
 // VHK goals/<n>-<name>.md frontmatter 표준. vspec/vooster 호환.
 export type GoalStatus = 'NOT_STARTED' | 'IN_PROGRESS' | 'DONE' | 'BLOCKED'
@@ -32,8 +33,9 @@ export function parseFrontmatter(content: string): {
   frontmatter: GoalFrontmatter
   body: string
 } {
-  const m = content.match(FRONTMATTER_RE)
-  if (!m) return { frontmatter: {}, body: content }
+  const normalized = stripBom(content)
+  const m = normalized.match(FRONTMATTER_RE)
+  if (!m) return { frontmatter: {}, body: normalized }
   const fm = parseSimpleYaml(m[1])
   // closing `---\n` 직후의 잔여 개행 1~N 개는 파싱 아티팩트 — body 표현에서 제거.
   const body = (m[2] ?? '').replace(/^\r?\n+/, '')

--- a/src/lib/interactive.ts
+++ b/src/lib/interactive.ts
@@ -1,12 +1,26 @@
 import chalk from 'chalk'
 
+// 프롬프트 가능 여부 단일출처. stdin TTY + --yes 아님.
+// VHK_FORCE_INTERACTIVE=1 = Git Bash/MinTTY 탈출구. 비-TTY 는 undefined → !!.
+export function isInteractive(opts?: { yes?: boolean }): boolean {
+  if (opts?.yes) return false
+  if (process.env.VHK_FORCE_INTERACTIVE === '1') return true
+  return !!process.stdin.isTTY
+}
+
+// benign 프롬프트: 비대화형이면 ask 호출 없이 fallback (stdin 미접근 = MCP 안전).
+export async function promptOrDefault<T>(ask: () => Promise<T>, fallback: T, opts?: { yes?: boolean }): Promise<T> {
+  if (!isInteractive(opts)) return fallback
+  try { return await ask() } catch (err) { if (isPromptAbortError(err)) return fallback; throw err }
+}
+
 /**
  * 대화형 명령 진입 가드 — 비-TTY(파이프/CI/EOF stdin)면 inquirer 프롬프트가
  * `ERR_USE_AFTER_CLOSE` 로 크래시하므로, 진입부에서 friendly 안내 + 비-0 종료 신호 후 중단한다.
  * 반환 true = 대화형 진행 가능. (VHK-014)
  */
 export function ensureInteractive(hint = ''): boolean {
-  if (process.stdin.isTTY) return true
+  if (isInteractive()) return true
   console.error(chalk.yellow('  ⚠️  이 명령은 대화형 입력이 필요합니다 — 비-TTY/파이프 환경에서는 실행할 수 없어요.'))
   if (hint) console.error(chalk.dim(`     ${hint}`))
   process.exitCode = 1

--- a/src/lib/risk-policy.ts
+++ b/src/lib/risk-policy.ts
@@ -1,9 +1,10 @@
 import type { SafetyMode } from './safety-mode.js'
 
 /**
- * 정책 적용 대상 high-risk 액션 8종 — 되돌리기 어렵거나 외부에 영향 주는 작업.
+ * 정책 적용 대상 high-risk 액션 9종 — 되돌리기 어렵거나 외부에 영향 주는 작업.
  * (undo: 커밋 되돌림 / deploy·publish: 외부 배포 / migrate: 패키지매니저 전환 /
- *  cloud-pull: 로컬 .vhk 덮어씀 / resume: HARD_STOP 해제 / env-write: 시크릿 파일 변경 / delete: 삭제)
+ *  cloud-pull: 로컬 .vhk 덮어씀 / resume: HARD_STOP 해제 / env-write: 시크릿 파일 변경 /
+ *  delete: 삭제 / restore: 백업 덮어쓰기 — 로컬 파일을 백업으로 복원)
  */
 export const HIGH_RISK_ACTIONS = [
   'undo',
@@ -14,6 +15,7 @@ export const HIGH_RISK_ACTIONS = [
   'resume',
   'env-write',
   'delete',
+  'restore',
 ] as const
 
 export type HighRiskAction = (typeof HIGH_RISK_ACTIONS)[number]
@@ -42,6 +44,7 @@ export const NL_GUARDED_ACTIONS: Readonly<Record<string, string>> = {
   env: 'env-write',
   save: 'save',
   sync: 'sync',
+  restore: 'restore',
 }
 
 export function isHighRisk(action: string): action is HighRiskAction {

--- a/src/lib/safety-guard.ts
+++ b/src/lib/safety-guard.ts
@@ -45,7 +45,12 @@ export async function runGuarded<T>(
   }
 
   if (guard === 'warn') {
-    // lite — 막지 않고 경고만
+    // R13/E8: lite 여도 비대화형(stdin 비-TTY)+미승인이면 destructive 중단 — 경고 볼 사람 없음.
+    const canConfirm = deps.isTTY ?? !!process.stdin.isTTY
+    if (!deps.approved && !canConfirm) {
+      log(`⚠️ 위험 작업(${action}) — lite 지만 비대화형+미승인 → 중단. (--yes 로 승인)`)
+      return { outcome: { ran: false, guard, reason: 'lite-noninteractive-block' } }
+    }
     log(`⚠️ 위험 작업(${action}) — lite 모드: 경고만 하고 진행합니다.`)
     return { outcome: { ran: true, guard, reason: 'lite-warn' }, result: await run() }
   }
@@ -55,7 +60,7 @@ export async function runGuarded<T>(
     if (deps.approved === true) {
       return { outcome: { ran: true, guard, reason: 'approved' }, result: await run() }
     }
-    const tty = deps.isTTY ?? !!process.stdout.isTTY
+    const tty = deps.isTTY ?? !!process.stdin.isTTY
     if (tty && deps.confirm) {
       const ok = await deps.confirm()
       if (ok) return { outcome: { ran: true, guard, reason: 'confirmed' }, result: await run() }

--- a/tests/goal-frontmatter.test.ts
+++ b/tests/goal-frontmatter.test.ts
@@ -52,6 +52,13 @@ describe('parseFrontmatter', () => {
     expect(body.startsWith('# Mission:')).toBe(true)
   })
 
+  it('UTF-8 BOM 이 있어도 frontmatter 를 파싱한다 (Windows PowerShell 호환)', () => {
+    const { frontmatter, body } = parseFrontmatter('\ufeff' + SAMPLE)
+    expect(frontmatter.type).toBe('goal')
+    expect(frontmatter.id).toBe(0)
+    expect(body.startsWith('# Mission:')).toBe(true)
+  })
+
   it('frontmatter 없는 파일은 빈 객체 + 전체 본문 반환', () => {
     const content = '# 그냥 마크다운\n\n본문'
     const { frontmatter, body } = parseFrontmatter(content)

--- a/tests/interactive.test.ts
+++ b/tests/interactive.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { ensureInteractive, isPromptAbortError } from '../src/lib/interactive.js'
+import { ensureInteractive, isPromptAbortError, isInteractive, promptOrDefault } from '../src/lib/interactive.js'
 
 function setTTY(value: boolean | undefined): boolean | undefined {
   const orig = process.stdin.isTTY
@@ -34,4 +34,29 @@ describe('interactive — 대화형 가드 (VHK-014)', () => {
     expect(isPromptAbortError(new Error('ExitPromptError'))).toBe(true)
     expect(isPromptAbortError(new Error('일반 에러'))).toBe(false)
   })
+})
+
+describe('isInteractive (감지 SoT)', () => {
+  // 비고: 이 Node 환경에서 process.stdin.isTTY 는 read-only(Socket) 라
+  // 직접 대입이 불가 → 기존 setTTY(Object.defineProperty) 헬퍼로 동일 의도 유지.
+  const origEnv = process.env.VHK_FORCE_INTERACTIVE
+  let origTTY: boolean | undefined
+  afterEach(() => { setTTY(origTTY); process.env.VHK_FORCE_INTERACTIVE = origEnv })
+  it('stdin TTY 면 true', () => { origTTY = setTTY(true); expect(isInteractive()).toBe(true) })
+  it('비-TTY 면 false', () => { origTTY = setTTY(undefined); expect(isInteractive()).toBe(false) })
+  it('--yes 면 TTY 라도 false', () => { origTTY = setTTY(true); expect(isInteractive({ yes: true })).toBe(false) })
+  it('VHK_FORCE_INTERACTIVE=1 면 비-TTY 라도 true', () => { origTTY = setTTY(undefined); process.env.VHK_FORCE_INTERACTIVE = '1'; expect(isInteractive()).toBe(true) })
+})
+
+describe('promptOrDefault', () => {
+  let origTTY: boolean | undefined
+  afterEach(() => { setTTY(origTTY) })
+  it('대화형 → ask 결과', async () => { origTTY = setTTY(true); expect(await promptOrDefault(async () => 'asked', 'fb')).toBe('asked') })
+  it('비대화형 → ask 미호출 + fallback (MCP 불변식)', async () => {
+    origTTY = setTTY(undefined)
+    const ask = vi.fn(async () => 'asked')
+    expect(await promptOrDefault(ask, 'fb')).toBe('fb'); expect(ask).not.toHaveBeenCalled()
+  })
+  it('ask 가 abort 던지면 fallback', async () => { origTTY = setTTY(true); expect(await promptOrDefault(async () => { throw new Error('User force closed the prompt') }, 'fb')).toBe('fb') })
+  it('ask 가 비-abort 에러면 rethrow', async () => { origTTY = setTTY(true); await expect(promptOrDefault(async () => { throw new Error('boom') }, 'fb')).rejects.toThrow('boom') })
 })

--- a/tests/safety-coverage.test.ts
+++ b/tests/safety-coverage.test.ts
@@ -4,6 +4,7 @@ import {
   HIGH_RISK_ACTIONS,
   STRICT_EXTRA_ACTIONS,
   NL_GUARDED_ACTIONS,
+  isHighRisk,
 } from '../src/lib/risk-policy.js'
 
 // 가드가 필요한 action 전체 = high-risk ∪ strict-extra(save/sync).
@@ -13,6 +14,7 @@ const GUARDED = new Set<string>([...HIGH_RISK_ACTIONS, ...STRICT_EXTRA_ACTIONS])
 const HANDLER_ACTION: Record<string, string> = {
   undo: 'undo', deploy: 'deploy', publish: 'publish', migrate: 'migrate',
   cloudPull: 'cloud-pull', env: 'env-write', save: 'save', sync: 'sync', resume: 'resume',
+  restore: 'restore',
 }
 
 describe('완전성 가드 — high-risk 무바이패스 (적대리뷰 R2)', () => {
@@ -35,7 +37,7 @@ describe('완전성 가드 — high-risk 무바이패스 (적대리뷰 R2)', () 
 
   it('CLI 등록: 가드대상 + CLI 커맨드 있는 action 은 전부 guardCli/guardCliDefer 경유 (index.ts)', () => {
     const idx = readFileSync('src/index.ts', 'utf-8')
-    const CLI_ACTIONS = ['deploy', 'publish', 'migrate', 'env-write', 'cloud-pull', 'undo', 'resume', 'save', 'sync']
+    const CLI_ACTIONS = ['deploy', 'publish', 'migrate', 'env-write', 'cloud-pull', 'undo', 'resume', 'save', 'sync', 'restore']
     for (const a of CLI_ACTIONS) {
       // undo/resume 는 guardCliDefer(명령 자체확인 위임), 나머지는 guardCli
       expect(new RegExp(`guardCli(Defer)?\\('${a}'`).test(idx), `CLI '${a}' 가드 미경유`).toBe(true)
@@ -70,6 +72,10 @@ describe('완전성 가드 — high-risk 무바이패스 (적대리뷰 R2)', () 
     expect(idx.includes("guardCli('delete'")).toBe(false)
     expect(idx.includes(".command('delete'")).toBe(false)
     expect(Object.keys(NL_GUARDED_ACTIONS)).not.toContain('delete')
+  })
+
+  it('restore 는 high-risk (백업 덮어쓰기)', () => {
+    expect(isHighRisk('restore')).toBe(true)
   })
 
   it('high-risk 별도 나열 리스트는 risk-policy 외에 없음(드리프트 소스 감사)', () => {

--- a/tests/safety-coverage.test.ts
+++ b/tests/safety-coverage.test.ts
@@ -90,3 +90,19 @@ describe('완전성 가드 — high-risk 무바이패스 (적대리뷰 R2)', () 
     }
   })
 })
+
+// HIGH_RISK_ACTIONS 를 risk-policy 원본에서 직접 순회 — 위 CLI_ACTIONS(손관리 미러)와 달리
+// 새 high-risk 액션이 추가되면 자동으로 검사 대상에 포함되어 가드 누락 드리프트를 차단한다.
+describe('HIGH_RISK 완전성 — index.ts guard 경유', () => {
+  const idx = readFileSync('src/index.ts', 'utf-8')
+  // env-write 는 env 명령에서 guardCli('env-write'...) 로 등록.
+  // delete 는 현재 CLI 직접 명령 없음(진입점 없는 예약 액션) → 예외.
+  //   (safety-coverage 의 "'delete' 는 진입점 없는 예약 액션" 테스트가 .command('delete')/guardCli('delete') 부재를 별도 검증)
+  const EXEMPT = new Set(['delete'])
+  for (const a of HIGH_RISK_ACTIONS) {
+    if (EXEMPT.has(a)) continue
+    it(`${a} 는 index.ts 에서 guard 경유`, () => {
+      expect(new RegExp(`guardCli(Defer)?\\('${a}'`).test(idx)).toBe(true)
+    })
+  }
+})

--- a/tests/safety-guard.test.ts
+++ b/tests/safety-guard.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
@@ -20,10 +20,11 @@ describe('runGuarded — 단일 chokepoint', () => {
     expect(t.ran).toBe(true)
   })
 
-  it('lite + high-risk → 경고만 하고 실행', async () => {
+  it('lite + high-risk + 대화형(isTTY) → 경고만 하고 실행', async () => {
     const t = tracker()
     const logs: string[] = []
-    const { outcome } = await runGuarded('deploy', { channel: 'cli', mode: 'lite', log: (m) => logs.push(m) }, t.run)
+    // R13: lite 의 "경고만 하고 실행" 은 대화형(경고 볼 사람 있음)에서만 유효.
+    const { outcome } = await runGuarded('deploy', { channel: 'cli', mode: 'lite', isTTY: true, log: (m) => logs.push(m) }, t.run)
     expect(outcome.ran).toBe(true)
     expect(t.ran).toBe(true)
     expect(logs.join(' ')).toMatch(/경고|warn|lite/i)
@@ -103,5 +104,25 @@ describe('CLI 가드 e2e — standard 모드 high-risk 차단 (행동 검증)', 
     // 실제 배포 흐름(플랫폼 선택)으로 진입하지 않음
     expect(out).not.toMatch(/어떤 플랫폼에 배포/)
     fs.rmSync(tmp, { recursive: true, force: true })
+  })
+})
+
+describe('runGuarded — lite 비대화형 destructive 중단 (R13)', () => {
+  it('lite + 비대화형(isTTY:false) + 미승인 → 실행 안 함', async () => {
+    const run = vi.fn(async () => 'ran')
+    const { outcome } = await runGuarded('undo', { channel: 'cli', mode: 'lite', isTTY: false, approved: false }, run)
+    expect(run).not.toHaveBeenCalled()
+    expect(outcome.ran).toBe(false)
+  })
+  it('lite + 대화형(isTTY:true) → 경고 후 실행', async () => {
+    const run = vi.fn(async () => 'ran')
+    const { outcome } = await runGuarded('undo', { channel: 'cli', mode: 'lite', isTTY: true }, run)
+    expect(outcome.ran).toBe(true)
+    expect(run).toHaveBeenCalled()
+  })
+  it('lite + 비대화형 + --yes 승인 → 실행', async () => {
+    const run = vi.fn(async () => 'ran')
+    const { outcome } = await runGuarded('undo', { channel: 'cli', mode: 'lite', isTTY: false, approved: true }, run)
+    expect(outcome.ran).toBe(true)
   })
 })

--- a/tests/safety-mode.test.ts
+++ b/tests/safety-mode.test.ts
@@ -34,12 +34,12 @@ describe('safety-mode — 모드 정의', () => {
   })
 })
 
-describe('risk-policy — high-risk 8종 + 채널/모드 정책', () => {
-  it('high-risk 8종 포함', () => {
-    for (const a of ['undo', 'deploy', 'publish', 'migrate', 'cloud-pull', 'resume', 'env-write', 'delete']) {
+describe('risk-policy — high-risk 9종 + 채널/모드 정책', () => {
+  it('high-risk 9종 포함', () => {
+    for (const a of ['undo', 'deploy', 'publish', 'migrate', 'cloud-pull', 'resume', 'env-write', 'delete', 'restore']) {
       expect(HIGH_RISK_ACTIONS).toContain(a)
     }
-    expect(HIGH_RISK_ACTIONS.length).toBe(8)
+    expect(HIGH_RISK_ACTIONS.length).toBe(9)
   })
 
   it('isHighRisk 판정', () => {

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -83,6 +83,31 @@ describe('save', () => {
     process.exitCode = exitBefore
   })
 
+  it('비-TTY 면 커밋 메시지 inquirer 없이 기본값(chore: vhk save) 사용', async () => {
+    // vitest = 비-TTY (stdin.isTTY undefined). promptOrDefault 가 ask() 미호출 → fallback.
+    const ttyBefore = process.stdin.isTTY
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+    try {
+      vi.mocked(execFileSync).mockImplementation((_file, args) => {
+        if (Array.isArray(args) && args[0] === 'rev-parse') return 'true'
+        return ''
+      })
+      mockGitOut.mockImplementation((args: string[]) => {
+        if (args[0] === 'status') return ' M file.ts'
+        return ''
+      })
+      mockHasGitRemote.mockReturnValue(false)
+      const { save } = await import('../src/commands/save.js')
+      await expect(save()).resolves.not.toThrow()
+      // inquirer 프롬프트 미호출 (비대화형 = stdin 미접근, MCP 안전)
+      expect(vi.mocked(inquirer.prompt)).not.toHaveBeenCalled()
+      // 커밋은 fallback 메시지로 수행
+      expect(mockGitRun).toHaveBeenCalledWith(['commit', '-m', 'chore: vhk save'], '/repo')
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: ttyBefore, configurable: true })
+    }
+  })
+
   it('commit 실패 시 staged 안내', async () => {
     vi.mocked(execFileSync).mockImplementation((_file, args) => {
       if (Array.isArray(args) && args[0] === 'rev-parse') return 'true'


### PR DESCRIPTION
## 요약
MCP-first 대비 대화형/비대화형 통합 가드 P1 (#14). 3버킷(auto-default / refuse-essential / destructive-guarded) + 감지 SoT.

## 커밋 (TDD, subagent-driven)
- feat(interactive): isInteractive/promptOrDefault 감지 SoT
- fix(safety): restore HIGH_RISK + guardCli + NL
- fix(safety): lite 여도 비대화형+미승인 destructive 중단 (R13/E8)
- refactor(init): 로컬 isNonInteractive → SoT (stdin 축)
- fix(gate,save): gate essential 거부 + save 기본메시지/secrets 안전중단
- test(safety): HIGH_RISK 완전성 + save 비대화형 커버리지
- feat: check-goal-11 게이트 + Goal 11 DONE

## 검증
- 585 vitest 통과, tsc/build clean
- Goal 11 풀게이트 통과
- 실측 스파이크: pipe gate 거부 / undo 중단 / VHK_FORCE_INTERACTIVE 탈출구 작동
- 최종 코드리뷰: READY TO MERGE (no blockers)

설계: docs/superpowers/specs/2026-06-01-mcp-noninteractive-guard-design.md
P2(잔여 명령 마이그 + save push) = Goal 12 백로그.

Refs #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)