### PR TITLE
chore(state): Goal 17 (vhk mission) 등록

### DIFF
--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -1,10 +1,10 @@
 # Next Task
 
-_Auto-updated 2026-06-02T14:22:18.613Z via `vhk goal next`._
+_Auto-updated 2026-06-02T15:01:18.941Z via `vhk goal next`._
 
 ```
-TASK: Goal 16 — vhk sync 확대 — Gemini CLI + Cline (P2)
+TASK: Goal 17 — vhk mission — Mission Contract (scope/intent 층) — P3
   status: NOT_STARTED
-  priority: P2
-  file: goals\16-sync-expand.md
+  priority: P3
+  file: goals\17-mission.md
 ```

--- a/goals/17-mission.md
+++ b/goals/17-mission.md
@@ -1,0 +1,50 @@
+---
+vhk_format: 1
+type: goal
+id: 17
+title: vhk mission — Mission Contract (scope/intent 층) — P3
+status: NOT_STARTED
+priority: P3
+version: v1.9.0
+---
+
+# Goal 17: vhk mission (Mission Contract v0)
+
+> 출처: Trust Loop 배치 7. scope/intent 층 (mission → verify → review). 전제: verify(Goal 13)·review(Goal 15) 완료.
+> 작업의 목표·허용범위·금지선을 계약으로 선언하고, 현재 변경이 계약 안인지 검증한다.
+
+## 배경
+verify 는 게이트 통과를, review 는 거짓완료를 본다. 하지만 "이 변경이 애초에 하기로 한 범위 안인가?"는 아무도 안 본다. mission 은 작업 전 **계약(목표·허용 glob·금지 glob)** 을 선언하고, 변경 파일이 계약을 벗어나는지(scope 밖 경고 / forbidden 위반) 검증하는 scope 가드.
+
+## 철학
+① 계약 먼저 — 무엇을 할지/안 할지 명시 ② 경로 glob 기준 v0 — 의미 검증 아님(정직한 한계 disclaimer) ③ 신뢰도 신호지 하드블록 아님(strict 연동은 후속) ④ 별도 네임스페이스 — latest.json(verify 증거) 안 건드림.
+
+## 동작 (파일·계약)
+- 저장 `.vhk/mission.json`: `{ schemaVersion:1, objective, scope:string[](허용 glob), forbidden:string[](금지 glob), createdAt, updatedAt }`. BOM-safe `readJsonFile` 읽기.
+- `vhk mission set` — 계약 선언/갱신. `--objective`/`--scope`(반복)/`--forbidden`(반복) + 대화형 fallback(비-TTY 가드, `--yes`).
+- `vhk mission` (기본) — 현재 계약 표시. 없으면 안내 + exit 1.
+- `vhk mission check` — git 변경파일(working tree + staged) ↔ scope/forbidden glob 교차검증. forbidden 매칭=위반(강, exit 1), scope 밖=경고.
+- `vhk mission clear` — 계약 삭제.
+- 자체 glob→RegExp(외부 의존 0), secret 미포함(경로·objective 텍스트만), 크로스플랫폼.
+
+## Completion Check
+- [ ] vhk mission set → .vhk/mission.json 생성/갱신 (schema v1, BOM-safe)
+- [ ] vhk mission (기본) → 계약 표시, 없으면 안내 + exit 1
+- [ ] vhk mission check → forbidden 매칭=위반(exit 1) / scope 밖=경고 (순수 checkMission 회귀 가드)
+- [ ] vhk mission clear → mission.json 삭제
+- [ ] 판정에 "경로 glob 기준 — objective 의미 검증 아님" disclaimer 명시
+- [ ] mission.json 별도 네임스페이스 — latest.json(verify 증거) 불변
+- [ ] 자연어/commander 양 경로 동작 (mission/미션) + secret 누출 0 (vhk secure scan)
+- [ ] vhk goal sync → check-goal-17.mjs 생성 → vhk goal check --id 17 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build + secure), 기존 회귀 0
+
+## 제외 범위
+- objective 의미 검증(자연어 부합) → v0 밖
+- forbidden 액션 금지(safety-mode/risk-policy 와 중복) → v0 제외, 경로 glob만
+- strict mode 하드블록 연동 → 후속
+- git diff 의미 분석 → v0 밖(경로 매칭만)
+
+## Mandatory Reading
+- src/commands/verify.ts / review.ts (latest.json·판정 패턴 — disclaimer/exit 정책)
+- src/lib/read-json.ts (readJsonFile/stripBom), src/lib/interactive.ts (isInteractive/promptOrDefault)
+- simple-git status (변경파일 수집), src/lib/git.ts (기존 사용 패턴)

--- a/scripts/check-goal-17.mjs
+++ b/scripts/check-goal-17.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// scripts/check-goal-17.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 17 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 17] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 17 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 17 gate passes'); process.exit(0) }
+console.log('❌ goal 17 gate failed'); process.exit(1)


### PR DESCRIPTION
## 요약
Goal 17(`vhk mission` — Mission Contract: 목표·허용/금지 glob 계약 선언·검증, Trust Loop scope 층)를 goal 파일로 **등록만**.

> ⚠️ 등록 전용 — mission 구현 코드 없음. 구현은 STEP B(별도 PR). goals/17 NOT_STARTED 유지.

## 변경 (3파일, 코드 0)
- `goals/17-mission.md` (id 17, NOT_STARTED, P3, v1.9.0)
- `scripts/check-goal-17.mjs` (goal sync 생성물, BOM-safe)
- `docs/state/next-task.md` (active → Goal 17)

## 검증
`vhk goal list` → `[17] ⚪ NOT_STARTED P3 v1.9.0` / `vhk goal next` → Goal 17. 코드 0 → 656 무손상.

## 다음 (STEP B)
src/commands/mission.ts: .vhk/mission.json + set/show/check/clear, 순수 checkMission + 자체 glob, simple-git 변경파일, 7배선, 테스트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)