### PR TITLE
feat(sync): Gemini CLI + Cline 타깃 추가 (Goal 16, v1.8.1)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -10,7 +10,11 @@ Cursor에게 한국어로 말해도 됩니다.
 | 저장 | `git add . && git commit -m "메시지"` | "저장해" |
 | 오늘 정리 | `vhk 정리` | "오늘 한 일 정리해" |
 | 규칙 점검 | `vhk 점검` | "규칙 점검해" |
+| 규칙 동기화 | `vhk 규칙` | "규칙 동기화해" |
 | 보안 스캔 | `vhk 보안 scan` | "보안 스캔 돌려" |
+
+> `vhk sync` 대상(7): `.cursorrules` · `.windsurfrules` · `.github/copilot-instructions.md` · `.agents/rules/vhk-rules.md` · `AGENTS.md` · `GEMINI.md`(Gemini CLI) · `.clinerules`(Cline) + `CLAUDE.md`(하이브리드). 모두 RULES.md 단일소스에서 생성.
+
 | 빌드+테스트 | `pnpm build; pnpm test --run` | "빌드하고 테스트 돌려" |
 | 배포 | `vhk 배포` | "배포해" |
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -13,7 +13,7 @@ Cursor에게 한국어로 말해도 됩니다.
 | 규칙 동기화 | `vhk 규칙` | "규칙 동기화해" |
 | 보안 스캔 | `vhk 보안 scan` | "보안 스캔 돌려" |
 
