### PR TITLE
release: v1.6.6 — 비대화형 가드 P2 (#14 Goal 12) + RFC 0038 (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 (다음 릴리즈 누적 영역)
 
+## [1.6.6] - 2026-06-02
+
+> **비대화형 가드 P2 (#14 Goal 12) + `.vhk` 규격 RFC (#38).** Goal 11 이 깐 3버킷 계약을
+> 잔여 대화형 명령(theme/sync/ship/design)으로 확장하고, `save` push 정책을 확정.
+> 철학 유지: 절대 안 멈춤 + 위험작업 무단실행 0 + 비-TTY 면 stdin 미접근(MCP RPC 보호).
+
+### Added
+
+- **`vhk theme --yes` (`-y`)** — 기존 파일 덮어쓰기 확인을 스킵(비대화형 자동 덮어쓰기). 충돌 확인은
+  `promptOrDefault`(stdin SoT)로 마이그 → 비-TTY·미승인이면 inquirer 미호출·기본 보존(① auto-default).
+- **`docs/rfc/0038-vhk-spec.md`** — `.vhk/` 규격 v1.1 제안(#38). 누락 항목(`.synced`·`backups/`·
+  `config.json`) 정합 + `reports/` 서브디렉토리(Goal 13 verify 증거화) 도입. 코드 아님(스펙/토론).
+
+### Fixed
+
+- **`vhk sync` 확인 축 정정 (stdout → stdin, E8/R1)** — drift 덮어쓰기 확인이 stdout TTY 로 판단해
+  MCP 불변식(비-TTY=stdin 미접근)과 어긋나던 문제. 이제 `isInteractive`/`promptOrDefault`(stdin 축)로
+  통일. 비-TTY/`--yes` → 자동 덮어쓰기(백업 먼저라 손실 0), 동작 보존.
+- **`vhk ship` 비-TTY 크래시 가드** — 배포 체크리스트·회고는 본질적 대화형(② refuse-essential) →
+  진입부 `ensureInteractive()` 로 비-TTY 에서 friendly 거부 + `exit 1`(멈춤/EOF 크래시 제거).
+
+### Note
+
+- **`save` push 정책 결정(S5) = `strict-extra` 유지.** commit 은 로컬·되돌리기 가능(undo), push 는
+  사용자 자기 remote 대상이라 deploy/publish(외부 배포=high-risk)와 등급이 다름 → `save` 를 HIGH_RISK
+  로 승격하지 않는다. push 차단을 원하면 `strict` 모드(이미 비-TTY·미승인 save 차단)가 탈출구.
+  회귀 테스트로 계약 고정(`tests/safety-guard.test.ts`).
+- **동작 변경:** 비-TTY(파이프/CI/MCP)에서 `vhk ship` 은 `--yes` 가 아니라 **TTY 환경**이 필요합니다
+  (자동답 불가한 본질적 대화형). 테스트 585 → 596(신규 11), 회귀 0.
+
 ## [1.6.5] - 2026-06-02
 
 > **핫픽스 — `vhk save` 취소 동작.** v1.6.4 의 `promptOrDefault` 가 대화형에서도

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,16 +13,16 @@ tags: [process, documentation]
 
 - **레포:** <https://github.com/byh3071-cpu/vhk> (public)
 - **npm:** @byh3071/vhk (public, scoped)
-- **버전:** v1.6.5 (package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
+- **버전:** v1.6.6 (package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
 - **MCP tool:** 24/24 (Goal 0 DONE)
-- **테스트:** 585 pass (vitest)
+- **테스트:** 596 pass (vitest)
 - **패키지 매니저:** pnpm
 
 ## 현재 상태
 
-- **Phase:** Phase 5 이후 — Goal 11(대화형/비대화형 통합 가드, #14) + v1.6.4 출시.
+- **Phase:** Phase 5 이후 — Goal 12(비대화형 가드 P2, #14) DONE + RFC 0038(#38) → v1.6.6 PR.
 - **블로커:** 없음
-- **다음 액션:** Goal 12(P2, 비대화형 가드 잔여) 백로그. OPEN = #38(RFC .vhk 규격).
+- **다음 액션:** Batch B — Goal 13(P1, verify 증거화) → v1.7.0. publish 는 사람(2FA OTP).
 - **마지막 업데이트:** 2026-06-02
 
 ## 코딩 컨벤션

--- a/docs/rfc/0038-vhk-spec.md
+++ b/docs/rfc/0038-vhk-spec.md
@@ -1,0 +1,148 @@
+---
+rfc: 38
+title: "`.vhk/` 규격 v1.1 — 누락 항목 정합 + `reports/` 서브디렉토리 도입"
+status: Proposed
+author: VHK
+created: 2026-06-02
+discussion: https://github.com/byh3071-cpu/vhk/issues/38
+normative_ref: docs/spec.md
+supersedes_note: "RFC 0001 (`.vhk/` v1.0) 의 후속. 0001/`spec.md` 가 정의한 v1.0 계약은 유지하고, 이 RFC 는 v1.1 증분만 다룬다."
+spec_version_target: "1.1"
+---
+
+# RFC 0038 — `.vhk/` 규격 v1.1
+
+> **번호 안내:** 이 저장소의 RFC 는 보통 일련번호(`0001`)다. 본 문서는 이슈 **#38**(`.vhk` 규격 트랙)을
+> 추적하려고 이슈 번호를 파일명에 쓴다. 규범 기반은 여전히 [RFC 0001](./0001-vhk-directory-spec.md) +
+> [`docs/spec.md`](../spec.md)(`spec_version 1.0`)이며, 본 RFC 는 그 위의 **v1.1 증분 제안**이다.
+> 둘이 어긋나면 `spec.md` 가 기준이고, 이 RFC 채택 시 `spec.md` 를 v1.1 로 갱신한다.
+
+## 1. 요약 (Summary)
+
+RFC 0001 이 `.vhk/` v1.0 의 공유/로컬 경계와 평면 파일 모델을 고정했다. 그 후 구현이 **규격에
+등재되지 않은 항목**(`.synced`, `backups/`)을 추가했고, Goal 13(verify 증거화)이 **첫 서브디렉토리**
+(`reports/`)를 요구한다. 본 RFC 는 두 가지를 한다:
+
+1. **정합(reconcile):** 코드엔 있으나 `spec.md` 표에 없는 `.synced`·`backups/` 를 규격에 등재하고,
+   v1.0 §0 의 *"하위 폴더 없는 평면 구조"* 단언이 이미 `backups/`(서브디렉토리)로 깨졌음을 바로잡는다.
+2. **확장(extend):** `reports/` 서브디렉토리를 도입해 `verify` 의 증거 산출물(`reports/latest.json`,
+   후속 `reports/latest.html`)을 담는다.
+
+변경은 **순수 가산(additive)** — 기존 파일명·포맷·트래킹 정책을 바꾸지 않으므로 `spec_version` 은
+**1.0 → 1.1**(minor) 만 올린다. 마이그레이션 불필요.
+
+## 2. 동기 (Motivation)
+
+- **규격-구현 드리프트:** v1.0 §4(호환성 정책)는 *"새 파일은 표·스키마에 먼저 등록한 뒤 구현한다"* 고
+  못박았지만, `.synced`(sync 마커)와 `backups/`(sync 백업)는 구현이 먼저 들어가고 규격에 빠졌다.
+  드리프트는 외부 도구·문서 신뢰를 깬다 → 정본을 코드에 맞춰 닫는다.
+- **"평면" 단언의 사실 오류:** v1.0 §0 은 `.vhk/` 가 평면이라고 단언하지만 `backups/<stamp>/…` 는 이미
+  중첩 폴더다. 규격이 사실과 어긋난 채로 두면 v2.0 폴더화 논의(0001 §7.2)의 출발점이 흐려진다.
+- **증거 산출물의 집(home)이 필요:** Goal 13 은 게이트 실행 결과를 `reports/latest.json` 으로 항상
+  남긴다(거짓완료 방지·성장 루프 입력). 평면 루트에 흩뿌리면 산출물/상태 파일 경계가 모호해지고,
+  후속 `latest.html`·리포트 히스토리가 루트를 오염시킨다. → 전용 서브디렉토리 `reports/` 로 격리.
+
+## 3. 가이드 설명 (비개발자 포함)
+
+v1.0 의 "공유할 것 vs 내 것만" 경계는 그대로다. v1.1 은 거기에 **"자동 생성된 임시 산출물"** 한 칸을 더
+나눈다.
+
+- `reports/` = VHK 가 검증을 돌리고 남기는 **증거 리포트**가 사는 곳. "테스트 진짜 돌렸어?"에
+  파일로 답한다.
+- `backups/` = `vhk sync` 가 파일을 덮어쓰기 직전 떠 두는 **로컬 복구본**(이미 동작 중, 규격에만 추가).
+- `.synced` = "이 프로젝트에서 sync 가 한 번이라도 돌았나"를 기록하는 작은 **마커**(이미 동작 중).
+
+세 항목 모두 **로컬 전용(커밋·백업 제외)** — 개인 환경 산물이라 팀/클라우드로 새지 않는다.
+
+## 4. 규격 변경 (Reference) — v1.1 증분
+
+### 4.1 파일/디렉토리 목록 추가
+
+`spec.md §1` 표에 아래 행을 추가한다(기존 행 무변경):
+
+| 경로 | 포맷 | 트래킹 | 생성 주체 | 목적 |
+| --- | --- | --- | --- | --- |
+| `.synced` | text(ISO 타임스탬프) | ❌ 로컬 전용 | `vhk sync` | 첫 sync 판정 마커. 내용 = 마지막 sync 시각(ISO) |
+| `backups/<stamp>/…` | 디렉토리 | ❌ 로컬 전용 | `vhk sync`(덮어쓰기 직전) | sync 덮어쓰기 전 원본 백업. `vhk restore` 가 복원 |
+| `config.json` | JSON | ❌ 로컬 전용(권장) | `vhk mode` | 프로젝트 설정. 현재 `{ "safetyMode": "lite\|standard\|strict" }` |
+| `reports/` | 디렉토리 | ❌ 로컬 전용 | `vhk verify` | **(신규 v1.1)** 검증 증거 산출물 디렉토리 |
+| `reports/latest.json` | JSON | ❌ 로컬 전용 | `vhk verify` | **(신규 v1.1)** 최신 검증 리포트. 스키마 §4.3 |
+
+> 참고: `config.json` 은 v1.0 표에 누락됐었다(코드: `src/lib/config.ts`). 정합 차원에서 함께 등재한다.
+> 읽기는 절대 throw 하지 않고 없으면 기본값(`standard`)으로 동작한다.
+
+### 4.2 "평면 구조" 단언 정정
+
+`spec.md §0` 의 *"하위 폴더 없는 평면 파일 모음"* 을 다음으로 대체:
+
+> `.vhk/` 는 **루트는 평면 파일 위주**이되, 자동 생성 산출물은 전용 서브디렉토리
+> (`backups/`, `reports/`)로 격리한다. 상태/설정 파일은 루트 평면, 산출물·히스토리는 서브디렉토리 —
+> 이 둘의 경계가 트래킹 정책(전부 로컬 전용)과 일치한다.
+
+### 4.3 `reports/latest.json` 스키마 (신규)
+
+Goal 13 의 계약. **head(기계용) + body(사람용)** 2단 구조.
+
+```jsonc
+{
+  "schemaVersion": 1,                       // number, 필수
+  "generatedAt": "2026-06-02T...Z",         // string(ISO/UTC), 필수 — 머신 타임스탬프
+  "date": "2026-06-02",                      // string(localDate), 필수 — 사람용 날짜
+  "status": "PASS",                          // "PASS" | "WARN" | "FAIL", 필수
+  "summary": { "total": 4, "pass": 4, "fail": 0, "skip": 0 },  // 카운트(기계용 head)
+  "gates": [                                  // 게이트별 실제 종료코드 기반 결과(body)
+    { "id": "typecheck", "label": "tsc --noEmit", "status": "pass", "exitCode": 0, "skipped": false }
+  ],
+  "nextActions": [ "..." ]                    // string[], 다음 행동 힌트
+}
+```
+
+- `status` 도출: 하나라도 `fail` → `FAIL`; fail 없고 `skip` 있음 → `WARN`; 전부 `pass` → `PASS`.
+- **거짓 PASS 금지:** 결과는 실제 프로세스 종료코드에서만 나온다. 게이트 스크립트 부재 → `skip`(WARN),
+  실행 자체 실패(ENOENT 등) → `fail`. 추측 금지.
+- **시크릿 비포함:** secret/env 값·스캔이 찾은 시크릿 본문은 리포트에 넣지 않는다(`.vhkignore` 존중).
+  게이트 메타(이름·종료코드·통과여부)만 기록.
+
+### 4.4 트래킹 / 클라우드 정책
+
+- `reports/`·`backups/`·`.synced`·`config.json` → **로컬 전용**: `.vhk/.gitignore` 에 등재(이미
+  `backups/`·`.synced` 류는 코드가 자기방어). `vhk cloud push` 기본 제외 집합에도 포함.
+- 근거: 검증 리포트·백업·마커·설정은 **개인 환경 산물**이라 팀 공유·클라우드 백업 대상이 아니다.
+
+## 5. 설계 근거 & 대안 (Rationale & Alternatives)
+
+- **왜 minor 범프(1.0→1.1)인가:** 파일명·포맷·기존 정책 무변경 + 신규는 전부 가산 → 호환성 안 깨짐.
+  v1.0 §4 의 "평면→폴더 등 호환성 깨는 변경만 spec_version 상향" 과 충돌하지 않게, "단언 정정 +
+  서브디렉토리 추가"는 호환 가산으로 분류해 **minor** 로 둔다(major 아님).
+- **왜 `reports/` 서브디렉토리(루트 평면 아님):** ① 산출물 히스토리(`latest.html`, 향후 타임스탬프
+  리포트)가 루트를 오염시키지 않음 ② 트래킹 정책이 디렉토리 단위로 깔끔(전체 ignore) ③ "상태=루트,
+  산출물=서브디렉토리" 멘탈 모델이 `backups/` 선례와 일관.
+- **대안 — 루트 평면 유지(`vhk-report.json`):** 거부. `latest.html`·히스토리까지 루트에 쌓이면 §4.2
+  경계가 다시 무너진다.
+- **대안 — `reports/` 를 커밋(공유):** 거부. 리포트는 로컬 환경(설치된 toolchain) 산물이라 기기마다
+  달라 팀 공유 시 머지 충돌·노이즈. 필요하면 사용자가 옵트인으로 `.vhkignore`/`.gitignore` 조정.
+
+## 6. 마이그레이션 & 호환성 (Compatibility)
+
+- **마이그레이션 불필요.** 기존 `.vhk/` 는 그대로 유효. `.synced`·`backups/` 는 이미 존재하던 것을
+  규격에 등재할 뿐, `reports/` 는 `vhk verify` 가 필요 시 `mkdir -p` 로 생성(lazy).
+- v1.0 클라이언트가 v1.1 디렉토리를 만나도 `reports/`·`backups/` 를 모를 뿐 동작 안 깨짐(전방 호환).
+- GA 안정성: 기존 tool API·파일 시그니처 변경 0.
+
+## 7. 미해결 질문 (Unresolved Questions)
+
+1. **리포트 히스토리:** `latest.json` 외에 타임스탬프 스냅샷(`reports/<stamp>.json`)을 둘지, 둔다면
+   `backups/` 처럼 보존 정책(prune)을 적용할지. (배치 6 `--report` 논의로 이관 가능)
+2. **`.synced` 내용 계약:** 현재 "마지막 sync 시각" 한 줄. 멀티 RULES.md/모노레포에서 per-target
+   마커가 필요할지.
+3. **`config.json` 확장:** safetyMode 외 설정(예: 기본 verify 게이트 셋) 추가 시 스키마 버저닝.
+4. **v2.0 폴더화:** 루트 평면 파일들도 카테고리 폴더로 옮길지(0001 §7.2 연장). 본 RFC 는 산출물만
+   서브디렉토리로 분리하고 상태/설정 루트는 유지 — v2.0 의 부분 선례.
+
+## 8. 채택 시 작업 (If Accepted)
+
+- [ ] `docs/spec.md` → `spec_version 1.1` 갱신: §1 표에 `.synced`·`backups/`·`config.json`·`reports/`
+      추가, §0 평면 단언 정정, §2 에 `reports/latest.json` 스키마 추가.
+- [ ] `.vhk/README.md` 트래킹 표에 신규 항목 반영(`src/templates/vhk-dir.ts`).
+- [ ] Goal 13 구현이 `reports/latest.json` 을 본 스키마로 산출(별도 PR — 본 RFC 는 코드 아님).
+- [ ] RFC 0001 §7.2(폴더화)에 본 RFC 를 "부분 선례"로 상호 링크.

--- a/goals/12-noninteractive-guard-p2.md
+++ b/goals/12-noninteractive-guard-p2.md
@@ -3,8 +3,9 @@ vhk_format: 1
 type: goal
 id: 12
 title: 비대화형 가드 P2 — 잔여 명령 마이그 + save push 검토
-status: NOT_STARTED
+status: DONE
 priority: P2
+completed: 2026-06-02
 ---
 
 # Goal 12: 비대화형 가드 P2 (#14 후속)
@@ -24,10 +25,26 @@ P1 이 안전핵심(감지 SoT + restore + lite-block + gate)을 처리. P2 는 
 - (선택) `VHK_MCP_MODE` env → channel='mcp' preview UX (P1 에서 YAGNI 로 제외했던 것).
 
 ## Completion Check
-- [ ] theme/design-palette/sync/ship 비-TTY 일관 동작 + 테스트
-- [ ] save push 비대화형 정책 결정·구현
-- [ ] 회귀 없음 (P1 동작 보존)
-- [ ] 공통 게이트 통과
+- [x] theme/design-palette/sync/ship 비-TTY 일관 동작 + 테스트
+- [x] save push 비대화형 정책 결정·구현
+- [x] 회귀 없음 (P1 동작 보존)
+- [x] 공통 게이트 통과
+
+## 구현 결과 (2026-06-02)
+- **theme** (① auto-default): 덮어쓰기 확인을 `promptOrDefault(…, false)`(stdin SoT)로 마이그 +
+  `-y/--yes` 추가. 비-TTY·미승인 → inquirer 미호출(MCP 안전)·기본 보존(멈춤 없음).
+- **ship** (② refuse-essential): 진입부 `ensureInteractive()` — 비-TTY 면 friendly 거부 + exit 1.
+- **sync** (① auto-default): 확인 축을 **stdout→stdin**(`isInteractive`/`promptOrDefault`, E8/R1)으로 정정.
+  비-TTY/`--yes` → 자동 덮어쓰기(백업 먼저라 손실 0). 기존 `syncCore` 시그니처 무변경.
+- **design / design-palette** (② refuse-essential): Goal 11 의 `ensureInteractive` 이미 적용 →
+  코드 무변경, 비-TTY 거부 테스트(`tests/design-guard.test.ts`)로 계약 잠금.
+- **S5 결정 = `strict-extra` 유지** (high-risk 승격 ❌). 근거: commit 은 로컬·되돌리기 가능(undo),
+  push 는 사용자 자기 remote 대상이라 deploy/publish(외부 배포=high-risk)와 등급 다름.
+  spec ③ 버킷도 save 를 "strict 일 때만" destructive 로 분류. 최빈 명령을 standard 에서 막으면
+  UX 파괴 — push 차단을 원하면 `strict` 모드(이미 비-TTY·미승인 save 차단)가 탈출구.
+  `save.ts` 무변경(기존 save 테스트 보존) + 회귀 테스트로 계약 잠금(`tests/safety-guard.test.ts`).
+- 제외: `VHK_MCP_MODE` preview UX — 여전히 YAGNI(비-TTY 가 MCP 안전 이미 커버). 후속 goal 로.
+- 테스트: 585 → 596 (신규 11). 회귀 0.
 
 ## Mandatory Reading
 - `docs/superpowers/specs/2026-06-01-mcp-noninteractive-guard-design.md` §9 (스코프 P2)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Vibe Harness Kit — AI 코딩 도구·기기를 바꿔도 규칙·맥락이 따라가는 포터빌리티 CLI (sync: Cursor·Claude·Windsurf·Copilot·Antigravity / cloud 백업)",
   "bin": {
     "vhk": "dist/index.js",

--- a/scripts/check-goal-12.mjs
+++ b/scripts/check-goal-12.mjs
@@ -50,9 +50,22 @@ if (!skipDeep) {
   if (scripts.build) gate('build', run(pm, ['run', 'build']))
 }
 
-// ─── goal 12 고유 검증 (직접 추가) ───────────────────────────────
-// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
-// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+// ─── goal 12 고유 검증 (비대화형 가드 P2) ───────────────────────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// ① auto-default: theme 덮어쓰기 확인을 promptOrDefault(stdin SoT)로 마이그 + --yes
+must(/promptOrDefault/.test(read('src/commands/theme.ts') ?? ''), 'theme 비대화형 기본값 (① auto-default)')
+must(/--yes|options\?\.yes/.test(read('src/commands/theme.ts') ?? ''), 'theme --yes 강제 덮어쓰기')
+must(/theme.*--yes|--yes.*theme/s.test(read('src/index.ts') ?? '') || /\.command\('theme'\)[\s\S]{0,200}--yes/.test(read('src/index.ts') ?? ''), 'index theme --yes 옵션 등록')
+// ② refuse-essential: ship 진입 가드
+must(/ensureInteractive\(/.test(read('src/commands/ship.ts') ?? ''), 'ship essential 진입거부 (② refuse)')
+// sync 확인 축 = stdin SoT (stdout 아님 — E8/R1)
+const syncSrc = read('src/commands/sync.ts') ?? ''
+must(/promptOrDefault/.test(syncSrc) && /isInteractive/.test(syncSrc), 'sync 확인 축 stdin SoT 마이그 (E8)')
+must(!/!!process\.stdout\.isTTY && !opts\.yes/.test(syncSrc), 'sync 구 stdout 축 제거')
+// S5 결정: save 는 strict-extra 유지(high-risk 승격 안 함)
+const riskSrc = read('src/lib/risk-policy.ts') ?? ''
+must(/STRICT_EXTRA_ACTIONS[\s\S]*?'save'/.test(riskSrc), 'save strict-extra 유지 (S5)')
+must(!/HIGH_RISK_ACTIONS[\s\S]*?'save'[\s\S]*?\] as const/.test(riskSrc), 'save 는 HIGH_RISK 승격 안 함 (S5)')
 
 if (pass) { console.log('✅ goal 12 gate passes'); process.exit(0) }
 console.log('❌ goal 12 gate failed'); process.exit(1)

--- a/src/commands/ship.ts
+++ b/src/commands/ship.ts
@@ -6,6 +6,7 @@ import { ko } from '../i18n/ko.js'
 import { log } from '../utils/logger.js'
 import { printNextStep } from '../lib/next-step.js'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
+import { ensureInteractive } from '../lib/interactive.js'
 import { localDate } from '../lib/date.js'
 
 const CHECKLIST = [
@@ -64,6 +65,9 @@ export function updateChangelogUnreleased(
 
 export async function ship() {
   if (!ensureNotHardStopped('ship')) return // VHK-020
+  // ② refuse-essential: 체크리스트·회고는 자동답이 불가한 본질적 대화형 입력 →
+  // 비-TTY(파이프/CI/MCP)면 inquirer 크래시(ERR_USE_AFTER_CLOSE) 대신 friendly 거부 + exit 1 (절대 안 멈춤).
+  if (!ensureInteractive('배포 체크리스트·회고는 대화형 입력이 필요합니다. PowerShell 등 TTY 에서 실행하세요.')) return
   console.log(chalk.bold(`\n${ko.ship.title}\n`))
 
   const cwd = process.cwd()

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -8,6 +8,7 @@ import { printNextStep } from '../lib/next-step.js'
 import { normalizeForCompare } from '../lib/drift.js'
 import { saveBackup, pruneBackups, ensureVhkIgnored } from '../lib/backup.js'
 import { PREAMBLE_TITLE } from '../lib/rules-import.js'
+import { isInteractive, promptOrDefault } from '../lib/interactive.js'
 
 interface RulesSection {
   title: string
@@ -442,22 +443,26 @@ export async function sync(opts: SyncOptions = {}): Promise<void> {
   const sections = parseRulesMd(fs.readFileSync(rulesPath, 'utf-8'))
   console.log(chalk.dim(`  📄 RULES.md 파싱 완료 — ${sections.length}개 섹션`))
 
-  // 비대화형(CI/MCP subprocess: isTTY=false)·--yes → 자동 덮어쓰기(멈춤 금지).
+  // 비대화형(CI/MCP subprocess)·--yes → 자동 덮어쓰기(멈춤 금지).
   // TTY → drift 시 inquirer 확인(기본 거부). 어느 쪽이든 백업이 먼저라 손실 0.
-  const interactive = !!process.stdout.isTTY && !opts.yes
-  const confirmOverwrite = async (drifted: SyncPlanItem[]): Promise<boolean> => {
-    if (!interactive) return true
-    for (const d of drifted) console.log(chalk.yellow(`  ${ko.sync.driftWarn(d.path)}`))
-    const { confirm } = await inquirer.prompt<{ confirm: boolean }>([
-      {
-        type: 'confirm',
-        name: 'confirm',
-        message: ko.sync.driftConfirm(drifted.length),
-        default: false,
+  // 감지 축 = stdin(SoT isInteractive) — stdout 아님(E8/R1). 비-TTY 면 stdin 미접근(MCP 안전).
+  const confirmOverwrite = async (drifted: SyncPlanItem[]): Promise<boolean> =>
+    promptOrDefault(
+      async () => {
+        for (const d of drifted) console.log(chalk.yellow(`  ${ko.sync.driftWarn(d.path)}`))
+        const { confirm } = await inquirer.prompt<{ confirm: boolean }>([
+          {
+            type: 'confirm',
+            name: 'confirm',
+            message: ko.sync.driftConfirm(drifted.length),
+            default: false,
+          },
+        ])
+        return confirm
       },
-    ])
-    return confirm
-  }
+      true, // 비대화형/--yes → 자동 덮어쓰기(백업이 먼저라 손실 0, 멱등)
+      { yes: opts.yes },
+    )
 
   const result = await syncCore(cwd, opts, confirmOverwrite)
 
@@ -487,7 +492,7 @@ export async function sync(opts: SyncOptions = {}): Promise<void> {
 
   if (result.backupId) {
     if (result.firstSync) console.log(chalk.cyan(`  ${ko.sync.firstSync}`))
-    if (!process.stdout.isTTY) {
+    if (!isInteractive(opts)) {
       console.log(chalk.yellow(`  ${ko.sync.nonTtyAuto(result.backedUp.length, result.backupId)}`))
     } else {
       console.log(chalk.cyan(`  ${ko.sync.backupSaved(result.backedUp.length, result.backupId)}`))

--- a/src/commands/theme.ts
+++ b/src/commands/theme.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk'
 import inquirer from 'inquirer'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
+import { promptOrDefault } from '../lib/interactive.js'
 
 function generateDarkCSS(): string {
   return `/* vhk theme — 다크/라이트 모드 CSS 변수 */
@@ -60,7 +61,7 @@ export function initTheme(): void {
 `
 }
 
-export async function theme(): Promise<void> {
+export async function theme(options?: { yes?: boolean }): Promise<void> {
   console.log(chalk.bold('\n🌙 ' + t('theme.title')))
   console.log(chalk.gray('─'.repeat(40)))
 
@@ -69,14 +70,21 @@ export async function theme(): Promise<void> {
   const conflicts = [cssPath, togglePath].filter((p) => existsSync(p))
 
   if (conflicts.length > 0) {
-    const { overwrite } = await inquirer.prompt<{ overwrite: boolean }>([{
-      type: 'confirm',
-      name: 'overwrite',
-      message: `다음 파일이 이미 있어요. 덮어쓸까요?\n   ${conflicts.join('\n   ')}`,
-      default: false,
-    }])
+    // ① auto-default(benign): --yes 면 덮어쓰기, 비대화형(비-TTY)이면 stdin 미접근 → 기본 false(보존).
+    // 비-TTY 에서 inquirer 를 호출하지 않아 MCP 파이프 안전(R19/E5) + 절대 안 멈춤.
+    const overwrite = options?.yes === true
+      ? true
+      : await promptOrDefault(
+          async () => (await inquirer.prompt<{ overwrite: boolean }>([{
+            type: 'confirm',
+            name: 'overwrite',
+            message: `다음 파일이 이미 있어요. 덮어쓸까요?\n   ${conflicts.join('\n   ')}`,
+            default: false,
+          }])).overwrite,
+          false,
+        )
     if (!overwrite) {
-      console.log(chalk.yellow('\n⏭️  생성 취소 — 기존 파일 유지.'))
+      console.log(chalk.yellow('\n⏭️  생성 취소 — 기존 파일 유지. (비대화형이면 --yes 로 덮어쓰기)'))
       return
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -371,8 +371,9 @@ program
 program
   .command('theme')
   .alias('테마')
+  .option('-y, --yes', '기존 파일 덮어쓰기 확인 스킵 (비대화형 자동 덮어쓰기)')
   .description('다크/라이트 모드 CSS + 토글 유틸리티 생성')
-  .action(async () => { await theme() })
+  .action(async (opts: { yes?: boolean }) => { await theme(opts) })
 
 const refCmd = program
   .command('ref')

--- a/tests/design-guard.test.ts
+++ b/tests/design-guard.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Goal 12: design / design-palette 는 ② refuse-essential — 팔레트 선택은 자동답 불가.
+// 비-TTY 면 ensureInteractive 로 friendly 거부(파일 미생성, inquirer 미호출, exit 1).
+const mockExistsSync = vi.fn()
+const mockMkdirSync = vi.fn()
+const mockWriteFileSync = vi.fn()
+const mockPrompt = vi.fn()
+
+vi.mock('node:fs', () => ({
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
+  mkdirSync: (...a: unknown[]) => mockMkdirSync(...a),
+  writeFileSync: (...a: unknown[]) => mockWriteFileSync(...a),
+}))
+vi.mock('inquirer', () => ({
+  default: { prompt: (...a: unknown[]) => mockPrompt(...a) },
+}))
+
+let origTTY: boolean | undefined
+
+describe('design / design-palette 가드 — 비-TTY refuse-essential', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    origTTY = process.stdin.isTTY
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+    process.exitCode = 0
+  })
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: origTTY, configurable: true })
+    process.exitCode = 0
+  })
+
+  it('design 비-TTY → inquirer 미호출 + 파일 미생성 + exit 1', async () => {
+    const { design } = await import('../src/commands/design.js')
+    await expect(design()).resolves.not.toThrow()
+    expect(mockPrompt).not.toHaveBeenCalled()
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('design-palette 비-TTY → 동일하게 거부 (design 위임)', async () => {
+    const { designPalette } = await import('../src/commands/design.js')
+    await expect(designPalette()).resolves.not.toThrow()
+    expect(mockPrompt).not.toHaveBeenCalled()
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(1)
+  })
+})

--- a/tests/safety-guard.test.ts
+++ b/tests/safety-guard.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { runGuarded } from '../src/lib/safety-guard.js'
+import { resolveGuard } from '../src/lib/risk-policy.js'
 
 function tracker() {
   let ran = false
@@ -124,5 +125,34 @@ describe('runGuarded — lite 비대화형 destructive 중단 (R13)', () => {
     const run = vi.fn(async () => 'ran')
     const { outcome } = await runGuarded('undo', { channel: 'cli', mode: 'lite', isTTY: false, approved: true }, run)
     expect(outcome.ran).toBe(true)
+  })
+})
+
+// Goal 12 / S5: save push 정책 결정 = "strict-extra 유지"(high-risk 승격 안 함).
+// 근거: commit 은 로컬·되돌리기 가능(undo 존재), push 는 사용자 자기 remote 대상이라
+// deploy/publish(외부 배포=high-risk)와 등급이 다름. spec 의 ③ destructive 버킷도
+// save 를 "strict 일 때만" 분류함. 가장 빈번한 명령을 standard 에서 막으면 UX 파괴.
+// strict 모드 = push 를 막고 싶은 사용자용 탈출구(이미 동작). 이 테스트가 그 계약을 잠근다.
+describe('Goal 12 / S5 — save push 정책 (strict-extra 유지)', () => {
+  it('standard 모드: save 는 가드 없이 allow (push 자동진행 — 회귀 가드)', () => {
+    expect(resolveGuard('save', 'standard', 'cli')).toBe('allow')
+  })
+  it('strict 모드: save 는 confirm 으로 승격(push 막을 사용자용 탈출구)', () => {
+    expect(resolveGuard('save', 'strict', 'cli')).toBe('confirm')
+  })
+  it('strict + 비대화형(isTTY:false) + 미승인 → save 차단(commit/push 둘 다 미실행)', async () => {
+    const run = vi.fn(async () => 'ran')
+    const { outcome } = await runGuarded('save', { channel: 'cli', mode: 'strict', isTTY: false, approved: false }, run)
+    expect(run).not.toHaveBeenCalled()
+    expect(outcome.ran).toBe(false)
+  })
+  it('strict + --yes 승인 → save 실행 허용', async () => {
+    const run = vi.fn(async () => 'ran')
+    const { outcome } = await runGuarded('save', { channel: 'cli', mode: 'strict', isTTY: false, approved: true }, run)
+    expect(outcome.ran).toBe(true)
+  })
+  it('save 는 HIGH_RISK 로 승격되지 않음 — lite 에선 가드 없이 allow', () => {
+    // high-risk 였다면 lite 에서 warn(비대화형 차단)이 됐을 것. allow 여야 결정 유지.
+    expect(resolveGuard('save', 'lite', 'cli')).toBe('allow')
   })
 })

--- a/tests/ship-guard.test.ts
+++ b/tests/ship-guard.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Goal 12: ship 은 ② refuse-essential — 비-TTY(파이프/CI/MCP)면 대화형 입력 불가 →
+// inquirer 크래시 대신 friendly 거부 + exit 1 (절대 안 멈춤).
+const mockPrompt = vi.fn()
+vi.mock('inquirer', () => ({
+  default: { prompt: (...a: unknown[]) => mockPrompt(...a) },
+}))
+
+let origTTY: boolean | undefined
+
+describe('ship 가드 — 비-TTY refuse-essential', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    origTTY = process.stdin.isTTY
+    process.exitCode = 0
+  })
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: origTTY, configurable: true })
+    process.exitCode = 0
+  })
+
+  it('비-TTY → inquirer 미호출 + exitCode 1 (크래시/멈춤 없음)', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+    const { ship } = await import('../src/commands/ship.js')
+    await expect(ship()).resolves.not.toThrow()
+    expect(mockPrompt).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(1)
+  })
+})

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 const mockExistsSync = vi.fn()
 const mockMkdirSync = vi.fn()
@@ -15,10 +15,19 @@ vi.mock('inquirer', () => ({
   default: { prompt: (...a: unknown[]) => mockPrompt(...a) },
 }))
 
-describe('theme', () => {
+// Goal 12: theme 의 덮어쓰기 확인이 promptOrDefault(stdin SoT)로 마이그됨 →
+// 대화형 확인 테스트는 TTY 모사 필요(design.test.ts 선례). 비-TTY 동작은 아래 별도 describe.
+let origTTY: boolean | undefined
+
+describe('theme (대화형 — TTY)', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     vi.spyOn(console, 'log').mockImplementation(() => {})
+    origTTY = process.stdin.isTTY
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+  })
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: origTTY, configurable: true })
   })
 
   it('모듈을 import 할 수 있다', async () => {
@@ -83,6 +92,45 @@ describe('theme', () => {
     const { theme } = await import('../src/commands/theme.js')
     await theme()
 
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(2)
+  })
+})
+
+// Goal 12: ① auto-default — 비-TTY(MCP/CI/파이프)에서 멈추지 않고 안전 동작.
+describe('theme (비대화형 — 비-TTY)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    origTTY = process.stdin.isTTY
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+  })
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: origTTY, configurable: true })
+  })
+
+  it('충돌 없으면 비-TTY 라도 두 파일 생성 (멈춤 없음)', async () => {
+    mockExistsSync.mockReturnValue(false)
+    const { theme } = await import('../src/commands/theme.js')
+    await expect(theme()).resolves.not.toThrow()
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(2)
+    // 충돌 없음 → 프롬프트 자체가 없음
+    expect(mockPrompt).not.toHaveBeenCalled()
+  })
+
+  it('충돌 + --yes 없음 → inquirer 미호출(stdin 미접근) + 기본 보존(파일 안 씀)', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p).includes('theme.css'))
+    const { theme } = await import('../src/commands/theme.js')
+    await theme()
+    // MCP 불변식: 비-TTY 면 stdin 미접근 = inquirer 호출 0
+    expect(mockPrompt).not.toHaveBeenCalled()
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
+  })
+
+  it('충돌 + --yes → inquirer 없이 덮어씀 (비대화형 강제 진행)', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p).includes('theme.css'))
+    const { theme } = await import('../src/commands/theme.js')
+    await theme({ yes: true })
+    expect(mockPrompt).not.toHaveBeenCalled()
     expect(mockWriteFileSync).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
