### PR TITLE
chore(state): Goal 16 (vhk sync 확대) 등록

### DIFF
--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -1,10 +1,10 @@
 # Next Task
 
-_Auto-updated 2026-06-02T12:51:04.339Z via `vhk goal next`._
+_Auto-updated 2026-06-02T14:22:18.613Z via `vhk goal next`._
 
 ```
-TASK: Goal 15 — vhk review (적대적 자기검증 v0) — P1
+TASK: Goal 16 — vhk sync 확대 — Gemini CLI + Cline (P2)
   status: NOT_STARTED
-  priority: P1
-  file: goals\15-review.md
+  priority: P2
+  file: goals\16-sync-expand.md
 ```

--- a/goals/16-sync-expand.md
+++ b/goals/16-sync-expand.md
@@ -18,7 +18,7 @@ version: v1.8.1
 
 ## 동작 (파일·계약)
 - Gemini CLI → 루트 `GEMINI.md` (공식 GEMINI.md 컨텍스트 파일, Markdown 무제한).
-- Cline → 루트 `.clinerules` (공식 docs.cline.bot/customization/cline-rules, Markdown 무제한).
+- Cline → `.clinerules/vhk-rules.md` (공식 docs.cline.bot/features/cline-rules — `.clinerules/` 디렉터리 다중 규칙 파일, Markdown 무제한).
 - `SYNC_TARGETS`(src/commands/sync.ts) 레지스트리에 2 엔트리 추가 + 각 생성함수(`buildCodingDoc` 재사용) + ko 메시지.
 - drift 감지·백업·.synced·--dry-run·비대화형 가드는 레지스트리 순회라 **추가 배선 0** 으로 자동 반영.
 - 크로스플랫폼(path 조합), secret 미포함(RULES.md 그대로 변환).
@@ -28,7 +28,7 @@ version: v1.8.1
 
 ## Completion Check
 - [ ] vhk sync → 루트 `GEMINI.md` 생성 (RULES.md 본문 반영)
-- [ ] vhk sync → 루트 `.clinerules` 생성 (RULES.md 본문 반영)
+- [ ] vhk sync → `.clinerules/vhk-rules.md` 생성 (RULES.md 본문 반영)
 - [ ] SYNC_TARGETS 5종 → 7종 (회귀 가드: 길이·경로)
 - [ ] drift 감지/백업/--dry-run 이 새 2종 자동 포함 (추가 배선 0 확인)
 - [ ] Zed(.rules) 미추가 (기존 AGENTS.md/CLAUDE.md/.cursorrules 로 커버 — 중복 방지)

