### PR TITLE
feat(mission): vhk mission — Mission Contract v0 (Goal 17, v1.9.0)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -36,6 +36,17 @@ Cursor에게 한국어로 말해도 됩니다.
 
 > `review` 는 증거(latest.json)와 goal 완료조건을 교차검증해 "거짓완료 의심"을 찾습니다. 판정은 신뢰도 신호이며 보장이 아닙니다(미검증·stale 증거는 통과로 취급하지 않음).
 
+## 미션 계약 (mission)
+
+| 하고 싶은 것 | 터미널 명령 | Cursor에게 말하기 |
+|-------------|-----------|------------------|
+| 작업 범위 선언 | `vhk mission set --objective "..." --scope "src/**" --forbidden "**/*.env"` | "미션 정해줘" |
+| 현재 계약 보기 | `vhk mission` | "미션 보여줘" |
+| 변경이 계약 안인지 검증 | `vhk mission check` | "미션 검증해" |
+| 계약 삭제 | `vhk mission clear` | — |
+
+> `mission` 은 작업의 목표·허용/금지 범위를 `.vhk/mission.json` 계약으로 선언하고, 변경 파일이 계약(scope/forbidden glob) 안인지 검증합니다. **경로 glob 기준**이며 objective 의미 부합은 검증하지 않습니다(보장 아님). forbidden 위반 시 exit 1.
+
 ## 환경 점검
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ vhk 기획 끝났고 바로 시작
 | `vhk memory` | `기억` | 결정사항 기억 관리 (`add` / `list` / `remove`, `.vhk/memory.json` 기반, 태그 지원) |
 | `vhk brief` | `브리핑` | 프로젝트 정보 + git 상태 + 결정사항 + 레퍼런스 통합 보고서 `.vhk/brief.md` |
 | `vhk goal` | `목표` | Goal 단계별 미션 관리 (`init` / `list` / `next` / `check` / `done`) — vspec/vooster 패턴 |
+| `vhk mission` | `미션` | 미션 계약(`set` / `check` / `clear`) — 작업 범위·금지선 선언·검증 (`.vhk/mission.json`, 경로 glob) |
 | `vhk blocker <설명>` | `블로커` | 블로커 1건 → `docs/state/blockers.md` append. 3건 누적 시 `.vhk/HARD_STOP` 자동 생성 |
 | `vhk learn <교훈>` | `교훈` | 교훈 1건 → `docs/state/learnings.md` append (memory.json 과 별도 SoT) |
 | `vhk resume --confirm` | `재개` | `.vhk/HARD_STOP` 해제 (사람 확인 필요, 자동 호출 금지) |

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -1,10 +1,10 @@
 # Next Task
 
-_Auto-updated 2026-06-02T14:22:18.613Z via `vhk goal next`._
+_Auto-updated 2026-06-02T15:01:18.941Z via `vhk goal next`._
 
 ```
-TASK: Goal 16 — vhk sync 확대 — Gemini CLI + Cline (P2)
+TASK: Goal 17 — vhk mission — Mission Contract (scope/intent 층) — P3
   status: NOT_STARTED
-  priority: P2
-  file: goals\16-sync-expand.md
+  priority: P3
+  file: goals\17-mission.md
 ```

