### PR TITLE
chore(state): Goal 18 (memory schema v2) 등록

### DIFF
--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -1,10 +1,10 @@
 # Next Task
 
-_Auto-updated 2026-06-02T15:01:18.941Z via `vhk goal next`._
+_Auto-updated 2026-06-02T15:52:17.916Z via `vhk goal next`._
 
 ```
-TASK: Goal 17 — vhk mission — Mission Contract (scope/intent 층) — P3
+TASK: Goal 18 — 기억 구조화 — memory schema v2 (4버킷 + learn 통합) — P1
   status: NOT_STARTED
-  priority: P3
-  file: goals\17-mission.md
+  priority: P1
+  file: goals\18-memory-schema-v2.md
 ```

--- a/goals/18-memory-schema-v2.md
+++ b/goals/18-memory-schema-v2.md
@@ -1,0 +1,56 @@
+---
+vhk_format: 1
+type: goal
+id: 18
+title: 기억 구조화 — memory schema v2 (4버킷 + learn 통합) — P1
+status: NOT_STARTED
+priority: P1
+version: v2.0.0
+---
+
+# Goal 18: memory schema v2 (Evolution Loop 도미노 2)
+
+> 출처: Evolution Loop 로드맵. 평면 memory.json → 4버킷 구조화. `.vhk` 포맷 breaking → **v2.0.0**.
+> 전제: Trust Loop(scope/verify/review) 완성. 기억을 패턴(19)·진화(20)의 학습 입력으로 구조화.
+
+## 현황 (18-A 코드 확인 결과)
+- **memory.json v1** = `.vhk/memory.json` **평면 JSON 배열** `[{ content, addedAt, tags? }]` (schemaVersion 없음).
+  `src/commands/memory.ts` `loadMemories`/`saveMemories`, `memoryAdd/List/Remove`. BOM-safe `readJsonFile` 사용.
+- **learn** = `src/commands/agent.ts:37` → `appendLearning`(`src/lib/state-files.ts`) → `docs/state/learnings.md` append.
+  현재 메시지(agent.ts:49) "결정사항은 vhk memory add — **SoT 분리**". ← 18에서 통합으로 갱신.
+- **learnings.md** = append-only `- [YYYY-MM-DD goal-N] 한 줄 교훈.` (실패와 무관한 독립 교훈 다수).
+- **독립 교훈 표현 결정:** learnings.md 항목 → `failures` 의 `FailEntry { what:'', why:'', lesson: 교훈텍스트 }`
+  (실패 본문 없음 → what 비우고 lesson 만 채움). 날짜/goal 태그는 tags 로 보존.
+- **"분리 SoT / 이중기록 금지" 문구 위치:** agent.ts:49(코드 메시지), CLAUDE.md, AGENTS.md → 18-C 에서 통합으로 갱신.
+
+## 동작 (파일·계약)
+- **v2 스키마**: `{ schemaVersion:2, decisions[], failures[], successes[], patterns[] }`.
+  - decisions: v1 평면 항목 이관. failures: `{...,why?,lesson?}`(교훈 단일 SoT). successes: `{...,why?}`. patterns: 19에서 채움(v0 빈 배열).
+  - 모든 항목 `status: 'active'|'resolved'|'archived'`(기본 active) + `resolvedAt?/archivedAt?`.
+- **자동 마이그레이션**(멱등): v1 배열 읽으면 v2 로 변환·`.bak` 백업 후 재기록. learnings.md 흡수 → failures.
+- **learn 통합(breaking)**: `vhk learn` → memory v2 `failures.lesson` 기록. learnings.md 신규 기록 중단(기존은 흡수).
+- 기존 `memory add/list/remove` 무파괴. BOM-safe. secret 미포함.
+
+## 철학
+① 기억은 학습 입력 — 구조화해야 패턴·진화가 본다 ② 교훈 단일 SoT(learn 통합, 이중기록 폐지) ③ 선순환(status+archive — 해결된 실수는 조용해짐) ④ 자동 마이그레이션·백업(데이터 손실 0) ⑤ GA 약속대로 breaking 은 메이저(v2.0.0).
+
+## Completion Check
+- [ ] memory.json `schemaVersion:2` + 4버킷(decisions/failures/successes/patterns)
+- [ ] failures `{what,why,lesson}` · successes `{what,why}` 타입
+- [ ] v1 평면 배열 → v2 자동 마이그레이션 (멱등 — v2 재실행 무변경) + `.bak` 백업
+- [ ] learn → memory v2 failures.lesson 통합 + docs/state/learnings.md 마이그레이션 흡수
+- [ ] "분리 SoT/이중기록 금지" 문구 갱신 (agent.ts·CLAUDE.md·AGENTS.md — 문서·코드 불일치 0)
+- [ ] 항목 status(active/resolved/archived) + `vhk memory archive <n>` 명령
+- [ ] 기존 memory add/list/remove 무파괴 (회귀 0) · BOM-safe
+- [ ] vhk goal sync → check-goal-18.mjs 생성 → vhk goal check --id 18 통과
+- [ ] CHANGELOG breaking 명시 + 공통 게이트(typecheck+test+build+secure)
+
+## 제외 범위
+- patterns 채우기(감지) → Goal 19. evolve/적용 → Goal 20.
+- 의미기반 분석(v0=구조/빈도). 외부 ML/LLM/라이브러리.
+- profile.json → Goal 20.
+
+## Mandatory Reading
+- src/commands/memory.ts (v1 평면 배열 + load/save)
+- src/commands/agent.ts (learn) + src/lib/state-files.ts (appendLearning/learnings.md)
+- src/lib/read-json.ts (readJsonFile/stripBom — BOM-safe)

--- a/scripts/check-goal-18.mjs
+++ b/scripts/check-goal-18.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// scripts/check-goal-18.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 18 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 18] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 18 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 18 gate passes'); process.exit(0) }
+console.log('❌ goal 18 gate failed'); process.exit(1)


### PR DESCRIPTION
## 요약
Goal 18(memory schema v2 — 평면 memory.json → 4버킷 + learn 통합, **breaking → v2.0.0**)를 goal 파일로 **등록만**.

> ⚠️ 등록 전용 — 구현 코드 없음. 구현은 STEP B. goals/18 NOT_STARTED 유지.

## 18-A 코드 확인 결과(현황, 추정 금지)
- memory.json v1 = `.vhk/memory.json` **평면 배열** `[{content,addedAt,tags?}]`(schemaVersion 없음).
- `vhk learn` → `appendLearning` → `docs/state/learnings.md`(메시지 "SoT 분리" — 18에서 통합으로 갱신).
- 독립 교훈(실패 무관) 표현: `failures` 의 `{what:'', lesson: 교훈}` 으로 마이그.

## 변경 (3파일, 코드 0)
- `goals/18-memory-schema-v2.md` (id 18, NOT_STARTED, P1, v2.0.0)
- `scripts/check-goal-18.mjs` (BOM-safe)
- `docs/state/next-task.md` (active → Goal 18)

## 다음 (STEP B)
순수 `migrateMemory` + 4버킷 타입 + learn 통합 + learnings.md 흡수 + status/archive + .bak + 테스트 + 분리SoT 문구 갱신.

🤖 Generated with [Claude Code](https://claude.com/claude-code)