--- a/goals/16-sync-expand.md
+++ b/goals/16-sync-expand.md
@@ -1,0 +1,47 @@
+---
+vhk_format: 1
+type: goal
+id: 16
+title: vhk sync 확대 — Gemini CLI + Cline (P2)
+status: NOT_STARTED
+priority: P2
+version: v1.8.1
+---
+
+# Goal 16: vhk sync 확대 (Gemini CLI + Cline)
+
+> 출처: 포터빌리티 로드맵 STEP 1.5 잔여. RULES.md 단일소스 → AI 코딩 도구 규칙 파일 동기화 대상 확대.
+> 전제: sync 5종(Cursor·Windsurf·Copilot·Antigravity·AGENTS.md) 완료(v1.5.0). SYNC_TARGETS 레지스트리 경유.
+
+## 배경
+`vhk sync` 는 RULES.md 를 단일소스로 여러 AI 도구 규칙 파일을 생성한다. 사용자가 도구를 바꿔도 규칙이 따라가는 포터빌리티가 핵심. 현재 5종 → 공식 경로가 검증된 2종(Gemini CLI, Cline)을 추가한다.
+
+## 동작 (파일·계약)
+- Gemini CLI → 루트 `GEMINI.md` (공식 GEMINI.md 컨텍스트 파일, Markdown 무제한).
+- Cline → 루트 `.clinerules` (공식 docs.cline.bot/customization/cline-rules, Markdown 무제한).
+- `SYNC_TARGETS`(src/commands/sync.ts) 레지스트리에 2 엔트리 추가 + 각 생성함수(`buildCodingDoc` 재사용) + ko 메시지.
+- drift 감지·백업·.synced·--dry-run·비대화형 가드는 레지스트리 순회라 **추가 배선 0** 으로 자동 반영.
+- 크로스플랫폼(path 조합), secret 미포함(RULES.md 그대로 변환).
+
+## 철학
+① RULES.md 단일소스 — 도구별 출력은 파생물 ② 공식 경로만(근거 없으면 제외) ③ 레지스트리 1곳 추가 = sync·drift·백업 자동 ④ 기존 sync 동작 무손상.
+
+## Completion Check
+- [ ] vhk sync → 루트 `GEMINI.md` 생성 (RULES.md 본문 반영)
+- [ ] vhk sync → 루트 `.clinerules` 생성 (RULES.md 본문 반영)
+- [ ] SYNC_TARGETS 5종 → 7종 (회귀 가드: 길이·경로)
+- [ ] drift 감지/백업/--dry-run 이 새 2종 자동 포함 (추가 배선 0 확인)
+- [ ] Zed(.rules) 미추가 (기존 AGENTS.md/CLAUDE.md/.cursorrules 로 커버 — 중복 방지)
+- [ ] COMMANDS.md / README sync 대상 표 갱신 (7종)
+- [ ] vhk goal sync → check-goal-16.mjs 생성 → vhk goal check --id 16 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build + secure), 기존 회귀 0
+
+## 제외 범위
+- Zed `.rules` (중복 — zed.dev/docs/ai/rules 가 AGENTS.md·CLAUDE.md·.cursorrules 읽음)
+- 공식 경로 근거 없는 임의 도구 (Continue/기타) → 근거 확보 시 별도 goal
+- sync UX/대화형 변경 → 범위 밖
+
+## Mandatory Reading
+- src/commands/sync.ts (SYNC_TARGETS 레지스트리 + SyncTarget 타입 + buildCodingDoc)
+- src/lib/drift.ts (SYNC_TARGETS 순회 — 자동 반영)
+- src/i18n/ko.ts (ko.sync.* 완료 메시지)

--- a/scripts/check-goal-16.mjs
+++ b/scripts/check-goal-16.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// scripts/check-goal-16.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 16 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 16] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 16 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 16 gate passes'); process.exit(0) }
+console.log('❌ goal 16 gate failed'); process.exit(1)


### PR DESCRIPTION
## 요약

Goal 16(`vhk sync` 확대 — Gemini CLI `GEMINI.md` + Cline `.clinerules`)를 goal 파일로 **등록만**. PR #94/#97 등록 성격.

> ⚠️ **등록 전용 — sync 구현 코드 없음.** 실제 구현은 STEP B(별도 PR). goals/16 NOT_STARTED 유지.

## 변경 (3파일, 코드 0)
- `goals/16-sync-expand.md` (id 16, NOT_STARTED, P2, v1.8.1, Completion Check 미체크)
- `scripts/check-goal-16.mjs` (vhk goal sync 생성물, BOM-safe readJson)
- `docs/state/next-task.md` (active → Goal 16)

## 검증
- `vhk goal list` → `[16] ⚪ NOT_STARTED P2 v1.8.1` / `vhk goal next` → active Goal 16
- 코드 변경 0 → 기존 652 무손상

## 다음 (STEP B)
SYNC_TARGETS +2(GEMINI.md/.clinerules) + 생성함수 + ko 메시지 + 테스트(5→7) + check-goal-16 고유검증 + COMMANDS/README. Zed 제외(중복).

🤖 Generated with [Claude Code](https://claude.com/claude-code)