--- a/goals/17-mission.md
+++ b/goals/17-mission.md
@@ -1,0 +1,50 @@
+---
+vhk_format: 1
+type: goal
+id: 17
+title: vhk mission — Mission Contract (scope/intent 층) — P3
+status: NOT_STARTED
+priority: P3
+version: v1.9.0
+---
+
+# Goal 17: vhk mission (Mission Contract v0)
+
+> 출처: Trust Loop 배치 7. scope/intent 층 (mission → verify → review). 전제: verify(Goal 13)·review(Goal 15) 완료.
+> 작업의 목표·허용범위·금지선을 계약으로 선언하고, 현재 변경이 계약 안인지 검증한다.
+
+## 배경
+verify 는 게이트 통과를, review 는 거짓완료를 본다. 하지만 "이 변경이 애초에 하기로 한 범위 안인가?"는 아무도 안 본다. mission 은 작업 전 **계약(목표·허용 glob·금지 glob)** 을 선언하고, 변경 파일이 계약을 벗어나는지(scope 밖 경고 / forbidden 위반) 검증하는 scope 가드.
+
+## 철학
+① 계약 먼저 — 무엇을 할지/안 할지 명시 ② 경로 glob 기준 v0 — 의미 검증 아님(정직한 한계 disclaimer) ③ 신뢰도 신호지 하드블록 아님(strict 연동은 후속) ④ 별도 네임스페이스 — latest.json(verify 증거) 안 건드림.
+
+## 동작 (파일·계약)
+- 저장 `.vhk/mission.json`: `{ schemaVersion:1, objective, scope:string[](허용 glob), forbidden:string[](금지 glob), createdAt, updatedAt }`. BOM-safe `readJsonFile` 읽기.
+- `vhk mission set` — 계약 선언/갱신. `--objective`/`--scope`(반복)/`--forbidden`(반복) + 대화형 fallback(비-TTY 가드, `--yes`).
+- `vhk mission` (기본) — 현재 계약 표시. 없으면 안내 + exit 1.
+- `vhk mission check` — git 변경파일(working tree + staged) ↔ scope/forbidden glob 교차검증. forbidden 매칭=위반(강, exit 1), scope 밖=경고.
+- `vhk mission clear` — 계약 삭제.
+- 자체 glob→RegExp(외부 의존 0), secret 미포함(경로·objective 텍스트만), 크로스플랫폼.
+
+## Completion Check
+- [ ] vhk mission set → .vhk/mission.json 생성/갱신 (schema v1, BOM-safe)
+- [ ] vhk mission (기본) → 계약 표시, 없으면 안내 + exit 1
+- [ ] vhk mission check → forbidden 매칭=위반(exit 1) / scope 밖=경고 (순수 checkMission 회귀 가드)
+- [ ] vhk mission clear → mission.json 삭제
+- [ ] 판정에 "경로 glob 기준 — objective 의미 검증 아님" disclaimer 명시
+- [ ] mission.json 별도 네임스페이스 — latest.json(verify 증거) 불변
+- [ ] 자연어/commander 양 경로 동작 (mission/미션) + secret 누출 0 (vhk secure scan)
+- [ ] vhk goal sync → check-goal-17.mjs 생성 → vhk goal check --id 17 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build + secure), 기존 회귀 0
+
+## 제외 범위
+- objective 의미 검증(자연어 부합) → v0 밖
+- forbidden 액션 금지(safety-mode/risk-policy 와 중복) → v0 제외, 경로 glob만
+- strict mode 하드블록 연동 → 후속
+- git diff 의미 분석 → v0 밖(경로 매칭만)
+
+## Mandatory Reading
+- src/commands/verify.ts / review.ts (latest.json·판정 패턴 — disclaimer/exit 정책)
+- src/lib/read-json.ts (readJsonFile/stripBom), src/lib/interactive.ts (isInteractive/promptOrDefault)
+- simple-git status (변경파일 수집), src/lib/git.ts (기존 사용 패턴)

--- a/scripts/check-goal-17.mjs
+++ b/scripts/check-goal-17.mjs
@@ -52,9 +52,19 @@ if (!skipDeep) {
   if (scripts.build) gate('build', run(pm, ['run', 'build']))
 }
 
-// ─── goal 17 고유 검증 (직접 추가) ───────────────────────────────
-// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
-// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+// ─── goal 17 고유 검증 (vhk mission — Mission Contract) ───────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+const ms = read('src/commands/mission.ts') ?? ''
+const idx = read('src/index.ts') ?? ''
+must(/export function checkMission/.test(ms) && /export function globToRegExp/.test(ms), 'mission.ts: checkMission + globToRegExp 순수 함수 export')
+must(/missionSet/.test(ms) && /missionShow/.test(ms) && /missionCheck/.test(ms) && /missionClear/.test(ms), 'set/show/check/clear 4개 서브커맨드')
+must(/MISSION_PATH_REL/.test(ms) && /mission\.json/.test(ms) && !/REPORT_PATH_REL/.test(ms), '.vhk/mission.json 별도 네임스페이스 (verify 의 REPORT_PATH_REL 미사용)')
+must(/readJsonFile<Mission>/.test(ms), 'mission.json BOM-safe 읽기(readJsonFile)')
+must(/MISSION_DISCLAIMER/.test(ms) && /경로 glob|의미/.test(ms), '"경로 glob 기준 — 의미 검증 아님" disclaimer')
+must(/violations\.length > 0 \? 1 : 0/.test(ms), 'forbidden 위반 시 exit 1 (scope 경고는 0)')
+must(/command\('mission'\)/.test(idx) && /command\('set'\)/.test(idx) && /command\('check'\)/.test(idx), 'index 에 mission + set/check/clear 등록')
+must(/import \{ simpleGit \}/.test(ms) && !/minimatch|picomatch/.test(ms), 'glob 자체 구현(외부 의존 0) + simple-git 변경파일')
+must(existsSync('tests/mission.test.ts'), 'mission 테스트 존재(checkMission 회귀 가드)')
 
 if (pass) { console.log('✅ goal 17 gate passes'); process.exit(0) }
 console.log('❌ goal 17 gate failed'); process.exit(1)

