### PR TITLE
chore(state): Goal 15 (vhk review) 등록

### DIFF
--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -1,13 +1,10 @@
 # Next Task
 
-_Updated 2026-06-02 — goal 0~13 전부 DONE (v1.7.0 출시 완료). 백로그 비어있음._
+_Auto-updated 2026-06-02T12:51:04.339Z via `vhk goal next`._
 
 ```
-TASK: goal 0~13 전부 DONE. v1.7.0 출시 완료 (Goal 13 verify 증거화 / latest.json).
-  다음 = Trust Loop 배치 6 → Goal 14 (vhk verify --report)
-  - Goal 14 (VHK-023) vhk verify --report: .vhk/reports/latest.json → 무빌드 정적 HTML(latest.html, Human Panel MVP)
-  - 후속: STEP 1.5 sync 대상 확대(Antigravity/Copilot), 배치 7 vhk mission, 배치 8+ Evolution Loop
-  status: Goal 14 등록됨 (goals/14-verify-report.md) — 착수 대기
-  note: `vhk goal next` 는 전부 DONE 이면 갱신하지 않으므로 수동 기록.
-        publish 는 사람만 (2FA OTP).
+TASK: Goal 15 — vhk review (적대적 자기검증 v0) — P1
+  status: NOT_STARTED
+  priority: P1
+  file: goals\15-review.md
 ```

--- a/goals/15-review.md
+++ b/goals/15-review.md
@@ -1,0 +1,48 @@
+---
+vhk_format: 1
+type: goal
+id: 15
+title: vhk review (적대적 자기검증 v0) — P1
+status: NOT_STARTED
+priority: P1
+version: v1.8.0
+---
+
+# Goal 15: vhk review (적대적 자기검증 v0)
+
+> 출처: Trust Loop 로드맵 배치 5 (잔여 — verify JSON은 Goal 13에서 완료). 전제: Goal 13(latest.json) 완료, Goal 14(HTML 패널) 권장.
+> 성장 루프에서 "증거 → 적대적 재검증" 단계. verify가 모은 증거를 그대로 믿지 않고, 거짓완료를 적극적으로 찾는 반대 심문 층.
+
+## 배경
+verify(Goal 13)는 게이트를 실제 실행해 latest.json에 증거를 남긴다. 하지만 "게이트 통과 = 진짜 완료"는 아니다 — 테스트가 변경을 안 건드리거나, 완료조건 일부만 채우고 done 선언하는 거짓완료가 여전히 가능하다. review는 같은 증거를 적대적으로 다시 심문해 "이 완료 주장이 증거로 버티나?"를 판정한다.
+
+## 철학
+① 증거를 믿지 말고 의심 — 통과 신호도 반례를 먼저 찾음 ② 새 증거 안 만듦 — latest.json + goal 완료조건을 교차검증만 ③ 판정은 보장이 아니라 신뢰도 — "거짓완료 의심" 플래그 + 근거 제시 ④ 비결정·거짓양성 주의 — 수렴 정지선, "보장 아님" 표기 필수.
+
+## 동작 (파일·계약)
+- src/commands/review.ts: .vhk/reports/latest.json + 대상 goal의 Completion Check를 읽어 교차검증. 각 완료조건이 실제 증거(게이트 결과·변경 파일)로 뒷받침되는지 매핑.
+- 출력: 의심 항목 리스트(완료조건 ↔ 증거 갭) + 신뢰도 요약 + "AI에게 다시 물을 프롬프트". 결과는 latest.json에 review 섹션으로 병합(SoT 유지).
+- --id N: 특정 goal 대상. 없으면 active goal.
+- 거짓완료 신호 감지: 완료조건 체크됐는데 대응 증거 없음 / 테스트 0건 추가 / status DONE인데 게이트 FAIL 등.
+- 크로스플랫폼: 게이트 재실행 없이 기존 latest.json 읽기 우선(없으면 verify 선실행 안내).
+- secret/env 미포함 (latest.json 그대로 사용).
+
+## Completion Check
+- [ ] vhk review → latest.json + goal Completion Check 교차검증, 갭 리스트 출력
+- [ ] 완료조건 체크됐으나 증거 없음 → "거짓완료 의심" 플래그 (회귀 가드: 빈 증거로 done 시 잡힘)
+- [ ] 판정에 "보장 아님" 표기 + 신뢰도 수준 명시 (거짓 PASS 단언 금지)
+- [ ] latest.json 없을 때 동작 정의대로 (verify 선실행 안내 or 명확 종료)
+- [ ] --id N / active goal 양쪽 동작
+- [ ] review 출력에 secret 누출 0 (vhk secure scan)
+- [ ] vhk goal sync → check-goal-15.mjs 생성 → vhk goal check --id 15 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
+
+## 제외 범위
+- Verify Swarm / 멀티 에이전트 적대 검증 런타임 → 버림(플랫폼 레이어)
+- 반복 패턴 감지 / evolve → 배치 8+
+- HTML 리포트에 review 시각화 → 후속(배치 6 확장)
+
+## Mandatory Reading
+- src/commands/verify.ts (Goal 13 verifyEvidence/latest.json 스키마)
+- src/commands/goal.ts (Completion Check·status·게이트 로직)
+- Trust Loop 로드맵 "배치 5" + 원칙 가드(수렴 정지선·보장 아님 표기)

--- a/scripts/check-goal-15.mjs
+++ b/scripts/check-goal-15.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// scripts/check-goal-15.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 15 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 15] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 15 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 15 gate passes'); process.exit(0) }
+console.log('❌ goal 15 gate failed'); process.exit(1)


### PR DESCRIPTION
## 요약

다음 작업 **`vhk review`** (적대적 자기검증 v0, P1, v1.8.0)를 goal 파일로 **등록만** 한다. PR #94(Goal 14 등록)와 동일 성격.

> ⚠️ **등록 전용 — `vhk review` 구현 코드 없음.** `src/commands/review.ts` 안 만듦. 실제 구현은 **STEP B 별도 사이클**.

main = goal 0~14 전부 DONE → NOT_STARTED 백로그가 비어 `vhk goal next` 가 집을 게 없던 상태. Goal 15 등록으로 다음 active 를 명시.

## 변경 (3파일, 코드 0)

- **`goals/15-review.md`** (신규) — `id:15` `status:NOT_STARTED` `priority:P1` `version:v1.8.0`. Completion Check 7개 **전부 미체크**(미착수).
- **`scripts/check-goal-15.mjs`** — `vhk goal sync` 생성물(self-contained, BOM-safe `readJson` — raw `JSON.parse(readFileSync)` 인접 패턴 0).
- **`docs/state/next-task.md`** — active → Goal 15 (`vhk goal next` 자동 갱신).

## 검증

- `vhk goal list` → `[15] ⚪ NOT_STARTED P1 v1.8.0`
- `vhk goal next` → active = Goal 15
- `node --check scripts/check-goal-15.mjs` syntax OK
- 코드 변경 0 → 기존 629 테스트 무손상. grep 게이트(src/ 스캔) 영향 없음.
- `vhk goal check --id 15` 는 **미실행** — 구현 0이라 Completion Check 미충족이 정상(게이트 통과는 STEP B 구현 후).

## 안 한 것

- review 구현, npm publish(사람 2FA), goal done(미착수 유지).

## 다음 (STEP B — 별도 사이클)

`vhk review` 구현: latest.json + goal Completion Check 교차검증, 거짓완료 의심 플래그, "보장 아님" 표기, `--id`/active, secret 누출 0, check-goal-15 고유검증 + goal done. → v1.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)