### PR TITLE
chore(state): v1.7.0 기준 next-task 갱신 + Goal 14 (verify --report) 등록

### DIFF
--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -1,11 +1,13 @@
 # Next Task
 
-_Updated 2026-06-01 — goal 0~10 전부 DONE (자기개선 배치 7~10 포함)._
+_Updated 2026-06-02 — goal 0~13 전부 DONE (v1.7.0 출시 완료). 백로그 비어있음._
 
 ```
-TASK: 자기개선 goal 0~10 전부 DONE. 다음 = v1.6.3
-  - #82 (VHK-022) .vhk/cloud.json gitignore — 보안/신뢰
-  - #80 (VHK-021) goal 파일 스키마 문서화 (type:goal, id 숫자 → silent skip)
-  status: 새 작업 대기
+TASK: goal 0~13 전부 DONE. v1.7.0 출시 완료 (Goal 13 verify 증거화 / latest.json).
+  다음 = Trust Loop 배치 6 → Goal 14 (vhk verify --report)
+  - Goal 14 (VHK-023) vhk verify --report: .vhk/reports/latest.json → 무빌드 정적 HTML(latest.html, Human Panel MVP)
+  - 후속: STEP 1.5 sync 대상 확대(Antigravity/Copilot), 배치 7 vhk mission, 배치 8+ Evolution Loop
+  status: Goal 14 등록됨 (goals/14-verify-report.md) — 착수 대기
   note: `vhk goal next` 는 전부 DONE 이면 갱신하지 않으므로 수동 기록.
+        publish 는 사람만 (2FA OTP).
 ```

--- a/goals/14-verify-report.md
+++ b/goals/14-verify-report.md
@@ -1,0 +1,47 @@
+---
+vhk_format: 1
+type: goal
+id: 14
+title: vhk verify --report (Human Panel HTML v0) — P2
+status: NOT_STARTED
+priority: P2
+version: v1.7.1
+---
+
+# Goal 14: vhk verify --report (Human Panel HTML v0)
+
+> 출처: Trust Loop 로드맵 배치 6. 전제: Goal 13(verify 증거화 / latest.json) 완료됨 (v1.7.0).
+> 성장 루프에서 "증거 → 사람이 읽는 패널" 단계. 증거는 이미 latest.json에 있음 → 사람용 표면만 추가.
+
+## 배경
+Goal 13으로 `vhk verify`가 `.vhk/reports/latest.json`(기계용)을 항상 남기게 됐다. 하지만 비개발자·리뷰어가 JSON을 직접 읽긴 어렵다. 같은 증거를 **사람이 한눈에 보는 정적 HTML**로 렌더해 검증 결과를 설득력 있게 보여준다.
+
+## 철학
+① 새 증거 만들지 않음 — latest.json을 읽어 렌더만 (단일 진실원천 유지) ② 무빌드·무의존 — 외부 CDN/번들러 없이 인라인 정적 HTML ③ 오프라인 동작 ④ 기존 verify 동작 무손상 (옵션 추가만).
+
+## 동작 (파일·계약)
+- `vhk verify --report`: 최신 `.vhk/reports/latest.json`을 읽어 `.vhk/reports/latest.html` 생성.
+  - latest.json이 없으면 verify를 1회 선실행해 생성한 뒤 렌더 (또는 명확한 안내 후 종료).
+- `latest.html`: 인라인 CSS, 외부 의존 0. status 배지(PASS/WARN/FAIL) + 게이트별 결과 표 + nextActions + generatedAt.
+- `--open`(선택): 생성 후 기본 브라우저로 열기 (비대화형/CI/MCP에서는 자동 스킵).
+- 크로스플랫폼: 경로 조합 path.join, 쓰기 권한 없으면 친절 에러 + exit≠0.
+- secret/env 값 미포함 (latest.json이 이미 미포함 — 그대로 렌더).
+
+## Completion Check
+- [ ] `vhk verify --report` → latest.json 읽어 latest.html 생성 (외부 의존 0)
+- [ ] latest.json 없을 때 동작 정의대로 (verify 선실행 or 안내 종료)
+- [ ] status=FAIL 리포트가 HTML에 FAIL로 정확히 렌더 (거짓 PASS 표시 회귀 가드)
+- [ ] --open 비대화형/CI/MCP에서 자동 스킵 (TTY 없으면 안 엶)
+- [ ] HTML에 secret 누출 0 (vhk secure scan)
+- [ ] vhk goal sync → check-goal-14.mjs 생성 → vhk goal check --id 14 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 599 회귀 0
+
+## 제외 범위
+- 멀티 리포트 히스토리 뷰어 / 추세 그래프 → 배치 8+ (Evidence Ledger 확장)
+- vhk review 적대 검증 → 별도 goal
+- 서버·웹 대시보드 (정적 파일만)
+
+## Mandatory Reading
+- `src/commands/verify.ts` (Goal 13 verifyEvidence/buildReport — latest.json 스키마)
+- `.vhk/reports/latest.json` 스키마: { schemaVersion, generatedAt, status, summary, gates[], nextActions[] }
+- 핸드오프 페이지 §1 릴리즈 큐 (배치 6 위치)

--- a/scripts/check-goal-14.mjs
+++ b/scripts/check-goal-14.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// scripts/check-goal-14.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 14 gate.')
+  process.exit(1)
+}
+
+const pkg = existsSync('package.json') ? JSON.parse(readFileSync('package.json', 'utf-8')) : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 14] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 14 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 14 gate passes'); process.exit(0) }
+console.log('❌ goal 14 gate failed'); process.exit(1)


### PR DESCRIPTION
## 요약
상태 문서·계약만 손대는 **드래프트 PR** (코드 변경 / publish 없음). goal 0~13이 전부 DONE이라 백로그가 비었고, `vhk goal next`가 돌려면 다음 작업을 새 goal로 등록해야 해서 정리.

## 변경
- `docs/state/next-task.md` — stale 갱신. 기존 "다음 = v1.6.3"은 이미 v1.7.0까지 출시됨 → "goal 0~13 전부 DONE, 다음 = Goal 14"로 정리.
- `goals/14-verify-report.md` (신규, NOT_STARTED) — Trust Loop 배치 6 = `vhk verify --report`(latest.json → 무빌드 정적 HTML). Goal 13 포맷 그대로 맞춤.

## 주의
- 이 PR은 **구현이 아니라 작업 등록**임. 실제 구현(verify --report)은 Goal 14 착수 시 별도 사이클.
- `vhk goal sync`는 아직 안 돌렸음 → 머지 전에 로컬에서 `vhk goal sync` 돌려 `scripts/check-goal-14.mjs` 백필 권장.
- publish는 사람만 (2FA OTP).