### PR TITLE
feat(verify): --report 사람용 HTML 리포트 (Goal 14, v1.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 (다음 릴리즈 누적 영역)
 
+## [1.7.1] - 2026-06-02
+
+> **verify --report (Human Panel HTML v0, Goal 14, 배치 6).** Goal 13 의 `latest.json`(기계용 증거)을
+> 같은 진실원천 그대로 사람이 한눈에 보는 **정적 HTML**로 렌더. 성장 루프의 "증거 → 사람이 읽는 패널" 단계.
+> 철학: 새 증거 안 만듦(렌더만) + 무빌드·무의존(인라인 CSS, 오프라인) + 기존 verify 무손상(옵션 추가만).
+
+### Added
+
+- **`vhk verify --report`** (`src/commands/verify-report.ts`) — `.vhk/reports/latest.json` 을 읽어
+  사람용 정적 HTML `.vhk/reports/latest.html` 생성. `renderReportHtml(report)` 순수 함수 —
+  인라인 CSS, **외부 의존 0**(CDN/스크립트 없음), 오프라인 동작. status 배지(PASS/WARN/FAIL) +
+  게이트별 표(label·종료코드·detail) + nextActions + generatedAt. `escapeHtml` 로 사용자 텍스트 이스케이프.
+  latest.json 없으면 verify 1회 선실행 후 렌더, 있으면 **BOM-safe `readJsonFile`** 로 읽음.
+- **`vhk verify --open`** — 리포트 생성 후 기본 브라우저로 열기(`safeExecFile`, shell 없는 argv 호출).
+  비대화형/CI/MCP(비-TTY)에서는 `isInteractive()` 로 **자동 스킵**.
+
+### Security
+
+- HTML 에 **secret/env 미포함** — latest.json 이 이미 미포함(Goal 13) → 그대로 렌더(누출 0).
+  쓰기 권한 없으면 크래시 대신 친절 에러 + exit≠0.
+
+### Note
+
+- 기존 `vhk verify` / `--json` 동작 무손상(옵션 추가만). 테스트 11개 추가(FAIL→HTML 회귀 가드 포함).
+
 ## [1.7.0] - 2026-06-02
 
 > **verify 증거화 (Evidence Ledger v0, #13 Goal 13).** `vhk verify` 가 lite(체크리스트 안내)에서

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,16 +13,16 @@ tags: [process, documentation]
 
 - **레포:** <https://github.com/byh3071-cpu/vhk> (public)
 - **npm:** @byh3071/vhk (public, scoped)
-- **버전:** v1.7.0 (package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
+- **버전:** v1.7.1 (package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
 - **MCP tool:** 24/24 (Goal 0 DONE)
-- **테스트:** 599 pass (vitest)
+- **테스트:** 623 pass (vitest)
 - **패키지 매니저:** pnpm
 
 ## 현재 상태
 
-- **Phase:** Phase 5 이후 — Goal 13(verify 증거화, #13) DONE → v1.7.0 PR (v1.6.6 스택 위).
+- **Phase:** Phase 5 이후 — Goal 14(verify --report HTML, 배치 6) DONE → v1.7.1 PR (#94 Goal14 등록 스택 위).
 - **블로커:** 없음
-- **다음 액션:** 배치 6(verify --report JSON→HTML), STEP 1.5(sync 확대). publish 는 사람(2FA OTP).
+- **다음 액션:** STEP 4(raw JSON.parse 금지 grep 게이트), STEP 1.5(sync 확대), 배치 7(vhk mission). publish 는 사람(2FA OTP).
 - **마지막 업데이트:** 2026-06-02
 
 ## 코딩 컨벤션

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -1,11 +1,13 @@
 # Next Task
 
-_Updated 2026-06-01 — goal 0~10 전부 DONE (자기개선 배치 7~10 포함)._
+_Updated 2026-06-02 — goal 0~13 전부 DONE (v1.7.0 출시 완료). 백로그 비어있음._
 
 ```
-TASK: 자기개선 goal 0~10 전부 DONE. 다음 = v1.6.3
-  - #82 (VHK-022) .vhk/cloud.json gitignore — 보안/신뢰
-  - #80 (VHK-021) goal 파일 스키마 문서화 (type:goal, id 숫자 → silent skip)
-  status: 새 작업 대기
+TASK: goal 0~13 전부 DONE. v1.7.0 출시 완료 (Goal 13 verify 증거화 / latest.json).
+  다음 = Trust Loop 배치 6 → Goal 14 (vhk verify --report)
+  - Goal 14 (VHK-023) vhk verify --report: .vhk/reports/latest.json → 무빌드 정적 HTML(latest.html, Human Panel MVP)
+  - 후속: STEP 1.5 sync 대상 확대(Antigravity/Copilot), 배치 7 vhk mission, 배치 8+ Evolution Loop
+  status: Goal 14 등록됨 (goals/14-verify-report.md) — 착수 대기
   note: `vhk goal next` 는 전부 DONE 이면 갱신하지 않으므로 수동 기록.
+        publish 는 사람만 (2FA OTP).
 ```

--- a/goals/14-verify-report.md
+++ b/goals/14-verify-report.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 14
 title: vhk verify --report (Human Panel HTML v0) — P2
-status: NOT_STARTED
+status: DONE
 priority: P2
 version: v1.7.1
+completed: 2026-06-02
 ---
 
 # Goal 14: vhk verify --report (Human Panel HTML v0)

--- a/goals/14-verify-report.md
+++ b/goals/14-verify-report.md
@@ -1,0 +1,47 @@
+---
+vhk_format: 1
+type: goal
+id: 14
+title: vhk verify --report (Human Panel HTML v0) — P2
+status: NOT_STARTED
+priority: P2
+version: v1.7.1
+---
+
+# Goal 14: vhk verify --report (Human Panel HTML v0)
+
+> 출처: Trust Loop 로드맵 배치 6. 전제: Goal 13(verify 증거화 / latest.json) 완료됨 (v1.7.0).
+> 성장 루프에서 "증거 → 사람이 읽는 패널" 단계. 증거는 이미 latest.json에 있음 → 사람용 표면만 추가.
+
+## 배경
+Goal 13으로 `vhk verify`가 `.vhk/reports/latest.json`(기계용)을 항상 남기게 됐다. 하지만 비개발자·리뷰어가 JSON을 직접 읽긴 어렵다. 같은 증거를 **사람이 한눈에 보는 정적 HTML**로 렌더해 검증 결과를 설득력 있게 보여준다.
+
+## 철학
+① 새 증거 만들지 않음 — latest.json을 읽어 렌더만 (단일 진실원천 유지) ② 무빌드·무의존 — 외부 CDN/번들러 없이 인라인 정적 HTML ③ 오프라인 동작 ④ 기존 verify 동작 무손상 (옵션 추가만).
+
+## 동작 (파일·계약)
+- `vhk verify --report`: 최신 `.vhk/reports/latest.json`을 읽어 `.vhk/reports/latest.html` 생성.
+  - latest.json이 없으면 verify를 1회 선실행해 생성한 뒤 렌더 (또는 명확한 안내 후 종료).
+- `latest.html`: 인라인 CSS, 외부 의존 0. status 배지(PASS/WARN/FAIL) + 게이트별 결과 표 + nextActions + generatedAt.
+- `--open`(선택): 생성 후 기본 브라우저로 열기 (비대화형/CI/MCP에서는 자동 스킵).
+- 크로스플랫폼: 경로 조합 path.join, 쓰기 권한 없으면 친절 에러 + exit≠0.
+- secret/env 값 미포함 (latest.json이 이미 미포함 — 그대로 렌더).
+
+## Completion Check
+- [ ] `vhk verify --report` → latest.json 읽어 latest.html 생성 (외부 의존 0)
+- [ ] latest.json 없을 때 동작 정의대로 (verify 선실행 or 안내 종료)
+- [ ] status=FAIL 리포트가 HTML에 FAIL로 정확히 렌더 (거짓 PASS 표시 회귀 가드)
+- [ ] --open 비대화형/CI/MCP에서 자동 스킵 (TTY 없으면 안 엶)
+- [ ] HTML에 secret 누출 0 (vhk secure scan)
+- [ ] vhk goal sync → check-goal-14.mjs 생성 → vhk goal check --id 14 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 599 회귀 0
+
+## 제외 범위
+- 멀티 리포트 히스토리 뷰어 / 추세 그래프 → 배치 8+ (Evidence Ledger 확장)
+- vhk review 적대 검증 → 별도 goal
+- 서버·웹 대시보드 (정적 파일만)
+
+## Mandatory Reading
+- `src/commands/verify.ts` (Goal 13 verifyEvidence/buildReport — latest.json 스키마)
+- `.vhk/reports/latest.json` 스키마: { schemaVersion, generatedAt, status, summary, gates[], nextActions[] }
+- 핸드오프 페이지 §1 릴리즈 큐 (배치 6 위치)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Vibe Harness Kit — AI 코딩 도구·기기를 바꿔도 규칙·맥락이 따라가는 포터빌리티 CLI (sync: Cursor·Claude·Windsurf·Copilot·Antigravity / cloud 백업)",
   "bin": {
     "vhk": "dist/index.js",

--- a/scripts/check-goal-14.mjs
+++ b/scripts/check-goal-14.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// scripts/check-goal-14.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 14 gate.')
+  process.exit(1)
+}
+
+const pkg = existsSync('package.json') ? JSON.parse(readFileSync('package.json', 'utf-8')) : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 14] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 14 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 14 gate passes'); process.exit(0) }
+console.log('❌ goal 14 gate failed'); process.exit(1)

--- a/scripts/check-goal-14.mjs
+++ b/scripts/check-goal-14.mjs
@@ -50,9 +50,18 @@ if (!skipDeep) {
   if (scripts.build) gate('build', run(pm, ['run', 'build']))
 }
 
-// ─── goal 14 고유 검증 (직접 추가) ───────────────────────────────
-// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
-// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+// ─── goal 14 고유 검증 (verify --report → 사람용 정적 HTML) ───────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+const vr = read('src/commands/verify-report.ts') ?? ''
+const vf = read('src/commands/verify.ts') ?? ''
+const idx = read('src/index.ts') ?? ''
+must(/export function renderReportHtml/.test(vr) && /export function escapeHtml/.test(vr), 'renderReportHtml + escapeHtml export (순수 렌더러)')
+must(!/https?:\/\//.test(vr) && !/<script\s+src/i.test(vr), '렌더러 외부 의존 0 (URL/외부 스크립트 없음 — 오프라인)')
+must(/--report/.test(idx) && /--open/.test(idx), 'index 에 verify --report / --open 옵션')
+must(/REPORT_HTML_PATH_REL/.test(vf) && /readJsonFile<VerifyReport>/.test(vf), 'latest.html 쓰기 + latest.json BOM-safe 읽기(readJsonFile)')
+must(/renderReportHtml\(/.test(vf), 'verify 가 renderReportHtml 로 렌더(새 증거 안 만듦)')
+must(/isInteractive\(\)/.test(vf) && /자동 스킵/.test(vf), '--open 비대화형/CI/MCP 자동 스킵')
+must(existsSync('tests/verify-report.test.ts'), 'verify-report 테스트 존재(FAIL 회귀 가드 포함)')
 
 if (pass) { console.log('✅ goal 14 gate passes'); process.exit(0) }
 console.log('❌ goal 14 gate failed'); process.exit(1)

--- a/src/commands/verify-report.ts
+++ b/src/commands/verify-report.ts
@@ -1,0 +1,130 @@
+import type { GateResult, ReportStatus, VerifyReport } from './verify.js'
+
+/**
+ * Goal 14: verify 증거(latest.json) → 사람이 읽는 정적 HTML.
+ * 철학: ① 새 증거 안 만듦(렌더만) ② 외부 의존 0(인라인 CSS, CDN/스크립트 없음) ③ 오프라인 동작
+ *      ④ secret/env 미포함(latest.json 이 이미 미포함 — 그대로 렌더).
+ * renderReportHtml 은 **순수 함수** — 파일 읽기/쓰기 없음(테스트 용이 + 단일 책임).
+ */
+
+/** HTML 특수문자 이스케이프 — detail/label/nextActions 의 사용자 텍스트 안전 렌더(태그 주입·깨짐 방지). */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/** 상태별 색상 토큰 (배지/표 셀 공용). 외부 폰트/리소스 없이 색상값만. */
+const STATUS_COLOR: Record<ReportStatus, { bg: string; fg: string; label: string }> = {
+  PASS: { bg: '#16a34a', fg: '#ffffff', label: 'PASS' },
+  WARN: { bg: '#d97706', fg: '#ffffff', label: 'WARN' },
+  FAIL: { bg: '#dc2626', fg: '#ffffff', label: 'FAIL' },
+}
+
+/** 게이트 상태(pass/fail/skip) → 한글 라벨 + 색상. */
+const GATE_STATUS: Record<GateResult['status'], { color: string; label: string }> = {
+  pass: { color: '#16a34a', label: '통과' },
+  fail: { color: '#dc2626', label: '실패' },
+  skip: { color: '#d97706', label: '건너뜀' },
+}
+
+function renderGateRow(g: GateResult): string {
+  const s = GATE_STATUS[g.status]
+  const exit = g.exitCode === null ? '—' : String(g.exitCode)
+  const detail = g.detail ? escapeHtml(g.detail) : ''
+  return `      <tr>
+        <td class="gate-label">${escapeHtml(g.label)}</td>
+        <td><span class="gate-status" style="color:${s.color}">${s.label}</span></td>
+        <td class="gate-exit">${escapeHtml(exit)}</td>
+        <td class="gate-detail">${detail}</td>
+      </tr>`
+}
+
+/**
+ * VerifyReport → 완성된 HTML 문자열. 외부 의존 0(인라인 <style>, 스크립트 없음).
+ * @param report .vhk/reports/latest.json 의 파싱 결과(스키마 v1)
+ */
+export function renderReportHtml(report: VerifyReport): string {
+  const c = STATUS_COLOR[report.status]
+  const s = report.summary
+  const rows = report.gates.map(renderGateRow).join('\n')
+  const actions = report.nextActions
+    .map((a) => `        <li>${escapeHtml(a)}</li>`)
+    .join('\n')
+
+  return `<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>vhk verify 리포트 — ${c.label}</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 2rem 1rem;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Noto Sans KR", sans-serif;
+    background: #f8fafc; color: #0f172a; line-height: 1.55;
+  }
+  .wrap { max-width: 760px; margin: 0 auto; }
+  header { display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; margin-bottom: 0.5rem; }
+  h1 { font-size: 1.25rem; margin: 0; font-weight: 700; }
+  .badge {
+    display: inline-block; padding: 0.35rem 1rem; border-radius: 9999px;
+    font-weight: 800; font-size: 1rem; letter-spacing: 0.05em;
+    background: ${c.bg}; color: ${c.fg};
+  }
+  .summary { color: #475569; font-size: 0.95rem; margin: 0.25rem 0 1.5rem; }
+  .summary strong { color: #0f172a; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 1.75rem; font-size: 0.95rem; }
+  th, td { text-align: left; padding: 0.6rem 0.75rem; border-bottom: 1px solid #e2e8f0; }
+  th { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; color: #64748b; }
+  .gate-label { font-weight: 600; }
+  .gate-status { font-weight: 700; }
+  .gate-exit { font-variant-numeric: tabular-nums; color: #475569; }
+  .gate-detail { color: #64748b; font-size: 0.88rem; }
+  h2 { font-size: 1rem; margin: 0 0 0.5rem; }
+  ul { margin: 0 0 1.75rem; padding-left: 1.25rem; }
+  li { margin: 0.2rem 0; }
+  footer { color: #94a3b8; font-size: 0.8rem; border-top: 1px solid #e2e8f0; padding-top: 0.75rem; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #0f172a; color: #e2e8f0; }
+    .summary { color: #94a3b8; } .summary strong { color: #e2e8f0; }
+    th { color: #94a3b8; } th, td { border-color: #1e293b; }
+    .gate-exit { color: #94a3b8; } .gate-detail { color: #94a3b8; }
+    footer { color: #64748b; border-color: #1e293b; }
+  }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <h1>🔎 vhk verify 리포트</h1>
+      <span class="badge">${c.label}</span>
+    </header>
+    <p class="summary">
+      게이트 <strong>${s.total}</strong>개 — 통과 ${s.pass} / 실패 ${s.fail} / 건너뜀 ${s.skip}
+    </p>
+    <table>
+      <thead>
+        <tr><th>게이트</th><th>상태</th><th>종료코드</th><th>비고</th></tr>
+      </thead>
+      <tbody>
+${rows}
+      </tbody>
+    </table>
+    <h2>다음 행동</h2>
+    <ul>
+${actions}
+    </ul>
+    <footer>
+      생성: ${escapeHtml(report.generatedAt)} · 날짜: ${escapeHtml(report.date)} · schema v${report.schemaVersion}
+    </footer>
+  </div>
+</body>
+</html>
+`
+}

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -10,6 +10,9 @@ import { ensureVhkIgnored } from '../lib/backup.js'
 import { readJsonFile } from '../lib/read-json.js'
 import { localDate } from '../lib/date.js'
 import { scanProjectForSecrets, filterSevereFindings } from '../lib/scan-secrets.js'
+import { renderReportHtml } from './verify-report.js'
+import { isInteractive } from '../lib/interactive.js'
+import { safeExecFile } from '../lib/exec.js'
 
 /**
  * 저장/위험 작업 전 돌려야 하는 검증 묶음.
@@ -32,6 +35,8 @@ export function verificationChecklist(): string[] {
 export const REPORT_SCHEMA_VERSION = 1
 export const REPORT_DIR_REL = join('.vhk', 'reports')
 export const REPORT_PATH_REL = join(REPORT_DIR_REL, 'latest.json')
+/** Goal 14: 사람용 정적 HTML 리포트 경로(같은 증거 latest.json 을 렌더). */
+export const REPORT_HTML_PATH_REL = join(REPORT_DIR_REL, 'latest.html')
 
 export type GateRunStatus = 'pass' | 'fail' | 'skip'
 export type ReportStatus = 'PASS' | 'WARN' | 'FAIL'
@@ -277,11 +282,87 @@ const STATUS_BADGE: Record<ReportStatus, string> = {
   FAIL: chalk.red.bold('FAIL'),
 }
 
-export async function verify(opts: { json?: boolean } = {}): Promise<void> {
+/**
+ * Goal 14: `--report` — latest.json 을 사람용 정적 HTML 로 렌더.
+ * 새 증거를 만들지 않는다(단일 진실원천) — latest.json 이 있으면 읽고(BOM-safe),
+ * 없으면 verify 1회 선실행해 증거를 만든 뒤 같은 report 를 렌더.
+ */
+async function renderVerifyReport(cwd: string, opts: { open?: boolean }): Promise<void> {
+  const jsonPath = join(cwd, REPORT_PATH_REL)
+  let report: VerifyReport
+  if (existsSync(jsonPath)) {
+    try {
+      report = readJsonFile<VerifyReport>(jsonPath)
+    } catch {
+      // 손상된 latest.json → verify 재실행으로 증거 재생성(렌더 전용 원칙 유지: 깨진 증거는 무효).
+      console.log(chalk.yellow('  ⚠️  기존 latest.json 손상 — verify 재실행으로 증거를 다시 만듭니다.'))
+      report = verifyEvidence(cwd).report
+    }
+  } else {
+    console.log(chalk.dim('  latest.json 없음 — verify 1회 선실행으로 증거를 만듭니다.'))
+    report = verifyEvidence(cwd).report
+  }
+
+  const html = renderReportHtml(report)
+  const htmlPath = join(cwd, REPORT_HTML_PATH_REL)
+  try {
+    mkdirSync(join(cwd, REPORT_DIR_REL), { recursive: true })
+    writeFileSync(htmlPath, html, 'utf-8')
+  } catch (e) {
+    // 쓰기 권한 없음 등 → 크래시 대신 친절 안내 + 비-0 종료.
+    console.error(
+      chalk.red(`  ❌ 리포트 HTML 을 쓸 수 없습니다 (${REPORT_HTML_PATH_REL}): ${e instanceof Error ? e.message : String(e)}`)
+    )
+    console.error(chalk.dim('     해당 경로의 쓰기 권한을 확인하세요.'))
+    process.exitCode = 1
+    return
+  }
+
+  console.log(chalk.bold('\n🔎 검증 리포트 (verify --report)'))
+  console.log(`  결과: ${STATUS_BADGE[report.status]}`)
+  console.log(chalk.dim(`  📄 HTML: ${REPORT_HTML_PATH_REL}`))
+  process.exitCode = report.status === 'FAIL' ? 1 : 0
+
+  if (opts.open) {
+    // 비대화형/CI/MCP(비-TTY)에서는 브라우저 열기 자동 스킵.
+    if (isInteractive()) openReportInBrowser(htmlPath)
+    else console.log(chalk.dim('  (비대화형/CI/MCP — --open 자동 스킵)'))
+    return
+  }
+  printNextStep({
+    message: '리포트 생성 완료. 브라우저로 열려면:',
+    command: 'vhk verify --report --open',
+    cursorHint: '리포트 열어줘',
+  })
+}
+
+/** 기본 브라우저로 로컬 HTML 열기 — shell 없는 argv 호출(ref.ts 패턴 답습, 인젝션 차단). */
+function openReportInBrowser(filePath: string): void {
+  let result
+  if (process.platform === 'darwin') {
+    result = safeExecFile('open', [filePath])
+  } else if (process.platform === 'win32') {
+    // rundll32 url.dll,FileProtocolHandler: 쉘 없이 ShellExecute → cmd 파싱 없음.
+    result = safeExecFile('rundll32.exe', ['url.dll,FileProtocolHandler', filePath])
+  } else {
+    result = safeExecFile('xdg-open', [filePath])
+  }
+  if (result.ok) console.log(chalk.green('  ✅ 브라우저에서 열었습니다.'))
+  else console.log(chalk.yellow('  ⚠️  브라우저를 열 수 없습니다. 위 파일을 직접 여세요.'))
+}
+
+export async function verify(opts: { json?: boolean; report?: boolean; open?: boolean } = {}): Promise<void> {
   // HARD_STOP 활성 → 게이트 실행 거부 + exit 1 (PRD §9).
   if (!ensureNotHardStopped('verify')) return
 
   const cwd = process.cwd()
+
+  // --report: latest.json → 사람용 HTML 렌더(증거는 만들지 않고 읽음; 없으면 선실행). json 보다 우선.
+  if (opts.report) {
+    await renderVerifyReport(cwd, opts)
+    return
+  }
+
   const { report, path } = verifyEvidence(cwd)
 
   // --json: 경로 대신 stdout 으로 리포트 JSON (CI 용). 다른 콘솔 출력 없음.

--- a/src/index.ts
+++ b/src/index.ts
@@ -444,8 +444,10 @@ program
   .command('verify')
   .alias('사전점검')
   .option('--json', '리포트 JSON 을 stdout 으로 출력 (CI용 — 경로 대신)')
+  .option('--report', 'latest.json 을 사람용 정적 HTML(.vhk/reports/latest.html) 로 렌더 (외부 의존 0)')
+  .option('--open', '리포트 생성 후 기본 브라우저로 열기 (비대화형/CI/MCP 자동 스킵)')
   .description('검증 게이트(tsc/test/build/secure) 실제 실행 + 증거 기록 (.vhk/reports/latest.json)')
-  .action(async (opts: { json?: boolean }) => { await verify(opts) })
+  .action(async (opts: { json?: boolean; report?: boolean; open?: boolean }) => { await verify(opts) })
 
 program
   .command('context-show')

--- a/tests/verify-report.test.ts
+++ b/tests/verify-report.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { renderReportHtml, escapeHtml } from '../src/commands/verify-report.js'
+import {
+  buildReport,
+  verify,
+  REPORT_PATH_REL,
+  REPORT_HTML_PATH_REL,
+  type GateResult,
+  type VerifyReport,
+} from '../src/commands/verify.js'
+
+function gate(id: GateResult['id'], status: GateResult['status'], exitCode: number | null = 0, detail?: string): GateResult {
+  return { id, label: id, status, exitCode, skipped: status === 'skip', detail }
+}
+
+function report(gates: GateResult[]): VerifyReport {
+  return buildReport(gates, '2026-06-02T00:00:00.000Z', '2026-06-02')
+}
+
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-vreport-'))
+}
+
+describe('verify-report — escapeHtml', () => {
+  it('태그/앰퍼샌드/따옴표 이스케이프', () => {
+    expect(escapeHtml('<script>alert("x")&\'`')).toBe('&lt;script&gt;alert(&quot;x&quot;)&amp;&#39;`')
+  })
+})
+
+describe('verify-report — renderReportHtml (배지)', () => {
+  it('status=FAIL → HTML 에 FAIL 배지 (거짓 PASS 회귀 가드)', () => {
+    const html = renderReportHtml(report([gate('typecheck', 'pass'), gate('test', 'fail', 1)]))
+    // 배지 클래스 안에 FAIL 표기
+    expect(html).toMatch(/class="badge"[^>]*>FAIL</)
+    // 거짓 PASS 표시 없음 — 배지에 PASS 가 들어가면 안 됨
+    expect(html).not.toMatch(/class="badge"[^>]*>PASS</)
+    expect(html).not.toMatch(/class="badge"[^>]*>WARN</)
+  })
+
+  it('status=PASS / WARN 각 배지 렌더', () => {
+    expect(renderReportHtml(report([gate('typecheck', 'pass'), gate('secure', 'pass')]))).toMatch(/class="badge"[^>]*>PASS</)
+    expect(renderReportHtml(report([gate('typecheck', 'pass'), gate('build', 'skip', null)]))).toMatch(/class="badge"[^>]*>WARN</)
+  })
+})
+
+describe('verify-report — renderReportHtml (게이트 표 + nextActions)', () => {
+  it('각 게이트 label·종료코드·detail 포함', () => {
+    const html = renderReportHtml(
+      report([gate('test', 'fail', 7, '종료코드 7'), gate('build', 'skip', null)])
+    )
+    expect(html).toContain('test')
+    expect(html).toContain('build')
+    expect(html).toContain('>7<') // 종료코드 셀
+    expect(html).toContain('종료코드 7') // detail
+    expect(html).toContain('—') // skip 게이트 exitCode null → —
+  })
+
+  it('nextActions 가 리스트로 렌더', () => {
+    const html = renderReportHtml(report([gate('typecheck', 'pass'), gate('secure', 'pass')]))
+    // 통과 시 nextActions = 저장 안내
+    expect(html).toMatch(/<li>[^<]*(저장|vhk save)[^<]*<\/li>/)
+  })
+})
+
+describe('verify-report — renderReportHtml (안전성)', () => {
+  it('detail 의 태그가 이스케이프되어 생짜 <script> 미출력', () => {
+    const html = renderReportHtml(report([gate('test', 'fail', 1, '<script>alert(1)</script>')]))
+    expect(html).not.toContain('<script>alert(1)</script>')
+    expect(html).toContain('&lt;script&gt;')
+  })
+
+  it('외부 의존 0 — URL/CDN/외부 스크립트 없음 (오프라인 보장)', () => {
+    const html = renderReportHtml(report([gate('typecheck', 'pass')]))
+    expect(html).not.toMatch(/https?:\/\//)
+    expect(html).not.toMatch(/<script\s+src/i)
+    expect(html).not.toMatch(/cdn/i)
+  })
+
+  it('완결 HTML 문서 (DOCTYPE + html 닫힘)', () => {
+    const html = renderReportHtml(report([gate('typecheck', 'pass')]))
+    expect(html.trimStart()).toMatch(/^<!DOCTYPE html>/)
+    expect(html).toContain('</html>')
+  })
+})
+
+describe('verify-report — verify({report}) 통합', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    process.exitCode = 0
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+    process.exitCode = 0
+  })
+
+  it('기존 FAIL latest.json → latest.html 에 FAIL 렌더 (증거 재생성 안 함)', async () => {
+    const d = tmp()
+    const fail = report([gate('test', 'fail', 1)])
+    fs.mkdirSync(path.join(d, '.vhk', 'reports'), { recursive: true })
+    fs.writeFileSync(path.join(d, REPORT_PATH_REL), JSON.stringify(fail, null, 2), 'utf-8')
+    process.chdir(d)
+    await verify({ report: true })
+    const html = fs.readFileSync(path.join(d, REPORT_HTML_PATH_REL), 'utf-8')
+    expect(html).toMatch(/class="badge"[^>]*>FAIL</)
+    expect(process.exitCode).toBe(1)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('latest.json 없으면 verify 선실행 후 latest.html 생성', async () => {
+    const d = tmp()
+    fs.writeFileSync(path.join(d, 'package.json'), JSON.stringify({ name: 'tp', version: '0.0.0' }), 'utf-8')
+    process.chdir(d)
+    await verify({ report: true })
+    expect(fs.existsSync(path.join(d, REPORT_PATH_REL))).toBe(true) // 증거 선실행됨
+    expect(fs.existsSync(path.join(d, REPORT_HTML_PATH_REL))).toBe(true) // HTML 렌더됨
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('BOM 붙은 latest.json 도 읽어 렌더 (Windows 회귀)', async () => {
+    const d = tmp()
+    const r = report([gate('typecheck', 'pass'), gate('secure', 'pass')])
+    fs.mkdirSync(path.join(d, '.vhk', 'reports'), { recursive: true })
+    fs.writeFileSync(path.join(d, REPORT_PATH_REL), '﻿' + JSON.stringify(r), 'utf-8')
+    process.chdir(d)
+    await verify({ report: true })
+    const html = fs.readFileSync(path.join(d, REPORT_HTML_PATH_REL), 'utf-8')
+    expect(html).toMatch(/class="badge"[^>]*>PASS</)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})


### PR DESCRIPTION
## 요약

Goal 14 (배치 6 / #13 후속) — `vhk verify --report`: `latest.json`(기계용 증거)을 같은 진실원천 그대로 사람이 읽는 **정적 HTML**(`.vhk/reports/latest.html`)로 렌더. 새 증거를 만들지 않고 읽어서 렌더만 한다.

> ⚠️ **#94(Goal 14 등록) 위에 스택**. base=main 이라 #94 머지 전까지 diff 에 #94 의 2파일(goals/14, check-goal-14.mjs 기반본)이 같이 보일 수 있음 — #94 머지 후 깔끔해짐.

## 변경

- **`renderReportHtml(report)`** (`src/commands/verify-report.ts`) — 순수 함수. 인라인 CSS, **외부 의존 0**(CDN/스크립트 없음), 오프라인 동작. status 배지(PASS/WARN/FAIL) + 게이트별 표 + nextActions + generatedAt. `escapeHtml` 로 사용자 텍스트 이스케이프.
- **`vhk verify --report`** — latest.json 없으면 verify 1회 선실행 후 렌더, 있으면 **BOM-safe `readJsonFile`** 로 읽음. 쓰기 권한 없으면 친절 에러 + exit≠0.
- **`vhk verify --open`** — `safeExecFile`(shell 없는 argv) 로 기본 브라우저 열기. 비대화형/CI/MCP(비-TTY)에서 `isInteractive()` 로 **자동 스킵**.
- 기존 `verify`/`--json` 무손상(옵션 추가만). secret/env 미포함(latest.json 그대로).
- v1.7.1 범프 + CHANGELOG + CLAUDE.md 현재상태. Goal 14 → DONE.

## 게이트

- ✅ `pnpm exec tsc --noEmit` / `pnpm build` / `pnpm test:run` — **623 pass** (신규 11 추가, 회귀 0)
- ✅ `vhk goal check --id 14` — 기본 게이트 + 고유검증 7/7 통과
- ✅ 수동 e2e: FAIL latest.json → HTML FAIL 배지 + exit 1, 외부의존 0, `--open` 비-TTY 자동 스킵

## 테스트 (11 추가)

- status=FAIL → HTML FAIL 렌더 **회귀 가드** (거짓 PASS 없음)
- escapeHtml(태그 주입 방지), 외부 의존 0 가드, BOM latest.json 읽기, 통합(`verify({report})`)

## 안 한 것

- npm publish (사람이 2FA OTP). 버전범프/CHANGELOG/PR 까지만.
- 멀티 리포트 히스토리/추세 그래프 → 배치 8+ (제외 범위)

🤖 Generated with [Claude Code](https://claude.com/claude-code)