@
## 요약 (Batch A)

v1.6.5 → **v1.6.6**. Goal 12(비대화형 가드 P2) + `.vhk` 규격 RFC(#38) 묶음. **publish 는 사람(2FA OTP)** — 이 PR 은 코드/문서/버전 범프까지만.

## A-1) Goal 12 — 비대화형 가드 P2 (#14)

Goal 11 의 3버킷 계약(stdin SoT)을 잔여 대화형 명령으로 확장:

| 명령 | 버킷 | 변경 |
| --- | --- | --- |
| `theme` | ① auto-default | 덮어쓰기 확인 `promptOrDefault`(stdin) + `-y/--yes`. 비-TTY·미승인 → inquirer 미호출·보존 |
| `ship` | ② refuse-essential | 진입부 `ensureInteractive()` → 비-TTY 거부 + `exit 1`(크래시 제거) |
| `sync` | ① auto-default | 확인 축 **stdout→stdin** 정정(E8/R1). 비-TTY/`--yes`→자동 덮어쓰기(백업 먼저, 손실 0) |
| `design`/`design-palette` | ② refuse-essential | Goal 11 가드 유지, 비-TTY 거부 테스트로 계약 잠금 |

**S5 결정 = `save` push `strict-extra` 유지** (high-risk 승격 ❌): commit=로컬·되돌리기 가능(undo), push=자기 remote(외부 배포 아님). spec ③ 버킷도 save 를 strict 일 때만 destructive 로 분류. 최빈 명령을 standard 에서 막으면 UX 파괴 → push 차단은 `strict` 모드가 탈출구(이미 비-TTY·미승인 save 차단). `save.ts` 무변경(기존 테스트 보존) + 회귀 테스트로 잠금.

`vhk goal done 12` → DONE (게이트 통과, `check-goal-12.mjs` 고유 검증 추가).

## A-2) RFC 0038 — `.vhk` 규격 v1.1 (#38)

`docs/rfc/0038-vhk-spec.md`. RFC 0001/`spec.md`(v1.0) 후속. 코드엔 있으나 규격 표에 누락된 `.synced`·`backups/`·`config.json` 정합 + v1.0 "평면 구조" 단언 정정(이미 `backups/` 로 깨짐) + Goal 13 용 `reports/` 서브디렉토리 + `reports/latest.json` 스키마 도입. 순수 가산 → `spec_version 1.0→1.1`. **코드 변경 아님(스펙/토론).**

## 게이트

- ✅ typecheck (tsc --noEmit)
- ✅ test: **596 pass** (585 → 596, 신규 11 / 회귀 0)
- ✅ build (tsup)
- ✅ `vhk goal check --id 12` 통과

## 테스트 규칙 노트

기존 단언은 전부 보존. `theme.test.ts` 는 대화형 확인 테스트가 마이그 후에도 대화형으로 돌도록 `beforeEach` 에 TTY 모사를 추가(Goal 11 의 `design.test.ts` 선례). 비-TTY 동작은 신규 테스트(`theme`/`ship-guard`/`design-guard`/`safety-guard`)로 커버. 그 외 기존 테스트 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@