--- a/scripts/check-goal-17.mjs
+++ b/scripts/check-goal-17.mjs
@@ -64,7 +64,9 @@ must(/MISSION_DISCLAIMER/.test(ms) && /경로 glob|의미/.test(ms), '"경로 gl
 must(/violations\.length > 0 \? 1 : 0/.test(ms), 'forbidden 위반 시 exit 1 (scope 경고는 0)')
 must(/command\('mission'\)/.test(idx) && /command\('set'\)/.test(idx) && /command\('check'\)/.test(idx), 'index 에 mission + set/check/clear 등록')
 must(/import \{ simpleGit \}/.test(ms) && !/minimatch|picomatch/.test(ms), 'glob 자체 구현(외부 의존 0) + simple-git 변경파일')
-must(existsSync('tests/mission.test.ts'), 'mission 테스트 존재(checkMission 회귀 가드)')
+must(/--clear-scope/.test(idx) && /collectGlob\)/.test(idx) && !/collectGlob, \[\]\)/.test(idx), 'mission set 보존: collectGlob default [] 제거 + --clear-scope 명시(기존 안 덮음)')
+must(/clearScope \? \[\]/.test(ms), 'missionSet: clearScope 명시 시에만 비움(미지정은 기존 보존)')
+must(existsSync('tests/mission.test.ts'), 'mission 테스트 존재(checkMission + 보존 회귀 가드)')
 
 if (pass) { console.log('✅ goal 17 gate passes'); process.exit(0) }
 console.log('❌ goal 17 gate failed'); process.exit(1)

--- a/scripts/check-goal-17.mjs
+++ b/scripts/check-goal-17.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// scripts/check-goal-17.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 17 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 17] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 17 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 17 gate passes'); process.exit(0) }
+console.log('❌ goal 17 gate failed'); process.exit(1)

