### PR TITLE
release: v1.7.0 — verify 증거화 Evidence Ledger v0 (#13 Goal 13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 ### Note
 
 - **Windows 1급** — `.cmd` shim 은 `cmd.exe` 래핑(CVE-2024-27980), maxBuffer 64MB 상향(ENOBUFS 거짓실패 방지).
+  `package.json` 은 `readJsonFile`(UTF-8 BOM 제거)로 읽어 PowerShell `Set-Content -Encoding utf8` BOM 에도 안 죽고,
+  손상 시에도 게이트 skip 후 **증거(latest.json)는 항상 기록**(계약 유지).
 - **기존 시그니처 호환** — `--json` 옵션만 추가, `verify()` 무인자 호출(자연어 라우터) 그대로 동작.
   `HARD_STOP` 존재 시 거부 + exit 1. 규격: `docs/rfc/0038-vhk-spec.md`(`reports/` 도입). 테스트 599 pass.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 (다음 릴리즈 누적 영역)
 
+## [1.7.0] - 2026-06-02
+
+> **verify 증거화 (Evidence Ledger v0, #13 Goal 13).** `vhk verify` 가 lite(체크리스트 안내)에서
+> **실제 게이트 실행 + 증거 기록**으로 승격. 성장 루프(learning·pattern·evolve)의 입력 데이터 토대.
+> 철학: 결과는 실제 종료코드에서만(거짓 PASS 금지) + 성공·실패 무관 항상 증거 + Windows 1급.
+
+### Added
+
+- **`vhk verify` 증거화** (`src/commands/verify.ts`) — 게이트 4종(typecheck/test:run/build 외부 +
+  secure in-process)을 **실제 실행**하고 각 종료코드를 수집. 결과를 **항상**
+  `.vhk/reports/latest.json` 으로 기록(성공·실패 무관). 스키마: `{ schemaVersion, generatedAt,
+  date, status(PASS|WARN|FAIL), summary, gates[], nextActions[] }` — head(요약·기계용) + body(사람용).
+- **`vhk verify --json`** — 경로 대신 리포트 JSON 을 stdout 으로(CI용).
+- **거짓 PASS 금지** — 게이트 스크립트/설정 없으면 `skip`(WARN), 실행 자체 실패는 `fail`(추측 금지).
+  `status`: fail 하나라도 → FAIL, 없고 skip 있으면 → WARN, 전부 pass → PASS. `exitCode`: FAIL=1.
+
+### Security
+
+- `latest.json` 에 **시크릿 값 미포함** — secure 게이트는 severe 발견 **건수만** 기록(값 미수집).
+  리포트 자체가 `vhk secure scan` 에 안 걸린다(누출 0). `reports/` 는 로컬 전용(`.vhk/.gitignore` 자동 등재).
+
+### Note
+
+- **Windows 1급** — `.cmd` shim 은 `cmd.exe` 래핑(CVE-2024-27980), maxBuffer 64MB 상향(ENOBUFS 거짓실패 방지).
+- **기존 시그니처 호환** — `--json` 옵션만 추가, `verify()` 무인자 호출(자연어 라우터) 그대로 동작.
+  `HARD_STOP` 존재 시 거부 + exit 1. 규격: `docs/rfc/0038-vhk-spec.md`(`reports/` 도입). 테스트 599 pass.
+
 ## [1.6.6] - 2026-06-02
 
 > **비대화형 가드 P2 (#14 Goal 12) + `.vhk` 규격 RFC (#38).** Goal 11 이 깐 3버킷 계약을

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,16 +13,16 @@ tags: [process, documentation]
 
 - **레포:** <https://github.com/byh3071-cpu/vhk> (public)
 - **npm:** @byh3071/vhk (public, scoped)
-- **버전:** v1.6.6 (package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
+- **버전:** v1.7.0 (package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
 - **MCP tool:** 24/24 (Goal 0 DONE)
-- **테스트:** 596 pass (vitest)
+- **테스트:** 599 pass (vitest)
 - **패키지 매니저:** pnpm
 
 ## 현재 상태
 
-- **Phase:** Phase 5 이후 — Goal 12(비대화형 가드 P2, #14) DONE + RFC 0038(#38) → v1.6.6 PR.
+- **Phase:** Phase 5 이후 — Goal 13(verify 증거화, #13) DONE → v1.7.0 PR (v1.6.6 스택 위).
 - **블로커:** 없음
-- **다음 액션:** Batch B — Goal 13(P1, verify 증거화) → v1.7.0. publish 는 사람(2FA OTP).
+- **다음 액션:** 배치 6(verify --report JSON→HTML), STEP 1.5(sync 확대). publish 는 사람(2FA OTP).
 - **마지막 업데이트:** 2026-06-02
 
 ## 코딩 컨벤션

--- a/docs/superpowers/specs/2026-06-02-verify-evidence-design.md
+++ b/docs/superpowers/specs/2026-06-02-verify-evidence-design.md
@@ -1,0 +1,93 @@
+# 설계 — vhk verify 증거화 (Evidence Ledger v0, Goal 13)
+
+- **날짜:** 2026-06-02
+- **goal:** 13 (P1, v1.7.0)
+- **PRD:** 핸드오프 페이지 §5 / `goals/13-verify-evidence.md`
+- **상태:** 설계 확정 → 구현 완료
+
+## 1. 문제
+
+`vhk verify` 가 lite — 체크리스트 텍스트만 출력하고 **실제 실행·결과 저장이 없다**
+(verify.ts 구 주석: "메타러너 자리 — 묶음 안내만(lite)"). 결과:
+
+- "테스트 없이 완료 선언" 같은 **거짓완료를 잡을 증거가 안 남는다.**
+- 성장 루프(learning·pattern·evolve)의 **입력 데이터가 없어** 후속 기능이 전부 막힌다.
+- 매 검증마다 사람이 결과를 눈으로 보고 옮기는 **수동 반복.**
+
+## 2. 철학 (핵심)
+
+1. **결과는 실제 실행 신호에서만** — 게이트 프로세스의 실제 종료코드로만 PASS/FAIL 판정. 거짓 PASS 금지.
+2. **성공·실패 무관 항상 증거** — `vhk verify` 는 어떤 결과든 `.vhk/reports/latest.json` 을 쓴다.
+3. **Windows 1급** — `.cmd` shim 은 `cmd.exe` 래핑(CVE-2024-27980), maxBuffer 상향(ENOBUFS 거짓실패 방지).
+4. **기존 시그니처 호환** — 옵션(`--json`)만 추가. `verify()` 무인자 호출(nlp-run) 그대로 동작.
+
+## 3. 동작 (계약)
+
+### 3.1 게이트 4종
+
+| id | 라벨 | 실행 방식 | pass 조건 |
+| --- | --- | --- | --- |
+| `typecheck` | `tsc --noEmit` | 외부(pm run typecheck → 없으면 tsconfig 있을 때 `pm exec tsc --noEmit`) | exit 0 |
+| `test` | `test:run` | 외부(`test:run` → vitest `test -- --run` → `test`) | exit 0 |
+| `build` | `build` | 외부(`pm run build`) | exit 0 |
+| `secure` | `secure scan` | **in-process** `scanProjectForSecrets` | severe(critical/high) 0건 |
+
+- 외부 게이트의 스크립트/설정이 없으면 **skip(WARN)** — 거짓 PASS 금지(돌리지 않은 걸 통과로 안 봄).
+- `secure` 는 우리 스캐너라 in-process 실행 — **시크릿 본문은 리포트에 안 넣고 severe count 만** 기록(누출 0).
+- 실행 자체 실패(ENOENT 등)는 **fail 로 기록**, 추측 금지.
+
+### 3.2 상태 집계
+
+`fail` 하나라도 → **FAIL** · 없고 `skip` 있으면 → **WARN** · 전부 `pass` → **PASS**.
+`process.exitCode = FAIL ? 1 : 0` (WARN/PASS 는 0 — CI 가 skip 을 치명으로 안 보게).
+
+### 3.3 `.vhk/reports/latest.json` 스키마
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-06-02T...Z",   // UTC ISO (머신용)
+  "date": "2026-06-02",                // localDate (사람용)
+  "status": "PASS",                    // PASS | WARN | FAIL
+  "summary": { "total": 4, "pass": 4, "fail": 0, "skip": 0 },   // head(기계용)
+  "gates": [ { "id","label","status","exitCode","skipped","detail?" } ],  // body(사람용)
+  "nextActions": [ "..." ]
+}
+```
+
+- 항상 생성/갱신(`mkdir -p .vhk/reports`). `reports/` 는 로컬 전용 → `.vhk/.gitignore` 등재(RFC 0038).
+- `--json`: 경로 대신 리포트 JSON 을 stdout 으로(CI용). 다른 콘솔 출력 없음.
+- CLI 기본: 게이트별 한 줄 + 상태 배지 + 파일 경로만(상세는 파일).
+
+## 4. 컴포넌트 변경
+
+| 파일 | 변경 |
+| --- | --- |
+| `src/commands/verify.ts` | lite → 증거화. `execGate`/`runGates`/`runSecureGate`/`aggregateStatus`/`buildReport`/`verifyEvidence`/`verify(opts)` 추가. `verificationChecklist` 보존(mode.test 호환). |
+| `src/index.ts` | `verify` 에 `--json` 옵션 + opts 전달 |
+| `.vhk/.gitignore` | `reports/` 자동 등재(`ensureVhkIgnored`) |
+
+## 5. 테스트
+
+- **순수 함수**: `aggregateStatus`(FAIL>WARN>PASS 우선), `buildReport`(스키마·summary 카운트), `buildNextActions`.
+- **planning/gate**: `detectPm`(lockfile), `runGates`(temp 프로젝트 — 스크립트 유무 → pass/skip), `runSecureGate`(시크릿 0/유 → pass/fail, **리포트에 시크릿 본문 없음**).
+- **거짓 PASS 회귀 가드**: test 게이트를 일부러 깬 temp 프로젝트 → `status=FAIL` + 해당 gate `fail`.
+- **scripts 없음** → skip+WARN(PASS 아님).
+- **증거 기록**: `verifyEvidence` 가 성공·실패 무관 `.vhk/reports/latest.json` 생성 + 스키마 통과.
+- **--json**: stdout 에 리포트 JSON, secret 본문 0.
+- **HARD_STOP**: 존재 시 `verify` 거부 + exitCode 1.
+
+## 6. 제외 범위 (이번 아님)
+
+- HTML 리포트(`latest.html`) → 배치 6 (`vhk verify --report`).
+- 리포트 히스토리/타임스탬프 스냅샷 → RFC 0038 §7 미해결.
+- `vhk review` 적대 검증 / 반복 패턴 감지 / evolve → 배치 8+.
+
+## 7. 결정 기록
+
+- **secure 는 in-process** (외부 `vhk secure scan` spawn 아님): 자기 CLI 의 서브커맨드를 자기가 spawn 하는 건
+  느리고 dist 의존. in-process 가 실제 신호 + 시크릿 본문 미수집을 동시에 만족.
+- **exitCode 매핑**: FAIL→1, WARN/PASS→0. WARN(=skip)을 치명으로 보면 게이트 미구비 프로젝트가 CI 에서
+  항상 깨져 도입 장벽이 됨. skip 은 커버리지 경고지 실패가 아님.
+- **시크릿 미포함**: gates 엔 id/label/status/exitCode/메타만. secure 는 count 만 → `.vhk/reports/latest.json`
+  자체가 `vhk secure scan` 에 안 걸림(누출 0).

--- a/goals/13-verify-evidence.md
+++ b/goals/13-verify-evidence.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 13
 title: vhk verify 증거화 (Evidence Ledger v0) — P1
-status: NOT_STARTED
+status: DONE
 priority: P1
 version: v1.7.0
+completed: 2026-06-02
 ---
 
 # Goal 13: vhk verify 증거화 (Evidence Ledger v0)
@@ -27,14 +28,21 @@ verify가 lite — 체크리스트 텍스트만 출력, 실제 실행·결과 �
 - secret/env 값 latest.json 미포함 (.vhkignore 존중).
 
 ## Completion Check
-- [ ] verify 실행 시 성공·실패 무관 latest.json 생성 + 스키마 통과
-- [ ] 게이트별 실제 종료코드 기반 (파이프로 exit code 안 가림)
-- [ ] test 일부러 깸 → status=FAIL + 해당 gate fail 기록 (거짓 PASS 회귀 가드)
-- [ ] package.json scripts 없음 → skip+WARN (거짓 PASS 금지)
-- [ ] HARD_STOP 존재 → 거부 + exit 1
-- [ ] --json stdout 출력 + secret 누출 0 (vhk secure scan)
-- [ ] vhk goal sync → check-goal-13.mjs 생성 → vhk goal check --id 13 통과
-- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 540+ 회귀 0
+- [x] verify 실행 시 성공·실패 무관 latest.json 생성 + 스키마 통과
+- [x] 게이트별 실제 종료코드 기반 (파이프로 exit code 안 가림)
+- [x] test 일부러 깸 → status=FAIL + 해당 gate fail 기록 (거짓 PASS 회귀 가드)
+- [x] package.json scripts 없음 → skip+WARN (거짓 PASS 금지)
+- [x] HARD_STOP 존재 → 거부 + exit 1
+- [x] --json stdout 출력 + secret 누출 0 (vhk secure scan)
+- [x] vhk goal sync → check-goal-13.mjs 생성 → vhk goal check --id 13 통과
+- [x] 공통 게이트 통과 (typecheck + test + build), 기존 540+ 회귀 0 (599 pass)
+
+## 구현 결과 (2026-06-02)
+- `src/commands/verify.ts`: `verifyEvidence`(항상 `.vhk/reports/latest.json` 기록) + `runGates`
+  (tsc/test:run/build 외부 실행 + 종료코드, secure in-process) + `aggregateStatus`/`buildReport`.
+- `--json`(CI stdout), Windows `cmd.exe` 래핑 + maxBuffer 64MB, HARD_STOP 거부, exitCode FAIL=1.
+- secret 미포함: secure 게이트는 severe count 만(값 미수집) → 리포트 누출 0. reports/ 로컬 전용(RFC 0038).
+- 기존 호환: `verificationChecklist` 보존, `verify()` 무인자 호출 동작. 테스트 585→599(신규 14), 회귀 0.
 
 ## 제외 범위
 - HTML 리포트(latest.html) → 배치 6

--- a/goals/13-verify-evidence.md
+++ b/goals/13-verify-evidence.md
@@ -1,0 +1,47 @@
+---
+vhk_format: 1
+type: goal
+id: 13
+title: vhk verify 증거화 (Evidence Ledger v0) — P1
+status: NOT_STARTED
+priority: P1
+version: v1.7.0
+---
+
+# Goal 13: vhk verify 증거화 (Evidence Ledger v0)
+
+> 설계 전문: `docs/superpowers/specs/2026-06-02-verify-evidence-design.md` (착수 시 작성)
+> PRD 전문: 핸드오프 페이지 §5. 출처: 성장 루프(learning·pattern·evolve) 입력 데이터 토대.
+
+## 배경
+verify가 lite — 체크리스트 텍스트만 출력, 실제 실행·결과 저장 X (verify.ts 주석: "메타러너 자리 — 묶음 안내만(lite)"). 거짓완료를 잡을 증거가 안 남고, 성장 루프 입력이 없어 후속 기능 전부 막힘.
+
+## 철학
+① 결과는 실제 실행 신호에서만 — 거짓 PASS 금지 ② 성공·실패 무관 항상 증거 남김 ③ Windows 1급 ④ 기존 verify 시그니처 호환(옵션 추가만).
+
+## 동작 (파일·계약)
+- `src/commands/verify.ts`: 게이트(tsc / test:run / build / secure scan) 실제 실행 + 각 exit code 수집. CLI엔 한 줄 요약 + 파일 경로만 출력.
+- `.vhk/reports/latest.json`: 항상 생성/갱신. 스키마 `{ schemaVersion, generatedAt, status(PASS|WARN|FAIL), summary, gates[], nextActions[] }` (head=기계용 / body=사람용).
+- `--json` 옵션: 경로 대신 stdout JSON (CI용). 날짜=localDate(), 타임스탬프=UTC.
+- 크로스플랫폼: execFile cmd.exe 래핑(CVE-2024-27980), maxBuffer 상향(ENOBUFS 거짓실패 방지).
+- secret/env 값 latest.json 미포함 (.vhkignore 존중).
+
+## Completion Check
+- [ ] verify 실행 시 성공·실패 무관 latest.json 생성 + 스키마 통과
+- [ ] 게이트별 실제 종료코드 기반 (파이프로 exit code 안 가림)
+- [ ] test 일부러 깸 → status=FAIL + 해당 gate fail 기록 (거짓 PASS 회귀 가드)
+- [ ] package.json scripts 없음 → skip+WARN (거짓 PASS 금지)
+- [ ] HARD_STOP 존재 → 거부 + exit 1
+- [ ] --json stdout 출력 + secret 누출 0 (vhk secure scan)
+- [ ] vhk goal sync → check-goal-13.mjs 생성 → vhk goal check --id 13 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 540+ 회귀 0
+
+## 제외 범위
+- HTML 리포트(latest.html) → 배치 6
+- vhk review 적대 검증 → 별도 goal
+- 반복 패턴 감지 / evolve / pattern suggest → 배치 8+
+
+## Mandatory Reading
+- `src/commands/verify.ts` (현재 lite 구현)
+- `goals/11-noninteractive-guard.md` (Windows cmd.exe 래핑 / .mjs 게이트 선례)
+- 핸드오프 페이지 §5 PRD (상세 요구사항)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "1.6.6",
+  "version": "1.7.0",
   "description": "Vibe Harness Kit — AI 코딩 도구·기기를 바꿔도 규칙·맥락이 따라가는 포터빌리티 CLI (sync: Cursor·Claude·Windsurf·Copilot·Antigravity / cloud 백업)",
   "bin": {
     "vhk": "dist/index.js",

--- a/scripts/check-goal-13.mjs
+++ b/scripts/check-goal-13.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// scripts/check-goal-13.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 13 gate.')
+  process.exit(1)
+}
+
+const pkg = existsSync('package.json') ? JSON.parse(readFileSync('package.json', 'utf-8')) : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 13] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 13 고유 검증 (verify 증거화) ───────────────────────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+const v = read('src/commands/verify.ts') ?? ''
+must(/export function verifyEvidence/.test(v) && /reports[\\/]+latest\.json|REPORT_PATH_REL/.test(v), 'verifyEvidence → .vhk/reports/latest.json')
+must(/export function runGates/.test(v) && /execFileSync/.test(v), '게이트 실제 실행(외부 프로세스 종료코드)')
+must(/schemaVersion/.test(v) && /aggregateStatus/.test(v) && /'PASS'|"PASS"/.test(v), '리포트 스키마 + 상태 집계(PASS/WARN/FAIL)')
+must(/cmd\.exe/.test(v) && /maxBuffer/.test(v), 'Windows 1급(cmd.exe 래핑 + maxBuffer 상향)')
+must(/filterSevereFindings/.test(v) && !/maskSecret|f\.match/.test(v), 'secure 게이트 count 만(시크릿 값 미수집)')
+must(/ensureNotHardStopped\('verify'\)/.test(v), 'HARD_STOP 거부')
+must(/--json/.test(read('src/index.ts') ?? ''), 'index verify --json 옵션')
+must(/export function verificationChecklist/.test(v), 'verificationChecklist 보존(기존 호환)')
+
+if (pass) { console.log('✅ goal 13 gate passes'); process.exit(0) }
+console.log('❌ goal 13 gate failed'); process.exit(1)

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import chalk from 'chalk'
 import { readConfig } from '../lib/config.js'
@@ -7,6 +7,7 @@ import { SAFETY_MODE_DESC } from '../lib/safety-mode.js'
 import { printNextStep } from '../lib/next-step.js'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
 import { ensureVhkIgnored } from '../lib/backup.js'
+import { readJsonFile } from '../lib/read-json.js'
 import { localDate } from '../lib/date.js'
 import { scanProjectForSecrets, filterSevereFindings } from '../lib/scan-secrets.js'
 
@@ -124,15 +125,29 @@ function runScriptGate(
 }
 
 /**
+ * package.json 의 scripts 를 안전하게 읽는다. **절대 throw 하지 않는다** —
+ * verify 의 핵심 계약("성공·실패 무관 항상 증거 남김")을 지키려면 package.json 파싱이
+ * verifyEvidence 보다 먼저 죽으면 안 된다. readJsonFile 로 UTF-8 BOM(PowerShell
+ * Set-Content -Encoding utf8 등) 제거 + 손상/없음이면 빈 객체(→ 외부 게이트 skip, 거짓 PASS 금지).
+ */
+export function readPackageScripts(cwd: string): Record<string, string> {
+  const pkgPath = join(cwd, 'package.json')
+  if (!existsSync(pkgPath)) return {}
+  try {
+    const pkg = readJsonFile<{ scripts?: Record<string, string> }>(pkgPath)
+    return pkg.scripts ?? {}
+  } catch {
+    // BOM 외 손상(깨진 JSON) → 빈 scripts. verify 는 죽지 않고 증거는 남긴다.
+    return {}
+  }
+}
+
+/**
  * 게이트 4종 실행 → 결과 배열. tsc/test/build 는 외부 프로세스(실제 종료코드),
  * secure 는 in-process 스캐너(시크릿 본문 미수집 — count 만).
  */
 export function runGates(cwd: string): GateResult[] {
-  const pkgPath = join(cwd, 'package.json')
-  const pkg = existsSync(pkgPath)
-    ? (JSON.parse(readFileSync(pkgPath, 'utf-8')) as { scripts?: Record<string, string> })
-    : {}
-  const scripts = pkg.scripts ?? {}
+  const scripts = readPackageScripts(cwd)
   const pm = detectPm(cwd)
   const gates: GateResult[] = []
 

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -1,13 +1,24 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import chalk from 'chalk'
 import { readConfig } from '../lib/config.js'
 import { SAFETY_MODE_DESC } from '../lib/safety-mode.js'
 import { printNextStep } from '../lib/next-step.js'
+import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
+import { ensureVhkIgnored } from '../lib/backup.js'
+import { localDate } from '../lib/date.js'
+import { scanProjectForSecrets, filterSevereFindings } from '../lib/scan-secrets.js'
 
 /**
- * 저장/위험 작업 전 돌려야 하는 검증 묶음 — 현재는 "메타러너 자리"(lite).
- * 실제 실행은 사용자/CI 가 돌리는 기계 게이트를 가리키고, 여기선 묶음을 안내만 한다.
- * (PRD: 검증 루프 강제 ≠ 전문 개발자 대체. 기계 게이트 위에 얹는 안내층.)
+ * 저장/위험 작업 전 돌려야 하는 검증 묶음.
+ * Goal 13(Evidence Ledger v0): lite 안내층을 **실제 실행 + 증거 기록**으로 승격.
+ * 게이트(typecheck/test/build/secure)를 실제로 돌리고 결과를 `.vhk/reports/latest.json` 으로 남긴다.
+ * 철학: ① 결과는 실제 종료코드에서만(거짓 PASS 금지) ② 성공·실패 무관 항상 증거 ③ Windows 1급
+ *      ④ 기존 verify 시그니처 호환(옵션 추가만).
  */
+
+/** 권장 검증 묶음 안내 (사람용 체크리스트 — Goal 13 이전부터 쓰던 SoT, mode 등이 참조). */
 export function verificationChecklist(): string[] {
   return [
     '타입 체크 — pnpm exec tsc --noEmit',
@@ -17,21 +28,288 @@ export function verificationChecklist(): string[] {
   ]
 }
 
-export async function verify(): Promise<void> {
-  console.log(chalk.bold('\n🔎 검증 묶음 (verify — lite)'))
-  console.log(chalk.gray('─'.repeat(40)))
+export const REPORT_SCHEMA_VERSION = 1
+export const REPORT_DIR_REL = join('.vhk', 'reports')
+export const REPORT_PATH_REL = join(REPORT_DIR_REL, 'latest.json')
 
+export type GateRunStatus = 'pass' | 'fail' | 'skip'
+export type ReportStatus = 'PASS' | 'WARN' | 'FAIL'
+
+export interface GateResult {
+  /** 안정 식별자 (기계용) */
+  id: 'typecheck' | 'test' | 'build' | 'secure'
+  /** 사람용 라벨 */
+  label: string
+  status: GateRunStatus
+  /** 실제 프로세스 종료코드. skip/in-process 게이트는 null. */
+  exitCode: number | null
+  skipped: boolean
+  /** 사람용 한 줄 사유 (시크릿 본문은 절대 넣지 않음 — count 등 메타만). */
+  detail?: string
+}
+
+export interface VerifyReport {
+  schemaVersion: number
+  /** 머신 타임스탬프 (UTC ISO) */
+  generatedAt: string
+  /** 사람용 날짜 (localDate, 로컬 타임존) */
+  date: string
+  status: ReportStatus
+  summary: { total: number; pass: number; fail: number; skip: number }
+  gates: GateResult[]
+  nextActions: string[]
+}
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+
+/** 패키지 매니저 감지 (lockfile 기준). cwd 상대. */
+export function detectPm(cwd: string): 'pnpm' | 'yarn' | 'npm' {
+  if (existsSync(join(cwd, 'pnpm-lock.yaml'))) return 'pnpm'
+  if (existsSync(join(cwd, 'yarn.lock'))) return 'yarn'
+  return 'npm'
+}
+
+/**
+ * 외부 게이트 1개 실행 + **실제 종료코드** 수집. 파이프로 exit code 를 가리지 않는다.
+ * Windows: pnpm/npm/yarn 은 .cmd shim → cmd.exe 래핑(Node CVE-2024-27980 의 EINVAL 회피).
+ * maxBuffer 상향(64MB): 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+ */
+export function execGate(cmd: string, args: string[], cwd: string): { exitCode: number; out: string } {
+  let bin = cmd
+  let argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    bin = 'cmd.exe'
+    argv = ['/d', '/s', '/c', `${cmd}.cmd`, ...args]
+  }
+  try {
+    execFileSync(bin, argv, {
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+      maxBuffer: 64 * 1024 * 1024,
+      timeout: 600_000,
+      killSignal: 'SIGTERM',
+    })
+    return { exitCode: 0, out: '' }
+  } catch (e) {
+    const err = e as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string; code?: string }
+    // execFileSync 는 비-0 종료 시 err.status = 종료코드. ENOENT 등 실행 자체 실패는 status 없음 → 1 로 기록(추측 금지).
+    const exitCode = typeof err.status === 'number' ? err.status : 1
+    const out = ((err.stdout?.toString?.() ?? '') + (err.stderr?.toString?.() ?? '')).trim()
+    return { exitCode, out }
+  }
+}
+
+/** typecheck/test/build 외부 게이트 1종 실행. 스크립트/설정 없으면 skip(WARN) — 거짓 PASS 금지. */
+function runScriptGate(
+  id: 'typecheck' | 'test' | 'build',
+  label: string,
+  cwd: string,
+  pm: 'pnpm' | 'yarn' | 'npm',
+  argvFor: (pm: string) => string[] | null
+): GateResult {
+  const argv = argvFor(pm)
+  if (!argv) {
+    return { id, label, status: 'skip', exitCode: null, skipped: true, detail: '해당 스크립트/설정 없음 — skip(WARN)' }
+  }
+  const { exitCode } = execGate(pm, argv, cwd)
+  return {
+    id,
+    label,
+    status: exitCode === 0 ? 'pass' : 'fail',
+    exitCode,
+    skipped: false,
+    detail: exitCode === 0 ? undefined : `종료코드 ${exitCode}`,
+  }
+}
+
+/**
+ * 게이트 4종 실행 → 결과 배열. tsc/test/build 는 외부 프로세스(실제 종료코드),
+ * secure 는 in-process 스캐너(시크릿 본문 미수집 — count 만).
+ */
+export function runGates(cwd: string): GateResult[] {
+  const pkgPath = join(cwd, 'package.json')
+  const pkg = existsSync(pkgPath)
+    ? (JSON.parse(readFileSync(pkgPath, 'utf-8')) as { scripts?: Record<string, string> })
+    : {}
+  const scripts = pkg.scripts ?? {}
+  const pm = detectPm(cwd)
+  const gates: GateResult[] = []
+
+  // typecheck — scripts.typecheck 우선, 없으면 tsconfig.json 있을 때 tsc --noEmit, 둘 다 없으면 skip
+  gates.push(
+    runScriptGate('typecheck', 'tsc --noEmit', cwd, pm, () => {
+      if (scripts.typecheck) return ['run', 'typecheck']
+      if (existsSync(join(cwd, 'tsconfig.json'))) return pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']
+      return null
+    })
+  )
+
+  // test — test:run 우선, vitest test 면 --run, 그 외 test, 없으면 skip
+  gates.push(
+    runScriptGate('test', 'test:run', cwd, pm, () => {
+      if (scripts['test:run']) return ['run', 'test:run']
+      if (scripts.test && /vitest/.test(scripts.test)) return ['run', 'test', '--', '--run']
+      if (scripts.test) return ['run', 'test']
+      return null
+    })
+  )
+
+  // build — scripts.build 없으면 skip
+  gates.push(
+    runScriptGate('build', 'build', cwd, pm, () => (scripts.build ? ['run', 'build'] : null))
+  )
+
+  // secure — in-process 스캔. 시크릿 본문은 리포트에 넣지 않고 severe count 만 기록(누출 0).
+  gates.push(runSecureGate(cwd))
+
+  return gates
+}
+
+/** 보안 스캔 게이트 — severe(critical/high) 발견 시 fail. 시크릿 값은 리포트 미포함(count 만). */
+export function runSecureGate(cwd: string): GateResult {
+  try {
+    const severe = filterSevereFindings(scanProjectForSecrets(cwd).findings)
+    const n = severe.length
+    return {
+      id: 'secure',
+      label: 'secure scan',
+      status: n === 0 ? 'pass' : 'fail',
+      exitCode: n === 0 ? 0 : 1,
+      skipped: false,
+      detail: n === 0 ? undefined : `severe 시크릿 ${n}건 (값 미기록 — vhk secure scan 으로 확인)`,
+    }
+  } catch (e) {
+    // 스캔 자체 실패 → fail 로 기록(추측 금지).
+    return {
+      id: 'secure',
+      label: 'secure scan',
+      status: 'fail',
+      exitCode: 1,
+      skipped: false,
+      detail: `스캔 실행 실패: ${e instanceof Error ? e.message : String(e)}`,
+    }
+  }
+}
+
+/** 게이트 결과 → 전체 상태. fail 하나라도 → FAIL, 없고 skip 있으면 → WARN, 전부 pass → PASS. */
+export function aggregateStatus(gates: GateResult[]): ReportStatus {
+  if (gates.some((g) => g.status === 'fail')) return 'FAIL'
+  if (gates.some((g) => g.status === 'skip')) return 'WARN'
+  return 'PASS'
+}
+
+/** 실패/스킵 게이트로부터 다음 행동 힌트 생성 (사람·에이전트 공용). */
+export function buildNextActions(gates: GateResult[]): string[] {
+  const actions: string[] = []
+  for (const g of gates) {
+    if (g.status === 'fail') {
+      if (g.id === 'secure') actions.push('시크릿 제거 후 재검증 — vhk secure scan 으로 위치 확인')
+      else actions.push(`${g.label} 실패(종료코드 ${g.exitCode}) — 로그 확인 후 수정`)
+    } else if (g.status === 'skip') {
+      actions.push(`${g.label} 게이트 없음 — package.json scripts 에 추가하면 검증 커버리지 ↑`)
+    }
+  }
+  if (actions.length === 0) actions.push('검증 통과 — vhk save 로 저장하세요.')
+  return actions
+}
+
+/** 게이트 결과 → 리포트 객체(스키마). head(요약·기계용) + body(gates·사람용). */
+export function buildReport(gates: GateResult[], generatedAt: string, date: string): VerifyReport {
+  const summary = {
+    total: gates.length,
+    pass: gates.filter((g) => g.status === 'pass').length,
+    fail: gates.filter((g) => g.status === 'fail').length,
+    skip: gates.filter((g) => g.status === 'skip').length,
+  }
+  return {
+    schemaVersion: REPORT_SCHEMA_VERSION,
+    generatedAt,
+    date,
+    status: aggregateStatus(gates),
+    summary,
+    gates,
+    nextActions: buildNextActions(gates),
+  }
+}
+
+/**
+ * 게이트 실행 → 리포트 생성/기록. **항상** `.vhk/reports/latest.json` 을 쓴다(성공·실패 무관).
+ * reports/ 는 로컬 전용 산출물 → `.vhk/.gitignore` 에 등록(클라우드/추적 제외, RFC 0038).
+ * @returns 리포트 객체 + 기록 경로
+ */
+export function verifyEvidence(cwd: string = process.cwd()): { report: VerifyReport; path: string } {
+  const gates = runGates(cwd)
+  const report = buildReport(gates, new Date().toISOString(), localDate())
+
+  const dir = join(cwd, REPORT_DIR_REL)
+  mkdirSync(dir, { recursive: true })
+  const path = join(cwd, REPORT_PATH_REL)
+  writeFileSync(path, JSON.stringify(report, null, 2) + '\n', 'utf-8')
+  // reports/ 는 개인 환경 산물 → 로컬 전용(추적·클라우드 제외).
+  try {
+    ensureVhkIgnored(cwd, 'reports/')
+  } catch {
+    /* gitignore 갱신 실패는 치명적 아님 — 리포트는 이미 기록됨 */
+  }
+
+  return { report, path: REPORT_PATH_REL }
+}
+
+const STATUS_BADGE: Record<ReportStatus, string> = {
+  PASS: chalk.green.bold('PASS'),
+  WARN: chalk.yellow.bold('WARN'),
+  FAIL: chalk.red.bold('FAIL'),
+}
+
+export async function verify(opts: { json?: boolean } = {}): Promise<void> {
+  // HARD_STOP 활성 → 게이트 실행 거부 + exit 1 (PRD §9).
+  if (!ensureNotHardStopped('verify')) return
+
+  const cwd = process.cwd()
+  const { report, path } = verifyEvidence(cwd)
+
+  // --json: 경로 대신 stdout 으로 리포트 JSON (CI 용). 다른 콘솔 출력 없음.
+  if (opts.json) {
+    console.log(JSON.stringify(report, null, 2))
+    process.exitCode = report.status === 'FAIL' ? 1 : 0
+    return
+  }
+
+  console.log(chalk.bold('\n🔎 검증 묶음 (verify)'))
+  console.log(chalk.gray('─'.repeat(40)))
   const mode = readConfig().safetyMode
   console.log(chalk.dim(`  현재 Safety Mode: ${mode} — ${SAFETY_MODE_DESC[mode]}`))
-  console.log(chalk.cyan('\n  위험 작업/저장 전 권장 검증:'))
-  for (const item of verificationChecklist()) {
-    console.log(`   ☐ ${item}`)
-  }
-  console.log(chalk.dim('\n  ※ 메타러너(자동 실행) 자리 — 현재는 묶음 안내만(lite).'))
 
-  printNextStep({
-    message: '검증 통과 후 저장하세요:',
-    command: 'vhk save',
-    cursorHint: '저장해줘',
-  })
+  // 게이트별 한 줄
+  const icon = (s: GateRunStatus) => (s === 'pass' ? chalk.green('✓') : s === 'fail' ? chalk.red('✗') : chalk.yellow('⊘'))
+  for (const g of report.gates) {
+    const tail = g.detail ? chalk.dim(` — ${g.detail}`) : ''
+    console.log(`   ${icon(g.status)} ${g.label}${tail}`)
+  }
+
+  // 한 줄 요약 + 파일 경로
+  const s = report.summary
+  console.log(
+    `\n  결과: ${STATUS_BADGE[report.status]}  ` +
+      chalk.dim(`(pass ${s.pass} / fail ${s.fail} / skip ${s.skip}, 총 ${s.total})`)
+  )
+  console.log(chalk.dim(`  📄 증거: ${path}`))
+
+  process.exitCode = report.status === 'FAIL' ? 1 : 0
+
+  if (report.status === 'FAIL') {
+    printNextStep({
+      message: '검증 실패 — 아래를 먼저 고치세요:',
+      command: 'vhk verify',
+      cursorHint: '검증 다시 돌려줘',
+      alternative: report.nextActions[0],
+    })
+  } else {
+    printNextStep({
+      message: report.status === 'WARN' ? '검증 통과(일부 게이트 skip). 저장하려면:' : '검증 통과! 저장하려면:',
+      command: 'vhk save',
+      cursorHint: '저장해줘',
+    })
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -443,8 +443,9 @@ program
 program
   .command('verify')
   .alias('사전점검')
-  .description('저장/위험 작업 전 검증 묶음 안내 (lite)')
-  .action(async () => { await verify() })
+  .option('--json', '리포트 JSON 을 stdout 으로 출력 (CI용 — 경로 대신)')
+  .description('검증 게이트(tsc/test/build/secure) 실제 실행 + 증거 기록 (.vhk/reports/latest.json)')
+  .action(async (opts: { json?: boolean }) => { await verify(opts) })
 
 program
   .command('context-show')

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  aggregateStatus,
+  buildReport,
+  buildNextActions,
+  detectPm,
+  runSecureGate,
+  verifyEvidence,
+  verify,
+  REPORT_SCHEMA_VERSION,
+  REPORT_PATH_REL,
+  type GateResult,
+} from '../src/commands/verify.js'
+
+function gate(id: GateResult['id'], status: GateResult['status'], exitCode: number | null = 0): GateResult {
+  return { id, label: id, status, exitCode, skipped: status === 'skip' }
+}
+
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-verify-'))
+}
+
+describe('verify — 상태 집계 (aggregateStatus)', () => {
+  it('fail 하나라도 → FAIL (skip/pass 무관)', () => {
+    expect(aggregateStatus([gate('typecheck', 'pass'), gate('test', 'fail', 1), gate('build', 'skip', null)])).toBe('FAIL')
+  })
+  it('fail 없고 skip 있으면 → WARN (거짓 PASS 금지)', () => {
+    expect(aggregateStatus([gate('typecheck', 'pass'), gate('test', 'skip', null)])).toBe('WARN')
+  })
+  it('전부 pass → PASS', () => {
+    expect(aggregateStatus([gate('typecheck', 'pass'), gate('secure', 'pass')])).toBe('PASS')
+  })
+})
+
+describe('verify — 리포트 빌드 (buildReport)', () => {
+  it('스키마 + summary 카운트 정확', () => {
+    const gates = [gate('typecheck', 'pass'), gate('test', 'fail', 1), gate('build', 'skip', null), gate('secure', 'pass')]
+    const r = buildReport(gates, '2026-06-02T00:00:00.000Z', '2026-06-02')
+    expect(r.schemaVersion).toBe(REPORT_SCHEMA_VERSION)
+    expect(r.generatedAt).toBe('2026-06-02T00:00:00.000Z')
+    expect(r.date).toBe('2026-06-02')
+    expect(r.status).toBe('FAIL')
+    expect(r.summary).toEqual({ total: 4, pass: 2, fail: 1, skip: 1 })
+    expect(r.gates).toHaveLength(4)
+    expect(Array.isArray(r.nextActions)).toBe(true)
+    expect(r.nextActions.length).toBeGreaterThan(0)
+  })
+})
+
+describe('verify — nextActions', () => {
+  it('전부 pass 면 저장 안내', () => {
+    expect(buildNextActions([gate('typecheck', 'pass')]).join(' ')).toMatch(/vhk save|저장/)
+  })
+  it('fail 이면 수정 힌트', () => {
+    expect(buildNextActions([gate('test', 'fail', 1)]).join(' ')).toMatch(/실패|수정/)
+  })
+  it('skip 이면 스크립트 추가 힌트', () => {
+    expect(buildNextActions([gate('build', 'skip', null)]).join(' ')).toMatch(/scripts|게이트/)
+  })
+})
+
+describe('verify — detectPm', () => {
+  it('lockfile 로 pm 감지 (없으면 npm)', () => {
+    const d = tmp()
+    expect(detectPm(d)).toBe('npm')
+    fs.writeFileSync(path.join(d, 'pnpm-lock.yaml'), '', 'utf-8')
+    expect(detectPm(d)).toBe('pnpm')
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})
+
+describe('verify — verifyEvidence (실제 게이트 + 증거 기록)', () => {
+  it('scripts 없으면 외부 게이트 skip → WARN, latest.json 항상 생성 + 스키마 통과', () => {
+    const d = tmp()
+    fs.writeFileSync(path.join(d, 'package.json'), JSON.stringify({ name: 'tp', version: '0.0.0' }), 'utf-8')
+    const { report, path: rel } = verifyEvidence(d)
+    expect(rel).toBe(REPORT_PATH_REL)
+    // 파일이 실제로 생성됨
+    const onDisk = JSON.parse(fs.readFileSync(path.join(d, REPORT_PATH_REL), 'utf-8'))
+    expect(onDisk.schemaVersion).toBe(REPORT_SCHEMA_VERSION)
+    expect(onDisk.status).toBe(report.status)
+    // typecheck/test/build skip, secure pass(시크릿 없음) → WARN
+    expect(report.status).toBe('WARN')
+    expect(report.gates.find((g) => g.id === 'typecheck')?.status).toBe('skip')
+    expect(report.gates.find((g) => g.id === 'secure')?.status).toBe('pass')
+    // reports/ 로컬 전용 등재
+    expect(fs.readFileSync(path.join(d, '.vhk', '.gitignore'), 'utf-8')).toContain('reports/')
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('거짓 PASS 회귀 가드 — test 게이트 실패 시 status=FAIL + 해당 gate fail (실제 종료코드)', () => {
+    const d = tmp()
+    fs.writeFileSync(path.join(d, 'fail.js'), 'process.exit(1)\n', 'utf-8')
+    fs.writeFileSync(
+      path.join(d, 'package.json'),
+      JSON.stringify({ name: 'tp', version: '0.0.0', scripts: { 'test:run': 'node fail.js' } }),
+      'utf-8'
+    )
+    const { report } = verifyEvidence(d)
+    const testGate = report.gates.find((g) => g.id === 'test')
+    expect(testGate?.status).toBe('fail')
+    expect(testGate?.exitCode).toBe(1)
+    expect(report.status).toBe('FAIL')
+    fs.rmSync(d, { recursive: true, force: true })
+  }, 30_000)
+
+  it('secure 게이트 — severe 시크릿 발견 시 fail, 리포트에 시크릿 값 미포함(누출 0)', () => {
+    const d = tmp()
+    // 테스트 소스에 contiguous 매칭이 안 생기도록 런타임 조합 (repo 자체 스캔 회피).
+    const fakeKey = 'AKIA' + 'IOSFODNN7EXAMPLE'
+    fs.writeFileSync(path.join(d, 'leak.js'), `const k = "${fakeKey}"\n`, 'utf-8')
+    fs.writeFileSync(path.join(d, 'package.json'), JSON.stringify({ name: 'tp', version: '0.0.0' }), 'utf-8')
+    const { report } = verifyEvidence(d)
+    const secure = report.gates.find((g) => g.id === 'secure')
+    expect(secure?.status).toBe('fail')
+    expect(report.status).toBe('FAIL')
+    // 리포트 직렬화 어디에도 시크릿 값이 없어야 함
+    const json = JSON.stringify(report)
+    expect(json).not.toContain(fakeKey)
+    const onDisk = fs.readFileSync(path.join(d, REPORT_PATH_REL), 'utf-8')
+    expect(onDisk).not.toContain(fakeKey)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('runSecureGate — 시크릿 없으면 pass', () => {
+    const d = tmp()
+    fs.writeFileSync(path.join(d, 'a.js'), 'const x = 1\n', 'utf-8')
+    expect(runSecureGate(d).status).toBe('pass')
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})
+
+describe('verify — CLI (--json / HARD_STOP)', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    process.exitCode = 0
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+    process.exitCode = 0
+  })
+
+  it('--json → stdout 으로 리포트 JSON (파싱 가능)', async () => {
+    const d = tmp()
+    fs.writeFileSync(path.join(d, 'package.json'), JSON.stringify({ name: 'tp', version: '0.0.0' }), 'utf-8')
+    process.chdir(d)
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    await verify({ json: true })
+    const printed = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+    const parsed = JSON.parse(printed)
+    expect(parsed.schemaVersion).toBe(REPORT_SCHEMA_VERSION)
+    expect(['PASS', 'WARN', 'FAIL']).toContain(parsed.status)
+    process.chdir(origCwd) // Windows: cwd 인 디렉터리는 rmSync 불가 → 먼저 빠져나온다
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('HARD_STOP 존재 → verify 거부 + exitCode 1 + 리포트 미생성', async () => {
+    const d = tmp()
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    fs.writeFileSync(path.join(d, '.vhk', 'HARD_STOP'), 'ts\nreason\n', 'utf-8')
+    process.chdir(d)
+    await verify()
+    expect(process.exitCode).toBe(1)
+    expect(fs.existsSync(path.join(d, REPORT_PATH_REL))).toBe(false)
+    process.chdir(origCwd) // Windows: cwd 인 디렉터리는 rmSync 불가 → 먼저 빠져나온다
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -131,6 +131,37 @@ describe('verify — verifyEvidence (실제 게이트 + 증거 기록)', () => {
     expect(runSecureGate(d).status).toBe('pass')
     fs.rmSync(d, { recursive: true, force: true })
   })
+
+  it('BOM 붙은 package.json 에서도 크래시 없이 latest.json 생성 (Windows 회귀)', () => {
+    // PowerShell Set-Content -Encoding utf8 등은 파일 맨 앞에 ﻿(BOM)를 붙인다.
+    // raw JSON.parse 면 죽어서 증거(latest.json)도 못 남기던 버그 → readJsonFile(BOM strip) 회귀 가드.
+    const d = tmp()
+    fs.writeFileSync(
+      path.join(d, 'package.json'),
+      '﻿' + JSON.stringify({ name: 'tp', version: '0.0.0', scripts: { 'test:run': 'node ok.js' } }),
+      'utf-8'
+    )
+    fs.writeFileSync(path.join(d, 'ok.js'), 'process.exit(0)\n', 'utf-8')
+    const { report } = verifyEvidence(d)
+    // 계약: 성공·실패 무관 항상 증거 기록 — BOM 으로도 죽지 않음
+    expect(fs.existsSync(path.join(d, REPORT_PATH_REL))).toBe(true)
+    expect(report.schemaVersion).toBe(REPORT_SCHEMA_VERSION)
+    // scripts 가 정상 인식돼 test 게이트 실행됨(BOM 만 제거되고 본문 보존)
+    expect(report.gates.find((g) => g.id === 'test')?.skipped).toBe(false)
+    fs.rmSync(d, { recursive: true, force: true })
+  }, 30_000)
+
+  it('손상된 package.json → 크래시 없이 외부 게이트 skip + 증거 기록(거짓 PASS 금지)', () => {
+    const d = tmp()
+    fs.writeFileSync(path.join(d, 'package.json'), '{ this is not valid json', 'utf-8')
+    const { report } = verifyEvidence(d)
+    expect(fs.existsSync(path.join(d, REPORT_PATH_REL))).toBe(true)
+    // scripts 파싱 실패 → 외부 게이트 전부 skip(추측 PASS 금지)
+    expect(report.gates.find((g) => g.id === 'typecheck')?.status).toBe('skip')
+    expect(report.gates.find((g) => g.id === 'test')?.status).toBe('skip')
+    expect(report.gates.find((g) => g.id === 'build')?.status).toBe('skip')
+    fs.rmSync(d, { recursive: true, force: true })
+  })
 })
 
 describe('verify — CLI (--json / HARD_STOP)', () => {


### PR DESCRIPTION
@
## 요약 (Batch B)

**v1.7.0** — `vhk verify` 를 lite(체크리스트 안내)에서 **실제 게이트 실행 + 증거 기록**으로 승격. 성장 루프(learning·pattern·evolve)의 입력 데이터 토대.

> 🔗 **스택 PR.** base = `release/v1.6.6`(#91) → 이 PR diff 는 **Goal 13 변경만** 보입니다. **#91 먼저 머지** 후 이 PR 머지(머지 시 base 자동 main 재타깃). **publish 는 사람(2FA OTP).**

## Goal 13 — verify 증거화 (Evidence Ledger v0)

- **게이트 4종 실제 실행 + 종료코드 수집:** `typecheck` / `test:run` / `build`(외부 프로세스) + `secure`(in-process 스캔). 파이프로 exit code 안 가림.
- **`.vhk/reports/latest.json` 항상 생성/갱신**(성공·실패 무관). 스키마: `{ schemaVersion, generatedAt, date, status(PASS|WARN|FAIL), summary, gates[], nextActions[] }` — head(요약·기계용) + body(사람용).
- **거짓 PASS 금지:** 스크립트/설정 없으면 `skip`(WARN), 실행 자체 실패는 `fail`. `status` = fail→FAIL · skip→WARN · 전부 pass→PASS. `exitCode` FAIL=1.
- **`--json`** (CI용 stdout). **HARD_STOP** 존재 시 거부 + exit 1.
- **시크릿 누출 0:** secure 게이트는 severe **건수만** 기록(값 미수집) → 리포트가 `vhk secure scan` 에 안 걸림. `reports/` 로컬 전용(`.vhk/.gitignore` 자동 등재).
- **Windows 1급:** `.cmd` shim `cmd.exe` 래핑(CVE-2024-27980), maxBuffer 64MB.
- **기존 호환:** `verificationChecklist` 보존(mode.test), `verify()` 무인자 호출(자연어 라우터) 동작.

`vhk goal sync` → `check-goal-13.mjs` 백필 + goal-13 고유 검증 추가 → `vhk goal done 13` 게이트 통과 → **DONE**.

## 규격

`docs/rfc/0038-vhk-spec.md`(#38, Batch A 동봉)가 `reports/` 서브디렉토리 + `latest.json` 스키마를 `.vhk` 규격 v1.1 로 도입. 설계 전문: `docs/superpowers/specs/2026-06-02-verify-evidence-design.md`.

## 게이트

- ✅ typecheck (tsc --noEmit)
- ✅ test: **610 pass** (585 base + 11 Goal12 + 14 Goal13, 회귀 0)
- ✅ build (tsup)
- ✅ `vhk goal check --id 13` 통과
- ✅ 실 스모크: `vhk verify --json` → 4/4 PASS, latest.json 생성, reports/ gitignore 확인

## 테스트 (신규 14)

순수 함수(aggregateStatus/buildReport/buildNextActions/detectPm) + temp 프로젝트 실게이트 + **거짓 PASS 회귀 가드**(test 깸→FAIL) + skip→WARN + **secret 누출 0** + HARD_STOP 거부 + `--json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@