-> `vhk sync` 대상(7): `.cursorrules` · `.windsurfrules` · `.github/copilot-instructions.md` · `.agents/rules/vhk-rules.md` · `AGENTS.md` · `GEMINI.md`(Gemini CLI) · `.clinerules`(Cline) + `CLAUDE.md`(하이브리드). 모두 RULES.md 단일소스에서 생성.
+> `vhk sync` 대상(7): `.cursorrules` · `.windsurfrules` · `.github/copilot-instructions.md` · `.agents/rules/vhk-rules.md` · `AGENTS.md` · `GEMINI.md`(Gemini CLI) · `.clinerules/vhk-rules.md`(Cline) + `CLAUDE.md`(하이브리드). 모두 RULES.md 단일소스에서 생성.
 
 | 빌드+테스트 | `pnpm build; pnpm test --run` | "빌드하고 테스트 돌려" |
 | 배포 | `vhk 배포` | "배포해" |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AI 코딩 도구는 저마다 규칙 파일이 다르고(`.cursorrules`·`CLAUDE
 
 | 문제 | VHK 해결 | 명령 |
 |------|----------|------|
-| 도구마다 규칙 파일이 따로 논다 | `RULES.md` 한 벌 → Cursor·Claude·Windsurf·Copilot·Antigravity 규칙 동시 생성 | `vhk sync` |
+| 도구마다 규칙 파일이 따로 논다 | `RULES.md` 한 벌 → Cursor·Claude·Windsurf·Copilot·Antigravity·Gemini·Cline 규칙 동시 생성 | `vhk sync` |
 | 컴퓨터·환경 바뀌면 맥락 유실 | `.vhk/` 맥락을 GitHub gist로 백업·복원 | `vhk cloud push` / `pull` |
 | 새 프로젝트 세팅 반복 | 유형별 문서·규칙·맥락 뼈대를 한 번에 | `vhk init` |
 
@@ -145,7 +145,7 @@ vhk 기획 끝났고 바로 시작
 | `vhk gate` | `검증`, `아이디어` | 아이디어 검증 (퀵 5문항 / 풀 13문항 / 스킵) |
 | `vhk init` | `시작`, `만들기` | 프로젝트 초기화 + 하네스 생성 |
 | `vhk recap` | `정리`, `오늘` | Git 변경 → `docs/log/` 세션 로그 |
-| `vhk sync` | `규칙`, `맞추기` | RULES.md → `.cursorrules` + CLAUDE.md + `.windsurfrules` + `.github/copilot-instructions.md` + `.agents/rules/vhk-rules.md` (5개) |
+| `vhk sync` | `규칙`, `맞추기` | RULES.md → `.cursorrules` + CLAUDE.md + `.windsurfrules` + `.github/copilot-instructions.md` + `.agents/rules/vhk-rules.md` + `AGENTS.md` + `GEMINI.md` + `.clinerules` |
 | `vhk check` | `점검`, `린트` | RULES.md 규칙 위반 검사 |
 | `vhk secure` | `보안` | 시크릿·키 유출 스캔 (`scan` / `스캔` 동일). **CRITICAL/HIGH 발견 시 exit code 1** (CI용) |
 | `vhk ship` | `출하` | 배포 체크리스트 + 회고 + 빌드 로그 |

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ vhk 기획 끝났고 바로 시작
 | `vhk gate` | `검증`, `아이디어` | 아이디어 검증 (퀵 5문항 / 풀 13문항 / 스킵) |
 | `vhk init` | `시작`, `만들기` | 프로젝트 초기화 + 하네스 생성 |
 | `vhk recap` | `정리`, `오늘` | Git 변경 → `docs/log/` 세션 로그 |
-| `vhk sync` | `규칙`, `맞추기` | RULES.md → `.cursorrules` + CLAUDE.md + `.windsurfrules` + `.github/copilot-instructions.md` + `.agents/rules/vhk-rules.md` + `AGENTS.md` + `GEMINI.md` + `.clinerules` |
+| `vhk sync` | `규칙`, `맞추기` | RULES.md → `.cursorrules` + CLAUDE.md + `.windsurfrules` + `.github/copilot-instructions.md` + `.agents/rules/vhk-rules.md` + `AGENTS.md` + `GEMINI.md` + `.clinerules/vhk-rules.md` |
 | `vhk check` | `점검`, `린트` | RULES.md 규칙 위반 검사 |
 | `vhk secure` | `보안` | 시크릿·키 유출 스캔 (`scan` / `스캔` 동일). **CRITICAL/HIGH 발견 시 exit code 1** (CI용) |
 | `vhk ship` | `출하` | 배포 체크리스트 + 회고 + 빌드 로그 |

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -1,10 +1,10 @@
 # Next Task
 
-_Auto-updated 2026-06-02T12:51:04.339Z via `vhk goal next`._
+_Auto-updated 2026-06-02T14:22:18.613Z via `vhk goal next`._
 
 ```
-TASK: Goal 15 — vhk review (적대적 자기검증 v0) — P1
+TASK: Goal 16 — vhk sync 확대 — Gemini CLI + Cline (P2)
   status: NOT_STARTED
-  priority: P1
-  file: goals\15-review.md
+  priority: P2
+  file: goals\16-sync-expand.md
 ```

--- a/goals/16-sync-expand.md
+++ b/goals/16-sync-expand.md
@@ -18,7 +18,7 @@ version: v1.8.1
 
 ## 동작 (파일·계약)
 - Gemini CLI → 루트 `GEMINI.md` (공식 GEMINI.md 컨텍스트 파일, Markdown 무제한).
-- Cline → 루트 `.clinerules` (공식 docs.cline.bot/customization/cline-rules, Markdown 무제한).
+- Cline → `.clinerules/vhk-rules.md` (공식 docs.cline.bot/features/cline-rules — `.clinerules/` 디렉터리 다중 규칙 파일, Markdown 무제한).
 - `SYNC_TARGETS`(src/commands/sync.ts) 레지스트리에 2 엔트리 추가 + 각 생성함수(`buildCodingDoc` 재사용) + ko 메시지.
 - drift 감지·백업·.synced·--dry-run·비대화형 가드는 레지스트리 순회라 **추가 배선 0** 으로 자동 반영.
 - 크로스플랫폼(path 조합), secret 미포함(RULES.md 그대로 변환).
@@ -28,7 +28,7 @@ version: v1.8.1
 
 ## Completion Check
 - [ ] vhk sync → 루트 `GEMINI.md` 생성 (RULES.md 본문 반영)
-- [ ] vhk sync → 루트 `.clinerules` 생성 (RULES.md 본문 반영)
+- [ ] vhk sync → `.clinerules/vhk-rules.md` 생성 (RULES.md 본문 반영)
 - [ ] SYNC_TARGETS 5종 → 7종 (회귀 가드: 길이·경로)
 - [ ] drift 감지/백업/--dry-run 이 새 2종 자동 포함 (추가 배선 0 확인)
 - [ ] Zed(.rules) 미추가 (기존 AGENTS.md/CLAUDE.md/.cursorrules 로 커버 — 중복 방지)

--- a/goals/16-sync-expand.md
+++ b/goals/16-sync-expand.md
@@ -1,0 +1,47 @@
+---
+vhk_format: 1
+type: goal
+id: 16
+title: vhk sync 확대 — Gemini CLI + Cline (P2)
+status: NOT_STARTED
+priority: P2
+version: v1.8.1
+---
+
+# Goal 16: vhk sync 확대 (Gemini CLI + Cline)
+
+> 출처: 포터빌리티 로드맵 STEP 1.5 잔여. RULES.md 단일소스 → AI 코딩 도구 규칙 파일 동기화 대상 확대.
+> 전제: sync 5종(Cursor·Windsurf·Copilot·Antigravity·AGENTS.md) 완료(v1.5.0). SYNC_TARGETS 레지스트리 경유.
+
+## 배경
+`vhk sync` 는 RULES.md 를 단일소스로 여러 AI 도구 규칙 파일을 생성한다. 사용자가 도구를 바꿔도 규칙이 따라가는 포터빌리티가 핵심. 현재 5종 → 공식 경로가 검증된 2종(Gemini CLI, Cline)을 추가한다.
+
+## 동작 (파일·계약)
+- Gemini CLI → 루트 `GEMINI.md` (공식 GEMINI.md 컨텍스트 파일, Markdown 무제한).
+- Cline → 루트 `.clinerules` (공식 docs.cline.bot/customization/cline-rules, Markdown 무제한).
+- `SYNC_TARGETS`(src/commands/sync.ts) 레지스트리에 2 엔트리 추가 + 각 생성함수(`buildCodingDoc` 재사용) + ko 메시지.
+- drift 감지·백업·.synced·--dry-run·비대화형 가드는 레지스트리 순회라 **추가 배선 0** 으로 자동 반영.
+- 크로스플랫폼(path 조합), secret 미포함(RULES.md 그대로 변환).
+
+## 철학
+① RULES.md 단일소스 — 도구별 출력은 파생물 ② 공식 경로만(근거 없으면 제외) ③ 레지스트리 1곳 추가 = sync·drift·백업 자동 ④ 기존 sync 동작 무손상.
+
+## Completion Check
+- [ ] vhk sync → 루트 `GEMINI.md` 생성 (RULES.md 본문 반영)
+- [ ] vhk sync → 루트 `.clinerules` 생성 (RULES.md 본문 반영)
+- [ ] SYNC_TARGETS 5종 → 7종 (회귀 가드: 길이·경로)
+- [ ] drift 감지/백업/--dry-run 이 새 2종 자동 포함 (추가 배선 0 확인)
+- [ ] Zed(.rules) 미추가 (기존 AGENTS.md/CLAUDE.md/.cursorrules 로 커버 — 중복 방지)
+- [ ] COMMANDS.md / README sync 대상 표 갱신 (7종)
+- [ ] vhk goal sync → check-goal-16.mjs 생성 → vhk goal check --id 16 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build + secure), 기존 회귀 0
+
+## 제외 범위
+- Zed `.rules` (중복 — zed.dev/docs/ai/rules 가 AGENTS.md·CLAUDE.md·.cursorrules 읽음)
+- 공식 경로 근거 없는 임의 도구 (Continue/기타) → 근거 확보 시 별도 goal
+- sync UX/대화형 변경 → 범위 밖
+
+## Mandatory Reading
+- src/commands/sync.ts (SYNC_TARGETS 레지스트리 + SyncTarget 타입 + buildCodingDoc)
+- src/lib/drift.ts (SYNC_TARGETS 순회 — 자동 반영)
+- src/i18n/ko.ts (ko.sync.* 완료 메시지)

--- a/scripts/check-goal-16.mjs
+++ b/scripts/check-goal-16.mjs
@@ -56,7 +56,7 @@ if (!skipDeep) {
 const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
 const sy = read('src/commands/sync.ts') ?? ''
 must(/export function toGeminiMd/.test(sy) && /export function toClineRules/.test(sy), 'sync.ts: toGeminiMd + toClineRules 생성함수')
-must(/path: 'GEMINI\.md'/.test(sy) && /path: '\.clinerules'/.test(sy), "SYNC_TARGETS 에 GEMINI.md + .clinerules 등록")
+must(/path: 'GEMINI\.md'/.test(sy) && /path: '\.clinerules\/vhk-rules\.md'/.test(sy), "SYNC_TARGETS 에 GEMINI.md + .clinerules/vhk-rules.md 등록")
 must(!/path: '\.rules'/.test(sy), 'Zed .rules 미추가 (중복 방지)')
 must(/geminiDone/.test(read('src/i18n/ko.ts') ?? '') && /clineDone/.test(read('src/i18n/ko.ts') ?? ''), 'ko.sync geminiDone/clineDone 메시지')
 must(existsSync('tests/sync.test.ts') && /SYNC_TARGETS\).toHaveLength\(7\)/.test(read('tests/sync.test.ts') ?? ''), '테스트: SYNC_TARGETS 7종 회귀 가드')

--- a/scripts/check-goal-16.mjs
+++ b/scripts/check-goal-16.mjs
@@ -52,9 +52,15 @@ if (!skipDeep) {
   if (scripts.build) gate('build', run(pm, ['run', 'build']))
 }
 
-// ─── goal 16 고유 검증 (직접 추가) ───────────────────────────────
-// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
-// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+// ─── goal 16 고유 검증 (sync 확대 — Gemini CLI + Cline) ───────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+const sy = read('src/commands/sync.ts') ?? ''
+must(/export function toGeminiMd/.test(sy) && /export function toClineRules/.test(sy), 'sync.ts: toGeminiMd + toClineRules 생성함수')
+must(/path: 'GEMINI\.md'/.test(sy) && /path: '\.clinerules'/.test(sy), "SYNC_TARGETS 에 GEMINI.md + .clinerules 등록")
+must(!/path: '\.rules'/.test(sy), 'Zed .rules 미추가 (중복 방지)')
+must(/geminiDone/.test(read('src/i18n/ko.ts') ?? '') && /clineDone/.test(read('src/i18n/ko.ts') ?? ''), 'ko.sync geminiDone/clineDone 메시지')
+must(existsSync('tests/sync.test.ts') && /SYNC_TARGETS\).toHaveLength\(7\)/.test(read('tests/sync.test.ts') ?? ''), '테스트: SYNC_TARGETS 7종 회귀 가드')
+must(/GEMINI\.md/.test(read('COMMANDS.md') ?? ''), 'COMMANDS.md sync 표에 신규 대상 반영')
 
 if (pass) { console.log('✅ goal 16 gate passes'); process.exit(0) }
 console.log('❌ goal 16 gate failed'); process.exit(1)

--- a/scripts/check-goal-16.mjs
+++ b/scripts/check-goal-16.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// scripts/check-goal-16.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 16 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 16] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 16 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 16 gate passes'); process.exit(0) }
+console.log('❌ goal 16 gate failed'); process.exit(1)

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -109,6 +109,20 @@ export function toCopilotInstructions(sections: RulesSection[], projectName: str
 }
 
 /**
+ * Gemini CLI — 루트 GEMINI.md 컨텍스트 파일(공식, Markdown). 하드 글자수 제한 없음 → 절삭 안 함.
+ */
+export function toGeminiMd(sections: RulesSection[], projectName: string): string {
+  return buildCodingDoc('Gemini CLI Rules', sections, projectName)
+}
+
+/**
+ * Cline — 루트 .clinerules (공식 docs.cline.bot/customization/cline-rules, Markdown). 제한 없음.
+ */
+export function toClineRules(sections: RulesSection[], projectName: string): string {
+  return buildCodingDoc('Cline Rules', sections, projectName)
+}
+
+/**
  * Antigravity 규칙 파일 1개당 12,000 제한 (공식 docs는 "characters").
  * 측정 안전성: char/byte 어느 해석이든 안전하도록 **UTF-8 바이트 기준**으로 강제한다.
  * byteLength ≥ charCount 이므로 byteLength ≤ 12000 이면 char 수도 자동으로 ≤ 12000.
@@ -265,6 +279,9 @@ export const SYNC_TARGETS: SyncTarget[] = [
   { path: '.agents/rules/vhk-rules.md', generate: toAntigravityRules, doneMessage: ko.sync.antigravityDone },
   // AGENTS.md — 6번째 타겟. 항목 1개 추가로 sync·드리프트·백업 가드가 자동 반영된다.
   { path: 'AGENTS.md', generate: toAgentsMd, doneMessage: ko.sync.agentsDone },
+  // Goal 16 — Gemini CLI / Cline (공식 경로 검증). 레지스트리 추가만으로 drift·백업 자동 반영.
+  { path: 'GEMINI.md', generate: toGeminiMd, doneMessage: ko.sync.geminiDone },
+  { path: '.clinerules', generate: toClineRules, doneMessage: ko.sync.clineDone },
 ]
 
 /** 보존할 백업 개수 — 무한 증식 방지(스케일/팀 고려). */

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -116,7 +116,8 @@ export function toGeminiMd(sections: RulesSection[], projectName: string): strin
 }
 
 /**
- * Cline — 루트 .clinerules (공식 docs.cline.bot/customization/cline-rules, Markdown). 제한 없음.
+ * Cline — `.clinerules/vhk-rules.md` (공식 docs.cline.bot/features/cline-rules — `.clinerules/`
+ * 디렉터리에 다중 .md 규칙 파일. Antigravity `.agents/rules/vhk-rules.md` 와 동형). Markdown 무제한.
  */
 export function toClineRules(sections: RulesSection[], projectName: string): string {
   return buildCodingDoc('Cline Rules', sections, projectName)
@@ -281,7 +282,7 @@ export const SYNC_TARGETS: SyncTarget[] = [
   { path: 'AGENTS.md', generate: toAgentsMd, doneMessage: ko.sync.agentsDone },
   // Goal 16 — Gemini CLI / Cline (공식 경로 검증). 레지스트리 추가만으로 drift·백업 자동 반영.
   { path: 'GEMINI.md', generate: toGeminiMd, doneMessage: ko.sync.geminiDone },
-  { path: '.clinerules', generate: toClineRules, doneMessage: ko.sync.clineDone },
+  { path: '.clinerules/vhk-rules.md', generate: toClineRules, doneMessage: ko.sync.clineDone },
 ]
 
 /** 보존할 백업 개수 — 무한 증식 방지(스케일/팀 고려). */

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -240,7 +240,7 @@ export const ko = {
     antigravityDone: '✅ .agents/rules/vhk-rules.md 맞춤 완료',
     agentsDone: '✅ AGENTS.md 맞춤 완료',
     geminiDone: '✅ GEMINI.md 맞춤 완료',
-    clineDone: '✅ .clinerules 맞춤 완료',
+    clineDone: '✅ .clinerules/vhk-rules.md 맞춤 완료',
     antigravityTruncated: 'Antigravity 12,000자 제한으로 일부 절삭됨 — 전체는 RULES.md 참조',
     done: '🔄 맞추기 완료!',
     // 안전 가드 (배치 0) — 덮어쓰기 전 백업·드리프트 확인·미리보기

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -239,6 +239,8 @@ export const ko = {
     copilotDone: '✅ .github/copilot-instructions.md 맞춤 완료',
     antigravityDone: '✅ .agents/rules/vhk-rules.md 맞춤 완료',
     agentsDone: '✅ AGENTS.md 맞춤 완료',
+    geminiDone: '✅ GEMINI.md 맞춤 완료',
+    clineDone: '✅ .clinerules 맞춤 완료',
     antigravityTruncated: 'Antigravity 12,000자 제한으로 일부 절삭됨 — 전체는 RULES.md 참조',
     done: '🔄 맞추기 완료!',
     // 안전 가드 (배치 0) — 덮어쓰기 전 백업·드리프트 확인·미리보기

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -147,10 +147,10 @@ describe('vhk sync — Gemini CLI + Cline (Goal 16, 5→7종)', () => {
     expect(out).toContain('execSync 금지')
   })
 
-  it('SYNC_TARGETS 5 → 7종 (GEMINI.md/.clinerules 등록, drift/backup 자동 반영)', () => {
+  it('SYNC_TARGETS 5 → 7종 (GEMINI.md/.clinerules/vhk-rules.md 등록, drift/backup 자동 반영)', () => {
     const paths = SYNC_TARGETS.map((t) => t.path)
     expect(paths).toContain('GEMINI.md')
-    expect(paths).toContain('.clinerules')
+    expect(paths).toContain('.clinerules/vhk-rules.md')
     expect(SYNC_TARGETS).toHaveLength(7)
   })
 

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -7,6 +7,8 @@ import {
   toCursorrules,
   toWindsurfrules,
   toCopilotInstructions,
+  toGeminiMd,
+  toClineRules,
   toAntigravityRules,
   toAgentsMd,
   truncateForAntigravity,
@@ -126,6 +128,34 @@ describe('vhk sync — AGENTS.md 생성 (배치3 6번째 타겟)', () => {
     const out = toAgentsMd(sections, 'P')
     const titles = parseRulesMd(out).map((s) => s.title)
     expect(titles).toContain('Loop Protocol')
+  })
+})
+
+describe('vhk sync — Gemini CLI + Cline (Goal 16, 5→7종)', () => {
+  it('toGeminiMd — 헤더 + 자동생성 경고 + 코딩 규칙, 기록 섹션 제외', () => {
+    const out = toGeminiMd(parseRulesMd(SAMPLE_RULES), '데모 프로젝트')
+    expect(out).toContain('# 데모 프로젝트 — Gemini CLI Rules')
+    expect(out).toContain('자동 생성됨 (vhk sync). 직접 수정 금지')
+    expect(out).toContain('execSync 금지')
+    expect(out).not.toContain('docs/log/ 작성')
+  })
+
+  it('toClineRules — 헤더 + 자동생성 경고 + 코딩 규칙', () => {
+    const out = toClineRules(parseRulesMd(SAMPLE_RULES), '데모 프로젝트')
+    expect(out).toContain('# 데모 프로젝트 — Cline Rules')
+    expect(out).toContain('자동 생성됨 (vhk sync). 직접 수정 금지')
+    expect(out).toContain('execSync 금지')
+  })
+
+  it('SYNC_TARGETS 5 → 7종 (GEMINI.md/.clinerules 등록, drift/backup 자동 반영)', () => {
+    const paths = SYNC_TARGETS.map((t) => t.path)
+    expect(paths).toContain('GEMINI.md')
+    expect(paths).toContain('.clinerules')
+    expect(SYNC_TARGETS).toHaveLength(7)
+  })
+
+  it('Zed .rules 는 추가 안 함 (기존 AGENTS.md/CLAUDE.md/.cursorrules 로 커버 — 중복 방지)', () => {
+    expect(SYNC_TARGETS.map((t) => t.path)).not.toContain('.rules')
   })
 })
 


### PR DESCRIPTION
## 요약

Goal 16 — `vhk sync` 대상 **5종 → 7종**. RULES.md 단일소스에서 Gemini CLI(`GEMINI.md`) + Cline(`.clinerules`) 규칙 파일도 생성. 공식 경로 검증됨.

> ⚠️ #100(Goal 16 등록) 위 스택. base=main 이라 #100 머지 전까지 diff 에 16-A 3파일 같이 보임. goal done/v1.8.1 범프는 **STEP C**.

## 변경 (6파일 + 스택 3)
- **`src/commands/sync.ts`**: `toGeminiMd`/`toClineRules`(`buildCodingDoc` 재사용, markdown 무제한) + `SYNC_TARGETS` 2 엔트리.
- **배선 0**: drift(`SYNC_TARGETS` 순회)·백업·`.synced`·`--dry-run`·비대화형 가드 자동 반영(추가 코드 없음). `drift.test` 가 `results.length === SYNC_TARGETS.length` 로 자동 적응.
- `src/i18n/ko.ts`: `geminiDone`/`clineDone`.
- `tests/sync.test.ts`: 생성물 검증 + **7종 회귀 가드** + Zed 미추가.
- `check-goal-16.mjs` 고유검증 6건. `COMMANDS.md`/`README` sync 표.

## 게이트
- tsc OK / build OK / **656 pass**(신규 4, 회귀 0) / grep 0건 / `secure scan` 누출 0
- `vhk goal check --id 16` 공통 + 고유검증 **6/6** ✓
- e2e: `vhk sync` → `GEMINI.md`(`# … Gemini CLI Rules`) + `.clinerules` 생성 확인

## 제외
Zed `.rules`(이미 AGENTS.md/CLAUDE.md/.cursorrules 로 커버 — 중복). 공식 경로 근거 없는 도구.

🤖 Generated with [Claude Code](https://claude.com/claude-code)