--- a/src/commands/mission.ts
+++ b/src/commands/mission.ts
@@ -122,6 +122,8 @@ export async function missionSet(opts: {
   objective?: string
   scope?: string[]
   forbidden?: string[]
+  clearScope?: boolean
+  clearForbidden?: boolean
   yes?: boolean
 } = {}): Promise<void> {
   if (!ensureNotHardStopped('mission set')) return
@@ -143,12 +145,17 @@ export async function missionSet(opts: {
     }
   }
 
+  // 보존 규칙: 옵션 미제공(undefined) → 기존 값 유지. 제공 → 새 배열로 교체.
+  // 비우려면 명시적 --clear-scope / --clear-forbidden (실수로 비우는 사고 방지).
+  const scope = opts.clearScope ? [] : opts.scope ?? existing?.scope ?? []
+  const forbidden = opts.clearForbidden ? [] : opts.forbidden ?? existing?.forbidden ?? []
+
   const now = new Date().toISOString()
   const mission: Mission = {
     schemaVersion: MISSION_SCHEMA_VERSION,
     objective,
-    scope: opts.scope ?? existing?.scope ?? [],
-    forbidden: opts.forbidden ?? existing?.forbidden ?? [],
+    scope,
+    forbidden,
     createdAt: existing?.createdAt ?? now,
     updatedAt: now,
   }

--- a/src/commands/mission.ts
+++ b/src/commands/mission.ts
@@ -1,0 +1,231 @@
+import { existsSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import chalk from 'chalk'
+import inquirer from 'inquirer'
+import { simpleGit } from 'simple-git'
+import { readJsonFile } from '../lib/read-json.js'
+import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
+import { printNextStep } from '../lib/next-step.js'
+import { isInteractive } from '../lib/interactive.js'
+
+/**
+ * Goal 17: vhk mission — Mission Contract (Trust Loop scope/intent 층).
+ * 작업의 목표·허용범위·금지선을 계약(.vhk/mission.json)으로 선언하고, 현재 변경이 계약 안인지 검증.
+ * 철학: ① 계약 먼저 ② **경로 glob 기준 v0**(objective 의미 검증 아님 — disclaimer 명시)
+ *      ③ 신뢰도 신호지 하드블록 아님 ④ 별도 네임스페이스(.vhk/mission.json — latest.json 불변).
+ */
+
+export const MISSION_PATH_REL = join('.vhk', 'mission.json')
+export const MISSION_SCHEMA_VERSION = 1
+export const MISSION_DISCLAIMER =
+  '⚠️  mission check 는 경로 glob 기준입니다 — objective 의미 부합은 검증하지 않습니다(신뢰도 신호, 보장 아님).'
+
+export interface Mission {
+  schemaVersion: number
+  objective: string
+  /** 허용 경로 glob (비면 scope 경고 안 함). */
+  scope: string[]
+  /** 금지 경로 glob (매칭 시 위반). */
+  forbidden: string[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface MissionCheckResult {
+  violations: { file: string; pattern: string }[]
+  warnings: { file: string }[]
+  disclaimer: string
+}
+
+/** glob → RegExp. `**`=경로 전체(슬래시 포함), `*`=세그먼트 내, `?`=한 글자. 외부 의존 0. */
+export function globToRegExp(glob: string): RegExp {
+  let re = ''
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i]
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        re += '.*'
+        i++
+        if (glob[i + 1] === '/') i++ // `**/` 는 0개 이상 디렉터리
+      } else {
+        re += '[^/]*'
+      }
+    } else if (c === '?') {
+      re += '[^/]'
+    } else if ('.+^${}()|[]\\'.includes(c)) {
+      re += '\\' + c
+    } else {
+      re += c
+    }
+  }
+  return new RegExp('^' + re + '$')
+}
+
+/** 경로가 glob 목록 중 하나라도 매칭하는지. 경로 구분자는 posix(/)로 정규화. */
+function matchesAny(file: string, globs: string[]): string | null {
+  const norm = file.replace(/\\/g, '/')
+  for (const g of globs) {
+    if (globToRegExp(g).test(norm)) return g
+  }
+  return null
+}
+
+/**
+ * 변경 파일 ↔ 계약 교차검증. **순수 함수**(fs/git 없음 → 테스트 용이).
+ * forbidden 매칭 = 위반(강). scope 비어있지 않은데 scope 밖 = 경고. scope 비면 경고 안 함.
+ */
+export function checkMission(changedFiles: string[], mission: Mission): MissionCheckResult {
+  const violations: MissionCheckResult['violations'] = []
+  const warnings: MissionCheckResult['warnings'] = []
+  for (const file of changedFiles) {
+    const forbiddenHit = matchesAny(file, mission.forbidden)
+    if (forbiddenHit) {
+      violations.push({ file, pattern: forbiddenHit })
+      continue
+    }
+    if (mission.scope.length > 0 && !matchesAny(file, mission.scope)) {
+      warnings.push({ file })
+    }
+  }
+  return { violations, warnings, disclaimer: MISSION_DISCLAIMER }
+}
+
+/** .vhk/mission.json 읽기 (BOM-safe). 없거나 손상이면 null. */
+export function readMission(cwd: string = process.cwd()): Mission | null {
+  const p = join(cwd, MISSION_PATH_REL)
+  if (!existsSync(p)) return null
+  try {
+    const m = readJsonFile<Mission>(p)
+    if (m && typeof m.objective === 'string') return m
+    return null
+  } catch {
+    return null
+  }
+}
+
+function writeMission(cwd: string, mission: Mission): void {
+  mkdirSync(join(cwd, '.vhk'), { recursive: true })
+  writeFileSync(join(cwd, MISSION_PATH_REL), JSON.stringify(mission, null, 2) + '\n', 'utf-8')
+}
+
+/** working tree + staged 변경 파일 경로 (simple-git status — 추가/수정/삭제/이름변경/미추적 포함). */
+async function collectChangedFiles(cwd: string): Promise<string[]> {
+  const status = await simpleGit(cwd).status()
+  const set = new Set<string>()
+  for (const f of status.files) if (f.path) set.add(f.path.replace(/\\/g, '/'))
+  return [...set]
+}
+
+// ─── 서브커맨드 ───
+
+export async function missionSet(opts: {
+  objective?: string
+  scope?: string[]
+  forbidden?: string[]
+  yes?: boolean
+} = {}): Promise<void> {
+  if (!ensureNotHardStopped('mission set')) return
+  const cwd = process.cwd()
+  const existing = readMission(cwd)
+
+  let objective = opts.objective ?? existing?.objective ?? ''
+  if (!objective) {
+    if (isInteractive(opts)) {
+      const ans = await inquirer.prompt<{ obj: string }>([
+        { type: 'input', name: 'obj', message: '미션 목표(objective)는?' },
+      ])
+      objective = ans.obj.trim()
+    }
+    if (!objective) {
+      console.error(chalk.red('  ❌ objective 가 필요합니다. --objective "..." 로 지정하세요(비대화형).'))
+      process.exitCode = 1
+      return
+    }
+  }
+
+  const now = new Date().toISOString()
+  const mission: Mission = {
+    schemaVersion: MISSION_SCHEMA_VERSION,
+    objective,
+    scope: opts.scope ?? existing?.scope ?? [],
+    forbidden: opts.forbidden ?? existing?.forbidden ?? [],
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+  }
+  try {
+    writeMission(cwd, mission)
+  } catch (e) {
+    console.error(chalk.red(`  ❌ mission.json 기록 실패: ${e instanceof Error ? e.message : String(e)}`))
+    process.exitCode = 1
+    return
+  }
+  console.log(chalk.bold('\n🎯 미션 계약 저장'))
+  console.log(chalk.dim(`  📄 ${MISSION_PATH_REL}`))
+  console.log(`  objective: ${mission.objective}`)
+  console.log(`  scope: ${mission.scope.length ? mission.scope.join(', ') : '(제한 없음)'}`)
+  console.log(`  forbidden: ${mission.forbidden.length ? mission.forbidden.join(', ') : '(없음)'}`)
+  printNextStep({ message: '변경이 계약 안인지 검증하려면:', command: 'vhk mission check', cursorHint: '미션 검증해줘' })
+}
+
+export async function missionShow(): Promise<void> {
+  const cwd = process.cwd()
+  const mission = readMission(cwd)
+  if (!mission) {
+    console.error(chalk.yellow('  ⚠️  미션 계약이 없습니다 (.vhk/mission.json).'))
+    printNextStep({ message: '먼저 미션을 선언하세요:', command: 'vhk mission set --objective "..."', cursorHint: '미션 정해줘' })
+    process.exitCode = 1
+    return
+  }
+  console.log(chalk.bold('\n🎯 현재 미션 계약'))
+  console.log(`  objective: ${mission.objective}`)
+  console.log(`  scope: ${mission.scope.length ? mission.scope.join(', ') : '(제한 없음)'}`)
+  console.log(`  forbidden: ${mission.forbidden.length ? mission.forbidden.join(', ') : '(없음)'}`)
+  console.log(chalk.dim(`  생성 ${mission.createdAt} · 갱신 ${mission.updatedAt}`))
+}
+
+export async function missionCheck(): Promise<void> {
+  const cwd = process.cwd()
+  const mission = readMission(cwd)
+  if (!mission) {
+    console.error(chalk.yellow('  ⚠️  미션 계약이 없습니다 — 먼저 vhk mission set 으로 선언하세요.'))
+    process.exitCode = 1
+    return
+  }
+  const changed = await collectChangedFiles(cwd)
+  const result = checkMission(changed, mission)
+
+  console.log(chalk.bold('\n🎯 미션 계약 검증 (mission check)'))
+  console.log(chalk.dim(`  objective: ${mission.objective}  ·  변경 파일 ${changed.length}개`))
+
+  if (result.violations.length > 0) {
+    console.log(chalk.red.bold(`\n  🚫 forbidden 위반 ${result.violations.length}건`))
+    for (const v of result.violations) console.log(chalk.red(`   ✗ ${v.file}  (금지: ${v.pattern})`))
+  }
+  if (result.warnings.length > 0) {
+    console.log(chalk.yellow.bold(`\n  ⚠️  scope 밖 변경 ${result.warnings.length}건 (경고)`))
+    for (const w of result.warnings) console.log(chalk.yellow(`   ? ${w.file}`))
+  }
+  if (result.violations.length === 0 && result.warnings.length === 0) {
+    console.log(chalk.green('\n  ✓ 변경이 계약(scope/forbidden) 안입니다.'))
+  }
+  console.log(chalk.yellow(`\n  ${result.disclaimer}`))
+
+  // forbidden 위반만 실패(exit 1). scope 경고는 통과(0).
+  process.exitCode = result.violations.length > 0 ? 1 : 0
+}
+
+export async function missionClear(): Promise<void> {
+  const cwd = process.cwd()
+  const p = join(cwd, MISSION_PATH_REL)
+  if (!existsSync(p)) {
+    console.log(chalk.dim('  미션 계약이 없습니다 — 지울 것 없음.'))
+    return
+  }
+  try {
+    rmSync(p)
+    console.log(chalk.green('  ✅ 미션 계약 삭제됨 (.vhk/mission.json).'))
+  } catch (e) {
+    console.error(chalk.red(`  ❌ 삭제 실패: ${e instanceof Error ? e.message : String(e)}`))
+    process.exitCode = 1
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -460,7 +460,8 @@ program
   .description('적대적 자기검증 — latest.json ↔ goal 완료조건 교차검증 (거짓완료 의심 탐지, 보장 아님)')
   .action(async (opts: { id?: string }) => { await review(opts) })
 
-const collectGlob = (v: string, prev: string[]): string[] => prev.concat([v])
+// prev 기본 [] — default 미지정이라 옵션 미제공 시 opts 에 키 자체가 없음(undefined = 보존 신호).
+const collectGlob = (v: string, prev: string[] = []): string[] => prev.concat([v])
 const missionCmd = program
   .command('mission')
   .alias('미션')
@@ -470,11 +471,14 @@ const missionCmd = program
 missionCmd
   .command('set')
   .option('--objective <text>', '미션 목표(objective)')
-  .option('--scope <glob>', '허용 경로 glob (반복 가능)', collectGlob, [])
-  .option('--forbidden <glob>', '금지 경로 glob (반복 가능)', collectGlob, [])
+  // default 미지정 — 옵션 안 주면 opts.scope/forbidden 이 undefined → 기존 값 보존(빈 배열로 안 덮음).
+  .option('--scope <glob>', '허용 경로 glob (반복 가능, 제공 시 교체)', collectGlob)
+  .option('--forbidden <glob>', '금지 경로 glob (반복 가능, 제공 시 교체)', collectGlob)
+  .option('--clear-scope', 'scope 를 비움(명시적)')
+  .option('--clear-forbidden', 'forbidden 을 비움(명시적)')
   .option('-y, --yes', '대화형 프롬프트 스킵 (비대화형)')
-  .description('미션 계약 선언/갱신')
-  .action(async (opts: { objective?: string; scope?: string[]; forbidden?: string[]; yes?: boolean }) => { await missionSet(opts) })
+  .description('미션 계약 선언/갱신 (옵션 미지정 시 기존 scope/forbidden 보존)')
+  .action(async (opts: { objective?: string; scope?: string[]; forbidden?: string[]; clearScope?: boolean; clearForbidden?: boolean; yes?: boolean }) => { await missionSet(opts) })
 
 missionCmd
   .command('check')

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ import { start } from './commands/start.js'
 import { mode } from './commands/mode.js'
 import { verify } from './commands/verify.js'
 import { review } from './commands/review.js'
+import { missionSet, missionShow, missionCheck, missionClear } from './commands/mission.js'
 import { runGuarded } from './lib/safety-guard.js'
 import { ensureNotHardStopped } from './lib/hard-stop-guard.js'
 import { isPromptAbortError } from './lib/interactive.js'
@@ -137,6 +138,7 @@ const KO_ALIASES: Record<string, string> = {
   brief: '브리핑',
   goal: '목표',
   review: '검토',
+  mission: '미션',
   blocker: '블로커',
   learn: '교훈',
   resume: '재개',
@@ -457,6 +459,32 @@ program
   .option('--id <id>', '대상 goal id (없으면 active goal)')
   .description('적대적 자기검증 — latest.json ↔ goal 완료조건 교차검증 (거짓완료 의심 탐지, 보장 아님)')
   .action(async (opts: { id?: string }) => { await review(opts) })
+
+const collectGlob = (v: string, prev: string[]): string[] => prev.concat([v])
+const missionCmd = program
+  .command('mission')
+  .alias('미션')
+  .description('미션 계약 — 작업 목표·허용/금지 범위 선언·검증 (scope 가드, .vhk/mission.json)')
+  .action(async () => { await missionShow() })
+
+missionCmd
+  .command('set')
+  .option('--objective <text>', '미션 목표(objective)')
+  .option('--scope <glob>', '허용 경로 glob (반복 가능)', collectGlob, [])
+  .option('--forbidden <glob>', '금지 경로 glob (반복 가능)', collectGlob, [])
+  .option('-y, --yes', '대화형 프롬프트 스킵 (비대화형)')
+  .description('미션 계약 선언/갱신')
+  .action(async (opts: { objective?: string; scope?: string[]; forbidden?: string[]; yes?: boolean }) => { await missionSet(opts) })
+
+missionCmd
+  .command('check')
+  .description('변경 파일이 계약(scope/forbidden) 안인지 검증 — forbidden 위반 시 exit 1')
+  .action(async () => { await missionCheck() })
+
+missionCmd
+  .command('clear')
+  .description('미션 계약 삭제 (.vhk/mission.json)')
+  .action(async () => { await missionClear() })
 
 program
   .command('context-show')

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -44,6 +44,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'mode', '모드',
   'verify', '사전점검',
   'review', '검토',
+  'mission', '미션',
   'help',
 ])
 

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -15,6 +15,7 @@ export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
   design: ['palette'],
   env: ['check'],
   mode: ['lite', 'standard', 'strict'],
+  mission: ['set', 'check', 'clear'],
 }
 
 /** 한국어 별칭 → 영문 컨테이너 명령. 별칭도 같은 서브커맨드 집합을 공유한다. */
