### PR TITLE
feat(memory): schema v2 — 4버킷 + learn 통합 (Goal 18, v2.0.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,8 @@ cache hit 최대화 위해 동일 순서로:
 
 iteration 끝에 비-자명한 교훈 1 건이라도 있으면:
 
-- `vhk learn "<교훈>"` — `docs/state/learnings.md` 에 한 줄 append
-- **단일 SoT**: `vhk memory add` 와 이중 기록 금지. 결정사항 = memory, 교훈 = learnings.
+- `vhk learn "<교훈>"` — memory v2 `failures.lesson` 에 기록 (v2.0 통합)
+- **단일 출처 (v2)**: 교훈·결정·실패·성공 모두 `vhk memory` 4버킷. `vhk memory list` 로 확인.
 
 ## HARD_STOP
 
@@ -101,7 +101,7 @@ iteration 끝에 비-자명한 교훈 1 건이라도 있으면:
 - MCP handler 안에서 inquirer 호출
 - `vhk resume` 의 자동 호출
 - `docs/state/{blockers,learnings}.md` 의 과거 항목 수정/삭제 (append-only)
-- `vhk learn` 와 `vhk memory add` 의 이중 기록 (SoT 분리: learnings = 교훈, memory = 결정사항)
+- `docs/state/learnings.md` 에 신규 교훈 직접 추가 (v2: 교훈은 `vhk learn` → memory)
 - 게이트 실패에도 `vhk goal done` 으로 마킹 (실패 = 보존)
 
 ## Tech Stack (do not deviate)

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -47,6 +47,20 @@ Cursor에게 한국어로 말해도 됩니다.
 
 > `mission` 은 작업의 목표·허용/금지 범위를 `.vhk/mission.json` 계약으로 선언하고, 변경 파일이 계약(scope/forbidden glob) 안인지 검증합니다. **경로 glob 기준**이며 objective 의미 부합은 검증하지 않습니다(보장 아님). forbidden 위반 시 exit 1.
 
+## 기억 v2 (memory — 4버킷)
+
+| 하고 싶은 것 | 터미널 명령 | Cursor에게 말하기 |
+|-------------|-----------|------------------|
+| 결정 기록 | `vhk memory add "tRPC 채택" --type decision` | "이거 기억해" |
+| 실패+교훈 기록 | `vhk memory add "테스트 미커버" --type failure --why "..." --lesson "회귀 가드 먼저"` | "이 실수 기억해" |
+| 성공 기록 | `vhk memory add "롤백 빨랐다" --type success --why "백업 먼저"` | "이 성공 기억해" |
+| 교훈만 빠르게 | `vhk learn "PowerShell 은 && 미지원"` | "교훈 남겨" |
+| 목록 | `vhk memory list [--type failure] [--all]` | "기억 보여줘" |
+| 보관(선순환) | `vhk memory archive <번호>` | "이거 보관해" |
+| v1→v2 변환 | `vhk memory migrate` | — |
+
+> **v2.0 BREAKING**: 평면 memory.json → 4버킷(결정/실패/성공/패턴). 첫 실행 시 자동 마이그레이션(`.bak` 백업). **교훈은 `vhk learn`·`memory failure --lesson` 단일 SoT** (구 `docs/state/learnings.md` 분리 폐지·흡수). 보관(archive)된 항목은 패턴·진화에서 제외(선순환).
+
 ## 환경 점검
 
 ```bash

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -59,7 +59,7 @@ Cursor에게 한국어로 말해도 됩니다.
 | 보관(선순환) | `vhk memory archive <번호>` | "이거 보관해" |
 | v1→v2 변환 | `vhk memory migrate` | — |
 
-> **v2.0 BREAKING**: 평면 memory.json → 4버킷(결정/실패/성공/패턴). 첫 실행 시 자동 마이그레이션(`.bak` 백업). **교훈은 `vhk learn`·`memory failure --lesson` 단일 SoT** (구 `docs/state/learnings.md` 분리 폐지·흡수). 보관(archive)된 항목은 패턴·진화에서 제외(선순환).
+> **v2.0 BREAKING**: 평면 memory.json → 4버킷(결정/실패/성공/패턴). **조회 명령(`vhk memory list`·`context`·`brief`) 첫 실행 시에도 v1→v2 자동 마이그레이션 + `.v1.bak` 원본 백업**(어느 명령으로 먼저 실행해도 동일). **교훈은 `vhk learn`·`memory failure --lesson` 단일 SoT** (구 `docs/state/learnings.md` 분리 폐지·흡수). 보관(archive)된 항목은 패턴·진화에서 제외(선순환).
 
 ## 환경 점검
 

--- a/README.md
+++ b/README.md
@@ -172,12 +172,12 @@ vhk 기획 끝났고 바로 시작
 | `vhk update` | `업데이트` | VHK CLI 최신 버전으로 셀프 업데이트 |
 | `vhk context` | `맥락` | 프로젝트 트리·스택·CLI 명령 목록을 `.vhk/context.md`로 자동 생성 (AI 어시스턴트용). `--compact` 로 토큰 절감형(Active Goal + 최근 blockers/learnings/memories + 참조 링크) 출력 |
 | `vhk context-show` | `맥락보기` | 현재 컨텍스트 파일 내용 출력 |
-| `vhk memory` | `기억` | 결정사항 기억 관리 (`add` / `list` / `remove`, `.vhk/memory.json` 기반, 태그 지원) |
+| `vhk memory` | `기억` | 기억 v2 4버킷(결정/실패/성공) 관리 (`add --type` / `list [--all]` / `remove` / `archive` / `migrate`, `.vhk/memory.json`) |
 | `vhk brief` | `브리핑` | 프로젝트 정보 + git 상태 + 결정사항 + 레퍼런스 통합 보고서 `.vhk/brief.md` |
 | `vhk goal` | `목표` | Goal 단계별 미션 관리 (`init` / `list` / `next` / `check` / `done`) — vspec/vooster 패턴 |
 | `vhk mission` | `미션` | 미션 계약(`set` / `check` / `clear`) — 작업 범위·금지선 선언·검증 (`.vhk/mission.json`, 경로 glob) |
 | `vhk blocker <설명>` | `블로커` | 블로커 1건 → `docs/state/blockers.md` append. 3건 누적 시 `.vhk/HARD_STOP` 자동 생성 |
-| `vhk learn <교훈>` | `교훈` | 교훈 1건 → `docs/state/learnings.md` append (memory.json 과 별도 SoT) |
+| `vhk learn <교훈>` | `교훈` | 교훈 1건 → `memory.json` `failures.lesson` 단일 SoT (v2.0 통합 — 구 learnings.md 분리 폐지) |
 | `vhk resume --confirm` | `재개` | `.vhk/HARD_STOP` 해제 (사람 확인 필요, 자동 호출 금지) |
 
 ### 자율 루프 (v1.3+)

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ vhk 기획 끝났고 바로 시작
 | `vhk update` | `업데이트` | VHK CLI 최신 버전으로 셀프 업데이트 |
 | `vhk context` | `맥락` | 프로젝트 트리·스택·CLI 명령 목록을 `.vhk/context.md`로 자동 생성 (AI 어시스턴트용). `--compact` 로 토큰 절감형(Active Goal + 최근 blockers/learnings/memories + 참조 링크) 출력 |
 | `vhk context-show` | `맥락보기` | 현재 컨텍스트 파일 내용 출력 |
-| `vhk memory` | `기억` | 기억 v2 4버킷(결정/실패/성공) 관리 (`add --type` / `list [--all]` / `remove` / `archive` / `migrate`, `.vhk/memory.json`) |
+| `vhk memory` | `기억` | 기억 v2 4버킷(결정/실패/성공) 관리 (`add --type` / `list [--all]` / `remove` / `archive` / `migrate`). 조회 명령(`memory list`·`context`·`brief`) 첫 실행 시 v1→v2 자동 마이그레이션 + `.v1.bak` 원본 백업 |
 | `vhk brief` | `브리핑` | 프로젝트 정보 + git 상태 + 결정사항 + 레퍼런스 통합 보고서 `.vhk/brief.md` |
 | `vhk goal` | `목표` | Goal 단계별 미션 관리 (`init` / `list` / `next` / `check` / `done`) — vspec/vooster 패턴 |
 | `vhk mission` | `미션` | 미션 계약(`set` / `check` / `clear`) — 작업 범위·금지선 선언·검증 (`.vhk/mission.json`, 경로 glob) |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -44,19 +44,29 @@ updated: 2026-05-29
 
 ## 2. JSON 스키마
 
-### 2.1 `memory.json`
+### 2.1 `memory.json` (schema v2)
 
-의사결정·기억할 내용의 배열.
+**v2.0.0 BREAKING**: 평면 배열 → 4버킷 객체. v1(평면 배열)은 `vhk` 실행 시 자동 마이그레이션(`.bak` 백업, 멱등).
+교훈은 `failures.lesson` 단일 SoT (구 `docs/state/learnings.md` 흡수, `vhk learn` 통합).
 
 ```jsonc
-[
-  {
-    "content": "API는 tRPC 사용하기로 결정",  // string, 필수
-    "addedAt": "2026-05-29T12:00:00.000Z",     // string(ISO 8601), 필수
-    "tags": ["decision", "api"]                  // string[], 선택(기본 [])
-  }
-]
+{
+  "schemaVersion": 2,
+  "decisions": [
+    { "id": "d1", "content": "API는 tRPC", "tags": ["api"], "createdAt": "...", "status": "active" }
+  ],
+  "failures":  [
+    // status: active|resolved|archived (+resolvedAt/archivedAt). 패턴·진화는 active 만 본다.
+    { "id": "f1", "content": "테스트 미커버", "why": "...", "lesson": "회귀 가드 먼저", "tags": [], "createdAt": "...", "status": "active" }
+  ],
+  "successes": [
+    { "id": "s1", "content": "롤백 빨랐다", "why": "백업 먼저", "tags": [], "createdAt": "...", "status": "active" }
+  ],
+  "patterns": []  // Goal 19(vhk pattern)에서 채움
+}
 ```
+
+> v1 → v2: 평면 항목 → `decisions`, `docs/state/learnings.md` 교훈 → `failures`(lesson, content 비움). 마이그레이션 시 `memory.json.bak` 백업.
 
 ### 2.2 `refs.json`
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -66,7 +66,8 @@ updated: 2026-05-29
 }
 ```
 
-> v1 → v2: 평면 항목 → `decisions`, `docs/state/learnings.md` 교훈 → `failures`(lesson, content 비움). 마이그레이션 시 `memory.json.bak` 백업.
+> v1 → v2: 평면 항목 → `decisions`, `docs/state/learnings.md` 교훈 → `failures`(lesson, content 비움).
+> 백업: `memory.json.v1.bak`(v1 원본 write-once 영구) + `memory.json.bak`(롤링, 매 쓰기 직전).
 
 ### 2.2 `refs.json`
 

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -1,10 +1,10 @@
 # Next Task
 
-_Auto-updated 2026-06-02T15:01:18.941Z via `vhk goal next`._
+_Auto-updated 2026-06-02T15:52:17.916Z via `vhk goal next`._
 
 ```
-TASK: Goal 17 — vhk mission — Mission Contract (scope/intent 층) — P3
+TASK: Goal 18 — 기억 구조화 — memory schema v2 (4버킷 + learn 통합) — P1
   status: NOT_STARTED
-  priority: P3
-  file: goals\17-mission.md
+  priority: P1
+  file: goals\18-memory-schema-v2.md
 ```

--- a/goals/18-memory-schema-v2.md
+++ b/goals/18-memory-schema-v2.md
@@ -1,0 +1,56 @@
+---
+vhk_format: 1
+type: goal
+id: 18
+title: 기억 구조화 — memory schema v2 (4버킷 + learn 통합) — P1
+status: NOT_STARTED
+priority: P1
+version: v2.0.0
+---
+
+# Goal 18: memory schema v2 (Evolution Loop 도미노 2)
+
+> 출처: Evolution Loop 로드맵. 평면 memory.json → 4버킷 구조화. `.vhk` 포맷 breaking → **v2.0.0**.
+> 전제: Trust Loop(scope/verify/review) 완성. 기억을 패턴(19)·진화(20)의 학습 입력으로 구조화.
+
+## 현황 (18-A 코드 확인 결과)
+- **memory.json v1** = `.vhk/memory.json` **평면 JSON 배열** `[{ content, addedAt, tags? }]` (schemaVersion 없음).
+  `src/commands/memory.ts` `loadMemories`/`saveMemories`, `memoryAdd/List/Remove`. BOM-safe `readJsonFile` 사용.
+- **learn** = `src/commands/agent.ts:37` → `appendLearning`(`src/lib/state-files.ts`) → `docs/state/learnings.md` append.
+  현재 메시지(agent.ts:49) "결정사항은 vhk memory add — **SoT 분리**". ← 18에서 통합으로 갱신.
+- **learnings.md** = append-only `- [YYYY-MM-DD goal-N] 한 줄 교훈.` (실패와 무관한 독립 교훈 다수).
+- **독립 교훈 표현 결정:** learnings.md 항목 → `failures` 의 `FailEntry { what:'', why:'', lesson: 교훈텍스트 }`
+  (실패 본문 없음 → what 비우고 lesson 만 채움). 날짜/goal 태그는 tags 로 보존.
+- **"분리 SoT / 이중기록 금지" 문구 위치:** agent.ts:49(코드 메시지), CLAUDE.md, AGENTS.md → 18-C 에서 통합으로 갱신.
+
+## 동작 (파일·계약)
+- **v2 스키마**: `{ schemaVersion:2, decisions[], failures[], successes[], patterns[] }`.
+  - decisions: v1 평면 항목 이관. failures: `{...,why?,lesson?}`(교훈 단일 SoT). successes: `{...,why?}`. patterns: 19에서 채움(v0 빈 배열).
+  - 모든 항목 `status: 'active'|'resolved'|'archived'`(기본 active) + `resolvedAt?/archivedAt?`.
+- **자동 마이그레이션**(멱등): v1 배열 읽으면 v2 로 변환·`.bak` 백업 후 재기록. learnings.md 흡수 → failures.
+- **learn 통합(breaking)**: `vhk learn` → memory v2 `failures.lesson` 기록. learnings.md 신규 기록 중단(기존은 흡수).
+- 기존 `memory add/list/remove` 무파괴. BOM-safe. secret 미포함.
+
+## 철학
+① 기억은 학습 입력 — 구조화해야 패턴·진화가 본다 ② 교훈 단일 SoT(learn 통합, 이중기록 폐지) ③ 선순환(status+archive — 해결된 실수는 조용해짐) ④ 자동 마이그레이션·백업(데이터 손실 0) ⑤ GA 약속대로 breaking 은 메이저(v2.0.0).
+
+## Completion Check
+- [ ] memory.json `schemaVersion:2` + 4버킷(decisions/failures/successes/patterns)
+- [ ] failures `{what,why,lesson}` · successes `{what,why}` 타입
+- [ ] v1 평면 배열 → v2 자동 마이그레이션 (멱등 — v2 재실행 무변경) + `.bak` 백업
+- [ ] learn → memory v2 failures.lesson 통합 + docs/state/learnings.md 마이그레이션 흡수
+- [ ] "분리 SoT/이중기록 금지" 문구 갱신 (agent.ts·CLAUDE.md·AGENTS.md — 문서·코드 불일치 0)
+- [ ] 항목 status(active/resolved/archived) + `vhk memory archive <n>` 명령
+- [ ] 기존 memory add/list/remove 무파괴 (회귀 0) · BOM-safe
+- [ ] vhk goal sync → check-goal-18.mjs 생성 → vhk goal check --id 18 통과
+- [ ] CHANGELOG breaking 명시 + 공통 게이트(typecheck+test+build+secure)
+
+## 제외 범위
+- patterns 채우기(감지) → Goal 19. evolve/적용 → Goal 20.
+- 의미기반 분석(v0=구조/빈도). 외부 ML/LLM/라이브러리.
+- profile.json → Goal 20.
+
+## Mandatory Reading
+- src/commands/memory.ts (v1 평면 배열 + load/save)
+- src/commands/agent.ts (learn) + src/lib/state-files.ts (appendLearning/learnings.md)
+- src/lib/read-json.ts (readJsonFile/stripBom — BOM-safe)

--- a/scripts/check-goal-18.mjs
+++ b/scripts/check-goal-18.mjs
@@ -80,6 +80,7 @@ const walkTs = (dir) => {
 const scanTargets = [
   ...walkTs('src').filter((p) => !p.endsWith('commands/memory.ts')),
   'AGENTS.md', 'CLAUDE.md', 'docs/ARCHITECTURE.md', 'docs/context/agent-compact.md',
+  'README.md', 'COMMANDS.md', 'docs/spec.md',
 ].filter((p) => existsSync(p))
 const forbiddenHits = scanTargets.filter((f) => FORBIDDEN.test(readFileSync(f, 'utf-8')))
 must(forbiddenHits.length === 0, `learnings 분리 SoT 금지문구 0 (잔존: ${forbiddenHits.join(', ') || '없음'})`)

--- a/scripts/check-goal-18.mjs
+++ b/scripts/check-goal-18.mjs
@@ -6,7 +6,7 @@
 // Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
 
 import { execFileSync } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
 
 const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
 function run(cmd, args) {
@@ -64,6 +64,25 @@ must(/export function recordLesson/.test(mm) && /recordLesson/.test(ag) && !/app
 must(/status: 'active'|EntryStatus/.test(mm) && /export async function memoryArchive/.test(mm) && /archivedAt/.test(mm), 'status(active/resolved/archived) + memoryArchive')
 must(/copyFileSync/.test(mm) && /\.v1\.bak/.test(mm) && /\.bak/.test(mm), 'write-once .v1.bak(원본 영구) + 롤링 .bak')
 must(/readJsonFile|stripBom/.test(mm), 'BOM-safe 읽기')
+
+// ─── 금지문구 게이트: "learnings.md 분리 SoT" 잔존 차단 (v2 통합 정합) ───
+// src/** + 라이브 agent docs 만 검사. memory.ts(마이그 참조)·CHANGELOG·goals·tests(역사/메타) 제외.
+const FORBIDDEN = /SoT 분리|이중\s?기록|별도 SoT|learnings\.md append|memory\.json\s?과\s?별도/
+const walkTs = (dir) => {
+  const out = []
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = dir + '/' + e.name
+    if (e.isDirectory()) out.push(...walkTs(p))
+    else if (e.name.endsWith('.ts')) out.push(p)
+  }
+  return out
+}
+const scanTargets = [
+  ...walkTs('src').filter((p) => !p.endsWith('commands/memory.ts')),
+  'AGENTS.md', 'CLAUDE.md', 'docs/ARCHITECTURE.md', 'docs/context/agent-compact.md',
+].filter((p) => existsSync(p))
+const forbiddenHits = scanTargets.filter((f) => FORBIDDEN.test(readFileSync(f, 'utf-8')))
+must(forbiddenHits.length === 0, `learnings 분리 SoT 금지문구 0 (잔존: ${forbiddenHits.join(', ') || '없음'})`)
 
 if (pass) { console.log('✅ goal 18 gate passes'); process.exit(0) }
 console.log('❌ goal 18 gate failed'); process.exit(1)

--- a/scripts/check-goal-18.mjs
+++ b/scripts/check-goal-18.mjs
@@ -62,7 +62,7 @@ must(/why\?/.test(mm) && /lesson\?/.test(mm), 'FailEntry {why,lesson} · Success
 must(/parseLearnings|learnings/.test(mm) && /readLearningsRaw/.test(mm), 'learnings.md → failures 흡수')
 must(/export function recordLesson/.test(mm) && /recordLesson/.test(ag) && !/appendLearning/.test(ag), 'learn → memory 통합 (agent.ts recordLesson, appendLearning 제거)')
 must(/status: 'active'|EntryStatus/.test(mm) && /export async function memoryArchive/.test(mm) && /archivedAt/.test(mm), 'status(active/resolved/archived) + memoryArchive')
-must(/copyFileSync/.test(mm) && /\.bak/.test(mm), '.bak 백업 (writeMemory)')
+must(/copyFileSync/.test(mm) && /\.v1\.bak/.test(mm) && /\.bak/.test(mm), 'write-once .v1.bak(원본 영구) + 롤링 .bak')
 must(/readJsonFile|stripBom/.test(mm), 'BOM-safe 읽기')
 
 if (pass) { console.log('✅ goal 18 gate passes'); process.exit(0) }

--- a/scripts/check-goal-18.mjs
+++ b/scripts/check-goal-18.mjs
@@ -52,9 +52,18 @@ if (!skipDeep) {
   if (scripts.build) gate('build', run(pm, ['run', 'build']))
 }
 
-// ─── goal 18 고유 검증 (직접 추가) ───────────────────────────────
-// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
-// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+// ─── goal 18 고유 검증 (memory schema v2) ───────────────────────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+const mm = read('src/commands/memory.ts') ?? ''
+const ag = read('src/commands/agent.ts') ?? ''
+must(/export function migrateMemory/.test(mm) && /schemaVersion: 2|MEMORY_SCHEMA_VERSION = 2/.test(mm), 'migrateMemory export + schemaVersion 2')
+must(/decisions/.test(mm) && /failures/.test(mm) && /successes/.test(mm) && /patterns/.test(mm), '4버킷 (decisions/failures/successes/patterns)')
+must(/why\?/.test(mm) && /lesson\?/.test(mm), 'FailEntry {why,lesson} · SuccessEntry {why}')
+must(/parseLearnings|learnings/.test(mm) && /readLearningsRaw/.test(mm), 'learnings.md → failures 흡수')
+must(/export function recordLesson/.test(mm) && /recordLesson/.test(ag) && !/appendLearning/.test(ag), 'learn → memory 통합 (agent.ts recordLesson, appendLearning 제거)')
+must(/status: 'active'|EntryStatus/.test(mm) && /export async function memoryArchive/.test(mm) && /archivedAt/.test(mm), 'status(active/resolved/archived) + memoryArchive')
+must(/copyFileSync/.test(mm) && /\.bak/.test(mm), '.bak 백업 (writeMemory)')
+must(/readJsonFile|stripBom/.test(mm), 'BOM-safe 읽기')
 
 if (pass) { console.log('✅ goal 18 gate passes'); process.exit(0) }
 console.log('❌ goal 18 gate failed'); process.exit(1)

--- a/scripts/check-goal-18.mjs
+++ b/scripts/check-goal-18.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// scripts/check-goal-18.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 18 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 18] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 18 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 18 gate passes'); process.exit(0) }
+console.log('❌ goal 18 gate failed'); process.exit(1)

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -42,8 +42,8 @@ export async function learn(lesson: string): Promise<void> {
     process.exitCode = 1
     return
   }
-  // Goal 18(v2.0 breaking): 교훈은 memory v2 failures.lesson 단일 SoT 로 통합.
-  // (과거: learnings.md 별도 기록 + "SoT 분리". v2 에서 이중기록 폐지 — learnings.md 는 마이그레이션으로 흡수.)
+  // Goal 18(v2.0 breaking): 교훈은 memory v2 failures.lesson 한 곳(단일 출처)에 모은다.
+  // (과거엔 learnings.md 에 따로 적었으나 v2 는 통합 — learnings.md 기존 항목은 마이그레이션으로 흡수.)
   const goalId = activeGoalId()
   const entry = recordLesson(process.cwd(), lesson, goalId)
   console.log(chalk.green(`  ✅ 교훈 기록 → memory failures.lesson (${entry.id})`))

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -3,11 +3,11 @@ import { ko } from '../i18n/ko.js'
 import { listGoals } from '../lib/goal-frontmatter.js'
 import {
   appendBlocker,
-  appendLearning,
   clearHardStop,
   isHardStopActive,
   readHardStopReason,
 } from '../lib/state-files.js'
+import { recordLesson } from './memory.js'
 import { selectActiveId } from './goal.js'
 
 function activeGoalId(): number | undefined {
@@ -42,12 +42,12 @@ export async function learn(lesson: string): Promise<void> {
     process.exitCode = 1
     return
   }
+  // Goal 18(v2.0 breaking): 교훈은 memory v2 failures.lesson 단일 SoT 로 통합.
+  // (과거: learnings.md 별도 기록 + "SoT 분리". v2 에서 이중기록 폐지 — learnings.md 는 마이그레이션으로 흡수.)
   const goalId = activeGoalId()
-  appendLearning(lesson, goalId)
-  console.log(chalk.green('  ✅ learnings.md append.'))
-  console.log(
-    chalk.dim('  결정사항(decision)은 `vhk memory add` 로 별도 기록 — SoT 분리.')
-  )
+  const entry = recordLesson(process.cwd(), lesson, goalId)
+  console.log(chalk.green(`  ✅ 교훈 기록 → memory failures.lesson (${entry.id})`))
+  console.log(chalk.dim('  교훈·결정·실패·성공 모두 vhk memory (단일 SoT). vhk memory list 로 확인.'))
 }
 
 export interface ResumeOptions {

--- a/src/commands/brief.ts
+++ b/src/commands/brief.ts
@@ -91,18 +91,16 @@ export async function brief(): Promise<void> {
   )
   lines.push('')
 
-  // 3. 기억 (memory v2 4버킷 — active 만)
-  if (existsSync('.vhk/memory.json')) {
-    try {
-      const memLines = activeMemoryLines(readMemory(process.cwd()))
-      if (memLines.length > 0) {
-        lines.push('## 저장된 기억 (memory v2)')
-        lines.push('')
-        lines.push(...memLines)
-      }
-    } catch {
-      // 무시
+  // 3. 기억 (memory v2 4버킷 — active 만). readMemory 가 v1·learnings 흡수 처리 → 부재여도 흡수분 노출.
+  try {
+    const memLines = activeMemoryLines(readMemory(process.cwd()))
+    if (memLines.length > 0) {
+      lines.push('## 저장된 기억 (memory v2)')
+      lines.push('')
+      lines.push(...memLines)
     }
+  } catch {
+    // 무시
   }
 
   // 4. 레퍼런스

--- a/src/commands/brief.ts
+++ b/src/commands/brief.ts
@@ -4,6 +4,7 @@ import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { safeExecFile } from '../lib/exec.js'
 import { readJsonFile } from '../lib/read-json.js'
+import { readMemory, activeMemoryLines } from './memory.js'
 
 const BRIEF_PATH = '.vhk/brief.md'
 
@@ -90,20 +91,14 @@ export async function brief(): Promise<void> {
   )
   lines.push('')
 
-  // 3. 결정사항
+  // 3. 기억 (memory v2 4버킷 — active 만)
   if (existsSync('.vhk/memory.json')) {
     try {
-      const memories = readJsonFile<Array<{ content: string }>>('.vhk/memory.json')
-      if (Array.isArray(memories) && memories.length > 0) {
-        lines.push(`## 저장된 결정사항 (${memories.length}개)`)
+      const memLines = activeMemoryLines(readMemory(process.cwd()))
+      if (memLines.length > 0) {
+        lines.push('## 저장된 기억 (memory v2)')
         lines.push('')
-        for (const m of memories.slice(-5)) {
-          lines.push(`- ${m.content}`)
-        }
-        if (memories.length > 5) {
-          lines.push(`- ... 외 ${memories.length - 5}개`)
-        }
-        lines.push('')
+        lines.push(...memLines)
       }
     } catch {
       // 무시

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -14,7 +14,7 @@ import { readJsonFile } from '../lib/read-json.js'
 import { readMemory, activeMemoryLines } from './memory.js'
 import { listGoals } from '../lib/goal-frontmatter.js'
 import { selectActiveId } from './goal.js'
-import { getRecentLearnings, getActiveBlockers, isHardStopActive } from '../lib/state-files.js'
+import { getActiveBlockers, isHardStopActive } from '../lib/state-files.js'
 import { gitOut } from '../lib/git-repo.js'
 import { CONTEXT_GIT_MARKER } from '../lib/drift.js'
 
@@ -189,18 +189,17 @@ export async function context(opts: { compact?: boolean } = {}): Promise<void> {
     lines.push('')
   }
 
-  if (existsSync('.vhk/memory.json')) {
-    try {
-      // memory v2 4버킷 — active 만 누락 없이 (버킷별 최근 5개, 토큰 절감).
-      const memLines = activeMemoryLines(readMemory(process.cwd()))
-      if (memLines.length > 0) {
-        lines.push('## 저장된 기억 (memory v2)')
-        lines.push('')
-        lines.push(...memLines)
-      }
-    } catch {
-      // memory.json 파싱 실패 → 무시
+  try {
+    // memory v2 4버킷 — active 만 누락 없이(버킷별 최근 5개). readMemory 가 v1·learnings 흡수까지
+    // 처리하므로 memory.json 부재여도 learnings 흡수분이 여기서 노출(교훈 단일 출처).
+    const memLines = activeMemoryLines(readMemory(process.cwd()))
+    if (memLines.length > 0) {
+      lines.push('## 저장된 기억 (memory v2)')
+      lines.push('')
+      lines.push(...memLines)
     }
+  } catch {
+    // memory.json 파싱 실패 → 무시
   }
 
   // Goal 2 (자율 루프): active goal + 최근 learnings 3건 자동 포함.
@@ -221,13 +220,8 @@ export async function context(opts: { compact?: boolean } = {}): Promise<void> {
     }
   }
 
-  const recent = getRecentLearnings(3)
-  if (recent.length > 0) {
-    lines.push('## Recent Learnings')
-    lines.push('')
-    for (const r of recent) lines.push(r)
-    lines.push('')
-  }
+  // 교훈(learnings)은 v2 에서 memory failures.lesson 로 통합 — 위 "저장된 기억" 섹션에서 노출.
+  // (구 docs/state/learnings.md Recent Learnings 블록 제거 — 중복·stale 방지.)
 
   // 활성 blocker 최근 3건 — "지금 막힌 것"만. 해결(~~취소선~~) 항목은 제외.
   const activeBlockers = getActiveBlockers(3)

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -11,6 +11,7 @@ import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { readJsonFile } from '../lib/read-json.js'
+import { readMemory, activeMemoryLines } from './memory.js'
 import { listGoals } from '../lib/goal-frontmatter.js'
 import { selectActiveId } from './goal.js'
 import { getRecentLearnings, getActiveBlockers, isHardStopActive } from '../lib/state-files.js'
@@ -190,23 +191,12 @@ export async function context(opts: { compact?: boolean } = {}): Promise<void> {
 
   if (existsSync('.vhk/memory.json')) {
     try {
-      const memories = readJsonFile<Array<{ content: string; addedAt: string }>>(
-        '.vhk/memory.json'
-      )
-      if (Array.isArray(memories) && memories.length > 0) {
-        // 토큰 절감: 전체가 아니라 최근 5개만 삽입 (full/compact 공통).
-        const recentMemories = memories.slice(-5)
-        lines.push('## 저장된 결정사항')
+      // memory v2 4버킷 — active 만 누락 없이 (버킷별 최근 5개, 토큰 절감).
+      const memLines = activeMemoryLines(readMemory(process.cwd()))
+      if (memLines.length > 0) {
+        lines.push('## 저장된 기억 (memory v2)')
         lines.push('')
-        if (memories.length > recentMemories.length) {
-          lines.push(`_최근 ${recentMemories.length}개만 표시 (전체 ${memories.length}개)_`)
-          lines.push('')
-        }
-        for (const m of recentMemories) {
-          const date = new Date(m.addedAt).toLocaleDateString('ko-KR')
-          lines.push(`- ${m.content} _(${date})_`)
-        }
-        lines.push('')
+        lines.push(...memLines)
       }
     } catch {
       // memory.json 파싱 실패 → 무시

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -142,7 +142,7 @@ function getVhkCommands(): string[] {
 /**
  * vhk context — LLM 부팅 컨텍스트(.vhk/context.md) 생성.
  * compact 모드(--compact): 토큰 절감형. 전체 명령 목록/깊은 트리 대신 Active Goal +
- * 최근 learnings/blockers/memories + 참조 문서 링크만 담는다. 기본(full)은 기존 호환 유지.
+ * 최근 blockers + memory v2(결정/실패·교훈/성공) + 참조 문서 링크만 담는다. 기본(full)은 기존 호환 유지.
  */
 export async function context(opts: { compact?: boolean } = {}): Promise<void> {
   const compact = opts.compact === true
@@ -202,8 +202,8 @@ export async function context(opts: { compact?: boolean } = {}): Promise<void> {
     // memory.json 파싱 실패 → 무시
   }
 
-  // Goal 2 (자율 루프): active goal + 최근 learnings 3건 자동 포함.
-  // SoT 는 goals/<n>.md frontmatter + docs/state/learnings.md.
+  // Goal 2 (자율 루프): active goal 섹션. SoT 는 goals/<n>.md frontmatter.
+  // 교훈(learnings)은 v2 에서 memory failures.lesson 단일 출처 — 위 "저장된 기억(memory v2)" 섹션에서 노출.
   const goals = listGoals('goals')
   const activeId = selectActiveId(goals)
   if (activeId !== null) {

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -1,97 +1,328 @@
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync, copyFileSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
-import { readJsonFile } from '../lib/read-json.js'
+import { readJsonFile, stripBom } from '../lib/read-json.js'
 
-interface MemoryEntry {
+/**
+ * Goal 18: memory schema v2 — 평면 배열 → 4버킷(decisions/failures/successes/patterns).
+ * 교훈 단일 SoT(learn 통합), 항목 생명주기(status active/resolved/archived), 자동 마이그레이션(.bak).
+ * v1(평면 `[{content,addedAt,tags?}]`) → v2 멱등 변환. learnings.md(docs/state) → failures 흡수.
+ */
+
+export const MEMORY_PATH_REL = join('.vhk', 'memory.json')
+export const MEMORY_SCHEMA_VERSION = 2
+
+export type EntryStatus = 'active' | 'resolved' | 'archived'
+export type MemBucket = 'decision' | 'failure' | 'success'
+
+export interface MemEntry {
+  id: string
   content: string
-  addedAt: string
-  tags?: string[]
+  tags: string[]
+  createdAt: string
+  status: EntryStatus
+  resolvedAt?: string
+  archivedAt?: string
+}
+export interface FailEntry extends MemEntry {
+  why?: string
+  lesson?: string
+}
+export interface SuccessEntry extends MemEntry {
+  why?: string
+}
+/** Goal 19(pattern)에서 채움 — v0 은 빈 배열 + 최소 타입. */
+export interface PatternEntry {
+  id: string
+  [key: string]: unknown
 }
 
-const MEMORY_PATH = '.vhk/memory.json'
+export interface MemoryFileV2 {
+  schemaVersion: 2
+  decisions: MemEntry[]
+  failures: FailEntry[]
+  successes: SuccessEntry[]
+  patterns: PatternEntry[]
+}
 
-function loadMemories(): MemoryEntry[] {
-  if (!existsSync(MEMORY_PATH)) return []
-  try {
-    const parsed = readJsonFile<unknown>(MEMORY_PATH)
-    return Array.isArray(parsed) ? (parsed as MemoryEntry[]) : []
-  } catch {
-    return []
+function emptyV2(): MemoryFileV2 {
+  return { schemaVersion: MEMORY_SCHEMA_VERSION, decisions: [], failures: [], successes: [], patterns: [] }
+}
+
+function isV2(raw: unknown): raw is MemoryFileV2 {
+  return !!raw && typeof raw === 'object' && (raw as { schemaVersion?: number }).schemaVersion === 2
+}
+
+const BUCKET_PREFIX: Record<MemBucket, string> = { decision: 'd', failure: 'f', success: 's' }
+
+function arr<T>(v: unknown): T[] {
+  return Array.isArray(v) ? (v as T[]) : []
+}
+
+/** 이미 v2 인 객체를 안전 정규화(누락 버킷 채움). */
+function normalizeV2(raw: MemoryFileV2): MemoryFileV2 {
+  return {
+    schemaVersion: MEMORY_SCHEMA_VERSION,
+    decisions: arr<MemEntry>(raw.decisions),
+    failures: arr<FailEntry>(raw.failures),
+    successes: arr<SuccessEntry>(raw.successes),
+    patterns: arr<PatternEntry>(raw.patterns),
   }
 }
 
-function saveMemories(memories: MemoryEntry[]): void {
-  mkdirSync('.vhk', { recursive: true })
-  writeFileSync(MEMORY_PATH, JSON.stringify(memories, null, 2) + '\n', 'utf-8')
+/** learnings.md 본문 → { date, tag, lesson } 항목 파싱 (`- [YYYY-MM-DD goal-N] 교훈`). */
+function parseLearnings(rawLearnings: string): { date: string; tag: string; lesson: string }[] {
+  const out: { date: string; tag: string; lesson: string }[] = []
+  for (const line of rawLearnings.split(/\r?\n/)) {
+    const m = line.match(/^-\s*\[(\d{4}-\d{2}-\d{2})\s+([^\]]*)\]\s*(.+)$/)
+    if (m) out.push({ date: m[1], tag: m[2].trim(), lesson: m[3].trim() })
+  }
+  return out
 }
 
-export async function memoryAdd(content: string, tags?: string[]): Promise<void> {
+/**
+ * **순수** v1→v2 마이그레이션. v1 평면배열 → decisions, learnings.md 본문 → failures(lesson, what 비움).
+ * 이미 v2 면 멱등(rawLearnings 무시 — 재흡수 안 함). fs/git/Date 부수효과 없음.
+ */
+export function migrateMemory(rawMemory: unknown, rawLearnings?: string): MemoryFileV2 {
+  if (isV2(rawMemory)) return normalizeV2(rawMemory)
+
+  const v2 = emptyV2()
+  // v1 평면 배열 → decisions
+  if (Array.isArray(rawMemory)) {
+    rawMemory.forEach((m, i) => {
+      const item = m as { content?: unknown; tags?: unknown; addedAt?: unknown }
+      if (item && typeof item.content === 'string') {
+        v2.decisions.push({
+          id: `d${i + 1}`,
+          content: item.content,
+          tags: arr<string>(item.tags),
+          createdAt: typeof item.addedAt === 'string' ? item.addedAt : '',
+          status: 'active',
+        })
+      }
+    })
+  }
+  // learnings.md → failures (실패 본문 없음: content/what 비우고 lesson 만)
+  if (rawLearnings) {
+    parseLearnings(rawLearnings).forEach((l, i) => {
+      v2.failures.push({
+        id: `f${i + 1}`,
+        content: '',
+        tags: l.tag ? [l.tag] : [],
+        createdAt: l.date,
+        status: 'active',
+        lesson: l.lesson,
+      })
+    })
+  }
+  return v2
+}
+
+// ── fs 경계 (impure) ──
+
+function readRaw(cwd: string): unknown {
+  const p = join(cwd, MEMORY_PATH_REL)
+  if (!existsSync(p)) return null
+  try {
+    return readJsonFile<unknown>(p)
+  } catch {
+    return null
+  }
+}
+
+// learnings.md 는 JSON 이 아니라 텍스트 — BOM-safe 로 읽되 JSON.parse 안 함.
+function readLearningsRaw(cwd: string): string | undefined {
+  const p = join(cwd, 'docs', 'state', 'learnings.md')
+  if (!existsSync(p)) return undefined
+  try {
+    return stripBom(readFileSync(p, 'utf-8'))
+  } catch {
+    return undefined
+  }
+}
+
+/** memory.json 읽기 → 항상 v2 반환(v1/없으면 in-memory 마이그레이션, learnings 흡수). */
+export function readMemory(cwd: string = process.cwd()): MemoryFileV2 {
+  const raw = readRaw(cwd)
+  if (isV2(raw)) return normalizeV2(raw)
+  return migrateMemory(raw, readLearningsRaw(cwd))
+}
+
+/** memory.json 쓰기 — 기존 파일 있으면 .bak 백업 후 v2 재기록. */
+export function writeMemory(cwd: string, mem: MemoryFileV2): void {
+  const p = join(cwd, MEMORY_PATH_REL)
+  mkdirSync(join(cwd, '.vhk'), { recursive: true })
+  if (existsSync(p)) {
+    try {
+      copyFileSync(p, p + '.bak')
+    } catch {
+      /* 백업 실패는 치명적 아님 */
+    }
+  }
+  writeFileSync(p, JSON.stringify(mem, null, 2) + '\n', 'utf-8')
+}
+
+// ── id / 순서 헬퍼 ──
+
+function nextId(bucket: MemBucket, mem: MemoryFileV2): string {
+  const prefix = BUCKET_PREFIX[bucket]
+  const list = bucket === 'decision' ? mem.decisions : bucket === 'failure' ? mem.failures : mem.successes
+  let max = 0
+  for (const e of list) {
+    const m = e.id.match(new RegExp(`^${prefix}(\\d+)$`))
+    if (m) max = Math.max(max, Number(m[1]))
+  }
+  return `${prefix}${max + 1}`
+}
+
+/** decisions→failures→successes 안정 순서(번호 = 이 순서의 1-based). patterns 제외. */
+function orderedAll(mem: MemoryFileV2): { bucket: MemBucket; entry: MemEntry }[] {
+  return [
+    ...mem.decisions.map((entry) => ({ bucket: 'decision' as const, entry })),
+    ...mem.failures.map((entry) => ({ bucket: 'failure' as const, entry })),
+    ...mem.successes.map((entry) => ({ bucket: 'success' as const, entry })),
+  ]
+}
+
+// ── 커맨드 ──
+
+export async function memoryAdd(
+  content: string,
+  opts: { tags?: string[]; type?: MemBucket; why?: string; lesson?: string } = {}
+): Promise<void> {
   console.log(chalk.bold('\n🧠 ' + t('memory.addTitle')))
   console.log(chalk.gray('─'.repeat(40)))
-
-  if (!content) {
+  if (!content || !content.trim()) {
     console.log(chalk.red('❌ 기억할 내용을 입력해주세요.'))
-    console.log(chalk.gray('   예: vhk memory add "API는 tRPC 사용하기로 결정"'))
-    // 저장 실패 → 비-0 종료(silent exit 0 방지). VHK-016.
+    console.log(chalk.gray('   예: vhk memory add "API는 tRPC 사용" --type decision'))
     process.exitCode = 1
     return
   }
+  const cwd = process.cwd()
+  const mem = readMemory(cwd)
+  const type: MemBucket = opts.type ?? 'decision'
+  const base: MemEntry = {
+    id: nextId(type, mem),
+    content: content.trim(),
+    tags: opts.tags && opts.tags.length > 0 ? opts.tags : [],
+    createdAt: new Date().toISOString(),
+    status: 'active',
+  }
+  if (type === 'failure') mem.failures.push({ ...base, why: opts.why, lesson: opts.lesson })
+  else if (type === 'success') mem.successes.push({ ...base, why: opts.why })
+  else mem.decisions.push(base)
+  writeMemory(cwd, mem)
 
-  const memories = loadMemories()
-  memories.push({
-    content,
-    addedAt: new Date().toISOString(),
-    tags: tags && tags.length > 0 ? tags : [],
-  })
-  saveMemories(memories)
-
-  console.log(chalk.green(`\n✅ 기억 저장됨 (#${memories.length})`))
-  console.log(chalk.cyan(`   📝 ${content}`))
-
-  printNextStep({
-    message: '기억 저장 완료!',
-    command: 'vhk memory list',
-    cursorHint: '기억 목록 보여줘',
-  })
+  console.log(chalk.green(`\n✅ 기억 저장됨 (${type} #${base.id})`))
+  console.log(chalk.cyan(`   📝 ${base.content}`))
+  printNextStep({ message: '기억 저장 완료!', command: 'vhk memory list', cursorHint: '기억 목록 보여줘' })
 }
 
-export async function memoryList(): Promise<void> {
+const STATUS_ICON: Record<EntryStatus, string> = { active: '🟢', resolved: '✅', archived: '📦' }
+const BUCKET_LABEL: Record<MemBucket, string> = { decision: '결정', failure: '실패', success: '성공' }
+
+export async function memoryList(opts: { type?: MemBucket; all?: boolean } = {}): Promise<void> {
   console.log(chalk.bold('\n🧠 ' + t('memory.listTitle')))
   console.log(chalk.gray('─'.repeat(40)))
+  const mem = readMemory(process.cwd())
+  const all = orderedAll(mem)
+  const visible = all
+    .map((x, i) => ({ ...x, n: i + 1 }))
+    .filter((x) => (opts.all || x.entry.status === 'active') && (!opts.type || x.bucket === opts.type))
 
-  const memories = loadMemories()
-  if (memories.length === 0) {
-    console.log(chalk.yellow('\n📭 저장된 기억이 없습니다.'))
-    console.log(chalk.gray('   vhk memory add "내용"으로 추가하세요.'))
+  if (visible.length === 0) {
+    console.log(chalk.yellow('\n📭 표시할 기억이 없습니다.'))
+    console.log(chalk.gray('   vhk memory add "내용" --type decision|failure|success'))
     return
   }
+  console.log(chalk.cyan(`\n${visible.length}개${opts.all ? ' (보관 포함)' : ' (활성)'}:\n`))
+  for (const x of visible) {
+    const e = x.entry
+    const fail = e as FailEntry
+    console.log(`  [${x.n}] ${STATUS_ICON[e.status]} (${BUCKET_LABEL[x.bucket]}) ${e.content || (fail.lesson ? '💡 ' + fail.lesson : '(내용 없음)')}`)
+    if (fail.lesson && e.content) console.log(chalk.dim(`      💡 교훈: ${fail.lesson}`))
+    if (fail.why) console.log(chalk.dim(`      ↳ ${fail.why}`))
+    if (e.tags.length > 0) console.log(chalk.blue(`      🏷️  ${e.tags.join(', ')}`))
+  }
+}
 
-  console.log(chalk.cyan(`\n총 ${memories.length}개의 기억:\n`))
-  memories.forEach((m, index) => {
-    const date = new Date(m.addedAt).toLocaleDateString('ko-KR')
-    console.log(chalk.white(`  [${index + 1}] ${m.content}`))
-    if (m.tags && m.tags.length > 0) {
-      console.log(chalk.blue(`      🏷️  ${m.tags.join(', ')}`))
-    }
-    console.log(chalk.gray(`      📅 ${date}`))
-    console.log('')
-  })
+function resolveIndex(indexStr: string, len: number): number | null {
+  const idx = parseInt(indexStr, 10) - 1
+  if (Number.isNaN(idx) || idx < 0 || idx >= len) return null
+  return idx
 }
 
 export async function memoryRemove(indexStr: string): Promise<void> {
-  const memories = loadMemories()
-  const idx = parseInt(indexStr, 10) - 1
-
-  if (Number.isNaN(idx) || idx < 0 || idx >= memories.length) {
-    console.log(chalk.red(`❌ 유효하지 않은 번호입니다. (1~${memories.length || 0})`))
+  const cwd = process.cwd()
+  const mem = readMemory(cwd)
+  const all = orderedAll(mem)
+  const idx = resolveIndex(indexStr, all.length)
+  if (idx === null) {
+    console.log(chalk.red(`❌ 유효하지 않은 번호입니다. (1~${all.length || 0})`))
+    process.exitCode = 1
     return
   }
-
-  const removed = memories.splice(idx, 1)[0]
-  saveMemories(memories)
-
+  const { bucket, entry } = all[idx]
+  const list = bucket === 'decision' ? mem.decisions : bucket === 'failure' ? mem.failures : mem.successes
+  const pos = list.findIndex((e) => e.id === entry.id)
+  if (pos >= 0) list.splice(pos, 1)
+  writeMemory(cwd, mem)
   console.log(chalk.green('\n✅ 기억 삭제됨:'))
-  console.log(chalk.gray(`   ${removed.content}`))
+  console.log(chalk.gray(`   ${entry.content || (entry as FailEntry).lesson || entry.id}`))
+}
+
+export async function memoryArchive(indexStr: string): Promise<void> {
+  const cwd = process.cwd()
+  const mem = readMemory(cwd)
+  const all = orderedAll(mem)
+  const idx = resolveIndex(indexStr, all.length)
+  if (idx === null) {
+    console.log(chalk.red(`❌ 유효하지 않은 번호입니다. (1~${all.length || 0})`))
+    process.exitCode = 1
+    return
+  }
+  const { entry } = all[idx]
+  entry.status = 'archived'
+  entry.archivedAt = new Date().toISOString()
+  writeMemory(cwd, mem)
+  console.log(chalk.green(`\n📦 보관됨: ${entry.content || (entry as FailEntry).lesson || entry.id}`))
+  console.log(chalk.dim('   (패턴 감지·진화에서 제외됩니다 — 선순환)'))
+}
+
+export async function memoryMigrate(): Promise<void> {
+  const cwd = process.cwd()
+  const raw = readRaw(cwd)
+  if (isV2(raw)) {
+    console.log(chalk.dim('  이미 memory schema v2 입니다 — 변경 없음(멱등).'))
+    return
+  }
+  const v2 = migrateMemory(raw, readLearningsRaw(cwd))
+  writeMemory(cwd, v2)
+  console.log(chalk.green('\n✅ memory.json v1 → v2 마이그레이션 완료 (.bak 백업)'))
+  console.log(
+    chalk.dim(
+      `   decisions ${v2.decisions.length} · failures ${v2.failures.length} · successes ${v2.successes.length}` +
+        ` (learnings.md 교훈 흡수 — 이후 vhk learn 은 memory 에 기록)`
+    )
+  )
+}
+
+/** Goal 18: vhk learn → memory v2 failures.lesson 단일 SoT (learnings.md 신규 기록 중단). */
+export function recordLesson(cwd: string, lesson: string, goalId?: number): FailEntry {
+  const mem = readMemory(cwd)
+  const tag = goalId !== undefined ? `goal-${goalId}` : 'no-goal'
+  const entry: FailEntry = {
+    id: nextId('failure', mem),
+    content: '',
+    tags: [tag],
+    createdAt: new Date().toISOString(),
+    status: 'active',
+    lesson: lesson.trim(),
+  }
+  mem.failures.push(entry)
+  writeMemory(cwd, mem)
+  return entry
 }

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -151,11 +151,25 @@ export function readMemory(cwd: string = process.cwd()): MemoryFileV2 {
   return migrateMemory(raw, readLearningsRaw(cwd))
 }
 
-/** memory.json 쓰기 — 기존 파일 있으면 .bak 백업 후 v2 재기록. */
+/**
+ * memory.json 쓰기.
+ * - `.v1.bak` = **v1 원본 write-once 영구 백업** — 마이그레이션 순간(디스크가 v1)에 1회만 생성,
+ *   이미 있으면 안 덮음. 후속 add/archive/remove 가 v1 원본을 절대 못 지운다(breaking 복구 보장).
+ * - `.bak` = **롤링 백업** — 매 쓰기마다 직전 상태 보존(직전 1단계 되돌리기용).
+ */
 export function writeMemory(cwd: string, mem: MemoryFileV2): void {
   const p = join(cwd, MEMORY_PATH_REL)
   mkdirSync(join(cwd, '.vhk'), { recursive: true })
   if (existsSync(p)) {
+    // 마이그레이션 순간(디스크가 v1)에 v1 원본을 write-once 보존.
+    if (!isV2(readRaw(cwd)) && !existsSync(p + '.v1.bak')) {
+      try {
+        copyFileSync(p, p + '.v1.bak')
+      } catch {
+        /* 백업 실패는 치명적 아님 */
+      }
+    }
+    // 롤링 .bak (매 쓰기 직전 상태).
     try {
       copyFileSync(p, p + '.bak')
     } catch {
@@ -301,13 +315,40 @@ export async function memoryMigrate(): Promise<void> {
   }
   const v2 = migrateMemory(raw, readLearningsRaw(cwd))
   writeMemory(cwd, v2)
-  console.log(chalk.green('\n✅ memory.json v1 → v2 마이그레이션 완료 (.bak 백업)'))
+  console.log(chalk.green('\n✅ memory.json v1 → v2 마이그레이션 완료 (.v1.bak 원본 영구 백업)'))
   console.log(
     chalk.dim(
       `   decisions ${v2.decisions.length} · failures ${v2.failures.length} · successes ${v2.successes.length}` +
         ` (learnings.md 교훈 흡수 — 이후 vhk learn 은 memory 에 기록)`
     )
   )
+}
+
+/**
+ * vhk context / brief 용 — active 항목 요약 markdown 라인 (4버킷, 빈 버킷 생략, 버킷별 최근 limit).
+ * 누락 없이 decisions/failures/successes/patterns 의 active 만 렌더.
+ */
+export function activeMemoryLines(mem: MemoryFileV2, limit = 5): string[] {
+  const lines: string[] = []
+  const fmt = (e: MemEntry): string => {
+    const f = e as FailEntry
+    const base = e.content || (f.lesson ? `💡 ${f.lesson}` : e.id)
+    return e.content && f.lesson ? `${base} — 💡 ${f.lesson}` : base
+  }
+  const section = (label: string, list: MemEntry[]): void => {
+    const act = list.filter((e) => e.status === 'active')
+    if (act.length === 0) return
+    lines.push(`**${label}** (${act.length})`)
+    for (const e of act.slice(-limit)) lines.push(`- ${fmt(e)}`)
+    if (act.length > limit) lines.push(`- … 외 ${act.length - limit}개`)
+    lines.push('')
+  }
+  section('결정 (decisions)', mem.decisions)
+  section('실패·교훈 (failures)', mem.failures)
+  section('성공 (successes)', mem.successes)
+  const pats = mem.patterns.length
+  if (pats > 0) lines.push(`**패턴 후보 (patterns)**: ${pats}개 — \`vhk pattern\``, '')
+  return lines
 }
 
 /** Goal 18: vhk learn → memory v2 failures.lesson 단일 SoT (learnings.md 신규 기록 중단). */

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -144,11 +144,19 @@ function readLearningsRaw(cwd: string): string | undefined {
   }
 }
 
-/** memory.json 읽기 → 항상 v2 반환(v1/없으면 in-memory 마이그레이션, learnings 흡수). */
+/**
+ * memory.json 읽기 → 항상 v2.
+ * **계약 일관성**: 디스크가 v1 이면 read 경로(memory list / context / brief 등)에서도 1회 실제
+ * 마이그레이션을 영구화(v2 write + .v1.bak) — 어느 명령으로 첫 실행해도 동일 결과.
+ * 멱등: 이미 v2 면 no-op(재흡수·재기록 없음). 파일이 아예 없으면 빈 v2 만 반환(쓰지 않음).
+ */
 export function readMemory(cwd: string = process.cwd()): MemoryFileV2 {
   const raw = readRaw(cwd)
   if (isV2(raw)) return normalizeV2(raw)
-  return migrateMemory(raw, readLearningsRaw(cwd))
+  const v2 = migrateMemory(raw, readLearningsRaw(cwd))
+  // 디스크에 v1 파일이 실재할 때만 영구화(없는데 read 하면서 빈 파일 만들지 않음).
+  if (existsSync(join(cwd, MEMORY_PATH_REL))) writeMemory(cwd, v2)
+  return v2
 }
 
 /**

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -231,7 +231,8 @@ export function toAgentsMd(sections: RulesSection[], projectName: string): strin
     '## Loop Protocol',
     '- 루프: `context → goal next → 작업 → goal check → goal done`',
     '- 작업 시작 시 `.vhk/HARD_STOP` 확인 — 있으면 모든 자동화 즉시 중단.',
-    '- active goal 만 작업. `docs/state`(next-task/blockers/learnings)는 SoT, append-only.',
+    '- active goal 만 작업. `docs/state`(next-task/blockers)는 append-only.',
+    '- 교훈·결정·실패·성공은 `vhk memory`(memory v2 4버킷, 단일 출처).',
     '- 게이트(tsc / test:run / build) 통과해야만 `vhk goal done`.',
     '',
   ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import { audit } from './commands/audit.js'
 import { migrate } from './commands/migrate.js'
 import { update } from './commands/update.js'
 import { context, contextShow } from './commands/context.js'
-import { memoryAdd, memoryList, memoryRemove } from './commands/memory.js'
+import { memoryAdd, memoryList, memoryRemove, memoryArchive, memoryMigrate, type MemBucket } from './commands/memory.js'
 import { brief } from './commands/brief.js'
 import { start } from './commands/start.js'
 import { mode } from './commands/mode.js'
@@ -499,29 +499,48 @@ program
 const memoryCmd = program
   .command('memory')
   .alias('기억')
-  .description('결정사항 기억 관리 (add / list / remove)')
+  .description('기억 관리 v2 (decisions/failures/successes 4버킷) — add/list/remove/archive/migrate')
   .action(async () => { await memoryList() })
 
 memoryCmd
   .command('add <content>')
+  .option('--type <type>', '버킷: decision|failure|success (기본 decision)')
   .option('--tags <tags>', '태그 (쉼표 구분)')
-  .description('결정사항 기억 저장')
-  .action(async (content: string, opts: { tags?: string }) => {
+  .option('--why <why>', '원인 (failure/success)')
+  .option('--lesson <lesson>', '교훈 (failure)')
+  .description('기억 저장 (--type 으로 결정/실패/성공 구분)')
+  .action(async (content: string, opts: { type?: string; tags?: string; why?: string; lesson?: string }) => {
     const tags = opts.tags ? opts.tags.split(',').map((s) => s.trim()) : undefined
-    await memoryAdd(content, tags)
+    const type = (opts.type === 'failure' || opts.type === 'success' ? opts.type : 'decision') as MemBucket
+    await memoryAdd(content, { type, tags, why: opts.why, lesson: opts.lesson })
   })
 
 memoryCmd
   .command('list')
   .alias('목록')
-  .description('저장된 기억 목록')
-  .action(async () => { await memoryList() })
+  .option('--type <type>', '버킷 필터: decision|failure|success')
+  .option('--all', '보관(archived)·해결(resolved) 포함')
+  .description('저장된 기억 목록 (기본 활성만)')
+  .action(async (opts: { type?: string; all?: boolean }) => {
+    const type = (opts.type === 'decision' || opts.type === 'failure' || opts.type === 'success' ? opts.type : undefined) as MemBucket | undefined
+    await memoryList({ type, all: opts.all })
+  })
 
 memoryCmd
   .command('remove <index>')
   .alias('삭제')
   .description('기억 삭제 (1부터 시작하는 번호)')
   .action(async (index: string) => { await memoryRemove(index) })
+
+memoryCmd
+  .command('archive <index>')
+  .description('기억 보관 (활성→archived, 패턴/진화에서 제외)')
+  .action(async (index: string) => { await memoryArchive(index) })
+
+memoryCmd
+  .command('migrate')
+  .description('memory.json v1 → v2 마이그레이션 (.bak 백업, 멱등)')
+  .action(async () => { await memoryMigrate() })
 
 program
   .command('brief')

--- a/src/index.ts
+++ b/src/index.ts
@@ -539,7 +539,7 @@ memoryCmd
 
 memoryCmd
   .command('migrate')
-  .description('memory.json v1 → v2 마이그레이션 (.bak 백업, 멱등)')
+  .description('memory.json v1 → v2 마이그레이션 (.v1.bak 원본 영구 백업, 멱등)')
   .action(async () => { await memoryMigrate() })
 
 program
@@ -601,7 +601,7 @@ program
 program
   .command('learn <lesson>')
   .alias('교훈')
-  .description('교훈 기록 → docs/state/learnings.md append (memory.json 과 별도 SoT)')
+  .description('교훈 기록 → memory v2 failures.lesson 단일 SoT (v2.0 통합 — vhk memory list 로 확인)')
   .action(async (lesson: string) => { await learn(lesson) })
 
 program

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -9,7 +9,7 @@
 export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
   goal: ['list', 'next', 'check', 'init', 'done', 'sync'],
   ref: ['add', 'list', 'open'],
-  memory: ['add', 'list', 'remove'],
+  memory: ['add', 'list', 'remove', 'archive', 'migrate'],
   cloud: ['push', 'pull'],
   secure: ['scan'],
   design: ['palette'],

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -5,7 +5,7 @@
  * 사이에 기록하면 '어제' 날짜가 찍혀 하루 밀린다(블로커/학습/TIL/recap 로그 등 날짜 오기록).
  * `toLocaleDateString('sv-SE')` 는 로컬 타임존 + ISO 형식(YYYY-MM-DD)을 동시에 만족한다.
  *
- * 주의: 시각까지 필요한 머신 타임스탬프(생성시각 푸터·백업 파일명·HARD_STOP ts·memory addedAt)는
+ * 주의: 시각까지 필요한 머신 타임스탬프(생성시각 푸터·백업 파일명·HARD_STOP ts·memory createdAt)는
  *      Z(UTC) 표기가 명확하므로 `toISOString()` 을 그대로 둔다. 이 함수는 '날짜 표기' 전용.
  */
 export function localDate(d: Date = new Date()): string {

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -53,7 +53,7 @@ describe('blocker', () => {
   })
 })
 
-describe('learn — SoT 일관성 (memory.json 격리)', () => {
+describe('learn — memory v2 통합 SoT (Goal 18 breaking: learnings.md 분리 폐지)', () => {
   let origCwd: string
   let dir: string
   beforeEach(() => {
@@ -68,16 +68,22 @@ describe('learn — SoT 일관성 (memory.json 격리)', () => {
     vi.restoreAllMocks()
   })
 
-  it('learn 호출은 learnings.md 만 갱신, memory.json 무영향 (Forbidden 이중 기록 금지)', async () => {
+  it('learn 호출은 memory v2 failures.lesson 에 기록, learnings.md 신규 기록 안 함 (통합)', async () => {
     const { learn } = await import('../src/commands/agent.js')
     await learn('새 교훈')
-    expect(existsSync(join(dir, 'docs/state/learnings.md'))).toBe(true)
-    expect(existsSync(join(dir, '.vhk/memory.json'))).toBe(false)
+    // 통합: memory.json 에 기록
+    expect(existsSync(join(dir, '.vhk/memory.json'))).toBe(true)
+    const mem = JSON.parse(readFileSync(join(dir, '.vhk/memory.json'), 'utf-8'))
+    expect(mem.schemaVersion).toBe(2)
+    expect(mem.failures[0].lesson).toBe('새 교훈')
+    // learnings.md 신규 기록 중단
+    expect(existsSync(join(dir, 'docs/state/learnings.md'))).toBe(false)
   })
 
   it('빈 lesson 이면 기록 안 함', async () => {
     const { learn } = await import('../src/commands/agent.js')
     await learn('  ')
+    expect(existsSync(join(dir, '.vhk/memory.json'))).toBe(false)
     expect(existsSync(join(dir, 'docs/state/learnings.md'))).toBe(false)
   })
 })

--- a/tests/brief.test.ts
+++ b/tests/brief.test.ts
@@ -88,7 +88,7 @@ describe('brief', () => {
     expect(md).toContain('없음 ✅')
   })
 
-  it('memory.json 있으면 결정사항 섹션 포함', async () => {
+  it('memory.json 있으면 기억 섹션 포함 (v1 배열 자동 마이그)', async () => {
     mockExistsSync.mockImplementation((p: unknown) => String(p).includes('memory.json'))
     mockReadFileSync.mockImplementation((p: unknown) => {
       if (String(p).includes('memory.json'))
@@ -100,7 +100,7 @@ describe('brief', () => {
     await brief()
 
     const md = String(mockWriteFileSync.mock.calls[0][1])
-    expect(md).toContain('저장된 결정사항')
+    expect(md).toContain('저장된 기억')
     expect(md).toContain('결정-1')
   })
 })

--- a/tests/brief.test.ts
+++ b/tests/brief.test.ts
@@ -99,7 +99,9 @@ describe('brief', () => {
     const { brief } = await import('../src/commands/brief.js')
     await brief()
 
-    const md = String(mockWriteFileSync.mock.calls[0][1])
+    // readMemory 가 v1 디스크를 v2 로 영구화(write)하므로 brief.md 쓰기를 경로로 특정한다.
+    const call = mockWriteFileSync.mock.calls.find((c) => String(c[0]).includes('brief.md'))
+    const md = String(call![1])
     expect(md).toContain('저장된 기억')
     expect(md).toContain('결정-1')
   })

--- a/tests/context-loop.test.ts
+++ b/tests/context-loop.test.ts
@@ -37,9 +37,10 @@ describe('vhk context — Goal 2 자율 루프 확장', () => {
     vi.restoreAllMocks()
   })
 
-  it('## Active Goal + ## Recent Learnings 섹션 포함', async () => {
+  it('## Active Goal + 교훈(memory v2 흡수) 섹션 포함', async () => {
     makeGoalFile(dir, 0, 'DONE', 'Done Goal')
     makeGoalFile(dir, 1, 'IN_PROGRESS', '진행 중 미션')
+    // v2: learnings.md 의 교훈은 readMemory 가 failures 로 흡수 → "저장된 기억" 섹션에 노출.
     const { appendLearning } = await import('../src/lib/state-files.js')
     appendLearning('lesson alpha')
     appendLearning('lesson bravo')
@@ -52,7 +53,7 @@ describe('vhk context — Goal 2 자율 루프 확장', () => {
     expect(out).toContain('## Active Goal')
     expect(out).toContain('id**: 1')
     expect(out).toContain('진행 중 미션')
-    expect(out).toContain('## Recent Learnings')
+    expect(out).toContain('저장된 기억') // v2 memory 섹션(구 Recent Learnings 통합)
     expect(out).toContain('lesson alpha')
     expect(out).toContain('lesson charlie')
   })

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -263,3 +263,72 @@ describe('memory v2 — activeMemoryLines + context/brief 렌더 (회귀)', () =
     fs.rmSync(d, { recursive: true, force: true })
   })
 })
+
+describe('memory v2 — read 경로 마이그레이션 계약 일관성 (어느 명령 먼저든 동일)', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+  })
+
+  function seedV1Project(d: string): void {
+    execFileSync('git', ['init'], { cwd: d, stdio: 'pipe' })
+    fs.writeFileSync(path.join(d, 'package.json'), JSON.stringify({ name: 't', version: '0.0.0' }), 'utf-8')
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    fs.writeFileSync(path.join(d, MEMORY_PATH_REL), JSON.stringify([{ content: 'v1 결정' }]), 'utf-8')
+  }
+  function assertMigrated(d: string): void {
+    const m = JSON.parse(fs.readFileSync(path.join(d, MEMORY_PATH_REL), 'utf-8'))
+    expect(m.schemaVersion).toBe(2) // 디스크에 v2 영구화
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL + '.v1.bak'))).toBe(true) // 원본 보존
+  }
+
+  it('memory list 첫 실행 → 디스크 v2 + .v1.bak', async () => {
+    const d = tmp()
+    seedV1(d, [{ content: 'v1 결정' }])
+    process.chdir(d)
+    await memoryList()
+    assertMigrated(d)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('context 첫 실행 → 디스크 v2 + .v1.bak (memory list 안 거쳐도 동일)', async () => {
+    const d = tmp()
+    seedV1Project(d)
+    process.chdir(d)
+    await context()
+    assertMigrated(d)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('brief 첫 실행 → 디스크 v2 + .v1.bak', async () => {
+    const d = tmp()
+    seedV1Project(d)
+    process.chdir(d)
+    await brief()
+    assertMigrated(d)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('이미 v2 → read 가 파일 변경/.v1.bak 생성 안 함 (멱등)', async () => {
+    const d = tmp()
+    const v2: MemoryFileV2 = { schemaVersion: 2, decisions: [{ id: 'd1', content: 'x', tags: [], createdAt: '', status: 'active' }], failures: [], successes: [], patterns: [] }
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    fs.writeFileSync(path.join(d, MEMORY_PATH_REL), JSON.stringify(v2, null, 2) + '\n', 'utf-8')
+    const before = fs.readFileSync(path.join(d, MEMORY_PATH_REL), 'utf-8')
+    process.chdir(d)
+    await memoryList()
+    expect(fs.readFileSync(path.join(d, MEMORY_PATH_REL), 'utf-8')).toBe(before) // 무변경
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL + '.v1.bak'))).toBe(false) // .v1.bak 미생성
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -1,117 +1,175 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  migrateMemory,
+  readMemory,
+  writeMemory,
+  recordLesson,
+  memoryAdd,
+  memoryList,
+  memoryRemove,
+  memoryArchive,
+  memoryMigrate,
+  MEMORY_PATH_REL,
+  type MemoryFileV2,
+} from '../src/commands/memory.js'
 
-const mockExistsSync = vi.fn()
-const mockReadFileSync = vi.fn()
-const mockWriteFileSync = vi.fn()
-const mockMkdirSync = vi.fn()
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mem-'))
+}
+function seedV1(d: string, arr: unknown[]): void {
+  fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+  fs.writeFileSync(path.join(d, MEMORY_PATH_REL), JSON.stringify(arr), 'utf-8')
+}
+function seedLearnings(d: string, body: string): void {
+  fs.mkdirSync(path.join(d, 'docs', 'state'), { recursive: true })
+  fs.writeFileSync(path.join(d, 'docs', 'state', 'learnings.md'), body, 'utf-8')
+}
+function read(d: string): MemoryFileV2 {
+  return JSON.parse(fs.readFileSync(path.join(d, MEMORY_PATH_REL), 'utf-8'))
+}
 
-vi.mock('node:fs', () => ({
-  existsSync: (...a: unknown[]) => mockExistsSync(...a),
-  readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
-  writeFileSync: (...a: unknown[]) => mockWriteFileSync(...a),
-  mkdirSync: (...a: unknown[]) => mockMkdirSync(...a),
-}))
+describe('memory v2 — migrateMemory (순수)', () => {
+  it('v1 평면 배열 → decisions (status active)', () => {
+    const v2 = migrateMemory([{ content: 'A', addedAt: '2026-01-01', tags: ['x'] }, { content: 'B' }])
+    expect(v2.schemaVersion).toBe(2)
+    expect(v2.decisions).toHaveLength(2)
+    expect(v2.decisions[0]).toMatchObject({ content: 'A', tags: ['x'], status: 'active' })
+    expect(v2.failures).toEqual([])
+  })
+  it('learnings.md 흡수 → failures (lesson, content 비움)', () => {
+    const learnings = '# Learnings\n\n- [2026-05-27 goal-1] 교훈 하나.\n- [2026-05-28 release] 교훈 둘.\n'
+    const v2 = migrateMemory([], learnings)
+    expect(v2.failures).toHaveLength(2)
+    expect(v2.failures[0].content).toBe('')
+    expect(v2.failures[0].lesson).toBe('교훈 하나.')
+    expect(v2.failures[0].tags).toEqual(['goal-1'])
+  })
+  it('이미 v2 면 멱등 (learnings 재흡수 안 함)', () => {
+    const once = migrateMemory([{ content: 'A' }], '- [2026-01-01 goal-1] L.\n')
+    const twice = migrateMemory(once, '- [2026-01-01 goal-1] L.\n')
+    expect(twice.decisions).toHaveLength(1)
+    expect(twice.failures).toHaveLength(1) // 두 번째 호출이 재흡수하지 않음
+  })
+})
 
-describe('memory', () => {
+describe('memory v2 — read/write (fs)', () => {
+  it('readMemory: v1 + learnings 흡수 → v2 (BOM-safe)', () => {
+    const d = tmp()
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    fs.writeFileSync(path.join(d, MEMORY_PATH_REL), '﻿' + JSON.stringify([{ content: 'BOM 결정' }]), 'utf-8')
+    seedLearnings(d, '- [2026-01-01 goal-2] BOM 교훈.\n')
+    const mem = readMemory(d)
+    expect(mem.decisions[0].content).toBe('BOM 결정')
+    expect(mem.failures[0].lesson).toBe('BOM 교훈.')
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+  it('writeMemory: 기존 파일 있으면 .bak 백업', () => {
+    const d = tmp()
+    seedV1(d, [{ content: '원본' }])
+    writeMemory(d, migrateMemory(readMemory(d)))
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL + '.bak'))).toBe(true)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})
+
+describe('memory v2 — recordLesson (learn 통합)', () => {
+  it('교훈 → failures.lesson + learnings.md 신규 기록 안 함', () => {
+    const d = tmp()
+    const entry = recordLesson(d, 'PowerShell 은 && 미지원', 7)
+    expect(entry.lesson).toBe('PowerShell 은 && 미지원')
+    const mem = read(d)
+    expect(mem.failures[0].lesson).toBe('PowerShell 은 && 미지원')
+    expect(mem.failures[0].tags).toEqual(['goal-7'])
+    expect(fs.existsSync(path.join(d, 'docs', 'state', 'learnings.md'))).toBe(false) // learnings.md 미생성
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})
+
+describe('memory v2 — 커맨드 (tmp+chdir)', () => {
+  let origCwd: string
   beforeEach(() => {
-    vi.resetAllMocks()
+    origCwd = process.cwd()
     vi.spyOn(console, 'log').mockImplementation(() => {})
     process.exitCode = 0
   })
   afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
     process.exitCode = 0
   })
 
-  it('모듈을 import 할 수 있다', async () => {
-    const mod = await import('../src/commands/memory.js')
-    expect(mod.memoryAdd).toBeDefined()
-    expect(mod.memoryList).toBeDefined()
-    expect(mod.memoryRemove).toBeDefined()
+  it('memoryAdd --type failure (--why --lesson) → failures 버킷, status active', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('테스트가 변경 미커버', { type: 'failure', why: '테스트 안 짬', lesson: '회귀 가드 먼저' })
+    const mem = read(d)
+    expect(mem.failures).toHaveLength(1)
+    expect(mem.failures[0]).toMatchObject({ why: '테스트 안 짬', lesson: '회귀 가드 먼저', status: 'active' })
+    expect(mem.decisions).toEqual([])
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
   })
 
-  it('memoryAdd — 빈 content면 쓰지 않음 + exitCode=1 (VHK-016 저장실패 비-0)', async () => {
-    const { memoryAdd } = await import('../src/commands/memory.js')
+  it('memoryAdd --type success (--why) → successes', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('롤백 빨랐다', { type: 'success', why: '백업 먼저' })
+    expect(read(d).successes[0]).toMatchObject({ why: '백업 먼저', status: 'active' })
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('memoryAdd 기본 → decisions, 빈 content → exit 1', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('API tRPC')
+    expect(read(d).decisions[0].content).toBe('API tRPC')
     await memoryAdd('')
-    expect(mockWriteFileSync).not.toHaveBeenCalled()
     expect(process.exitCode).toBe(1)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
   })
 
-  it('memoryAdd — 새 content면 .vhk/memory.json에 추가', async () => {
-    mockExistsSync.mockReturnValue(false)
-    const { memoryAdd } = await import('../src/commands/memory.js')
-    await memoryAdd('API는 tRPC 사용', ['decision', 'arch'])
-
-    expect(mockMkdirSync).toHaveBeenCalledWith('.vhk', { recursive: true })
-    const call = mockWriteFileSync.mock.calls[0]
-    expect(String(call[0])).toContain('memory.json')
-    const data = JSON.parse(String(call[1]))
-    expect(data).toHaveLength(1)
-    expect(data[0].content).toBe('API는 tRPC 사용')
-    expect(data[0].tags).toEqual(['decision', 'arch'])
-    expect(data[0].addedAt).toBeDefined()
+  it('memoryArchive → status archived (활성 목록서 제외, 선순환)', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('보관 대상')
+    await memoryArchive('1')
+    const mem = read(d)
+    expect(mem.decisions[0].status).toBe('archived')
+    expect(mem.decisions[0].archivedAt).toBeDefined()
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
   })
 
-  it('memoryAdd — 기존 항목에 append', async () => {
-    mockExistsSync.mockReturnValue(true)
-    mockReadFileSync.mockReturnValue(
-      JSON.stringify([{ content: '기존', addedAt: '2026-01-01', tags: [] }])
-    )
-    const { memoryAdd } = await import('../src/commands/memory.js')
-    await memoryAdd('새 결정')
-
-    const data = JSON.parse(String(mockWriteFileSync.mock.calls[0][1]))
-    expect(data).toHaveLength(2)
-    expect(data[0].content).toBe('기존')
-    expect(data[1].content).toBe('새 결정')
-  })
-
-  it('memoryList — 항목 0이면 안내만, read 호출 X', async () => {
-    mockExistsSync.mockReturnValue(false)
-    const { memoryList } = await import('../src/commands/memory.js')
-    await memoryList()
-    expect(mockReadFileSync).not.toHaveBeenCalled()
-  })
-
-  it('memoryList — 항목 출력', async () => {
-    mockExistsSync.mockReturnValue(true)
-    mockReadFileSync.mockReturnValue(
-      JSON.stringify([
-        { content: 'A', addedAt: '2026-01-01T00:00:00.000Z', tags: [] },
-        { content: 'B', addedAt: '2026-02-01T00:00:00.000Z', tags: ['db'] },
-      ])
-    )
-    const logSpy = vi.spyOn(console, 'log')
-    const { memoryList } = await import('../src/commands/memory.js')
-    await memoryList()
-    const joined = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
-    expect(joined).toContain('A')
-    expect(joined).toContain('B')
-    expect(joined).toContain('db')
-  })
-
-  it('memoryRemove — 유효하지 않은 인덱스면 쓰지 않음', async () => {
-    mockExistsSync.mockReturnValue(true)
-    mockReadFileSync.mockReturnValue(
-      JSON.stringify([{ content: 'A', addedAt: '2026-01-01', tags: [] }])
-    )
-    const { memoryRemove } = await import('../src/commands/memory.js')
-    await memoryRemove('99')
-    expect(mockWriteFileSync).not.toHaveBeenCalled()
-  })
-
-  it('memoryRemove — 유효한 인덱스면 삭제 후 저장', async () => {
-    mockExistsSync.mockReturnValue(true)
-    mockReadFileSync.mockReturnValue(
-      JSON.stringify([
-        { content: 'A', addedAt: '2026-01-01', tags: [] },
-        { content: 'B', addedAt: '2026-02-01', tags: [] },
-      ])
-    )
-    const { memoryRemove } = await import('../src/commands/memory.js')
+  it('memoryRemove → 해당 항목 삭제', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('지울것')
+    await memoryAdd('남길것')
     await memoryRemove('1')
+    const mem = read(d)
+    expect(mem.decisions).toHaveLength(1)
+    expect(mem.decisions[0].content).toBe('남길것')
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
 
-    const data = JSON.parse(String(mockWriteFileSync.mock.calls[0][1]))
-    expect(data).toHaveLength(1)
-    expect(data[0].content).toBe('B')
+  it('memoryMigrate → v1 파일을 v2 로 재기록 (.bak)', async () => {
+    const d = tmp()
+    seedV1(d, [{ content: '결정1' }])
+    seedLearnings(d, '- [2026-01-01 goal-1] 교훈1.\n')
+    process.chdir(d)
+    await memoryMigrate()
+    const mem = read(d)
+    expect(mem.schemaVersion).toBe(2)
+    expect(mem.decisions[0].content).toBe('결정1')
+    expect(mem.failures[0].lesson).toBe('교훈1.')
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL + '.bak'))).toBe(true)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
   })
 })

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { context } from '../src/commands/context.js'
+import { brief } from '../src/commands/brief.js'
+import { activeMemoryLines } from '../src/commands/memory.js'
 import {
   migrateMemory,
   readMemory,
@@ -169,6 +173,92 @@ describe('memory v2 — 커맨드 (tmp+chdir)', () => {
     expect(mem.decisions[0].content).toBe('결정1')
     expect(mem.failures[0].lesson).toBe('교훈1.')
     expect(fs.existsSync(path.join(d, MEMORY_PATH_REL + '.bak'))).toBe(true)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('.v1.bak = v1 원본 write-once 영구 보존 (후속 add/archive 가 못 덮음) + 롤링 .bak 은 최신', async () => {
+    const d = tmp()
+    seedV1(d, [{ content: '원본 결정' }]) // v1: 1개
+    process.chdir(d)
+    await memoryMigrate() // .v1.bak = v1 원본
+    await memoryAdd('새 결정') // v2 덮어쓰기
+    await memoryAdd('또 결정', { type: 'success' })
+    // .v1.bak 은 v1 평면 배열 원본 그대로
+    const v1bak = JSON.parse(fs.readFileSync(path.join(d, MEMORY_PATH_REL + '.v1.bak'), 'utf-8'))
+    expect(Array.isArray(v1bak)).toBe(true)
+    expect(v1bak).toHaveLength(1)
+    expect(v1bak[0].content).toBe('원본 결정')
+    // 롤링 .bak 은 직전(v2) 상태 — v2 객체
+    const bak = JSON.parse(fs.readFileSync(path.join(d, MEMORY_PATH_REL + '.bak'), 'utf-8'))
+    expect(bak.schemaVersion).toBe(2)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})
+
+describe('memory v2 — activeMemoryLines + context/brief 렌더 (회귀)', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+  })
+
+  it('activeMemoryLines — active decisions/failures/successes 렌더, archived 제외', () => {
+    const mem: MemoryFileV2 = {
+      schemaVersion: 2,
+      decisions: [
+        { id: 'd1', content: '활성 결정', tags: [], createdAt: '', status: 'active' },
+        { id: 'd2', content: '보관 결정', tags: [], createdAt: '', status: 'archived' },
+      ],
+      failures: [{ id: 'f1', content: '', tags: [], createdAt: '', status: 'active', lesson: '교훈X' }],
+      successes: [{ id: 's1', content: '성공Y', tags: [], createdAt: '', status: 'active' }],
+      patterns: [],
+    }
+    const out = activeMemoryLines(mem).join('\n')
+    expect(out).toContain('활성 결정')
+    expect(out).toContain('교훈X')
+    expect(out).toContain('성공Y')
+    expect(out).not.toContain('보관 결정') // archived 제외
+  })
+
+  function seedProject(d: string): void {
+    execFileSync('git', ['init'], { cwd: d, stdio: 'pipe' })
+    fs.writeFileSync(path.join(d, 'package.json'), JSON.stringify({ name: 't', version: '0.0.0' }), 'utf-8')
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    const mem: MemoryFileV2 = {
+      schemaVersion: 2,
+      decisions: [{ id: 'd1', content: 'tRPC 채택 결정', tags: ['api'], createdAt: '2026-01-01', status: 'active' }],
+      failures: [],
+      successes: [],
+      patterns: [],
+    }
+    fs.writeFileSync(path.join(d, MEMORY_PATH_REL), JSON.stringify(mem, null, 2), 'utf-8')
+  }
+
+  it('vhk context → context.md 에 v2 decision 노출', async () => {
+    const d = tmp()
+    seedProject(d)
+    process.chdir(d)
+    await context()
+    const md = fs.readFileSync(path.join(d, '.vhk', 'context.md'), 'utf-8')
+    expect(md).toContain('tRPC 채택 결정')
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('vhk brief → brief.md 에 v2 decision 노출', async () => {
+    const d = tmp()
+    seedProject(d)
+    process.chdir(d)
+    await brief()
+    const md = fs.readFileSync(path.join(d, '.vhk', 'brief.md'), 'utf-8')
+    expect(md).toContain('tRPC 채택 결정')
     process.chdir(origCwd)
     fs.rmSync(d, { recursive: true, force: true })
   })


### PR DESCRIPTION
## 요약
Goal 18 — 평면 memory.json → **4버킷**(decisions/failures/successes/patterns). `.vhk` 포맷 **breaking → v2.0.0**.

> ⚠️ #106(등록) 위 스택. goal done/v2.0.0 범프/CLAUDE·AGENTS 분리SoT 문구는 **STEP C**. goals/18 NOT_STARTED 유지.

## 핵심
- **순수 `migrateMemory`**: v1 평면배열→decisions, `docs/state/learnings.md`→failures(lesson, content 비움), 멱등(v2 재호출 무변경).
- **learn 통합(breaking)**: `vhk learn` → memory `failures.lesson` 단일 SoT. learnings.md 신규기록 중단(기존 흡수). `appendLearning` 제거.
- **생명주기**: 모든 항목 `status active|resolved|archived` + `memory archive`(선순환 — 패턴/진화 제외).
- **자동 마이그레이션 + `.bak` 백업**(데이터 손실 0). BOM-safe(readJsonFile).
- 무파괴: add(--type)/list([--type][--all])/remove 유지 + archive/migrate 추가.

## 게이트
- tsc OK / build OK / **678 pass**(회귀 0) / grep 0 / secure 0
- `vhk goal check --id 18` 고유검증 **8/8** ✓
- e2e: v1 memory + learnings.md → `migrate` → v2 4버킷(decisions 1·failures 2 흡수)+.bak / `learn` → failures.lesson(f3) + learnings.md 불변

## 의도적 계약 변경 (놓치지 않게)
기존 `vhk learn` Forbidden "memory 와 이중기록 금지(SoT 분리)" 를 v2.0 breaking 으로 **통합**. agent.test 계약 테스트도 v2로 갱신. CLAUDE.md/AGENTS.md 문구는 STEP C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)