### PR TITLE
chore(release): v1.8.0 — vhk review (Goal 15 DONE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 (다음 릴리즈 누적 영역)
 
+## [1.8.0] - 2026-06-02
+
+> **vhk review — 적대적 자기검증 v0 (Goal 15, Trust Loop 배치 5).** verify(Goal 13)가 모은 증거(latest.json)를
+> 그대로 믿지 않고, goal 의 Completion Check 와 교차검증해 "거짓완료"를 적극적으로 찾는 반대 심문 층.
+> 철학: 증거를 의심 + 새 증거 안 만듦(렌더·심문만) + 판정은 보장이 아니라 신뢰도("보장 아님" 표기 필수).
+
+### Added
+
+- **`vhk review`** (`src/commands/review.ts`) — `.vhk/reports/latest.json` + 대상 goal 의 Completion Check 를
+  교차검증. 완료조건 ↔ 게이트 증거 매핑으로 거짓완료 의심(체크됨인데 게이트 fail/skip/부재, status DONE 인데
+  verify FAIL) + 미검증(unmapped) + 신뢰도(low/medium/high) 판정. 판정을 latest.json 의 `review` 섹션으로
+  병합(SoT 유지, 새 증거 안 만듦). `--id N` 또는 active goal. `검토` 별칭 + 자연어 라우팅.
+
+### Note (자기모순 방지 — 거짓 안심 금지)
+
+- **신뢰도 상한 규칙**: confidence high 는 (의심 0 **AND 미검증 0** AND coverage ≥ 0.5 AND 증거 신선) 일 때만.
+  unmapped 가 하나라도 있거나 stale(>6h)·신선도 미확인이면 medium 으로 캡 — 증거 없음 ≠ 통과.
+- **exit 정책**: exit 0 은 (vacuous | cleanHigh) 뿐. medium·low·병합 실패 → exit 1 + `goal done` 안내 금지.
+- **한계 disclaimer 명시**: 기능 완료조건의 미매핑·git diff 미사용(변경 미커버)·commit 바인딩 없음(신선도 추정).
+- **secret 누출 0**: latest.json 이 이미 시크릿 미포함 → review 도 파일 원문 echo 안 함(`vhk secure scan` 통과).
+
 ## [1.7.1] - 2026-06-02
 
 > **verify --report (Human Panel HTML v0, Goal 14, 배치 6).** Goal 13 의 `latest.json`(기계용 증거)을

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,16 +13,16 @@ tags: [process, documentation]
 
 - **레포:** <https://github.com/byh3071-cpu/vhk> (public)
 - **npm:** @byh3071/vhk (public, scoped)
-- **버전:** v1.7.1 (package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
+- **버전:** v1.8.0 (package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
 - **MCP tool:** 24/24 (Goal 0 DONE)
-- **테스트:** 623 pass (vitest)
+- **테스트:** 652 pass (vitest)
 - **패키지 매니저:** pnpm
 
 ## 현재 상태
 
-- **Phase:** Phase 5 이후 — Goal 14(verify --report HTML, 배치 6) DONE → v1.7.1 PR (#94 Goal14 등록 스택 위).
+- **Phase:** Phase 5 이후 — Goal 15(vhk review 적대적 자기검증, 배치 5) DONE → v1.8.0 릴리즈 PR.
 - **블로커:** 없음
-- **다음 액션:** STEP 4(raw JSON.parse 금지 grep 게이트), STEP 1.5(sync 확대), 배치 7(vhk mission). publish 는 사람(2FA OTP).
+- **다음 액션:** STEP 1.5(sync 확대), 배치 7(vhk mission), 배치 8+(Evolution Loop). publish 는 사람(2FA OTP).
 - **마지막 업데이트:** 2026-06-02
 
 ## 코딩 컨벤션

--- a/goals/15-review.md
+++ b/goals/15-review.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 15
 title: vhk review (적대적 자기검증 v0) — P1
-status: NOT_STARTED
+status: DONE
 priority: P1
 version: v1.8.0
+completed: 2026-06-02
 ---
 
 # Goal 15: vhk review (적대적 자기검증 v0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Vibe Harness Kit — AI 코딩 도구·기기를 바꿔도 규칙·맥락이 따라가는 포터빌리티 CLI (sync: Cursor·Claude·Windsurf·Copilot·Antigravity / cloud 백업)",
   "bin": {
     "vhk": "dist/index.js",


### PR DESCRIPTION
## 요약

STEP C — Goal 15(`vhk review`) 마감 + **v1.8.0 릴리즈 준비**. 코드 변경 0(구현은 #98 에서 머지됨), 상태/메타만.

> ⚠️ **npm publish 는 사람이 2FA OTP 로.** 이 PR 은 goal done + 버전범프 + CHANGELOG/CLAUDE.md + PR 까지만.

## 변경 (4파일, 코드 0)

- **`goals/15-review.md`** — status → **DONE** (completed 2026-06-02). `vhk goal done --id 15` 로 게이트 재검증 통과(tsc/test/build + 고유검증 18/18) 후 기록.
- **`package.json`** — 1.7.1 → **1.8.0** (MCP SERVER_VERSION = getVhkVersion 동적 → 자동 정합).
- **`CHANGELOG.md`** — `[1.8.0]` 항목(vhk review v0 + 거짓 안심 방지 규칙: 신뢰도 상한·exit 정책·한계 disclaimer·secret 0).
- **`CLAUDE.md`** — 현재상태(Goal 15 DONE, 테스트 652, 다음 액션 배치 7/8+).

## 게이트

- ✅ `vhk goal done --id 15` — 고유검증 18/18 + tsc/test/build 통과 후에만 DONE 기록
- ✅ `pnpm build` / `pnpm test:run` — **652 pass**(회귀 0)
- ✅ version 1.8.0 정합(SERVER_VERSION 동적)

## publish (머지 후 사람 — 2FA)

```
git checkout main && git pull
npm publish --access public --otp=<6자리>
git tag v1.8.0 && git push origin v1.8.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)