@@ -27,4 +28,5 @@ export const CONTAINER_ALIASES: Record<string, string> = {
   디자인: 'design',
   환경변수: 'env',
   모드: 'mode',
+  미션: 'mission',
 }

--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -37,6 +37,7 @@ export type NlpCommand =
   | 'mode'
   | 'verify'
   | 'review'
+  | 'mission'
 
 export type NlpConfidence = 'high' | 'low'
 
@@ -145,6 +146,12 @@ const RULES: NlpRule[] = [
     explanation: '적대적 자기검증 — 증거로 거짓완료 의심 (vhk review)',
     confidence: 'high',
     test: t => /적대\s*검증|자기\s*검증|거짓\s*완료|완료\s*심문|^review$|^검토$/.test(t),
+  },
+  {
+    command: 'mission',
+    explanation: '미션 계약 — 작업 범위·금지선 선언/검증 (vhk mission)',
+    confidence: 'high',
+    test: t => /미션\s*계약|작업\s*범위|범위\s*검증|^mission$|^미션$/.test(t),
   },
   {
     command: 'init',

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -36,6 +36,7 @@ import { quickActions } from '../commands/help.js'
 import { mode } from '../commands/mode.js'
 import { verify } from '../commands/verify.js'
 import { review } from '../commands/review.js'
+import { missionShow } from '../commands/mission.js'
 import { runGuarded } from './safety-guard.js'
 import { NL_GUARDED_ACTIONS } from './risk-policy.js'
 
@@ -132,6 +133,8 @@ export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<
       return verify()
     case 'review':
       return review()
+    case 'mission':
+      return missionShow()
   }
 }
 

