### PR TITLE
fix: vhk save 취소 동작 핫픽스 + v1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 (다음 릴리즈 누적 영역)
 
+## [1.6.5] - 2026-06-02
+
+> **핫픽스 — `vhk save` 취소 동작.** v1.6.4 의 `promptOrDefault` 가 대화형에서도
+> 프롬프트 abort(Ctrl+C/ESC)를 삼켜 fallback 으로 바꾸는 버그. `vhk save` 커밋 메시지
+> 입력 중 취소하면 취소가 무시되고 기본 메시지로 **원치 않는 커밋**이 발생했다.
+
+### Fixed
+
+- **`promptOrDefault` 가 대화형 취소(Ctrl+C/ESC)를 삼키던 버그** (`src/lib/interactive.ts`) —
+  비대화형은 이미 early-return 하므로 abort 는 항상 "사용자 취소". 이제 fallback 으로
+  바꾸지 않고 그대로 전파 → 전역 핸들러가 깔끔히 취소. `vhk save` 커밋 메시지 취소 시
+  더 이상 원치 않는 커밋이 생기지 않는다.
+
 ## [1.6.4] - 2026-06-02
 
 > **대화형/비대화형 통합 가드 (MCP·CI 안전, #14 Goal 11).** inquirer 쓰는 명령이

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ tags: [process, documentation]
 
 - **레포:** <https://github.com/byh3071-cpu/vhk> (public)
 - **npm:** @byh3071/vhk (public, scoped)
-- **버전:** v1.6.4 (package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
+- **버전:** v1.6.5 (package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
 - **MCP tool:** 24/24 (Goal 0 DONE)
 - **테스트:** 585 pass (vitest)
 - **패키지 매니저:** pnpm

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Vibe Harness Kit — AI 코딩 도구·기기를 바꿔도 규칙·맥락이 따라가는 포터빌리티 CLI (sync: Cursor·Claude·Windsurf·Copilot·Antigravity / cloud 백업)",
   "bin": {
     "vhk": "dist/index.js",

--- a/src/lib/interactive.ts
+++ b/src/lib/interactive.ts
@@ -9,9 +9,12 @@ export function isInteractive(opts?: { yes?: boolean }): boolean {
 }
 
 // benign 프롬프트: 비대화형이면 ask 호출 없이 fallback (stdin 미접근 = MCP 안전).
+// 대화형이면 그대로 ask — abort(Ctrl+C/ESC)는 삼키지 않고 전파한다.
+// (비대화형은 위에서 early-return 하므로, 여기 도달한 abort 는 항상 "사용자 취소"다.
+//  과거엔 이를 fallback 으로 바꿔 save 가 취소 의도를 무시하고 커밋하던 위험버그 — 제거.)
 export async function promptOrDefault<T>(ask: () => Promise<T>, fallback: T, opts?: { yes?: boolean }): Promise<T> {
   if (!isInteractive(opts)) return fallback
-  try { return await ask() } catch (err) { if (isPromptAbortError(err)) return fallback; throw err }
+  return await ask()
 }
 
 /**

--- a/tests/interactive.test.ts
+++ b/tests/interactive.test.ts
@@ -57,6 +57,6 @@ describe('promptOrDefault', () => {
     const ask = vi.fn(async () => 'asked')
     expect(await promptOrDefault(ask, 'fb')).toBe('fb'); expect(ask).not.toHaveBeenCalled()
   })
-  it('ask 가 abort 던지면 fallback', async () => { origTTY = setTTY(true); expect(await promptOrDefault(async () => { throw new Error('User force closed the prompt') }, 'fb')).toBe('fb') })
+  it('대화형서 abort(Ctrl+C/ESC=사용자 취소)면 fallback 안 쓰고 전파 (취소 보존)', async () => { origTTY = setTTY(true); await expect(promptOrDefault(async () => { throw new Error('User force closed the prompt') }, 'fb')).rejects.toThrow(/force closed/) })
   it('ask 가 비-abort 에러면 rethrow', async () => { origTTY = setTTY(true); await expect(promptOrDefault(async () => { throw new Error('boom') }, 'fb')).rejects.toThrow('boom') })
 })


### PR DESCRIPTION
v1.6.4 회귀 핫픽스.

## 버그
promptOrDefault 가 대화형에서도 프롬프트 abort(Ctrl+C/ESC)를 삼켜 fallback 반환 → vhk save 커밋 메시지 입력 중 취소하면 취소가 무시되고 기본 메시지로 원치 않는 커밋 발생.

## 수정
비대화형은 early-return 하므로 도달하는 abort 는 항상 사용자 취소 → fallback 안 쓰고 전파(전역 핸들러가 취소). save 취소 시 커밋 없음.

## 검증
585 테스트, tsc/build clean. 취소-보존 테스트로 회귀 고정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)