--- a/tests/mission.test.ts
+++ b/tests/mission.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { execFileSync } from 'node:child_process'
 import { simpleGit } from 'simple-git'
 import {
   globToRegExp,
@@ -143,6 +144,62 @@ describe('mission — 커맨드 통합', () => {
     await missionCheck()
     expect(process.exitCode).toBe(0)
     process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  // ── 보존(preserve) 회귀 — 옵션 미지정 시 기존 scope/forbidden 안 비움 ──
+  it('missionSet 옵션 미지정 → 기존 scope/forbidden 보존 (objective만 갱신)', async () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mission-'))
+    process.chdir(d)
+    await missionSet({ objective: 'old', scope: ['src/**'], forbidden: ['**/*.env'], yes: true })
+    await missionSet({ objective: 'new', yes: true }) // scope/forbidden 미지정
+    const m = readMission(d)!
+    expect(m.objective).toBe('new')
+    expect(m.scope).toEqual(['src/**'])
+    expect(m.forbidden).toEqual(['**/*.env'])
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('missionSet --clear-scope → scope 만 비움 (forbidden 보존)', async () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mission-'))
+    process.chdir(d)
+    await missionSet({ objective: 'o', scope: ['src/**'], forbidden: ['**/*.env'], yes: true })
+    await missionSet({ objective: 'o', clearScope: true, yes: true })
+    const m = readMission(d)!
+    expect(m.scope).toEqual([])
+    expect(m.forbidden).toEqual(['**/*.env'])
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})
+
+describe('mission — CLI 커맨더 경로 보존 회귀 (default [] 제거)', () => {
+  const DIST = path.join(process.cwd(), 'dist', 'index.js')
+  it('vhk mission set --objective new --yes → 기존 scope/forbidden 보존 + check 여전히 exit 1', () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mission-cli-'))
+    execFileSync('git', ['init'], { cwd: d, stdio: 'pipe' })
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    fs.writeFileSync(
+      path.join(d, MISSION_PATH_REL),
+      JSON.stringify(mission(['src/**'], ['**/*.env']), null, 2),
+      'utf-8'
+    )
+    // objective 만 갱신 — scope/forbidden 미지정. commander default [] 였다면 여기서 비워짐.
+    execFileSync('node', [DIST, 'mission', 'set', '--objective', 'new', '--yes'], { cwd: d, stdio: 'pipe' })
+    const m = JSON.parse(fs.readFileSync(path.join(d, MISSION_PATH_REL), 'utf-8'))
+    expect(m.objective).toBe('new')
+    expect(m.scope).toEqual(['src/**']) // 보존
+    expect(m.forbidden).toEqual(['**/*.env']) // 보존
+    // forbidden 매칭 파일 변경 → check 여전히 exit 1
+    fs.writeFileSync(path.join(d, 'leak.env'), 'TOKEN=x', 'utf-8')
+    let code = 0
+    try {
+      execFileSync('node', [DIST, 'mission', 'check'], { cwd: d, stdio: 'pipe' })
+    } catch (e) {
+      code = (e as { status?: number }).status ?? -1
+    }
+    expect(code).toBe(1)
     fs.rmSync(d, { recursive: true, force: true })
   })
 })

--- a/tests/mission.test.ts
+++ b/tests/mission.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { simpleGit } from 'simple-git'
+import {
+  globToRegExp,
+  checkMission,
+  readMission,
+  missionSet,
+  missionShow,
+  missionCheck,
+  MISSION_PATH_REL,
+  MISSION_DISCLAIMER,
+  type Mission,
+} from '../src/commands/mission.js'
+
+function mission(scope: string[], forbidden: string[]): Mission {
+  return { schemaVersion: 1, objective: 'o', scope, forbidden, createdAt: '', updatedAt: '' }
+}
+
+describe('mission — globToRegExp', () => {
+  it('`src/**` 는 src 하위 전체', () => {
+    expect(globToRegExp('src/**').test('src/a.ts')).toBe(true)
+    expect(globToRegExp('src/**').test('src/x/y/a.ts')).toBe(true)
+    expect(globToRegExp('src/**').test('lib/a.ts')).toBe(false)
+  })
+  it('`**/*.ts` 는 모든 깊이의 .ts', () => {
+    const re = globToRegExp('**/*.ts')
+    expect(re.test('a.ts')).toBe(true)
+    expect(re.test('src/x/a.ts')).toBe(true)
+    expect(re.test('a.js')).toBe(false)
+  })
+  it('`*.md` 는 루트 세그먼트만 (디렉터리 안 넘음)', () => {
+    expect(globToRegExp('*.md').test('README.md')).toBe(true)
+    expect(globToRegExp('*.md').test('docs/x.md')).toBe(false)
+  })
+})
+
+describe('mission — checkMission (순수)', () => {
+  it('forbidden 매칭 → 위반 (회귀 가드)', () => {
+    const r = checkMission(['src/secret.ts', 'src/a.ts'], mission([], ['**/secret*']))
+    expect(r.violations).toHaveLength(1)
+    expect(r.violations[0].file).toBe('src/secret.ts')
+  })
+  it('scope 밖 변경 → 경고', () => {
+    const r = checkMission(['docs/x.md'], mission(['src/**'], []))
+    expect(r.warnings).toHaveLength(1)
+    expect(r.violations).toHaveLength(0)
+  })
+  it('scope 안 변경 → 경고 0', () => {
+    expect(checkMission(['src/a.ts'], mission(['src/**'], [])).warnings).toHaveLength(0)
+  })
+  it('scope 비면 경고 안 함 (모두 허용)', () => {
+    expect(checkMission(['anything/x.js'], mission([], [])).warnings).toHaveLength(0)
+  })
+  it('forbidden 우선 (scope 안이어도 forbidden 이면 위반)', () => {
+    const r = checkMission(['src/.env'], mission(['src/**'], ['**/.env']))
+    expect(r.violations).toHaveLength(1)
+    expect(r.warnings).toHaveLength(0)
+  })
+  it('disclaimer 항상 존재 ("보장 아님" + 경로 glob 한계)', () => {
+    expect(checkMission([], mission([], [])).disclaimer).toBe(MISSION_DISCLAIMER)
+    expect(MISSION_DISCLAIMER).toMatch(/경로 glob|의미/)
+  })
+})
+
+describe('mission — readMission BOM-safe', () => {
+  it('BOM 붙은 mission.json 도 읽음', () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mission-'))
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    const m = mission(['src/**'], ['**/.env'])
+    fs.writeFileSync(path.join(d, MISSION_PATH_REL), '﻿' + JSON.stringify(m), 'utf-8')
+    const read = readMission(d)
+    expect(read?.objective).toBe('o')
+    expect(read?.forbidden).toEqual(['**/.env'])
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+  it('없으면 null', () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mission-'))
+    expect(readMission(d)).toBeNull()
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})
+
+describe('mission — 커맨드 통합', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    process.exitCode = 0
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+    process.exitCode = 0
+  })
+
+  it('mission set → mission.json 생성 (별도 네임스페이스, latest.json 불변)', async () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mission-'))
+    process.chdir(d)
+    await missionSet({ objective: 'auth 리팩터', scope: ['src/auth/**'], forbidden: ['**/*.env'], yes: true })
+    const m = JSON.parse(fs.readFileSync(path.join(d, MISSION_PATH_REL), 'utf-8'))
+    expect(m.schemaVersion).toBe(1)
+    expect(m.objective).toBe('auth 리팩터')
+    expect(m.forbidden).toEqual(['**/*.env'])
+    expect(fs.existsSync(path.join(d, '.vhk', 'reports', 'latest.json'))).toBe(false) // verify 증거 안 만듦
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('mission (계약 없음) → 안내 + exit 1', async () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mission-'))
+    process.chdir(d)
+    await missionShow()
+    expect(process.exitCode).toBe(1)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('mission check → forbidden 변경 시 위반 + exit 1', async () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mission-'))
+    await simpleGit(d).init()
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    fs.writeFileSync(path.join(d, MISSION_PATH_REL), JSON.stringify(mission(['src/**'], ['**/*.env'])), 'utf-8')
+    fs.writeFileSync(path.join(d, 'secret.env'), 'TOKEN=x', 'utf-8') // forbidden glob 매칭 (untracked)
+    process.chdir(d)
+    await missionCheck()
+    expect(process.exitCode).toBe(1)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('mission check → 계약 안 변경이면 exit 0', async () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mission-'))
+    await simpleGit(d).init()
+    fs.mkdirSync(path.join(d, 'src'), { recursive: true })
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    fs.writeFileSync(path.join(d, MISSION_PATH_REL), JSON.stringify(mission(['src/**', '.vhk/**'], ['**/*.env'])), 'utf-8')
+    fs.writeFileSync(path.join(d, 'src', 'a.ts'), 'export const a = 1\n', 'utf-8')
+    process.chdir(d)
+    await missionCheck()
+    expect(process.exitCode).toBe(0)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})


### PR DESCRIPTION
## 요약

Goal 17 — `vhk mission`: 작업의 목표·허용/금지 범위를 `.vhk/mission.json` 계약으로 선언하고, 변경 파일이 계약 안인지 검증. Trust Loop scope/intent 층(**mission → verify → review**).

> ⚠️ #103(등록) 위 스택. base=main. goal done/v1.9.0 범프는 **STEP C**.

## 서브커맨드
- `mission set --objective ... --scope <glob> --forbidden <glob>` — 계약 선언/갱신 (비대화형 가드)
- `mission` — 현재 계약 표시(없으면 exit 1)
- `mission check` — 변경(working tree+staged) ↔ glob 교차검증. **forbidden 위반=exit 1**, scope 밖=경고
- `mission clear` — 삭제

## 핵심 (v0 정직성)
- **경로 glob 기준** — objective 의미 검증 아님(disclaimer 명시, 보장 아님).
- `checkMission`/`globToRegExp` **순수 함수**(테스트 용이). glob 자체 구현 — **외부 의존 0**.
- `.vhk/mission.json` **별도 네임스페이스** — latest.json(verify 증거) 안 건드림. BOM-safe `readJsonFile`.
- 변경파일 = `simple-git status`(staged+modified+untracked). secret 미포함.

## 게이트
- tsc OK / build OK / **671 pass**(신규 15, 회귀 0) / grep 0 / secure scan 0
- `vhk goal check --id 17` 고유검증 **9/9** ✓ (R1 command-registry 단일소스 등록 — 컨테이너 누락 가드 통과)
- e2e: `mission set` → `mission check`(forbidden `*.env` 변경 → 위반 exit 1 + scope 경고 + disclaimer) → latest.json 미생성 확인

## 제외 (v0)
objective 의미 검증 / forbidden 액션 금지(safety-mode 중복) / strict 하드블록 → 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)