### PR TITLE
feat(memory): memory v2 생명주기 완성 — resolve/unarchive + learn MCP 툴 + 마이그레이션 UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ dist/
 
 # VHK 개인 메모/참고링크 — 로컬 전용 (docs/spec.md 트래킹 정책)
 .vhk/memory.json
+# 백업·원자적 쓰기 임시 파일 (.bak / .v1.bak / .tmp) 도 로컬 전용 — 절대 커밋 금지
+.vhk/memory.json.*
 .vhk/refs.json
 # secret gist 포인터 (gistId) — 공개 repo 노출 방지 (VHK-022)
 .vhk/cloud.json

--- a/.vhk/.gitignore
+++ b/.vhk/.gitignore
@@ -1,0 +1,1 @@
+reports/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,8 @@ cache hit 최대화 위해 동일 순서로:
 
 iteration 끝에 비-자명한 교훈 1 건이라도 있으면:
 
-- `vhk learn "<교훈>"` — `docs/state/learnings.md` 에 한 줄 append
-- **단일 SoT**: `vhk memory add` 와 이중 기록 금지. 결정사항 = memory, 교훈 = learnings.
+- `vhk learn "<교훈>"` — memory v2 `failures.lesson` 에 기록 (v2.0 통합)
+- **단일 출처 (v2)**: 교훈·결정·실패·성공 모두 `vhk memory` 4버킷. `vhk memory list` 로 확인.
 
 ## HARD_STOP
 
@@ -101,7 +101,7 @@ iteration 끝에 비-자명한 교훈 1 건이라도 있으면:
 - MCP handler 안에서 inquirer 호출
 - `vhk resume` 의 자동 호출
 - `docs/state/{blockers,learnings}.md` 의 과거 항목 수정/삭제 (append-only)
-- `vhk learn` 와 `vhk memory add` 의 이중 기록 (SoT 분리: learnings = 교훈, memory = 결정사항)
+- `docs/state/learnings.md` 에 신규 교훈 직접 추가 (v2: 교훈은 `vhk learn` → memory)
 - 게이트 실패에도 `vhk goal done` 으로 마킹 (실패 = 보존)
 
 ## Tech Stack (do not deviate)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 (다음 릴리즈 누적 영역)
 
+## [2.0.0] - 2026-06-03
+
+> **BREAKING — memory schema v2 (Goal 18, Evolution Loop 도미노 2).** 평면 `.vhk/memory.json` →
+> 4버킷(decisions/failures/successes/patterns) + 교훈 단일 SoT(learn 통합). 패턴(19)·진화(20)의 학습 입력 토대.
+> GA 약속대로 `.vhk` 포맷 breaking 은 메이저에서.
+
+### Changed (BREAKING)
+
+- **`memory.json` v1 → v2** (`src/commands/memory.ts`) — 평면 배열 → `{ schemaVersion:2, decisions[],
+  failures[], successes[], patterns[] }`. 항목 생명주기 `status: active|resolved|archived`(+ `vhk memory archive`).
+  `add --type decision|failure|success`(failure: `--why`/`--lesson`, success: `--why`), `list [--type][--all]`,
+  `remove`, `migrate` 추가.
+- **`vhk learn` 통합** — 교훈을 `memory failures.lesson` **단일 SoT** 로 기록. `docs/state/learnings.md`
+  신규 기록 중단(과거 `vhk learn` 의 learnings.md 분리 기록 폐지). 기존 learnings.md 내용은 마이그레이션으로 흡수.
+
+### Migration (자동·무손상)
+
+- **자동 v1 → v2** — `vhk` 실행 시(`memory`/`context`/`brief`/`learn` 등) v1 파일이면 **read 경로에서도 1회**
+  v2 로 변환. 어느 명령으로 첫 실행해도 동일 결과(멱등 — 이미 v2 면 no-op).
+- **`.v1.bak` 원본 영구 백업**(write-once, 안 덮음) + `.bak` 롤링 백업 — 데이터 손실 0.
+- `context`/`brief` 는 v2 4버킷(active)을 "저장된 기억" 섹션에 렌더.
+
 ## [1.9.0] - 2026-06-03
 
 > **vhk mission — Mission Contract v0 (Goal 17, Trust Loop 배치 7).** 작업의 목표·허용/금지 범위를

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,17 +13,19 @@ tags: [process, documentation]
 
 - **레포:** <https://github.com/byh3071-cpu/vhk> (public)
 - **npm:** @byh3071/vhk (public, scoped)
-- **버전:** v1.9.0 (package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
+- **버전:** v2.0.0 (package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
 - **MCP tool:** 24/24 (Goal 0 DONE)
-- **테스트:** 674 pass (vitest)
+- **테스트:** 686 pass (vitest)
 - **패키지 매니저:** pnpm
 
 ## 현재 상태
 
-- **Phase:** Phase 5 이후 — Goal 17(vhk mission, 배치 7) DONE → v1.9.0 릴리즈 PR. Trust Loop scope/verify/review 층 완성.
+- **Phase:** Phase 5 이후 — Goal 18(memory schema v2, Evolution Loop 도미노 2) DONE → v2.0.0 릴리즈 PR (breaking). 다음 = Goal 19(vhk pattern).
 - **블로커:** 없음
-- **다음 액션:** 배치 8+(Evolution Loop — 반복 패턴 감지/evolve). publish 는 사람(2FA OTP).
+- **다음 액션:** Goal 19(vhk pattern, v2.1.0), 20(vhk evolve, v2.2.0). publish 는 사람(2FA OTP).
 - **마지막 업데이트:** 2026-06-03
+
+> **기억 SoT (v2):** 교훈·결정·실패·성공은 `vhk memory`(memory v2 4버킷, `vhk learn`→`failures.lesson`). `docs/state/learnings.md` 는 v2 마이그레이션으로 흡수·신규기록 중단(분리 폐지).
 
 ## 코딩 컨벤션
 
@@ -78,7 +80,7 @@ tags: [process, documentation]
 
 - 단계별 미션은 `goals/<n>-<name>.md` (YAML frontmatter + 표준 섹션)
 - 공통 게이트는 `goals/_meta.md` + `scripts/check-meta.sh`
-- 현재 상태 SoT 는 `docs/state/next-task.md` / `blockers.md` / `learnings.md`
+- 현재 상태 SoT 는 `docs/state/next-task.md` / `blockers.md` (교훈은 v2 부터 `vhk memory` failures.lesson — `learnings.md` 는 흡수·동결)
 - 자세한 규약은 `goals/_meta.md` 와 `goals/0-mcp-full-coverage.md` 참조
 
 ## Stability Gates (v1.3.1+)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,8 @@ tags: [process, documentation]
 - **레포:** <https://github.com/byh3071-cpu/vhk> (public)
 - **npm:** @byh3071/vhk (public, scoped)
 - **버전:** v2.0.0 (package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
-- **MCP tool:** 24/24 (Goal 0 DONE)
-- **테스트:** 686 pass (vitest)
+- **MCP tool:** 25 (Goal 0 24 + `learn` v2.0 쓰기 도구)
+- **테스트:** 702 pass (vitest)
 - **패키지 매니저:** pnpm
 
 ## 현재 상태

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -47,6 +47,20 @@ Cursor에게 한국어로 말해도 됩니다.
 
 > `mission` 은 작업의 목표·허용/금지 범위를 `.vhk/mission.json` 계약으로 선언하고, 변경 파일이 계약(scope/forbidden glob) 안인지 검증합니다. **경로 glob 기준**이며 objective 의미 부합은 검증하지 않습니다(보장 아님). forbidden 위반 시 exit 1.
 
+## 기억 v2 (memory — 4버킷)
+
+| 하고 싶은 것 | 터미널 명령 | Cursor에게 말하기 |
+|-------------|-----------|------------------|
+| 결정 기록 | `vhk memory add "tRPC 채택" --type decision` | "이거 기억해" |
+| 실패+교훈 기록 | `vhk memory add "테스트 미커버" --type failure --why "..." --lesson "회귀 가드 먼저"` | "이 실수 기억해" |
+| 성공 기록 | `vhk memory add "롤백 빨랐다" --type success --why "백업 먼저"` | "이 성공 기억해" |
+| 교훈만 빠르게 | `vhk learn "PowerShell 은 && 미지원"` | "교훈 남겨" |
+| 목록 | `vhk memory list [--type failure] [--all]` | "기억 보여줘" |
+| 보관(선순환) | `vhk memory archive <번호>` | "이거 보관해" |
+| v1→v2 변환 | `vhk memory migrate` | — |
+
+> **v2.0 BREAKING**: 평면 memory.json → 4버킷(결정/실패/성공/패턴). 첫 실행 시 자동 마이그레이션(`.bak` 백업). **교훈은 `vhk learn`·`memory failure --lesson` 단일 SoT** (구 `docs/state/learnings.md` 분리 폐지·흡수). 보관(archive)된 항목은 패턴·진화에서 제외(선순환).
+
 ## 환경 점검
 
 ```bash

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -59,7 +59,7 @@ Cursor에게 한국어로 말해도 됩니다.
 | 보관(선순환) | `vhk memory archive <번호>` | "이거 보관해" |
 | v1→v2 변환 | `vhk memory migrate` | — |
 
-> **v2.0 BREAKING**: 평면 memory.json → 4버킷(결정/실패/성공/패턴). 첫 실행 시 자동 마이그레이션(`.bak` 백업). **교훈은 `vhk learn`·`memory failure --lesson` 단일 SoT** (구 `docs/state/learnings.md` 분리 폐지·흡수). 보관(archive)된 항목은 패턴·진화에서 제외(선순환).
+> **v2.0 BREAKING**: 평면 memory.json → 4버킷(결정/실패/성공/패턴). **조회 명령(`vhk memory list`·`context`·`brief`) 첫 실행 시에도 v1→v2 자동 마이그레이션 + `.v1.bak` 원본 백업**(어느 명령으로 먼저 실행해도 동일). **교훈은 `vhk learn`·`memory failure --lesson` 단일 SoT** (구 `docs/state/learnings.md` 분리 폐지·흡수). 보관(archive)된 항목은 패턴·진화에서 제외(선순환).
 
 ## 환경 점검
 

--- a/README.md
+++ b/README.md
@@ -172,12 +172,12 @@ vhk 기획 끝났고 바로 시작
 | `vhk update` | `업데이트` | VHK CLI 최신 버전으로 셀프 업데이트 |
 | `vhk context` | `맥락` | 프로젝트 트리·스택·CLI 명령 목록을 `.vhk/context.md`로 자동 생성 (AI 어시스턴트용). `--compact` 로 토큰 절감형(Active Goal + 최근 blockers/learnings/memories + 참조 링크) 출력 |
 | `vhk context-show` | `맥락보기` | 현재 컨텍스트 파일 내용 출력 |
-| `vhk memory` | `기억` | 결정사항 기억 관리 (`add` / `list` / `remove`, `.vhk/memory.json` 기반, 태그 지원) |
+| `vhk memory` | `기억` | 기억 v2 4버킷(결정/실패/성공) 관리 (`add --type` / `list [--all]` / `remove` / `archive` / `migrate`, `.vhk/memory.json`) |
 | `vhk brief` | `브리핑` | 프로젝트 정보 + git 상태 + 결정사항 + 레퍼런스 통합 보고서 `.vhk/brief.md` |
 | `vhk goal` | `목표` | Goal 단계별 미션 관리 (`init` / `list` / `next` / `check` / `done`) — vspec/vooster 패턴 |
 | `vhk mission` | `미션` | 미션 계약(`set` / `check` / `clear`) — 작업 범위·금지선 선언·검증 (`.vhk/mission.json`, 경로 glob) |
 | `vhk blocker <설명>` | `블로커` | 블로커 1건 → `docs/state/blockers.md` append. 3건 누적 시 `.vhk/HARD_STOP` 자동 생성 |
-| `vhk learn <교훈>` | `교훈` | 교훈 1건 → `docs/state/learnings.md` append (memory.json 과 별도 SoT) |
+| `vhk learn <교훈>` | `교훈` | 교훈 1건 → `memory.json` `failures.lesson` 단일 SoT (v2.0 통합 — 구 learnings.md 분리 폐지) |
 | `vhk resume --confirm` | `재개` | `.vhk/HARD_STOP` 해제 (사람 확인 필요, 자동 호출 금지) |
 
 ### 자율 루프 (v1.3+)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ vhk gate          # 퀵 5문항 — GO / 다듬기 / 다른 아이디어
 | 🎯 **Goals 체계** | 단계별 미션 + 게이트 스크립트로 AI가 목표를 스스로 추적 | `vhk goal init` |
 | ▶️ **자율 루프** | `goal next → 작업 → goal check → goal done`. FAIL 시 `vhk blocker` 수동 기록 → 블로커 3건 누적 시 HARD_STOP 자동 | `vhk goal next` |
 | 🚧 **HARD_STOP 안전장치** | 블로커 3건 누적 → `.vhk/HARD_STOP` 트립와이어. `vhk resume --confirm` 만 해제 | `vhk blocker "<증상>"` |
-| 🔌 **MCP 24 tool** | Cursor·Claude Desktop 등에서 vhk를 채팅으로 호출 | `vhk mcp-init` |
+| 🔌 **MCP 25 tool** | Cursor·Claude Desktop 등에서 vhk를 채팅으로 호출 | `vhk mcp-init` |
 | 📋 **컨텍스트 영속화** | `.vhk/context.md` + `memory.json` + `brief.md` 로 세션 간 맥락 유지 | `vhk context` |
 | 🔀 **드리프트 감지** | 규칙 파일이 RULES.md와 어긋나거나 context가 코드보다 낡으면 자동 경고 (읽기전용) | `vhk doctor` |
 
@@ -172,7 +172,7 @@ vhk 기획 끝났고 바로 시작
 | `vhk update` | `업데이트` | VHK CLI 최신 버전으로 셀프 업데이트 |
 | `vhk context` | `맥락` | 프로젝트 트리·스택·CLI 명령 목록을 `.vhk/context.md`로 자동 생성 (AI 어시스턴트용). `--compact` 로 토큰 절감형(Active Goal + 최근 blockers/learnings/memories + 참조 링크) 출력 |
 | `vhk context-show` | `맥락보기` | 현재 컨텍스트 파일 내용 출력 |
-| `vhk memory` | `기억` | 기억 v2 4버킷(결정/실패/성공) 관리 (`add --type` / `list [--all]` / `remove` / `archive` / `migrate`). 조회 명령(`memory list`·`context`·`brief`) 첫 실행 시 v1→v2 자동 마이그레이션 + `.v1.bak` 원본 백업 |
+| `vhk memory` | `기억` | 기억 v2 4버킷(결정/실패/성공/패턴) 관리 (`add --type` / `list [--all]` / `remove` / `archive` / `resolve` / `unarchive` / `migrate`). 조회 명령(`memory list`·`context`·`brief`) 첫 실행 시 v1→v2 자동 마이그레이션 + `.v1.bak` 원본 백업. 손상 파일은 read 경로에서 보존(원자적 write) |
 | `vhk brief` | `브리핑` | 프로젝트 정보 + git 상태 + 결정사항 + 레퍼런스 통합 보고서 `.vhk/brief.md` |
 | `vhk goal` | `목표` | Goal 단계별 미션 관리 (`init` / `list` / `next` / `check` / `done`) — vspec/vooster 패턴 |
 | `vhk mission` | `미션` | 미션 계약(`set` / `check` / `clear`) — 작업 범위·금지선 선언·검증 (`.vhk/mission.json`, 경로 glob) |
@@ -228,12 +228,12 @@ vhk mcp-init           # .cursor/mcp.json 자동 생성
 # 예: "상태 알려줘" → Cursor가 vhk status 도구 호출
 ```
 
-노출되는 MCP 도구 **24개** (v1.1):
+노출되는 MCP 도구 **25개** (v2.0 — `learn` 추가):
 
 - **git 워크플로 (8)**: `save`, `undo`, `status`, `diff`, `ship`, `doctor`, `check`, `recap`
 - **환경/규칙 (4)**: `env`, `env-check`, `sync`, `secure`
 - **품질/감사 (3)**: `audit`, `harness`, `mcp-init`
-- **컨텍스트/기록 (4)**: `context`, `context-show`, `memory-list`, `brief`
+- **컨텍스트/기록 (5)**: `context`, `context-show`, `memory-list`, `brief`, `learn` (교훈 1줄 → memory v2 failures.lesson 기록, 유일한 쓰기 도구)
 - **dry-info (4)**: `deploy`, `publish`, `migrate`, `update` — 인터랙티브 본질이라 실제 실행 안 함, 진단/안내만
 - **레퍼런스 (1)**: `ref-list`
 
@@ -252,7 +252,7 @@ vhk mcp                # stdio 서버 시작 (Cursor가 자동으로 호출)
 | 기능 | 설명 |
 |------|------|
 | **context** | 프로젝트 디렉토리 트리(3-depth) + 기술 스택(Next/Nuxt/Vue/Svelte/TS/Tailwind/tsup/Vite/...) 자동 감지 + 29개+ VHK 명령어 목록을 `.vhk/context.md` 마크다운으로 생성. AI 어시스턴트가 프로젝트 맥락을 즉시 파악 |
-| **memory** | `.vhk/memory.json` 결정사항 기억 관리. `add <content> --tags X,Y` / `list` / `remove <번호>`. NL은 list만 (add/remove는 인자 필수 → commander 전용) |
+| **memory** | `.vhk/memory.json` 기억 v2 4버킷(결정/실패/성공/패턴) 관리. `add <content> --type decision\|failure\|success` / `list [--all]` / `remove` / `archive` / `resolve` / `unarchive` / `migrate`. 손상 파일은 read 경로에서 덮어쓰지 않고 보존(원자적 write + `.v1.bak`/`.bak` 백업). NL은 list·migrate (인자 필요한 add/remove/archive/resolve 는 commander 전용) |
 | **brief** | 프로젝트 정보 + git 상태(브랜치·마지막 커밋·미커밋 변경) + 최근 결정사항 + 레퍼런스를 한 화면에 + `.vhk/brief.md` 저장. `safeExecFile` 기반 (Windows .cmd shim 안전) |
 | **자연어 확장** | `"맥락 만들어줘"` → context · `"컨텍스트 보여줘"` → context-show · `"기억 목록"` → memory · `"프로젝트 브리핑 만들어줘"` / `"상태 요약"` → brief |
 
@@ -280,7 +280,7 @@ vhk brief               # 세션 종료 시 상태 보고서
 - **공개 API 안정성**: 명령어 이름, CLI 인자, `.vhk/` 파일 포맷은 v2.0까지 breaking change 없음
 - **deprecation 절차**: 명령어/옵션 제거 전 1개 마이너 버전(1.x.0)에서 deprecation 경고
 - **i18n 키**: `ko.ts`의 `t()` 키 이름은 안정. 신규 키 누적, 기존 키 미제거
-- **MCP 서버 도구**: v1.0 GA 의 8개 baseline 도구(save/undo/status/diff/ship/doctor/check/recap) 인터페이스 안정 — v1.1 에서 16개 추가되어 총 24개
+- **MCP 서버 도구**: v1.0 GA 의 8개 baseline 도구(save/undo/status/diff/ship/doctor/check/recap) 인터페이스 안정 — v1.1 에서 16개 추가(총 24개), v2.0 에서 `learn` 추가(총 25개)
 
 > **`vhk memory` vs Claude Code `auto memory`** — `vhk memory`는 **프로젝트 단위** 결정사항(`.vhk/memory.json`, 팀 공유). Claude Code의 `auto memory`는 **사용자 단위** (`~/.claude/projects/.../memory/`, 개인 컨텍스트). 둘은 별개.
 
@@ -331,7 +331,7 @@ vhk ref open 1          # 1번 레퍼런스를 브라우저로 열기
 
 | 기능 | 설명 |
 |------|------|
-| **MCP 서버** | `vhk mcp` — stdio MCP 서버 첫 도입 (v0.6.0 당시 8개 도구 — save/undo/status/diff/ship/doctor/check/recap). 현재 v1.6 기준 **24개** 로 확장 — 위 "Cursor와 MCP로 연동하기" 섹션 참조 |
+| **MCP 서버** | `vhk mcp` — stdio MCP 서버 첫 도입 (v0.6.0 당시 8개 도구 — save/undo/status/diff/ship/doctor/check/recap). 현재 v2.0 기준 **25개** 로 확장 (`learn` 포함) — 위 "Cursor와 MCP로 연동하기" 섹션 참조 |
 | **mcp-init** | `vhk mcp-init` — Cursor `.cursor/mcp.json` 자동 생성. 재시작 한 번으로 연동 완료 |
 | **자연어 라우팅 확장** | `vhk mcp설정` → `vhk mcp-init` 별칭 |
 | **보안** | MCP save 도구의 shell injection 차단 — 모든 git 호출에 shell 미경유 `safeExecFile` 사용 |

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ vhk 기획 끝났고 바로 시작
 | `vhk update` | `업데이트` | VHK CLI 최신 버전으로 셀프 업데이트 |
 | `vhk context` | `맥락` | 프로젝트 트리·스택·CLI 명령 목록을 `.vhk/context.md`로 자동 생성 (AI 어시스턴트용). `--compact` 로 토큰 절감형(Active Goal + 최근 blockers/learnings/memories + 참조 링크) 출력 |
 | `vhk context-show` | `맥락보기` | 현재 컨텍스트 파일 내용 출력 |
-| `vhk memory` | `기억` | 기억 v2 4버킷(결정/실패/성공) 관리 (`add --type` / `list [--all]` / `remove` / `archive` / `migrate`, `.vhk/memory.json`) |
+| `vhk memory` | `기억` | 기억 v2 4버킷(결정/실패/성공) 관리 (`add --type` / `list [--all]` / `remove` / `archive` / `migrate`). 조회 명령(`memory list`·`context`·`brief`) 첫 실행 시 v1→v2 자동 마이그레이션 + `.v1.bak` 원본 백업 |
 | `vhk brief` | `브리핑` | 프로젝트 정보 + git 상태 + 결정사항 + 레퍼런스 통합 보고서 `.vhk/brief.md` |
 | `vhk goal` | `목표` | Goal 단계별 미션 관리 (`init` / `list` / `next` / `check` / `done`) — vspec/vooster 패턴 |
 | `vhk mission` | `미션` | 미션 계약(`set` / `check` / `clear`) — 작업 범위·금지선 선언·검증 (`.vhk/mission.json`, 경로 glob) |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -44,19 +44,29 @@ updated: 2026-05-29
 
 ## 2. JSON 스키마
 
-### 2.1 `memory.json`
+### 2.1 `memory.json` (schema v2)
 
-의사결정·기억할 내용의 배열.
+**v2.0.0 BREAKING**: 평면 배열 → 4버킷 객체. v1(평면 배열)은 `vhk` 실행 시 자동 마이그레이션(`.bak` 백업, 멱등).
+교훈은 `failures.lesson` 단일 SoT (구 `docs/state/learnings.md` 흡수, `vhk learn` 통합).
 
 ```jsonc
-[
-  {
-    "content": "API는 tRPC 사용하기로 결정",  // string, 필수
-    "addedAt": "2026-05-29T12:00:00.000Z",     // string(ISO 8601), 필수
-    "tags": ["decision", "api"]                  // string[], 선택(기본 [])
-  }
-]
+{
+  "schemaVersion": 2,
+  "decisions": [
+    { "id": "d1", "content": "API는 tRPC", "tags": ["api"], "createdAt": "...", "status": "active" }
+  ],
+  "failures":  [
+    // status: active|resolved|archived (+resolvedAt/archivedAt). 패턴·진화는 active 만 본다.
+    { "id": "f1", "content": "테스트 미커버", "why": "...", "lesson": "회귀 가드 먼저", "tags": [], "createdAt": "...", "status": "active" }
+  ],
+  "successes": [
+    { "id": "s1", "content": "롤백 빨랐다", "why": "백업 먼저", "tags": [], "createdAt": "...", "status": "active" }
+  ],
+  "patterns": []  // Goal 19(vhk pattern)에서 채움
+}
 ```
+
+> v1 → v2: 평면 항목 → `decisions`, `docs/state/learnings.md` 교훈 → `failures`(lesson, content 비움). 마이그레이션 시 `memory.json.bak` 백업.
 
 ### 2.2 `refs.json`
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -66,7 +66,8 @@ updated: 2026-05-29
 }
 ```
 
-> v1 → v2: 평면 항목 → `decisions`, `docs/state/learnings.md` 교훈 → `failures`(lesson, content 비움). 마이그레이션 시 `memory.json.bak` 백업.
+> v1 → v2: 평면 항목 → `decisions`, `docs/state/learnings.md` 교훈 → `failures`(lesson, content 비움).
+> 백업: `memory.json.v1.bak`(v1 원본 write-once 영구) + `memory.json.bak`(롤링, 매 쓰기 직전).
 
 ### 2.2 `refs.json`
 

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -1,10 +1,10 @@
 # Next Task
 
-_Auto-updated 2026-06-02T15:01:18.941Z via `vhk goal next`._
+_Auto-updated 2026-06-02T15:52:17.916Z via `vhk goal next`._
 
 ```
-TASK: Goal 17 — vhk mission — Mission Contract (scope/intent 층) — P3
+TASK: Goal 18 — 기억 구조화 — memory schema v2 (4버킷 + learn 통합) — P1
   status: NOT_STARTED
-  priority: P3
-  file: goals\17-mission.md
+  priority: P1
+  file: goals\18-memory-schema-v2.md
 ```

--- a/goals/18-memory-schema-v2.md
+++ b/goals/18-memory-schema-v2.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 18
 title: 기억 구조화 — memory schema v2 (4버킷 + learn 통합) — P1
-status: NOT_STARTED
+status: DONE
 priority: P1
 version: v2.0.0
+completed: 2026-06-03
 ---
 
 # Goal 18: memory schema v2 (Evolution Loop 도미노 2)

--- a/goals/18-memory-schema-v2.md
+++ b/goals/18-memory-schema-v2.md
@@ -1,0 +1,56 @@
+---
+vhk_format: 1
+type: goal
+id: 18
+title: 기억 구조화 — memory schema v2 (4버킷 + learn 통합) — P1
+status: NOT_STARTED
+priority: P1
+version: v2.0.0
+---
+
+# Goal 18: memory schema v2 (Evolution Loop 도미노 2)
+
+> 출처: Evolution Loop 로드맵. 평면 memory.json → 4버킷 구조화. `.vhk` 포맷 breaking → **v2.0.0**.
+> 전제: Trust Loop(scope/verify/review) 완성. 기억을 패턴(19)·진화(20)의 학습 입력으로 구조화.
+
+## 현황 (18-A 코드 확인 결과)
+- **memory.json v1** = `.vhk/memory.json` **평면 JSON 배열** `[{ content, addedAt, tags? }]` (schemaVersion 없음).
+  `src/commands/memory.ts` `loadMemories`/`saveMemories`, `memoryAdd/List/Remove`. BOM-safe `readJsonFile` 사용.
+- **learn** = `src/commands/agent.ts:37` → `appendLearning`(`src/lib/state-files.ts`) → `docs/state/learnings.md` append.
+  현재 메시지(agent.ts:49) "결정사항은 vhk memory add — **SoT 분리**". ← 18에서 통합으로 갱신.
+- **learnings.md** = append-only `- [YYYY-MM-DD goal-N] 한 줄 교훈.` (실패와 무관한 독립 교훈 다수).
+- **독립 교훈 표현 결정:** learnings.md 항목 → `failures` 의 `FailEntry { what:'', why:'', lesson: 교훈텍스트 }`
+  (실패 본문 없음 → what 비우고 lesson 만 채움). 날짜/goal 태그는 tags 로 보존.
+- **"분리 SoT / 이중기록 금지" 문구 위치:** agent.ts:49(코드 메시지), CLAUDE.md, AGENTS.md → 18-C 에서 통합으로 갱신.
+
+## 동작 (파일·계약)
+- **v2 스키마**: `{ schemaVersion:2, decisions[], failures[], successes[], patterns[] }`.
+  - decisions: v1 평면 항목 이관. failures: `{...,why?,lesson?}`(교훈 단일 SoT). successes: `{...,why?}`. patterns: 19에서 채움(v0 빈 배열).
+  - 모든 항목 `status: 'active'|'resolved'|'archived'`(기본 active) + `resolvedAt?/archivedAt?`.
+- **자동 마이그레이션**(멱등): v1 배열 읽으면 v2 로 변환·`.bak` 백업 후 재기록. learnings.md 흡수 → failures.
+- **learn 통합(breaking)**: `vhk learn` → memory v2 `failures.lesson` 기록. learnings.md 신규 기록 중단(기존은 흡수).
+- 기존 `memory add/list/remove` 무파괴. BOM-safe. secret 미포함.
+
+## 철학
+① 기억은 학습 입력 — 구조화해야 패턴·진화가 본다 ② 교훈 단일 SoT(learn 통합, 이중기록 폐지) ③ 선순환(status+archive — 해결된 실수는 조용해짐) ④ 자동 마이그레이션·백업(데이터 손실 0) ⑤ GA 약속대로 breaking 은 메이저(v2.0.0).
+
+## Completion Check
+- [ ] memory.json `schemaVersion:2` + 4버킷(decisions/failures/successes/patterns)
+- [ ] failures `{what,why,lesson}` · successes `{what,why}` 타입
+- [ ] v1 평면 배열 → v2 자동 마이그레이션 (멱등 — v2 재실행 무변경) + `.bak` 백업
+- [ ] learn → memory v2 failures.lesson 통합 + docs/state/learnings.md 마이그레이션 흡수
+- [ ] "분리 SoT/이중기록 금지" 문구 갱신 (agent.ts·CLAUDE.md·AGENTS.md — 문서·코드 불일치 0)
+- [ ] 항목 status(active/resolved/archived) + `vhk memory archive <n>` 명령
+- [ ] 기존 memory add/list/remove 무파괴 (회귀 0) · BOM-safe
+- [ ] vhk goal sync → check-goal-18.mjs 생성 → vhk goal check --id 18 통과
+- [ ] CHANGELOG breaking 명시 + 공통 게이트(typecheck+test+build+secure)
+
+## 제외 범위
+- patterns 채우기(감지) → Goal 19. evolve/적용 → Goal 20.
+- 의미기반 분석(v0=구조/빈도). 외부 ML/LLM/라이브러리.
+- profile.json → Goal 20.
+
+## Mandatory Reading
+- src/commands/memory.ts (v1 평면 배열 + load/save)
+- src/commands/agent.ts (learn) + src/lib/state-files.ts (appendLearning/learnings.md)
+- src/lib/read-json.ts (readJsonFile/stripBom — BOM-safe)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "description": "Vibe Harness Kit — AI 코딩 도구·기기를 바꿔도 규칙·맥락이 따라가는 포터빌리티 CLI (sync: Cursor·Claude·Windsurf·Copilot·Antigravity / cloud 백업)",
   "bin": {
     "vhk": "dist/index.js",

--- a/scripts/check-goal-18.mjs
+++ b/scripts/check-goal-18.mjs
@@ -80,6 +80,7 @@ const walkTs = (dir) => {
 const scanTargets = [
   ...walkTs('src').filter((p) => !p.endsWith('commands/memory.ts')),
   'AGENTS.md', 'CLAUDE.md', 'docs/ARCHITECTURE.md', 'docs/context/agent-compact.md',
+  'README.md', 'COMMANDS.md', 'docs/spec.md',
 ].filter((p) => existsSync(p))
 const forbiddenHits = scanTargets.filter((f) => FORBIDDEN.test(readFileSync(f, 'utf-8')))
 must(forbiddenHits.length === 0, `learnings 분리 SoT 금지문구 0 (잔존: ${forbiddenHits.join(', ') || '없음'})`)

--- a/scripts/check-goal-18.mjs
+++ b/scripts/check-goal-18.mjs
@@ -6,7 +6,7 @@
 // Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
 
 import { execFileSync } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
 
 const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
 function run(cmd, args) {
@@ -64,6 +64,25 @@ must(/export function recordLesson/.test(mm) && /recordLesson/.test(ag) && !/app
 must(/status: 'active'|EntryStatus/.test(mm) && /export async function memoryArchive/.test(mm) && /archivedAt/.test(mm), 'status(active/resolved/archived) + memoryArchive')
 must(/copyFileSync/.test(mm) && /\.v1\.bak/.test(mm) && /\.bak/.test(mm), 'write-once .v1.bak(원본 영구) + 롤링 .bak')
 must(/readJsonFile|stripBom/.test(mm), 'BOM-safe 읽기')
+
+// ─── 금지문구 게이트: "learnings.md 분리 SoT" 잔존 차단 (v2 통합 정합) ───
+// src/** + 라이브 agent docs 만 검사. memory.ts(마이그 참조)·CHANGELOG·goals·tests(역사/메타) 제외.
+const FORBIDDEN = /SoT 분리|이중\s?기록|별도 SoT|learnings\.md append|memory\.json\s?과\s?별도/
+const walkTs = (dir) => {
+  const out = []
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = dir + '/' + e.name
+    if (e.isDirectory()) out.push(...walkTs(p))
+    else if (e.name.endsWith('.ts')) out.push(p)
+  }
+  return out
+}
+const scanTargets = [
+  ...walkTs('src').filter((p) => !p.endsWith('commands/memory.ts')),
+  'AGENTS.md', 'CLAUDE.md', 'docs/ARCHITECTURE.md', 'docs/context/agent-compact.md',
+].filter((p) => existsSync(p))
+const forbiddenHits = scanTargets.filter((f) => FORBIDDEN.test(readFileSync(f, 'utf-8')))
+must(forbiddenHits.length === 0, `learnings 분리 SoT 금지문구 0 (잔존: ${forbiddenHits.join(', ') || '없음'})`)
 
 if (pass) { console.log('✅ goal 18 gate passes'); process.exit(0) }
 console.log('❌ goal 18 gate failed'); process.exit(1)

--- a/scripts/check-goal-18.mjs
+++ b/scripts/check-goal-18.mjs
@@ -62,7 +62,7 @@ must(/why\?/.test(mm) && /lesson\?/.test(mm), 'FailEntry {why,lesson} · Success
 must(/parseLearnings|learnings/.test(mm) && /readLearningsRaw/.test(mm), 'learnings.md → failures 흡수')
 must(/export function recordLesson/.test(mm) && /recordLesson/.test(ag) && !/appendLearning/.test(ag), 'learn → memory 통합 (agent.ts recordLesson, appendLearning 제거)')
 must(/status: 'active'|EntryStatus/.test(mm) && /export async function memoryArchive/.test(mm) && /archivedAt/.test(mm), 'status(active/resolved/archived) + memoryArchive')
-must(/copyFileSync/.test(mm) && /\.bak/.test(mm), '.bak 백업 (writeMemory)')
+must(/copyFileSync/.test(mm) && /\.v1\.bak/.test(mm) && /\.bak/.test(mm), 'write-once .v1.bak(원본 영구) + 롤링 .bak')
 must(/readJsonFile|stripBom/.test(mm), 'BOM-safe 읽기')
 
 if (pass) { console.log('✅ goal 18 gate passes'); process.exit(0) }

--- a/scripts/check-goal-18.mjs
+++ b/scripts/check-goal-18.mjs
@@ -52,9 +52,18 @@ if (!skipDeep) {
   if (scripts.build) gate('build', run(pm, ['run', 'build']))
 }
 
-// ─── goal 18 고유 검증 (직접 추가) ───────────────────────────────
-// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
-// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+// ─── goal 18 고유 검증 (memory schema v2) ───────────────────────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+const mm = read('src/commands/memory.ts') ?? ''
+const ag = read('src/commands/agent.ts') ?? ''
+must(/export function migrateMemory/.test(mm) && /schemaVersion: 2|MEMORY_SCHEMA_VERSION = 2/.test(mm), 'migrateMemory export + schemaVersion 2')
+must(/decisions/.test(mm) && /failures/.test(mm) && /successes/.test(mm) && /patterns/.test(mm), '4버킷 (decisions/failures/successes/patterns)')
+must(/why\?/.test(mm) && /lesson\?/.test(mm), 'FailEntry {why,lesson} · SuccessEntry {why}')
+must(/parseLearnings|learnings/.test(mm) && /readLearningsRaw/.test(mm), 'learnings.md → failures 흡수')
+must(/export function recordLesson/.test(mm) && /recordLesson/.test(ag) && !/appendLearning/.test(ag), 'learn → memory 통합 (agent.ts recordLesson, appendLearning 제거)')
+must(/status: 'active'|EntryStatus/.test(mm) && /export async function memoryArchive/.test(mm) && /archivedAt/.test(mm), 'status(active/resolved/archived) + memoryArchive')
+must(/copyFileSync/.test(mm) && /\.bak/.test(mm), '.bak 백업 (writeMemory)')
+must(/readJsonFile|stripBom/.test(mm), 'BOM-safe 읽기')
 
 if (pass) { console.log('✅ goal 18 gate passes'); process.exit(0) }
 console.log('❌ goal 18 gate failed'); process.exit(1)

--- a/scripts/check-goal-18.mjs
+++ b/scripts/check-goal-18.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// scripts/check-goal-18.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 18 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 18] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 18 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 18 gate passes'); process.exit(0) }
+console.log('❌ goal 18 gate failed'); process.exit(1)

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -42,8 +42,8 @@ export async function learn(lesson: string): Promise<void> {
     process.exitCode = 1
     return
   }
-  // Goal 18(v2.0 breaking): 교훈은 memory v2 failures.lesson 단일 SoT 로 통합.
-  // (과거: learnings.md 별도 기록 + "SoT 분리". v2 에서 이중기록 폐지 — learnings.md 는 마이그레이션으로 흡수.)
+  // Goal 18(v2.0 breaking): 교훈은 memory v2 failures.lesson 한 곳(단일 출처)에 모은다.
+  // (과거엔 learnings.md 에 따로 적었으나 v2 는 통합 — learnings.md 기존 항목은 마이그레이션으로 흡수.)
   const goalId = activeGoalId()
   const entry = recordLesson(process.cwd(), lesson, goalId)
   console.log(chalk.green(`  ✅ 교훈 기록 → memory failures.lesson (${entry.id})`))

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -3,11 +3,11 @@ import { ko } from '../i18n/ko.js'
 import { listGoals } from '../lib/goal-frontmatter.js'
 import {
   appendBlocker,
-  appendLearning,
   clearHardStop,
   isHardStopActive,
   readHardStopReason,
 } from '../lib/state-files.js'
+import { recordLesson } from './memory.js'
 import { selectActiveId } from './goal.js'
 
 function activeGoalId(): number | undefined {
@@ -42,12 +42,12 @@ export async function learn(lesson: string): Promise<void> {
     process.exitCode = 1
     return
   }
+  // Goal 18(v2.0 breaking): 교훈은 memory v2 failures.lesson 단일 SoT 로 통합.
+  // (과거: learnings.md 별도 기록 + "SoT 분리". v2 에서 이중기록 폐지 — learnings.md 는 마이그레이션으로 흡수.)
   const goalId = activeGoalId()
-  appendLearning(lesson, goalId)
-  console.log(chalk.green('  ✅ learnings.md append.'))
-  console.log(
-    chalk.dim('  결정사항(decision)은 `vhk memory add` 로 별도 기록 — SoT 분리.')
-  )
+  const entry = recordLesson(process.cwd(), lesson, goalId)
+  console.log(chalk.green(`  ✅ 교훈 기록 → memory failures.lesson (${entry.id})`))
+  console.log(chalk.dim('  교훈·결정·실패·성공 모두 vhk memory (단일 SoT). vhk memory list 로 확인.'))
 }
 
 export interface ResumeOptions {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -46,6 +46,12 @@ export async function learn(lesson: string): Promise<void> {
   // (과거엔 learnings.md 에 따로 적었으나 v2 는 통합 — learnings.md 기존 항목은 마이그레이션으로 흡수.)
   const goalId = activeGoalId()
   const entry = recordLesson(process.cwd(), lesson, goalId)
+  if (!entry) {
+    // memory.json 손상 의심 — 빈 v2 로 덮지 않고 중단(데이터 손실 방지).
+    console.log(chalk.red('  ❌ memory.json 손상 의심 — 교훈 기록 중단. 원본/백업 확인 후 다시 시도하세요.'))
+    process.exitCode = 1
+    return
+  }
   console.log(chalk.green(`  ✅ 교훈 기록 → memory failures.lesson (${entry.id})`))
   console.log(chalk.dim('  교훈·결정·실패·성공 모두 vhk memory (단일 SoT). vhk memory list 로 확인.'))
 }

--- a/src/commands/brief.ts
+++ b/src/commands/brief.ts
@@ -91,18 +91,16 @@ export async function brief(): Promise<void> {
   )
   lines.push('')
 
-  // 3. 기억 (memory v2 4버킷 — active 만)
-  if (existsSync('.vhk/memory.json')) {
-    try {
-      const memLines = activeMemoryLines(readMemory(process.cwd()))
-      if (memLines.length > 0) {
-        lines.push('## 저장된 기억 (memory v2)')
-        lines.push('')
-        lines.push(...memLines)
-      }
-    } catch {
-      // 무시
+  // 3. 기억 (memory v2 4버킷 — active 만). readMemory 가 v1·learnings 흡수 처리 → 부재여도 흡수분 노출.
+  try {
+    const memLines = activeMemoryLines(readMemory(process.cwd()))
+    if (memLines.length > 0) {
+      lines.push('## 저장된 기억 (memory v2)')
+      lines.push('')
+      lines.push(...memLines)
     }
+  } catch {
+    // 무시
   }
 
   // 4. 레퍼런스

--- a/src/commands/brief.ts
+++ b/src/commands/brief.ts
@@ -4,6 +4,7 @@ import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { safeExecFile } from '../lib/exec.js'
 import { readJsonFile } from '../lib/read-json.js'
+import { readMemory, activeMemoryLines } from './memory.js'
 
 const BRIEF_PATH = '.vhk/brief.md'
 
@@ -90,20 +91,14 @@ export async function brief(): Promise<void> {
   )
   lines.push('')
 
-  // 3. 결정사항
+  // 3. 기억 (memory v2 4버킷 — active 만)
   if (existsSync('.vhk/memory.json')) {
     try {
-      const memories = readJsonFile<Array<{ content: string }>>('.vhk/memory.json')
-      if (Array.isArray(memories) && memories.length > 0) {
-        lines.push(`## 저장된 결정사항 (${memories.length}개)`)
+      const memLines = activeMemoryLines(readMemory(process.cwd()))
+      if (memLines.length > 0) {
+        lines.push('## 저장된 기억 (memory v2)')
         lines.push('')
-        for (const m of memories.slice(-5)) {
-          lines.push(`- ${m.content}`)
-        }
-        if (memories.length > 5) {
-          lines.push(`- ... 외 ${memories.length - 5}개`)
-        }
-        lines.push('')
+        lines.push(...memLines)
       }
     } catch {
       // 무시

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -14,7 +14,7 @@ import { readJsonFile } from '../lib/read-json.js'
 import { readMemory, activeMemoryLines } from './memory.js'
 import { listGoals } from '../lib/goal-frontmatter.js'
 import { selectActiveId } from './goal.js'
-import { getRecentLearnings, getActiveBlockers, isHardStopActive } from '../lib/state-files.js'
+import { getActiveBlockers, isHardStopActive } from '../lib/state-files.js'
 import { gitOut } from '../lib/git-repo.js'
 import { CONTEXT_GIT_MARKER } from '../lib/drift.js'
 
@@ -189,18 +189,17 @@ export async function context(opts: { compact?: boolean } = {}): Promise<void> {
     lines.push('')
   }
 
-  if (existsSync('.vhk/memory.json')) {
-    try {
-      // memory v2 4버킷 — active 만 누락 없이 (버킷별 최근 5개, 토큰 절감).
-      const memLines = activeMemoryLines(readMemory(process.cwd()))
-      if (memLines.length > 0) {
-        lines.push('## 저장된 기억 (memory v2)')
-        lines.push('')
-        lines.push(...memLines)
-      }
-    } catch {
-      // memory.json 파싱 실패 → 무시
+  try {
+    // memory v2 4버킷 — active 만 누락 없이(버킷별 최근 5개). readMemory 가 v1·learnings 흡수까지
+    // 처리하므로 memory.json 부재여도 learnings 흡수분이 여기서 노출(교훈 단일 출처).
+    const memLines = activeMemoryLines(readMemory(process.cwd()))
+    if (memLines.length > 0) {
+      lines.push('## 저장된 기억 (memory v2)')
+      lines.push('')
+      lines.push(...memLines)
     }
+  } catch {
+    // memory.json 파싱 실패 → 무시
   }
 
   // Goal 2 (자율 루프): active goal + 최근 learnings 3건 자동 포함.
@@ -221,13 +220,8 @@ export async function context(opts: { compact?: boolean } = {}): Promise<void> {
     }
   }
 
-  const recent = getRecentLearnings(3)
-  if (recent.length > 0) {
-    lines.push('## Recent Learnings')
-    lines.push('')
-    for (const r of recent) lines.push(r)
-    lines.push('')
-  }
+  // 교훈(learnings)은 v2 에서 memory failures.lesson 로 통합 — 위 "저장된 기억" 섹션에서 노출.
+  // (구 docs/state/learnings.md Recent Learnings 블록 제거 — 중복·stale 방지.)
 
   // 활성 blocker 최근 3건 — "지금 막힌 것"만. 해결(~~취소선~~) 항목은 제외.
   const activeBlockers = getActiveBlockers(3)

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -11,6 +11,7 @@ import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { readJsonFile } from '../lib/read-json.js'
+import { readMemory, activeMemoryLines } from './memory.js'
 import { listGoals } from '../lib/goal-frontmatter.js'
 import { selectActiveId } from './goal.js'
 import { getRecentLearnings, getActiveBlockers, isHardStopActive } from '../lib/state-files.js'
@@ -190,23 +191,12 @@ export async function context(opts: { compact?: boolean } = {}): Promise<void> {
 
   if (existsSync('.vhk/memory.json')) {
     try {
-      const memories = readJsonFile<Array<{ content: string; addedAt: string }>>(
-        '.vhk/memory.json'
-      )
-      if (Array.isArray(memories) && memories.length > 0) {
-        // 토큰 절감: 전체가 아니라 최근 5개만 삽입 (full/compact 공통).
-        const recentMemories = memories.slice(-5)
-        lines.push('## 저장된 결정사항')
+      // memory v2 4버킷 — active 만 누락 없이 (버킷별 최근 5개, 토큰 절감).
+      const memLines = activeMemoryLines(readMemory(process.cwd()))
+      if (memLines.length > 0) {
+        lines.push('## 저장된 기억 (memory v2)')
         lines.push('')
-        if (memories.length > recentMemories.length) {
-          lines.push(`_최근 ${recentMemories.length}개만 표시 (전체 ${memories.length}개)_`)
-          lines.push('')
-        }
-        for (const m of recentMemories) {
-          const date = new Date(m.addedAt).toLocaleDateString('ko-KR')
-          lines.push(`- ${m.content} _(${date})_`)
-        }
-        lines.push('')
+        lines.push(...memLines)
       }
     } catch {
       // memory.json 파싱 실패 → 무시

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -142,7 +142,7 @@ function getVhkCommands(): string[] {
 /**
  * vhk context — LLM 부팅 컨텍스트(.vhk/context.md) 생성.
  * compact 모드(--compact): 토큰 절감형. 전체 명령 목록/깊은 트리 대신 Active Goal +
- * 최근 learnings/blockers/memories + 참조 문서 링크만 담는다. 기본(full)은 기존 호환 유지.
+ * 최근 blockers + memory v2(결정/실패·교훈/성공) + 참조 문서 링크만 담는다. 기본(full)은 기존 호환 유지.
  */
 export async function context(opts: { compact?: boolean } = {}): Promise<void> {
   const compact = opts.compact === true
@@ -202,8 +202,8 @@ export async function context(opts: { compact?: boolean } = {}): Promise<void> {
     // memory.json 파싱 실패 → 무시
   }
 
-  // Goal 2 (자율 루프): active goal + 최근 learnings 3건 자동 포함.
-  // SoT 는 goals/<n>.md frontmatter + docs/state/learnings.md.
+  // Goal 2 (자율 루프): active goal 섹션. SoT 는 goals/<n>.md frontmatter.
+  // 교훈(learnings)은 v2 에서 memory failures.lesson 단일 출처 — 위 "저장된 기억(memory v2)" 섹션에서 노출.
   const goals = listGoals('goals')
   const activeId = selectActiveId(goals)
   if (activeId !== null) {

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -1,97 +1,328 @@
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync, copyFileSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
-import { readJsonFile } from '../lib/read-json.js'
+import { readJsonFile, stripBom } from '../lib/read-json.js'
 
-interface MemoryEntry {
+/**
+ * Goal 18: memory schema v2 — 평면 배열 → 4버킷(decisions/failures/successes/patterns).
+ * 교훈 단일 SoT(learn 통합), 항목 생명주기(status active/resolved/archived), 자동 마이그레이션(.bak).
+ * v1(평면 `[{content,addedAt,tags?}]`) → v2 멱등 변환. learnings.md(docs/state) → failures 흡수.
+ */
+
+export const MEMORY_PATH_REL = join('.vhk', 'memory.json')
+export const MEMORY_SCHEMA_VERSION = 2
+
+export type EntryStatus = 'active' | 'resolved' | 'archived'
+export type MemBucket = 'decision' | 'failure' | 'success'
+
+export interface MemEntry {
+  id: string
   content: string
-  addedAt: string
-  tags?: string[]
+  tags: string[]
+  createdAt: string
+  status: EntryStatus
+  resolvedAt?: string
+  archivedAt?: string
+}
+export interface FailEntry extends MemEntry {
+  why?: string
+  lesson?: string
+}
+export interface SuccessEntry extends MemEntry {
+  why?: string
+}
+/** Goal 19(pattern)에서 채움 — v0 은 빈 배열 + 최소 타입. */
+export interface PatternEntry {
+  id: string
+  [key: string]: unknown
 }
 
-const MEMORY_PATH = '.vhk/memory.json'
+export interface MemoryFileV2 {
+  schemaVersion: 2
+  decisions: MemEntry[]
+  failures: FailEntry[]
+  successes: SuccessEntry[]
+  patterns: PatternEntry[]
+}
 
-function loadMemories(): MemoryEntry[] {
-  if (!existsSync(MEMORY_PATH)) return []
-  try {
-    const parsed = readJsonFile<unknown>(MEMORY_PATH)
-    return Array.isArray(parsed) ? (parsed as MemoryEntry[]) : []
-  } catch {
-    return []
+function emptyV2(): MemoryFileV2 {
+  return { schemaVersion: MEMORY_SCHEMA_VERSION, decisions: [], failures: [], successes: [], patterns: [] }
+}
+
+function isV2(raw: unknown): raw is MemoryFileV2 {
+  return !!raw && typeof raw === 'object' && (raw as { schemaVersion?: number }).schemaVersion === 2
+}
+
+const BUCKET_PREFIX: Record<MemBucket, string> = { decision: 'd', failure: 'f', success: 's' }
+
+function arr<T>(v: unknown): T[] {
+  return Array.isArray(v) ? (v as T[]) : []
+}
+
+/** 이미 v2 인 객체를 안전 정규화(누락 버킷 채움). */
+function normalizeV2(raw: MemoryFileV2): MemoryFileV2 {
+  return {
+    schemaVersion: MEMORY_SCHEMA_VERSION,
+    decisions: arr<MemEntry>(raw.decisions),
+    failures: arr<FailEntry>(raw.failures),
+    successes: arr<SuccessEntry>(raw.successes),
+    patterns: arr<PatternEntry>(raw.patterns),
   }
 }
 
-function saveMemories(memories: MemoryEntry[]): void {
-  mkdirSync('.vhk', { recursive: true })
-  writeFileSync(MEMORY_PATH, JSON.stringify(memories, null, 2) + '\n', 'utf-8')
+/** learnings.md 본문 → { date, tag, lesson } 항목 파싱 (`- [YYYY-MM-DD goal-N] 교훈`). */
+function parseLearnings(rawLearnings: string): { date: string; tag: string; lesson: string }[] {
+  const out: { date: string; tag: string; lesson: string }[] = []
+  for (const line of rawLearnings.split(/\r?\n/)) {
+    const m = line.match(/^-\s*\[(\d{4}-\d{2}-\d{2})\s+([^\]]*)\]\s*(.+)$/)
+    if (m) out.push({ date: m[1], tag: m[2].trim(), lesson: m[3].trim() })
+  }
+  return out
 }
 
-export async function memoryAdd(content: string, tags?: string[]): Promise<void> {
+/**
+ * **순수** v1→v2 마이그레이션. v1 평면배열 → decisions, learnings.md 본문 → failures(lesson, what 비움).
+ * 이미 v2 면 멱등(rawLearnings 무시 — 재흡수 안 함). fs/git/Date 부수효과 없음.
+ */
+export function migrateMemory(rawMemory: unknown, rawLearnings?: string): MemoryFileV2 {
+  if (isV2(rawMemory)) return normalizeV2(rawMemory)
+
+  const v2 = emptyV2()
+  // v1 평면 배열 → decisions
+  if (Array.isArray(rawMemory)) {
+    rawMemory.forEach((m, i) => {
+      const item = m as { content?: unknown; tags?: unknown; addedAt?: unknown }
+      if (item && typeof item.content === 'string') {
+        v2.decisions.push({
+          id: `d${i + 1}`,
+          content: item.content,
+          tags: arr<string>(item.tags),
+          createdAt: typeof item.addedAt === 'string' ? item.addedAt : '',
+          status: 'active',
+        })
+      }
+    })
+  }
+  // learnings.md → failures (실패 본문 없음: content/what 비우고 lesson 만)
+  if (rawLearnings) {
+    parseLearnings(rawLearnings).forEach((l, i) => {
+      v2.failures.push({
+        id: `f${i + 1}`,
+        content: '',
+        tags: l.tag ? [l.tag] : [],
+        createdAt: l.date,
+        status: 'active',
+        lesson: l.lesson,
+      })
+    })
+  }
+  return v2
+}
+
+// ── fs 경계 (impure) ──
+
+function readRaw(cwd: string): unknown {
+  const p = join(cwd, MEMORY_PATH_REL)
+  if (!existsSync(p)) return null
+  try {
+    return readJsonFile<unknown>(p)
+  } catch {
+    return null
+  }
+}
+
+// learnings.md 는 JSON 이 아니라 텍스트 — BOM-safe 로 읽되 JSON.parse 안 함.
+function readLearningsRaw(cwd: string): string | undefined {
+  const p = join(cwd, 'docs', 'state', 'learnings.md')
+  if (!existsSync(p)) return undefined
+  try {
+    return stripBom(readFileSync(p, 'utf-8'))
+  } catch {
+    return undefined
+  }
+}
+
+/** memory.json 읽기 → 항상 v2 반환(v1/없으면 in-memory 마이그레이션, learnings 흡수). */
+export function readMemory(cwd: string = process.cwd()): MemoryFileV2 {
+  const raw = readRaw(cwd)
+  if (isV2(raw)) return normalizeV2(raw)
+  return migrateMemory(raw, readLearningsRaw(cwd))
+}
+
+/** memory.json 쓰기 — 기존 파일 있으면 .bak 백업 후 v2 재기록. */
+export function writeMemory(cwd: string, mem: MemoryFileV2): void {
+  const p = join(cwd, MEMORY_PATH_REL)
+  mkdirSync(join(cwd, '.vhk'), { recursive: true })
+  if (existsSync(p)) {
+    try {
+      copyFileSync(p, p + '.bak')
+    } catch {
+      /* 백업 실패는 치명적 아님 */
+    }
+  }
+  writeFileSync(p, JSON.stringify(mem, null, 2) + '\n', 'utf-8')
+}
+
+// ── id / 순서 헬퍼 ──
+
+function nextId(bucket: MemBucket, mem: MemoryFileV2): string {
+  const prefix = BUCKET_PREFIX[bucket]
+  const list = bucket === 'decision' ? mem.decisions : bucket === 'failure' ? mem.failures : mem.successes
+  let max = 0
+  for (const e of list) {
+    const m = e.id.match(new RegExp(`^${prefix}(\\d+)$`))
+    if (m) max = Math.max(max, Number(m[1]))
+  }
+  return `${prefix}${max + 1}`
+}
+
+/** decisions→failures→successes 안정 순서(번호 = 이 순서의 1-based). patterns 제외. */
+function orderedAll(mem: MemoryFileV2): { bucket: MemBucket; entry: MemEntry }[] {
+  return [
+    ...mem.decisions.map((entry) => ({ bucket: 'decision' as const, entry })),
+    ...mem.failures.map((entry) => ({ bucket: 'failure' as const, entry })),
+    ...mem.successes.map((entry) => ({ bucket: 'success' as const, entry })),
+  ]
+}
+
+// ── 커맨드 ──
+
+export async function memoryAdd(
+  content: string,
+  opts: { tags?: string[]; type?: MemBucket; why?: string; lesson?: string } = {}
+): Promise<void> {
   console.log(chalk.bold('\n🧠 ' + t('memory.addTitle')))
   console.log(chalk.gray('─'.repeat(40)))
-
-  if (!content) {
+  if (!content || !content.trim()) {
     console.log(chalk.red('❌ 기억할 내용을 입력해주세요.'))
-    console.log(chalk.gray('   예: vhk memory add "API는 tRPC 사용하기로 결정"'))
-    // 저장 실패 → 비-0 종료(silent exit 0 방지). VHK-016.
+    console.log(chalk.gray('   예: vhk memory add "API는 tRPC 사용" --type decision'))
     process.exitCode = 1
     return
   }
+  const cwd = process.cwd()
+  const mem = readMemory(cwd)
+  const type: MemBucket = opts.type ?? 'decision'
+  const base: MemEntry = {
+    id: nextId(type, mem),
+    content: content.trim(),
+    tags: opts.tags && opts.tags.length > 0 ? opts.tags : [],
+    createdAt: new Date().toISOString(),
+    status: 'active',
+  }
+  if (type === 'failure') mem.failures.push({ ...base, why: opts.why, lesson: opts.lesson })
+  else if (type === 'success') mem.successes.push({ ...base, why: opts.why })
+  else mem.decisions.push(base)
+  writeMemory(cwd, mem)
 
-  const memories = loadMemories()
-  memories.push({
-    content,
-    addedAt: new Date().toISOString(),
-    tags: tags && tags.length > 0 ? tags : [],
-  })
-  saveMemories(memories)
-
-  console.log(chalk.green(`\n✅ 기억 저장됨 (#${memories.length})`))
-  console.log(chalk.cyan(`   📝 ${content}`))
-
-  printNextStep({
-    message: '기억 저장 완료!',
-    command: 'vhk memory list',
-    cursorHint: '기억 목록 보여줘',
-  })
+  console.log(chalk.green(`\n✅ 기억 저장됨 (${type} #${base.id})`))
+  console.log(chalk.cyan(`   📝 ${base.content}`))
+  printNextStep({ message: '기억 저장 완료!', command: 'vhk memory list', cursorHint: '기억 목록 보여줘' })
 }
 
-export async function memoryList(): Promise<void> {
+const STATUS_ICON: Record<EntryStatus, string> = { active: '🟢', resolved: '✅', archived: '📦' }
+const BUCKET_LABEL: Record<MemBucket, string> = { decision: '결정', failure: '실패', success: '성공' }
+
+export async function memoryList(opts: { type?: MemBucket; all?: boolean } = {}): Promise<void> {
   console.log(chalk.bold('\n🧠 ' + t('memory.listTitle')))
   console.log(chalk.gray('─'.repeat(40)))
+  const mem = readMemory(process.cwd())
+  const all = orderedAll(mem)
+  const visible = all
+    .map((x, i) => ({ ...x, n: i + 1 }))
+    .filter((x) => (opts.all || x.entry.status === 'active') && (!opts.type || x.bucket === opts.type))
 
-  const memories = loadMemories()
-  if (memories.length === 0) {
-    console.log(chalk.yellow('\n📭 저장된 기억이 없습니다.'))
-    console.log(chalk.gray('   vhk memory add "내용"으로 추가하세요.'))
+  if (visible.length === 0) {
+    console.log(chalk.yellow('\n📭 표시할 기억이 없습니다.'))
+    console.log(chalk.gray('   vhk memory add "내용" --type decision|failure|success'))
     return
   }
+  console.log(chalk.cyan(`\n${visible.length}개${opts.all ? ' (보관 포함)' : ' (활성)'}:\n`))
+  for (const x of visible) {
+    const e = x.entry
+    const fail = e as FailEntry
+    console.log(`  [${x.n}] ${STATUS_ICON[e.status]} (${BUCKET_LABEL[x.bucket]}) ${e.content || (fail.lesson ? '💡 ' + fail.lesson : '(내용 없음)')}`)
+    if (fail.lesson && e.content) console.log(chalk.dim(`      💡 교훈: ${fail.lesson}`))
+    if (fail.why) console.log(chalk.dim(`      ↳ ${fail.why}`))
+    if (e.tags.length > 0) console.log(chalk.blue(`      🏷️  ${e.tags.join(', ')}`))
+  }
+}
 
-  console.log(chalk.cyan(`\n총 ${memories.length}개의 기억:\n`))
-  memories.forEach((m, index) => {
-    const date = new Date(m.addedAt).toLocaleDateString('ko-KR')
-    console.log(chalk.white(`  [${index + 1}] ${m.content}`))
-    if (m.tags && m.tags.length > 0) {
-      console.log(chalk.blue(`      🏷️  ${m.tags.join(', ')}`))
-    }
-    console.log(chalk.gray(`      📅 ${date}`))
-    console.log('')
-  })
+function resolveIndex(indexStr: string, len: number): number | null {
+  const idx = parseInt(indexStr, 10) - 1
+  if (Number.isNaN(idx) || idx < 0 || idx >= len) return null
+  return idx
 }
 
 export async function memoryRemove(indexStr: string): Promise<void> {
-  const memories = loadMemories()
-  const idx = parseInt(indexStr, 10) - 1
-
-  if (Number.isNaN(idx) || idx < 0 || idx >= memories.length) {
-    console.log(chalk.red(`❌ 유효하지 않은 번호입니다. (1~${memories.length || 0})`))
+  const cwd = process.cwd()
+  const mem = readMemory(cwd)
+  const all = orderedAll(mem)
+  const idx = resolveIndex(indexStr, all.length)
+  if (idx === null) {
+    console.log(chalk.red(`❌ 유효하지 않은 번호입니다. (1~${all.length || 0})`))
+    process.exitCode = 1
     return
   }
-
-  const removed = memories.splice(idx, 1)[0]
-  saveMemories(memories)
-
+  const { bucket, entry } = all[idx]
+  const list = bucket === 'decision' ? mem.decisions : bucket === 'failure' ? mem.failures : mem.successes
+  const pos = list.findIndex((e) => e.id === entry.id)
+  if (pos >= 0) list.splice(pos, 1)
+  writeMemory(cwd, mem)
   console.log(chalk.green('\n✅ 기억 삭제됨:'))
-  console.log(chalk.gray(`   ${removed.content}`))
+  console.log(chalk.gray(`   ${entry.content || (entry as FailEntry).lesson || entry.id}`))
+}
+
+export async function memoryArchive(indexStr: string): Promise<void> {
+  const cwd = process.cwd()
+  const mem = readMemory(cwd)
+  const all = orderedAll(mem)
+  const idx = resolveIndex(indexStr, all.length)
+  if (idx === null) {
+    console.log(chalk.red(`❌ 유효하지 않은 번호입니다. (1~${all.length || 0})`))
+    process.exitCode = 1
+    return
+  }
+  const { entry } = all[idx]
+  entry.status = 'archived'
+  entry.archivedAt = new Date().toISOString()
+  writeMemory(cwd, mem)
+  console.log(chalk.green(`\n📦 보관됨: ${entry.content || (entry as FailEntry).lesson || entry.id}`))
+  console.log(chalk.dim('   (패턴 감지·진화에서 제외됩니다 — 선순환)'))
+}
+
+export async function memoryMigrate(): Promise<void> {
+  const cwd = process.cwd()
+  const raw = readRaw(cwd)
+  if (isV2(raw)) {
+    console.log(chalk.dim('  이미 memory schema v2 입니다 — 변경 없음(멱등).'))
+    return
+  }
+  const v2 = migrateMemory(raw, readLearningsRaw(cwd))
+  writeMemory(cwd, v2)
+  console.log(chalk.green('\n✅ memory.json v1 → v2 마이그레이션 완료 (.bak 백업)'))
+  console.log(
+    chalk.dim(
+      `   decisions ${v2.decisions.length} · failures ${v2.failures.length} · successes ${v2.successes.length}` +
+        ` (learnings.md 교훈 흡수 — 이후 vhk learn 은 memory 에 기록)`
+    )
+  )
+}
+
+/** Goal 18: vhk learn → memory v2 failures.lesson 단일 SoT (learnings.md 신규 기록 중단). */
+export function recordLesson(cwd: string, lesson: string, goalId?: number): FailEntry {
+  const mem = readMemory(cwd)
+  const tag = goalId !== undefined ? `goal-${goalId}` : 'no-goal'
+  const entry: FailEntry = {
+    id: nextId('failure', mem),
+    content: '',
+    tags: [tag],
+    createdAt: new Date().toISOString(),
+    status: 'active',
+    lesson: lesson.trim(),
+  }
+  mem.failures.push(entry)
+  writeMemory(cwd, mem)
+  return entry
 }

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -151,11 +151,25 @@ export function readMemory(cwd: string = process.cwd()): MemoryFileV2 {
   return migrateMemory(raw, readLearningsRaw(cwd))
 }
 
-/** memory.json 쓰기 — 기존 파일 있으면 .bak 백업 후 v2 재기록. */
+/**
+ * memory.json 쓰기.
+ * - `.v1.bak` = **v1 원본 write-once 영구 백업** — 마이그레이션 순간(디스크가 v1)에 1회만 생성,
+ *   이미 있으면 안 덮음. 후속 add/archive/remove 가 v1 원본을 절대 못 지운다(breaking 복구 보장).
+ * - `.bak` = **롤링 백업** — 매 쓰기마다 직전 상태 보존(직전 1단계 되돌리기용).
+ */
 export function writeMemory(cwd: string, mem: MemoryFileV2): void {
   const p = join(cwd, MEMORY_PATH_REL)
   mkdirSync(join(cwd, '.vhk'), { recursive: true })
   if (existsSync(p)) {
+    // 마이그레이션 순간(디스크가 v1)에 v1 원본을 write-once 보존.
+    if (!isV2(readRaw(cwd)) && !existsSync(p + '.v1.bak')) {
+      try {
+        copyFileSync(p, p + '.v1.bak')
+      } catch {
+        /* 백업 실패는 치명적 아님 */
+      }
+    }
+    // 롤링 .bak (매 쓰기 직전 상태).
     try {
       copyFileSync(p, p + '.bak')
     } catch {
@@ -301,13 +315,40 @@ export async function memoryMigrate(): Promise<void> {
   }
   const v2 = migrateMemory(raw, readLearningsRaw(cwd))
   writeMemory(cwd, v2)
-  console.log(chalk.green('\n✅ memory.json v1 → v2 마이그레이션 완료 (.bak 백업)'))
+  console.log(chalk.green('\n✅ memory.json v1 → v2 마이그레이션 완료 (.v1.bak 원본 영구 백업)'))
   console.log(
     chalk.dim(
       `   decisions ${v2.decisions.length} · failures ${v2.failures.length} · successes ${v2.successes.length}` +
         ` (learnings.md 교훈 흡수 — 이후 vhk learn 은 memory 에 기록)`
     )
   )
+}
+
+/**
+ * vhk context / brief 용 — active 항목 요약 markdown 라인 (4버킷, 빈 버킷 생략, 버킷별 최근 limit).
+ * 누락 없이 decisions/failures/successes/patterns 의 active 만 렌더.
+ */
+export function activeMemoryLines(mem: MemoryFileV2, limit = 5): string[] {
+  const lines: string[] = []
+  const fmt = (e: MemEntry): string => {
+    const f = e as FailEntry
+    const base = e.content || (f.lesson ? `💡 ${f.lesson}` : e.id)
+    return e.content && f.lesson ? `${base} — 💡 ${f.lesson}` : base
+  }
+  const section = (label: string, list: MemEntry[]): void => {
+    const act = list.filter((e) => e.status === 'active')
+    if (act.length === 0) return
+    lines.push(`**${label}** (${act.length})`)
+    for (const e of act.slice(-limit)) lines.push(`- ${fmt(e)}`)
+    if (act.length > limit) lines.push(`- … 외 ${act.length - limit}개`)
+    lines.push('')
+  }
+  section('결정 (decisions)', mem.decisions)
+  section('실패·교훈 (failures)', mem.failures)
+  section('성공 (successes)', mem.successes)
+  const pats = mem.patterns.length
+  if (pats > 0) lines.push(`**패턴 후보 (patterns)**: ${pats}개 — \`vhk pattern\``, '')
+  return lines
 }
 
 /** Goal 18: vhk learn → memory v2 failures.lesson 단일 SoT (learnings.md 신규 기록 중단). */

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -144,11 +144,19 @@ function readLearningsRaw(cwd: string): string | undefined {
   }
 }
 
-/** memory.json 읽기 → 항상 v2 반환(v1/없으면 in-memory 마이그레이션, learnings 흡수). */
+/**
+ * memory.json 읽기 → 항상 v2.
+ * **계약 일관성**: 디스크가 v1 이면 read 경로(memory list / context / brief 등)에서도 1회 실제
+ * 마이그레이션을 영구화(v2 write + .v1.bak) — 어느 명령으로 첫 실행해도 동일 결과.
+ * 멱등: 이미 v2 면 no-op(재흡수·재기록 없음). 파일이 아예 없으면 빈 v2 만 반환(쓰지 않음).
+ */
 export function readMemory(cwd: string = process.cwd()): MemoryFileV2 {
   const raw = readRaw(cwd)
   if (isV2(raw)) return normalizeV2(raw)
-  return migrateMemory(raw, readLearningsRaw(cwd))
+  const v2 = migrateMemory(raw, readLearningsRaw(cwd))
+  // 디스크에 v1 파일이 실재할 때만 영구화(없는데 read 하면서 빈 파일 만들지 않음).
+  if (existsSync(join(cwd, MEMORY_PATH_REL))) writeMemory(cwd, v2)
+  return v2
 }
 
 /**

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync, copyFileSync, readFileSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync, copyFileSync, readFileSync, renameSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
@@ -123,14 +123,42 @@ export function migrateMemory(rawMemory: unknown, rawLearnings?: string): Memory
 
 // ── fs 경계 (impure) ──
 
-function readRaw(cwd: string): unknown {
+/**
+ * 디스크 상태 3분기: 파일 없음(missing) / 파싱 성공(parsed) / 파일은 있으나 읽기·파싱 실패(error).
+ * **핵심**: missing 과 error 를 구분해야 read 경로가 손상 파일을 빈 v2 로 덮어쓰지 않는다(데이터 손실 방지).
+ */
+type RawResult =
+  | { kind: 'missing' }
+  | { kind: 'parsed'; value: unknown }
+  | { kind: 'error' }
+
+function readRaw(cwd: string): RawResult {
   const p = join(cwd, MEMORY_PATH_REL)
-  if (!existsSync(p)) return null
+  if (!existsSync(p)) return { kind: 'missing' }
   try {
-    return readJsonFile<unknown>(p)
+    return { kind: 'parsed', value: readJsonFile<unknown>(p) }
   } catch {
-    return null
+    return { kind: 'error' }
   }
+}
+
+/** 손상/IO 실패 경고 — 절대 덮어쓰지 않음을 사용자에게 고지(백업 위치 안내). */
+function warnUnreadable(cwd: string): void {
+  const p = join(cwd, MEMORY_PATH_REL)
+  console.error(chalk.red(`\n⚠️  ${MEMORY_PATH_REL} 를 읽을 수 없습니다 (손상/부분 쓰기 의심).`))
+  console.error(chalk.yellow(`   덮어쓰지 않고 빈 메모리로 진행합니다 — 원본 보존됨.`))
+  console.error(chalk.dim(`   확인/복구: ${p}  (백업: ${p}.bak / ${p}.v1.bak)`))
+}
+
+/**
+ * 파싱은 되나 v1(평면 배열)도 v2(객체)도 아닌 경우 경고 — **미래 스키마(v3+)·수동 편집 의심**.
+ * v2.0 이 schemaVersion 을 도입했으므로, 인식 불가 형식을 빈 v2 로 덮으면 미래 버전 파일을 파괴할 수 있다 → 보존.
+ */
+function warnUnrecognized(cwd: string): void {
+  const p = join(cwd, MEMORY_PATH_REL)
+  console.error(chalk.red(`\n⚠️  ${MEMORY_PATH_REL} 가 인식 가능한 형식이 아닙니다 (v1 배열/v2 객체 아님).`))
+  console.error(chalk.yellow(`   미래 스키마/수동 편집 의심 — 덮어쓰지 않습니다(원본 보존). 확인 후 다시 시도.`))
+  console.error(chalk.dim(`   확인: ${p}`))
 }
 
 // learnings.md 는 JSON 이 아니라 텍스트 — BOM-safe 로 읽되 JSON.parse 안 함.
@@ -146,17 +174,66 @@ function readLearningsRaw(cwd: string): string | undefined {
 
 /**
  * memory.json 읽기 → 항상 v2.
- * **계약 일관성**: 디스크가 v1 이면 read 경로(memory list / context / brief 등)에서도 1회 실제
+ * **계약 일관성**: 디스크가 v1 평면배열이면 read 경로(memory list / context / brief 등)에서도 1회 실제
  * 마이그레이션을 영구화(v2 write + .v1.bak) — 어느 명령으로 첫 실행해도 동일 결과.
  * 멱등: 이미 v2 면 no-op(재흡수·재기록 없음). 파일이 아예 없으면 빈 v2 만 반환(쓰지 않음).
+ * **안전**: 파일은 있으나 파싱 불가(손상/부분 write/IO) 면 **절대 덮어쓰지 않고** 경고 후 빈 v2 반환(원본 보존).
  */
 export function readMemory(cwd: string = process.cwd()): MemoryFileV2 {
   const raw = readRaw(cwd)
-  if (isV2(raw)) return normalizeV2(raw)
-  const v2 = migrateMemory(raw, readLearningsRaw(cwd))
-  // 디스크에 v1 파일이 실재할 때만 영구화(없는데 read 하면서 빈 파일 만들지 않음).
-  if (existsSync(join(cwd, MEMORY_PATH_REL))) writeMemory(cwd, v2)
-  return v2
+  if (raw.kind === 'error') {
+    warnUnreadable(cwd)
+    return emptyV2()
+  }
+  if (raw.kind === 'parsed') {
+    if (isV2(raw.value)) return normalizeV2(raw.value)
+    if (Array.isArray(raw.value)) {
+      // v1 평면 배열이 디스크에 **실재**할 때만 1회 영구화(+.v1.bak).
+      // 영구화 실패(파일 잠금 등)는 read 커맨드를 죽이지 않는다 — 메모리상 v2 로 진행, 다음 쓰기 때 재시도.
+      const v2 = migrateMemory(raw.value, readLearningsRaw(cwd))
+      try {
+        writeMemory(cwd, v2)
+      } catch {
+        console.error(chalk.yellow(`   (v2 영구화 보류 — ${MEMORY_PATH_REL} 잠금 의심. 이번엔 메모리상으로만 진행)`))
+      }
+      return v2
+    }
+    // 파싱되나 v1/v2 아님 (미래 스키마/수동 편집) → 덮어쓰지 않고 빈 v2 반환(원본 보존).
+    warnUnrecognized(cwd)
+    return emptyV2()
+  }
+  // 파일 없음 — 빈 v2(+learnings 흡수). 쓰지 않음.
+  return migrateMemory(null, readLearningsRaw(cwd))
+}
+
+type LoadOutcome = { ok: true; mem: MemoryFileV2 } | { ok: false }
+
+/**
+ * 마이그레이션은 하되 디스크에 영구화하지 **않는** 로더 — 곧바로 writeMemory 할 mutating 커맨드용.
+ * read 경로의 자동 영구화와 합쳐져 발생하던 첫 add 의 이중 write 를 제거(단일 write).
+ * **안전(blocker)**: 파일이 손상(parse/IO 실패)이면 `{ ok:false }` — 호출자는 **반드시 중단**해야 한다.
+ * 빈 v2 를 손상 파일 위에 mutate-write 하면 live 데이터·롤링 .bak 이 파괴됨(읽기 경로와 동일 원칙).
+ */
+function loadForMutation(cwd: string): LoadOutcome {
+  const raw = readRaw(cwd)
+  if (raw.kind === 'error') {
+    warnUnreadable(cwd)
+    return { ok: false }
+  }
+  if (raw.kind === 'parsed') {
+    if (isV2(raw.value)) return { ok: true, mem: normalizeV2(raw.value) }
+    if (Array.isArray(raw.value)) return { ok: true, mem: migrateMemory(raw.value, readLearningsRaw(cwd)) }
+    // 파싱되나 v1/v2 아님 (미래 스키마/수동 편집) → mutate 가 빈 v2 로 덮지 못하게 중단.
+    warnUnrecognized(cwd)
+    return { ok: false }
+  }
+  // 파일 없음 — 빈 v2(+learnings) 로 시작.
+  return { ok: true, mem: migrateMemory(null, readLearningsRaw(cwd)) }
+}
+
+/** active = 보관/해결되지 않은 항목. status 누락(외부 생성·구버전)도 active 로 간주 — 조용히 숨기지 않음. */
+function isActive(e: MemEntry): boolean {
+  return e.status !== 'archived' && e.status !== 'resolved'
 }
 
 /**
@@ -169,22 +246,41 @@ export function writeMemory(cwd: string, mem: MemoryFileV2): void {
   const p = join(cwd, MEMORY_PATH_REL)
   mkdirSync(join(cwd, '.vhk'), { recursive: true })
   if (existsSync(p)) {
-    // 마이그레이션 순간(디스크가 v1)에 v1 원본을 write-once 보존.
-    if (!isV2(readRaw(cwd)) && !existsSync(p + '.v1.bak')) {
+    const cur = readRaw(cwd)
+    const curIsV2 = cur.kind === 'parsed' && isV2(cur.value)
+    // 마이그레이션 순간(디스크가 v2 아닌 v1/미인식)에 원본을 write-once 보존.
+    // cur.kind==='error'(레이스로 막 손상) 면 손상본을 '원본'으로 박제하지 않는다(롤링 .bak 과 동일 가드).
+    if (cur.kind !== 'error' && !curIsV2 && !existsSync(p + '.v1.bak')) {
       try {
         copyFileSync(p, p + '.v1.bak')
       } catch {
         /* 백업 실패는 치명적 아님 */
       }
     }
-    // 롤링 .bak (매 쓰기 직전 상태).
-    try {
-      copyFileSync(p, p + '.bak')
-    } catch {
-      /* 백업 실패는 치명적 아님 */
+    // 롤링 .bak (매 쓰기 직전 상태). 단, 현재 live 가 **읽기 불가(손상)** 면 마지막 양호 백업을
+    // 손상본으로 덮지 않는다(정상 경로에선 도달 안 하지만 방어적으로 마지막 복구지점 보존).
+    if (cur.kind !== 'error') {
+      try {
+        copyFileSync(p, p + '.bak')
+      } catch {
+        /* 백업 실패는 치명적 아님 */
+      }
     }
   }
-  writeFileSync(p, JSON.stringify(mem, null, 2) + '\n', 'utf-8')
+  // 원자적 쓰기: temp 에 쓰고 rename — 부분 write 로 live 파일이 손상되는 창을 없앤다(손상 데이터 손실 근본 차단).
+  // rename 실패(Windows 잠금 등) 시 live 는 그대로(rename 은 live 를 안 건드림) — temp 만 정리하고 에러 전파.
+  const tmpPath = p + '.tmp'
+  writeFileSync(tmpPath, JSON.stringify(mem, null, 2) + '\n', 'utf-8')
+  try {
+    renameSync(tmpPath, p)
+  } catch (err) {
+    try {
+      rmSync(tmpPath, { force: true })
+    } catch {
+      /* 정리 실패는 치명적 아님 */
+    }
+    throw err
+  }
 }
 
 // ── id / 순서 헬퍼 ──
@@ -192,9 +288,10 @@ export function writeMemory(cwd: string, mem: MemoryFileV2): void {
 function nextId(bucket: MemBucket, mem: MemoryFileV2): string {
   const prefix = BUCKET_PREFIX[bucket]
   const list = bucket === 'decision' ? mem.decisions : bucket === 'failure' ? mem.failures : mem.successes
+  const idRe = new RegExp(`^${prefix}(\\d+)$`) // 루프 밖에서 1회 컴파일(prefix·패턴은 호출 내 불변).
   let max = 0
   for (const e of list) {
-    const m = e.id.match(new RegExp(`^${prefix}(\\d+)$`))
+    const m = e.id.match(idRe)
     if (m) max = Math.max(max, Number(m[1]))
   }
   return `${prefix}${max + 1}`
@@ -211,9 +308,11 @@ function orderedAll(mem: MemoryFileV2): { bucket: MemBucket; entry: MemEntry }[]
 
 // ── 커맨드 ──
 
+const VALID_BUCKETS: readonly MemBucket[] = ['decision', 'failure', 'success']
+
 export async function memoryAdd(
   content: string,
-  opts: { tags?: string[]; type?: MemBucket; why?: string; lesson?: string } = {}
+  opts: { tags?: string[]; type?: string; why?: string; lesson?: string } = {}
 ): Promise<void> {
   console.log(chalk.bold('\n🧠 ' + t('memory.addTitle')))
   console.log(chalk.gray('─'.repeat(40)))
@@ -223,9 +322,26 @@ export async function memoryAdd(
     process.exitCode = 1
     return
   }
+  // --type 검증: 잘못된 값을 조용히 decision 으로 강등하면 --lesson/--why 입력이 유실된다 → 거부.
+  const typeRaw = opts.type ?? 'decision'
+  if (!VALID_BUCKETS.includes(typeRaw as MemBucket)) {
+    console.log(chalk.red(`❌ --type 은 decision|failure|success 중 하나여야 합니다 (받은 값: ${typeRaw}).`))
+    process.exitCode = 1
+    return
+  }
+  const type = typeRaw as MemBucket
+  // decision 버킷은 why/lesson 을 저장하지 않는다 → 잘못 준 입력이 조용히 사라지지 않도록 경고.
+  if (type === 'decision' && (opts.why || opts.lesson)) {
+    console.log(chalk.yellow('⚠️  --why/--lesson 은 --type failure|success 에서만 저장됩니다 — decision 에서는 무시됨.'))
+  }
   const cwd = process.cwd()
-  const mem = readMemory(cwd)
-  const type: MemBucket = opts.type ?? 'decision'
+  const loaded = loadForMutation(cwd)
+  if (!loaded.ok) {
+    console.log(chalk.red('❌ memory.json 손상 의심 — 저장 중단 (원본 보존). 백업 확인 후 다시 시도하세요.'))
+    process.exitCode = 1
+    return
+  }
+  const mem = loaded.mem
   const base: MemEntry = {
     id: nextId(type, mem),
     content: content.trim(),
@@ -253,7 +369,7 @@ export async function memoryList(opts: { type?: MemBucket; all?: boolean } = {})
   const all = orderedAll(mem)
   const visible = all
     .map((x, i) => ({ ...x, n: i + 1 }))
-    .filter((x) => (opts.all || x.entry.status === 'active') && (!opts.type || x.bucket === opts.type))
+    .filter((x) => (opts.all || isActive(x.entry)) && (!opts.type || x.bucket === opts.type))
 
   if (visible.length === 0) {
     console.log(chalk.yellow('\n📭 표시할 기억이 없습니다.'))
@@ -264,7 +380,7 @@ export async function memoryList(opts: { type?: MemBucket; all?: boolean } = {})
   for (const x of visible) {
     const e = x.entry
     const fail = e as FailEntry
-    console.log(`  [${x.n}] ${STATUS_ICON[e.status]} (${BUCKET_LABEL[x.bucket]}) ${e.content || (fail.lesson ? '💡 ' + fail.lesson : '(내용 없음)')}`)
+    console.log(`  [${x.n}] ${STATUS_ICON[e.status] ?? '🟢'} (${BUCKET_LABEL[x.bucket]}) ${e.content || (fail.lesson ? '💡 ' + fail.lesson : '(내용 없음)')}`)
     if (fail.lesson && e.content) console.log(chalk.dim(`      💡 교훈: ${fail.lesson}`))
     if (fail.why) console.log(chalk.dim(`      ↳ ${fail.why}`))
     if (e.tags.length > 0) console.log(chalk.blue(`      🏷️  ${e.tags.join(', ')}`))
@@ -279,7 +395,13 @@ function resolveIndex(indexStr: string, len: number): number | null {
 
 export async function memoryRemove(indexStr: string): Promise<void> {
   const cwd = process.cwd()
-  const mem = readMemory(cwd)
+  const loaded = loadForMutation(cwd)
+  if (!loaded.ok) {
+    console.log(chalk.red('❌ memory.json 손상 의심 — 삭제 중단 (원본 보존).'))
+    process.exitCode = 1
+    return
+  }
+  const mem = loaded.mem
   const all = orderedAll(mem)
   const idx = resolveIndex(indexStr, all.length)
   if (idx === null) {
@@ -289,45 +411,115 @@ export async function memoryRemove(indexStr: string): Promise<void> {
   }
   const { bucket, entry } = all[idx]
   const list = bucket === 'decision' ? mem.decisions : bucket === 'failure' ? mem.failures : mem.successes
-  const pos = list.findIndex((e) => e.id === entry.id)
+  // id 가 아니라 **객체 동일성(reference)**으로 삭제 — 중복 id(외부 편집·클라우드 복원) 시 엉뚱한 항목이 지워지지 않게.
+  const pos = list.findIndex((e) => e === entry)
   if (pos >= 0) list.splice(pos, 1)
   writeMemory(cwd, mem)
   console.log(chalk.green('\n✅ 기억 삭제됨:'))
   console.log(chalk.gray(`   ${entry.content || (entry as FailEntry).lesson || entry.id}`))
 }
 
-export async function memoryArchive(indexStr: string): Promise<void> {
+/** index 문자열 → {cwd, mem, entry} 해석. 실패 시 에러 출력 + exitCode 1 후 null. status 전이 커맨드 공용. */
+function resolveEntryForMutation(
+  indexStr: string
+): { cwd: string; mem: MemoryFileV2; entry: MemEntry } | null {
   const cwd = process.cwd()
-  const mem = readMemory(cwd)
+  const loaded = loadForMutation(cwd)
+  if (!loaded.ok) {
+    console.log(chalk.red('❌ memory.json 손상 의심 — 작업 중단 (원본 보존).'))
+    process.exitCode = 1
+    return null
+  }
+  const mem = loaded.mem
   const all = orderedAll(mem)
   const idx = resolveIndex(indexStr, all.length)
   if (idx === null) {
     console.log(chalk.red(`❌ 유효하지 않은 번호입니다. (1~${all.length || 0})`))
     process.exitCode = 1
+    return null
+  }
+  return { cwd, mem, entry: all[idx].entry }
+}
+
+function entryLabel(entry: MemEntry): string {
+  return entry.content || (entry as FailEntry).lesson || entry.id
+}
+
+export async function memoryArchive(indexStr: string): Promise<void> {
+  const r = resolveEntryForMutation(indexStr)
+  if (!r) return
+  r.entry.status = 'archived'
+  r.entry.archivedAt = new Date().toISOString()
+  delete r.entry.resolvedAt
+  writeMemory(r.cwd, r.mem)
+  console.log(chalk.green(`\n📦 보관됨: ${entryLabel(r.entry)}`))
+  console.log(chalk.dim('   (패턴 감지·진화에서 제외됩니다 — 선순환). 되돌리기: vhk memory unarchive <번호>'))
+}
+
+/** 항목 해결 표시 (active→resolved). 실패가 교훈으로 정리됨을 기록 — 패턴/진화에서 제외. */
+export async function memoryResolve(indexStr: string): Promise<void> {
+  const r = resolveEntryForMutation(indexStr)
+  if (!r) return
+  r.entry.status = 'resolved'
+  r.entry.resolvedAt = new Date().toISOString()
+  delete r.entry.archivedAt
+  writeMemory(r.cwd, r.mem)
+  console.log(chalk.green(`\n✅ 해결됨: ${entryLabel(r.entry)}`))
+  console.log(chalk.dim('   (vhk memory list --all 로 확인. 되돌리기: vhk memory unarchive <번호>)'))
+}
+
+/** 보관/해결 항목을 다시 active 로 — 오조작 복구(archive/resolve 역전). */
+export async function memoryUnarchive(indexStr: string): Promise<void> {
+  const r = resolveEntryForMutation(indexStr)
+  if (!r) return
+  if (isActive(r.entry)) {
+    console.log(chalk.dim(`  이미 활성 항목입니다 — 변경 없음: ${entryLabel(r.entry)}`))
     return
   }
-  const { entry } = all[idx]
-  entry.status = 'archived'
-  entry.archivedAt = new Date().toISOString()
-  writeMemory(cwd, mem)
-  console.log(chalk.green(`\n📦 보관됨: ${entry.content || (entry as FailEntry).lesson || entry.id}`))
-  console.log(chalk.dim('   (패턴 감지·진화에서 제외됩니다 — 선순환)'))
+  r.entry.status = 'active'
+  delete r.entry.archivedAt
+  delete r.entry.resolvedAt
+  writeMemory(r.cwd, r.mem)
+  console.log(chalk.green(`\n🟢 활성으로 복구됨: ${entryLabel(r.entry)}`))
 }
 
 export async function memoryMigrate(): Promise<void> {
   const cwd = process.cwd()
   const raw = readRaw(cwd)
-  if (isV2(raw)) {
+  if (raw.kind === 'error') {
+    // 손상 파일을 빈 v2 로 덮지 않는다 — 원본 보존하고 중단.
+    warnUnreadable(cwd)
+    console.log(chalk.red('  ❌ 마이그레이션 중단 (손상 의심). 원본 확인 후 다시 시도하세요.'))
+    process.exitCode = 1
+    return
+  }
+  if (raw.kind === 'parsed' && isV2(raw.value)) {
     console.log(chalk.dim('  이미 memory schema v2 입니다 — 변경 없음(멱등).'))
     return
   }
-  const v2 = migrateMemory(raw, readLearningsRaw(cwd))
+  // 파싱되나 v1(배열)도 v2 도 아님 → 마이그레이션 대상 아님. 빈 v2 로 덮으면 미래 스키마 파괴 → 중단.
+  if (raw.kind === 'parsed' && !Array.isArray(raw.value)) {
+    warnUnrecognized(cwd)
+    console.log(chalk.red('  ❌ v1(평면 배열) 형식이 아니라 마이그레이션 대상이 아닙니다 — 중단(원본 보존).'))
+    process.exitCode = 1
+    return
+  }
+  const learnings = readLearningsRaw(cwd)
+  const hadFile = raw.kind === 'parsed' // 디스크에 (v2 아닌) 실제 파일이 있었는가 → .v1.bak 백업 생성됨
+  // 마이그레이션할 게 아무것도 없으면(파일 없음 + learnings 없음) 빈 파일을 만들지 않는다.
+  if (raw.kind === 'missing' && !learnings) {
+    console.log(chalk.yellow('  ℹ️  마이그레이션할 v1 memory.json / learnings.md 가 없습니다 — 변경 없음.'))
+    return
+  }
+  const v2 = migrateMemory(raw.kind === 'parsed' ? raw.value : null, learnings)
   writeMemory(cwd, v2)
-  console.log(chalk.green('\n✅ memory.json v1 → v2 마이그레이션 완료 (.v1.bak 원본 영구 백업)'))
+  // 백업 안내는 실제로 .v1.bak 이 만들어졌을 때만(기존 파일 존재). 신규 생성 시 거짓 백업 문구 금지.
+  const backupNote = hadFile ? ' (.v1.bak 원본 영구 백업)' : ' (신규 생성 — 원본 없음, 백업 없음)'
+  console.log(chalk.green(`\n✅ memory.json → v2 마이그레이션 완료${backupNote}`))
   console.log(
     chalk.dim(
       `   decisions ${v2.decisions.length} · failures ${v2.failures.length} · successes ${v2.successes.length}` +
-        ` (learnings.md 교훈 흡수 — 이후 vhk learn 은 memory 에 기록)`
+        (learnings ? ' (learnings.md 교훈 흡수 — 이후 vhk learn 은 memory 에 기록)' : '')
     )
   )
 }
@@ -344,7 +536,7 @@ export function activeMemoryLines(mem: MemoryFileV2, limit = 5): string[] {
     return e.content && f.lesson ? `${base} — 💡 ${f.lesson}` : base
   }
   const section = (label: string, list: MemEntry[]): void => {
-    const act = list.filter((e) => e.status === 'active')
+    const act = list.filter(isActive)
     if (act.length === 0) return
     lines.push(`**${label}** (${act.length})`)
     for (const e of act.slice(-limit)) lines.push(`- ${fmt(e)}`)
@@ -359,9 +551,14 @@ export function activeMemoryLines(mem: MemoryFileV2, limit = 5): string[] {
   return lines
 }
 
-/** Goal 18: vhk learn → memory v2 failures.lesson 단일 SoT (learnings.md 신규 기록 중단). */
-export function recordLesson(cwd: string, lesson: string, goalId?: number): FailEntry {
-  const mem = readMemory(cwd)
+/**
+ * Goal 18: vhk learn → memory v2 failures.lesson 단일 SoT (learnings.md 신규 기록 중단).
+ * 손상 파일이면 `null` 반환(빈 v2 로 덮어쓰지 않음) — 호출자가 중단·안내.
+ */
+export function recordLesson(cwd: string, lesson: string, goalId?: number): FailEntry | null {
+  const loaded = loadForMutation(cwd)
+  if (!loaded.ok) return null
+  const mem = loaded.mem
   const tag = goalId !== undefined ? `goal-${goalId}` : 'no-goal'
   const entry: FailEntry = {
     id: nextId('failure', mem),

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -231,7 +231,8 @@ export function toAgentsMd(sections: RulesSection[], projectName: string): strin
     '## Loop Protocol',
     '- 루프: `context → goal next → 작업 → goal check → goal done`',
     '- 작업 시작 시 `.vhk/HARD_STOP` 확인 — 있으면 모든 자동화 즉시 중단.',
-    '- active goal 만 작업. `docs/state`(next-task/blockers/learnings)는 SoT, append-only.',
+    '- active goal 만 작업. `docs/state`(next-task/blockers)는 append-only.',
+    '- 교훈·결정·실패·성공은 `vhk memory`(memory v2 4버킷, 단일 출처).',
     '- 게이트(tsc / test:run / build) 통과해야만 `vhk goal done`.',
     '',
   ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import { audit } from './commands/audit.js'
 import { migrate } from './commands/migrate.js'
 import { update } from './commands/update.js'
 import { context, contextShow } from './commands/context.js'
-import { memoryAdd, memoryList, memoryRemove, memoryArchive, memoryMigrate, type MemBucket } from './commands/memory.js'
+import { memoryAdd, memoryList, memoryRemove, memoryArchive, memoryResolve, memoryUnarchive, memoryMigrate, type MemBucket } from './commands/memory.js'
 import { brief } from './commands/brief.js'
 import { start } from './commands/start.js'
 import { mode } from './commands/mode.js'
@@ -499,7 +499,7 @@ program
 const memoryCmd = program
   .command('memory')
   .alias('기억')
-  .description('기억 관리 v2 (decisions/failures/successes 4버킷) — add/list/remove/archive/migrate')
+  .description('기억 관리 v2 (decisions/failures/successes 4버킷) — add/list/remove/archive/resolve/unarchive/migrate')
   .action(async () => { await memoryList() })
 
 memoryCmd
@@ -511,8 +511,8 @@ memoryCmd
   .description('기억 저장 (--type 으로 결정/실패/성공 구분)')
   .action(async (content: string, opts: { type?: string; tags?: string; why?: string; lesson?: string }) => {
     const tags = opts.tags ? opts.tags.split(',').map((s) => s.trim()) : undefined
-    const type = (opts.type === 'failure' || opts.type === 'success' ? opts.type : 'decision') as MemBucket
-    await memoryAdd(content, { type, tags, why: opts.why, lesson: opts.lesson })
+    // 잘못된 --type 은 강등하지 않고 그대로 넘긴다 — memoryAdd 가 검증·거부(입력 유실 방지).
+    await memoryAdd(content, { type: opts.type, tags, why: opts.why, lesson: opts.lesson })
   })
 
 memoryCmd
@@ -534,12 +534,26 @@ memoryCmd
 
 memoryCmd
   .command('archive <index>')
+  .alias('보관')
   .description('기억 보관 (활성→archived, 패턴/진화에서 제외)')
   .action(async (index: string) => { await memoryArchive(index) })
 
 memoryCmd
+  .command('resolve <index>')
+  .alias('해결')
+  .description('기억 해결 표시 (활성→resolved, 패턴/진화에서 제외)')
+  .action(async (index: string) => { await memoryResolve(index) })
+
+memoryCmd
+  .command('unarchive <index>')
+  .alias('복구')
+  .description('보관/해결 항목을 다시 활성으로 복구 (archive/resolve 역전)')
+  .action(async (index: string) => { await memoryUnarchive(index) })
+
+memoryCmd
   .command('migrate')
-  .description('memory.json v1 → v2 마이그레이션 (.v1.bak 원본 영구 백업, 멱등)')
+  .alias('마이그레이션')
+  .description('memory.json v1 → v2 마이그레이션 (기존 v1 있으면 .v1.bak 원본 백업, 멱등)')
   .action(async () => { await memoryMigrate() })
 
 program

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import { audit } from './commands/audit.js'
 import { migrate } from './commands/migrate.js'
 import { update } from './commands/update.js'
 import { context, contextShow } from './commands/context.js'
-import { memoryAdd, memoryList, memoryRemove } from './commands/memory.js'
+import { memoryAdd, memoryList, memoryRemove, memoryArchive, memoryMigrate, type MemBucket } from './commands/memory.js'
 import { brief } from './commands/brief.js'
 import { start } from './commands/start.js'
 import { mode } from './commands/mode.js'
@@ -499,29 +499,48 @@ program
 const memoryCmd = program
   .command('memory')
   .alias('기억')
-  .description('결정사항 기억 관리 (add / list / remove)')
+  .description('기억 관리 v2 (decisions/failures/successes 4버킷) — add/list/remove/archive/migrate')
   .action(async () => { await memoryList() })
 
 memoryCmd
   .command('add <content>')
+  .option('--type <type>', '버킷: decision|failure|success (기본 decision)')
   .option('--tags <tags>', '태그 (쉼표 구분)')
-  .description('결정사항 기억 저장')
-  .action(async (content: string, opts: { tags?: string }) => {
+  .option('--why <why>', '원인 (failure/success)')
+  .option('--lesson <lesson>', '교훈 (failure)')
+  .description('기억 저장 (--type 으로 결정/실패/성공 구분)')
+  .action(async (content: string, opts: { type?: string; tags?: string; why?: string; lesson?: string }) => {
     const tags = opts.tags ? opts.tags.split(',').map((s) => s.trim()) : undefined
-    await memoryAdd(content, tags)
+    const type = (opts.type === 'failure' || opts.type === 'success' ? opts.type : 'decision') as MemBucket
+    await memoryAdd(content, { type, tags, why: opts.why, lesson: opts.lesson })
   })
 
 memoryCmd
   .command('list')
   .alias('목록')
-  .description('저장된 기억 목록')
-  .action(async () => { await memoryList() })
+  .option('--type <type>', '버킷 필터: decision|failure|success')
+  .option('--all', '보관(archived)·해결(resolved) 포함')
+  .description('저장된 기억 목록 (기본 활성만)')
+  .action(async (opts: { type?: string; all?: boolean }) => {
+    const type = (opts.type === 'decision' || opts.type === 'failure' || opts.type === 'success' ? opts.type : undefined) as MemBucket | undefined
+    await memoryList({ type, all: opts.all })
+  })
 
 memoryCmd
   .command('remove <index>')
   .alias('삭제')
   .description('기억 삭제 (1부터 시작하는 번호)')
   .action(async (index: string) => { await memoryRemove(index) })
+
+memoryCmd
+  .command('archive <index>')
+  .description('기억 보관 (활성→archived, 패턴/진화에서 제외)')
+  .action(async (index: string) => { await memoryArchive(index) })
+
+memoryCmd
+  .command('migrate')
+  .description('memory.json v1 → v2 마이그레이션 (.bak 백업, 멱등)')
+  .action(async () => { await memoryMigrate() })
 
 program
   .command('brief')

--- a/src/index.ts
+++ b/src/index.ts
@@ -539,7 +539,7 @@ memoryCmd
 
 memoryCmd
   .command('migrate')
-  .description('memory.json v1 → v2 마이그레이션 (.bak 백업, 멱등)')
+  .description('memory.json v1 → v2 마이그레이션 (.v1.bak 원본 영구 백업, 멱등)')
   .action(async () => { await memoryMigrate() })
 
 program
@@ -601,7 +601,7 @@ program
 program
   .command('learn <lesson>')
   .alias('교훈')
-  .description('교훈 기록 → docs/state/learnings.md append (memory.json 과 별도 SoT)')
+  .description('교훈 기록 → memory v2 failures.lesson 단일 SoT (v2.0 통합 — vhk memory list 로 확인)')
   .action(async (lesson: string) => { await learn(lesson) })
 
 program

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -9,7 +9,7 @@
 export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
   goal: ['list', 'next', 'check', 'init', 'done', 'sync'],
   ref: ['add', 'list', 'open'],
-  memory: ['add', 'list', 'remove'],
+  memory: ['add', 'list', 'remove', 'archive', 'migrate'],
   cloud: ['push', 'pull'],
   secure: ['scan'],
   design: ['palette'],

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -9,7 +9,7 @@
 export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
   goal: ['list', 'next', 'check', 'init', 'done', 'sync'],
   ref: ['add', 'list', 'open'],
-  memory: ['add', 'list', 'remove', 'archive', 'migrate'],
+  memory: ['add', 'list', 'remove', 'archive', 'resolve', 'unarchive', 'migrate'],
   cloud: ['push', 'pull'],
   secure: ['scan'],
   design: ['palette'],

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -5,7 +5,7 @@
  * 사이에 기록하면 '어제' 날짜가 찍혀 하루 밀린다(블로커/학습/TIL/recap 로그 등 날짜 오기록).
  * `toLocaleDateString('sv-SE')` 는 로컬 타임존 + ISO 형식(YYYY-MM-DD)을 동시에 만족한다.
  *
- * 주의: 시각까지 필요한 머신 타임스탬프(생성시각 푸터·백업 파일명·HARD_STOP ts·memory addedAt)는
+ * 주의: 시각까지 필요한 머신 타임스탬프(생성시각 푸터·백업 파일명·HARD_STOP ts·memory createdAt)는
  *      Z(UTC) 표기가 명확하므로 `toISOString()` 을 그대로 둔다. 이 함수는 '날짜 표기' 전용.
  */
 export function localDate(d: Date = new Date()): string {

--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -211,12 +211,23 @@ const RULES: NlpRule[] = [
     test: t =>
       /감사|취약점|audit|vulnerability|보안\s*감사|보안\s*취약|의존성\s*취약/.test(t),
   },
+  // memory 마이그레이션은 패키지매니저 migrate 보다 **먼저** 평가 — "기억/메모리 마이그레이트" 가
+  // pnpm 전환(vhk migrate)으로 새지 않도록. 기억/메모리/memory 한정이라 bare "마이그레이트"는 안 가로챔.
+  {
+    command: 'memory',
+    args: ['migrate'],
+    explanation: 'memory.json v1 → v2 마이그레이션 (vhk memory migrate)',
+    confidence: 'high',
+    test: t => /(기억|메모리|memory)\s*(을|를)?\s*(마이그레이|migrat)/.test(t),
+  },
   {
     command: 'migrate',
     explanation: '패키지 매니저 전환 (vhk migrate)',
     confidence: 'high',
     test: t =>
-      /전환|마이그레이트|migrate|패키지\s*매니저|npm.*pnpm|pnpm.*npm|yarn.*전환|npm.*전환|pnpm.*전환/.test(t),
+      /전환|마이그레이(트|션)|migrate|패키지\s*매니저|npm.*pnpm|pnpm.*npm|yarn.*전환|npm.*전환|pnpm.*전환/.test(t)
+      // memory 마이그레이션 **의도**만 제외(인접 매칭) — "메모리 누수 때문에 pnpm 전환" 같은 정상 전환은 통과.
+      && !/(기억|메모리|memory)\s*(을|를)?\s*(마이그레이|migrat)/.test(t),
   },
   {
     command: 'update',
@@ -244,9 +255,11 @@ const RULES: NlpRule[] = [
     command: 'memory',
     explanation: '기억 목록 조회 (vhk memory list)',
     confidence: 'high',
+    // 보관(archive)/해결(resolve)/마이그레이션은 list 가 아니다 → **제외 토큰 한 곳**에서 오라우팅 차단.
+    // archive/resolve 는 <번호> 인자가 필요해 NL 미지원 → 매칭 안 되면 notMatched 가 정직(잘못된 list 실행 금지).
     test: t =>
       (/^기억$|기억\s*(목록|보|확인|뭐)|memory.*list|결정사항\s*(목록|확인|보여)/.test(t))
-      && !/(추가|add|삭제|remove|저장|기록해)/.test(t),
+      && !/(추가|add|삭제|remove|저장|기록해|보관|아카이브|archive|마이그레이|migrat|해결|복구)/.test(t),
   },
   {
     command: 'brief',

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -27,7 +27,7 @@ import { audit } from '../commands/audit.js'
 import { migrate } from '../commands/migrate.js'
 import { update } from '../commands/update.js'
 import { context, contextShow } from '../commands/context.js'
-import { memoryList } from '../commands/memory.js'
+import { memoryList, memoryMigrate } from '../commands/memory.js'
 import { brief } from '../commands/brief.js'
 import { start } from '../commands/start.js'
 import { goalCheck, goalDone, goalList, goalNext, goalSync } from '../commands/goal.js'
@@ -110,6 +110,7 @@ export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<
     case 'context-show':
       return contextShow()
     case 'memory':
+      if (route.args?.[0] === 'migrate') return memoryMigrate()
       return memoryList()
     case 'brief':
       return brief()

--- a/src/lib/state-files.ts
+++ b/src/lib/state-files.ts
@@ -65,28 +65,9 @@ export function appendBlocker(description: string, goalId?: number): {
   return { count, hardStopTripped }
 }
 
-export function appendLearning(lesson: string, goalId?: number): void {
-  ensureStateDir()
-  const tag = goalId !== undefined ? `goal-${goalId}` : 'no-goal'
-  const line = `- [${isoDate()} ${tag}] ${lesson.trim()}`
-  if (!existsSync(LEARNINGS_PATH)) {
-    writeFileSync(
-      LEARNINGS_PATH,
-      `# Learnings\n\n_Append-only. 한 줄 = 한 교훈._\n\n${line}\n`,
-      'utf-8'
-    )
-  } else {
-    appendFileSync(LEARNINGS_PATH, `${line}\n`, 'utf-8')
-  }
-}
-
-// learnings.md 의 마지막 N 줄 (헤더/메타 제외) 을 반환. vhk context 가 사용.
-export function getRecentLearnings(limit = 3): string[] {
-  if (!existsSync(LEARNINGS_PATH)) return []
-  const lines = readFileSync(LEARNINGS_PATH, 'utf-8').split(/\r?\n/)
-  const entries = lines.filter((l) => l.startsWith('- ['))
-  return entries.slice(-limit)
-}
+// NOTE(v2.0): appendLearning/getRecentLearnings 제거됨. 교훈 SoT 는 memory v2 failures.lesson
+//   (vhk learn → recordLesson). learnings.md 는 v1→v2 마이그레이션 **읽기 소스**로만 남는다
+//   (memory.ts readLearningsRaw 가 직접 읽음 — 신규 기록 경로 없음).
 
 // blockers.md 의 blocker 항목(활성 "- [" + 해결 "- ~~[") 중 마지막 N 개. vhk context 토큰 절감용.
 const BLOCKER_ENTRY_RE = /^- (~~)?\[/

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -662,8 +662,22 @@ export function createVhkMcpServer(): McpServer {
   // ─── memory-list ────────────────────────────────────────
   server.registerTool(
     'memory-list',
-    { description: '저장된 결정사항(memory) 목록 보기 (add/remove 는 인자 필요 → CLI 전용)' },
+    {
+      description:
+        'memory v2 활성 기억 목록 (decisions/failures/successes — 기본 active 만). add/remove/archive/resolve/unarchive/migrate 는 인자·쓰기 → CLI 전용',
+    },
     async () => runVhkCli(['memory', 'list'], 'memory list')
+  )
+
+  // ─── learn ──────────────────────────────────────────────
+  // 교훈 기록은 인자 1개(lesson)뿐이고 inquirer/process.exit 미사용 → MCP 안전(쓰기 도구).
+  server.registerTool(
+    'learn',
+    {
+      description: '교훈 1줄 기록 → memory v2 failures.lesson (단일 SoT, Evolution Loop 폐회로)',
+      inputSchema: { lesson: z.string().describe('기록할 교훈 한 줄') },
+    },
+    async ({ lesson }) => runVhkCli(['learn', lesson], 'learn')
   )
 
   // ─── context-show ───────────────────────────────────────

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -53,7 +53,7 @@ describe('blocker', () => {
   })
 })
 
-describe('learn — SoT 일관성 (memory.json 격리)', () => {
+describe('learn — memory v2 통합 SoT (Goal 18 breaking: learnings.md 분리 폐지)', () => {
   let origCwd: string
   let dir: string
   beforeEach(() => {
@@ -68,16 +68,22 @@ describe('learn — SoT 일관성 (memory.json 격리)', () => {
     vi.restoreAllMocks()
   })
 
-  it('learn 호출은 learnings.md 만 갱신, memory.json 무영향 (Forbidden 이중 기록 금지)', async () => {
+  it('learn 호출은 memory v2 failures.lesson 에 기록, learnings.md 신규 기록 안 함 (통합)', async () => {
     const { learn } = await import('../src/commands/agent.js')
     await learn('새 교훈')
-    expect(existsSync(join(dir, 'docs/state/learnings.md'))).toBe(true)
-    expect(existsSync(join(dir, '.vhk/memory.json'))).toBe(false)
+    // 통합: memory.json 에 기록
+    expect(existsSync(join(dir, '.vhk/memory.json'))).toBe(true)
+    const mem = JSON.parse(readFileSync(join(dir, '.vhk/memory.json'), 'utf-8'))
+    expect(mem.schemaVersion).toBe(2)
+    expect(mem.failures[0].lesson).toBe('새 교훈')
+    // learnings.md 신규 기록 중단
+    expect(existsSync(join(dir, 'docs/state/learnings.md'))).toBe(false)
   })
 
   it('빈 lesson 이면 기록 안 함', async () => {
     const { learn } = await import('../src/commands/agent.js')
     await learn('  ')
+    expect(existsSync(join(dir, '.vhk/memory.json'))).toBe(false)
     expect(existsSync(join(dir, 'docs/state/learnings.md'))).toBe(false)
   })
 })

--- a/tests/brief.test.ts
+++ b/tests/brief.test.ts
@@ -88,7 +88,7 @@ describe('brief', () => {
     expect(md).toContain('없음 ✅')
   })
 
-  it('memory.json 있으면 결정사항 섹션 포함', async () => {
+  it('memory.json 있으면 기억 섹션 포함 (v1 배열 자동 마이그)', async () => {
     mockExistsSync.mockImplementation((p: unknown) => String(p).includes('memory.json'))
     mockReadFileSync.mockImplementation((p: unknown) => {
       if (String(p).includes('memory.json'))
@@ -100,7 +100,7 @@ describe('brief', () => {
     await brief()
 
     const md = String(mockWriteFileSync.mock.calls[0][1])
-    expect(md).toContain('저장된 결정사항')
+    expect(md).toContain('저장된 기억')
     expect(md).toContain('결정-1')
   })
 })

--- a/tests/brief.test.ts
+++ b/tests/brief.test.ts
@@ -15,6 +15,9 @@ vi.mock('node:fs', () => ({
   readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
   writeFileSync: (...a: unknown[]) => mockWriteFileSync(...a),
   mkdirSync: (...a: unknown[]) => mockMkdirSync(...a),
+  // writeMemory 는 백업(copyFileSync)과 원자적 쓰기(renameSync)를 쓴다 — 모킹 누락 시 마이그 write 가 throw.
+  copyFileSync: () => undefined,
+  renameSync: () => undefined,
 }))
 
 describe('brief', () => {

--- a/tests/brief.test.ts
+++ b/tests/brief.test.ts
@@ -99,7 +99,9 @@ describe('brief', () => {
     const { brief } = await import('../src/commands/brief.js')
     await brief()
 
-    const md = String(mockWriteFileSync.mock.calls[0][1])
+    // readMemory 가 v1 디스크를 v2 로 영구화(write)하므로 brief.md 쓰기를 경로로 특정한다.
+    const call = mockWriteFileSync.mock.calls.find((c) => String(c[0]).includes('brief.md'))
+    const md = String(call![1])
     expect(md).toContain('저장된 기억')
     expect(md).toContain('결정-1')
   })

--- a/tests/context-loop.test.ts
+++ b/tests/context-loop.test.ts
@@ -37,9 +37,10 @@ describe('vhk context — Goal 2 자율 루프 확장', () => {
     vi.restoreAllMocks()
   })
 
-  it('## Active Goal + ## Recent Learnings 섹션 포함', async () => {
+  it('## Active Goal + 교훈(memory v2 흡수) 섹션 포함', async () => {
     makeGoalFile(dir, 0, 'DONE', 'Done Goal')
     makeGoalFile(dir, 1, 'IN_PROGRESS', '진행 중 미션')
+    // v2: learnings.md 의 교훈은 readMemory 가 failures 로 흡수 → "저장된 기억" 섹션에 노출.
     const { appendLearning } = await import('../src/lib/state-files.js')
     appendLearning('lesson alpha')
     appendLearning('lesson bravo')
@@ -52,7 +53,7 @@ describe('vhk context — Goal 2 자율 루프 확장', () => {
     expect(out).toContain('## Active Goal')
     expect(out).toContain('id**: 1')
     expect(out).toContain('진행 중 미션')
-    expect(out).toContain('## Recent Learnings')
+    expect(out).toContain('저장된 기억') // v2 memory 섹션(구 Recent Learnings 통합)
     expect(out).toContain('lesson alpha')
     expect(out).toContain('lesson charlie')
   })

--- a/tests/context-loop.test.ts
+++ b/tests/context-loop.test.ts
@@ -41,10 +41,13 @@ describe('vhk context — Goal 2 자율 루프 확장', () => {
     makeGoalFile(dir, 0, 'DONE', 'Done Goal')
     makeGoalFile(dir, 1, 'IN_PROGRESS', '진행 중 미션')
     // v2: learnings.md 의 교훈은 readMemory 가 failures 로 흡수 → "저장된 기억" 섹션에 노출.
-    const { appendLearning } = await import('../src/lib/state-files.js')
-    appendLearning('lesson alpha')
-    appendLearning('lesson bravo')
-    appendLearning('lesson charlie')
+    // (v2.0 에서 appendLearning 제거 — learnings.md 는 마이그레이션 읽기 소스로만 남음. 직접 작성해 흡수 검증.)
+    mkdirSync(join(dir, 'docs', 'state'), { recursive: true })
+    writeFileSync(
+      join(dir, 'docs', 'state', 'learnings.md'),
+      '# Learnings\n\n- [2026-01-01 no-goal] lesson alpha\n- [2026-01-02 no-goal] lesson bravo\n- [2026-01-03 no-goal] lesson charlie\n',
+      'utf-8'
+    )
 
     const { context } = await import('../src/commands/context.js')
     await context()

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -14,6 +14,10 @@ vi.mock('node:fs', () => ({
   mkdirSync: (...a: unknown[]) => mockMkdirSync(...a),
   readdirSync: (...a: unknown[]) => mockReaddirSync(...a),
   statSync: (...a: unknown[]) => mockStatSync(...a),
+  // writeMemory(readMemory 의 v1 자동 마이그)가 쓰는 fs — 시드가 v1 일 때 throw 방지(durability).
+  copyFileSync: () => undefined,
+  renameSync: () => undefined,
+  rmSync: () => undefined,
 }))
 
 describe('context', () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -46,6 +46,11 @@ describe('MCP Server', () => {
     expect(names.length).toBeGreaterThanOrEqual(24)
   })
 
+  it('v2.0 — learn 쓰기 tool 등록 (memory v2 SoT, Evolution Loop)', async () => {
+    const names = await getRegisteredToolNames()
+    expect(names).toContain('learn')
+  })
+
   it('SERVER_VERSION 이 package.json 과 정합 (lib/version SoT)', async () => {
     const { getVhkVersion } = await import('../src/lib/version.js')
     const pkgVersion = getVhkVersion()

--- a/tests/memory-v2-edge.test.ts
+++ b/tests/memory-v2-edge.test.ts
@@ -1,0 +1,433 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  migrateMemory,
+  readMemory,
+  writeMemory,
+  recordLesson,
+  memoryAdd,
+  memoryArchive,
+  activeMemoryLines,
+  MEMORY_PATH_REL,
+  type MemoryFileV2,
+} from '../src/commands/memory.js'
+import { context } from '../src/commands/context.js'
+
+// ────────────────────────────────────────────────────────────────────────────
+// 창 C — memory v2 엣지 하드닝 2탄 (ultracode 멀티렌즈 리뷰에서 도출 → 자체 검증).
+// 워크플로 권고는 그대로 안 씀: 기대값을 src/commands/memory.ts 실제 로직으로 재유도해
+// 못박음. (예: parseLearnings 정규식 `\]\s*(.+)` 은 `]` 직후 공백 없는 교훈도 매칭 →
+// 워크플로가 제시한 "length 1" 은 틀림. 실제 동작 기준으로 작성.)
+// 전부 현 구현에서 green = characterization. Windows: chdir(origCwd) → rmSync 순서.
+// ────────────────────────────────────────────────────────────────────────────
+
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-meme-'))
+}
+function memPath(d: string): string {
+  return path.join(d, MEMORY_PATH_REL)
+}
+function seedV1(d: string, arr: unknown[]): void {
+  fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+  fs.writeFileSync(memPath(d), JSON.stringify(arr), 'utf-8')
+}
+function seedRaw(d: string, raw: string): void {
+  fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+  fs.writeFileSync(memPath(d), raw, 'utf-8')
+}
+function seedV2(d: string, mem: MemoryFileV2): void {
+  fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+  fs.writeFileSync(memPath(d), JSON.stringify(mem, null, 2) + '\n', 'utf-8')
+}
+function readMem(d: string): MemoryFileV2 {
+  return JSON.parse(fs.readFileSync(memPath(d), 'utf-8'))
+}
+function rm(d: string): void {
+  fs.rmSync(d, { recursive: true, force: true })
+}
+function entry(over: Partial<MemoryFileV2['decisions'][number]> = {}) {
+  return { id: 'd1', content: 'x', tags: [], createdAt: '', status: 'active' as const, ...over }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// A — learnings.md 흡수(마이그레이션) 파싱 견고성
+//   parseLearnings regex: /^-\s*\[(\d{4}-\d{2}-\d{2})\s+([^\]]*)\]\s*(.+)$/
+// ════════════════════════════════════════════════════════════════════════════
+describe('memory v2 엣지 A — learnings 흡수 파싱', () => {
+  it('정상/무효 혼합 — date 없음·] 직전 공백 없음(태그 누락)·리스트 아님 은 드롭', () => {
+    const mixed =
+      '- [2026-01-01 goal-1] 유효교훈.\n' + // 매칭
+      '- [bad goal-1] 날짜불량\n' + // date 정규식 실패 → 드롭
+      '- [2026-01-02] 태그공백없음\n' + // date 뒤 `\s+태그` 없음 → 드롭
+      'random 일반 텍스트\n' // `^-\s*\[` 아님 → 드롭
+    const v2 = migrateMemory([], mixed)
+    expect(v2.failures).toHaveLength(1)
+    expect(v2.failures[0].lesson).toBe('유효교훈.')
+    expect(v2.failures[0].tags).toEqual(['goal-1'])
+  })
+
+  it('[characterization] `]` 직후 공백 없는 교훈도 매칭 (\\s* 가 0 허용)', () => {
+    const v2 = migrateMemory([], '- [2026-01-03 goal-2]즉시교훈\n')
+    expect(v2.failures).toHaveLength(1)
+    expect(v2.failures[0].lesson).toBe('즉시교훈')
+    expect(v2.failures[0].tags).toEqual(['goal-2'])
+  })
+
+  it('공백만 태그 → 빈 tags 배열', () => {
+    const v2 = migrateMemory([], '- [2026-01-01 ] 교훈.\n')
+    expect(v2.failures).toHaveLength(1)
+    expect(v2.failures[0].tags).toEqual([])
+    expect(v2.failures[0].lesson).toBe('교훈.')
+  })
+
+  it('다중 단어 태그 — 내부 공백 보존', () => {
+    const v2 = migrateMemory([], '- [2026-05-27 goal-1 extra] 교훈.\n')
+    expect(v2.failures[0].tags).toEqual(['goal-1 extra'])
+  })
+
+  it('공백만 교훈 → trim 후 빈 문자열 lesson (드롭 안 함)', () => {
+    const v2 = migrateMemory([], '- [2026-01-01 goal-1]     ')
+    expect(v2.failures).toHaveLength(1)
+    expect(v2.failures[0].lesson).toBe('')
+    expect(v2.failures[0].tags).toEqual(['goal-1'])
+  })
+
+  it('[characterization] 비현실 날짜(2026-13-01)도 의미검증 없이 as-is 저장', () => {
+    const v2 = migrateMemory([], '- [2026-13-01 goal-1] 교훈.\n')
+    expect(v2.failures).toHaveLength(1)
+    expect(v2.failures[0].createdAt).toBe('2026-13-01')
+  })
+
+  it('매칭 라인 0개 learnings → failures 빈 배열 (에러 없음)', () => {
+    expect(migrateMemory([], '# Learnings\n\n그냥 텍스트\n').failures).toEqual([])
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// B — v1 데이터 변형 흡수
+// ════════════════════════════════════════════════════════════════════════════
+describe('memory v2 엣지 B — v1 데이터 변형', () => {
+  it('tags 가 배열 아님(scalar/object) → [] 로 강제 (조용한 손실 특성)', () => {
+    const a = migrateMemory([{ content: 'A', tags: 'single' }])
+    expect(a.decisions[0].tags).toEqual([])
+    const b = migrateMemory([{ content: 'B', tags: { category: 'api' } }])
+    expect(b.decisions[0].tags).toEqual([])
+  })
+
+  it('addedAt 없으면 createdAt 빈 문자열', () => {
+    const v2 = migrateMemory([{ content: 'A' }])
+    expect(v2.decisions[0].createdAt).toBe('')
+    expect(v2.decisions[0].status).toBe('active')
+  })
+
+  it('emoji/RTL/결합문자 content — 마이그레이션+디스크 왕복 무손상', () => {
+    const d = tmp()
+    seedV1(d, [{ content: '결정 🎯' }, { content: 'café' }, { content: 'العربية' }])
+    const m1 = readMemory(d)
+    expect(m1.decisions[0].content).toBe('결정 🎯')
+    expect(m1.decisions[1].content).toBe('café')
+    expect(m1.decisions[2].content).toBe('العربية')
+    const m2 = readMemory(d) // 디스크 v2 재읽기
+    expect(JSON.stringify(m2)).toBe(JSON.stringify(m1))
+    rm(d)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// C — 인코딩 정규화 / 손상 v2
+// ════════════════════════════════════════════════════════════════════════════
+describe('memory v2 엣지 C — 인코딩/손상 v2', () => {
+  it('CRLF v2 입력 → read→write 후 canonical LF (CRLF 제거)', () => {
+    const d = tmp()
+    const v2: MemoryFileV2 = { schemaVersion: 2, decisions: [entry()], failures: [], successes: [], patterns: [] }
+    const crlf = JSON.stringify(v2, null, 2).replace(/\n/g, '\r\n') + '\r\n'
+    seedRaw(d, crlf)
+    expect(fs.readFileSync(memPath(d), 'utf-8')).toContain('\r\n')
+    writeMemory(d, readMemory(d))
+    const after = fs.readFileSync(memPath(d), 'utf-8')
+    expect(after).not.toContain('\r\n')
+    expect(after).toBe(JSON.stringify(v2, null, 2) + '\n')
+    rm(d)
+  })
+
+  it('BOM v2 → read→write 후 출력 BOM 없음(canonical)', () => {
+    const d = tmp()
+    const v2: MemoryFileV2 = { schemaVersion: 2, decisions: [entry({ content: 'canonical' })], failures: [], successes: [], patterns: [] }
+    seedRaw(d, '﻿' + JSON.stringify(v2, null, 2) + '\n')
+    expect(fs.readFileSync(memPath(d), 'utf-8').charCodeAt(0)).toBe(0xfeff)
+    writeMemory(d, readMemory(d))
+    const out = fs.readFileSync(memPath(d), 'utf-8')
+    expect(out.charCodeAt(0)).not.toBe(0xfeff)
+    expect(out.charCodeAt(0)).toBe(0x7b) // '{'
+    rm(d)
+  })
+
+  it('손상 v2(버킷 타입 틀림/누락) → arr() 안전 강등으로 빈 배열, 크래시 없음', () => {
+    const d = tmp()
+    seedRaw(d, '{"schemaVersion":2,"decisions":"notarray","failures":null,"successes":123,"patterns":{}}')
+    const m = readMemory(d)
+    expect(m.decisions).toEqual([])
+    expect(m.failures).toEqual([])
+    expect(m.successes).toEqual([])
+    expect(m.patterns).toEqual([])
+    rm(d)
+  })
+
+  it('버킷 전부 누락된 v2 → 빈 배열로 정규화', () => {
+    const d = tmp()
+    seedRaw(d, '{"schemaVersion":2}')
+    const m = readMemory(d)
+    expect(m.decisions).toEqual([])
+    expect(m.patterns).toEqual([])
+    rm(d)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// D — id / index 경계 (커맨드)
+// ════════════════════════════════════════════════════════════════════════════
+describe('memory v2 엣지 D — id/index 경계', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    process.exitCode = 0
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+    process.exitCode = 0
+  })
+
+  it('[characterization] nextId 는 malformed id(d1a/d3x) regex 필터 → 정상 id 만으로 max', async () => {
+    const d = tmp()
+    seedV2(d, {
+      schemaVersion: 2,
+      decisions: [
+        entry({ id: 'd1', content: 'ok' }),
+        entry({ id: 'd1a', content: 'malformed' }),
+        entry({ id: 'd2', content: 'ok' }),
+        entry({ id: 'd3x', content: 'malformed' }),
+      ],
+      failures: [],
+      successes: [],
+      patterns: [],
+    })
+    process.chdir(d)
+    await memoryAdd('새것') // max(1,2)=2 → d3
+    const added = readMem(d).decisions.find((e) => e.content === '새것')
+    expect(added?.id).toBe('d3')
+    process.chdir(origCwd)
+    rm(d)
+  })
+
+  it('빈 메모리에서 archive → exit 1 (remove 와 대칭, 크래시 없음)', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryArchive('1')
+    expect(process.exitCode).toBe(1)
+    process.chdir(origCwd)
+    rm(d)
+  })
+
+  it('[characterization] 소수 index("2.9") → parseInt 절삭 → 2번 항목 archive', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('첫째')
+    await memoryAdd('둘째')
+    await memoryArchive('2.9') // parseInt('2.9')=2 → idx1
+    const mem = readMem(d)
+    expect(mem.decisions[0].status).toBe('active')
+    expect(mem.decisions[1].status).toBe('archived')
+    process.chdir(origCwd)
+    rm(d)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// E — resolved 상태 (도달 불가 특성 + 전이)
+// ════════════════════════════════════════════════════════════════════════════
+describe('memory v2 엣지 E — resolved 상태', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    process.exitCode = 0
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+    process.exitCode = 0
+  })
+
+  it('[characterization/finding] 공개 커맨드로 resolved 생성 불가 (add→active, archive→archived)', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('결정')
+    await memoryAdd('실패', { type: 'failure', lesson: 'L' })
+    await memoryArchive('1')
+    const mem = readMem(d)
+    const statuses = [...mem.decisions, ...mem.failures].map((e) => e.status)
+    expect(statuses).not.toContain('resolved') // resolved 는 어떤 커맨드도 안 만듦
+    expect(mem.decisions[0].status).toBe('archived')
+    process.chdir(origCwd)
+    rm(d)
+  })
+
+  it('디스크의 resolved 항목 — resolvedAt 미설정(undefined), archive 시 archived+archivedAt', async () => {
+    const d = tmp()
+    seedV2(d, {
+      schemaVersion: 2,
+      decisions: [entry({ id: 'd1', content: '활성' }), entry({ id: 'd2', content: '해결', status: 'resolved' })],
+      failures: [],
+      successes: [],
+      patterns: [],
+    })
+    expect(readMem(d).decisions[1].resolvedAt).toBeUndefined() // 코드가 resolvedAt 안 씀
+    process.chdir(d)
+    await memoryArchive('2') // resolved → archived
+    const mem = readMem(d)
+    expect(mem.decisions[1].status).toBe('archived')
+    expect(typeof mem.decisions[1].archivedAt).toBe('string') // archivedAt 설정됨
+    process.chdir(origCwd)
+    rm(d)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// F — learn / recordLesson / memoryAdd lesson
+// ════════════════════════════════════════════════════════════════════════════
+describe('memory v2 엣지 F — learn/lesson', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    process.exitCode = 0
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+    process.exitCode = 0
+  })
+
+  it('recordLesson goalId=0(falsy 숫자) → tag goal-0 (no-goal 아님)', () => {
+    const d = tmp()
+    const e = recordLesson(d, '교훈', 0)
+    expect(e.tags).toEqual(['goal-0']) // goalId !== undefined → 0 도 유효
+    rm(d)
+  })
+
+  it('[characterization] recordLesson 은 공백 lesson 거부 안 함 → trim 후 빈 문자열 저장', () => {
+    const d = tmp()
+    const e = recordLesson(d, '    ')
+    expect(e.lesson).toBe('')
+    expect(readMem(d).failures).toHaveLength(1)
+    rm(d)
+  })
+
+  it('[characterization/finding] memoryAdd 의 lesson 은 trim 안 함 (recordLesson 과 불일치)', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('내용', { type: 'failure', lesson: '  공백둘러쌈  ' })
+    expect(readMem(d).failures[0].lesson).toBe('  공백둘러쌈  ') // verbatim (content 는 trim 되지만 lesson 은 아님)
+    process.chdir(origCwd)
+    rm(d)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// G — activeMemoryLines 렌더 분기
+// ════════════════════════════════════════════════════════════════════════════
+describe('memory v2 엣지 G — activeMemoryLines 렌더', () => {
+  it('active > limit → 최근 limit개 + "… 외 N개" 절단', () => {
+    const decisions = Array.from({ length: 7 }, (_, i) =>
+      entry({ id: `d${i + 1}`, content: `결정${i + 1}` })
+    )
+    const mem: MemoryFileV2 = { schemaVersion: 2, decisions, failures: [], successes: [], patterns: [] }
+    const out = activeMemoryLines(mem, 5).join('\n')
+    expect(out).toContain('결정3') // 최근 5개 = 결정3..7
+    expect(out).toContain('결정7')
+    expect(out).not.toContain('결정1') // 잘림
+    expect(out).toContain('… 외 2개')
+  })
+
+  it('failure 에 content+lesson 둘 다 → "content — 💡 lesson" 포맷', () => {
+    const mem: MemoryFileV2 = {
+      schemaVersion: 2,
+      decisions: [],
+      failures: [{ id: 'f1', content: '기술부채', tags: [], createdAt: '', status: 'active', lesson: '자동테스트 필수' }],
+      successes: [],
+      patterns: [],
+    }
+    expect(activeMemoryLines(mem).join('\n')).toContain('기술부채 — 💡 자동테스트 필수')
+  })
+
+  it('patterns 있으면 카운트 라인 노출', () => {
+    const mem: MemoryFileV2 = {
+      schemaVersion: 2,
+      decisions: [],
+      failures: [],
+      successes: [],
+      patterns: [{ id: 'p1' }, { id: 'p2' }],
+    }
+    const out = activeMemoryLines(mem).join('\n')
+    expect(out).toContain('2개')
+    expect(out).toContain('vhk pattern')
+  })
+
+  it('active 0 + patterns 0 → 빈 출력(섹션 헤더 없음)', () => {
+    const mem: MemoryFileV2 = {
+      schemaVersion: 2,
+      decisions: [entry({ status: 'archived' })],
+      failures: [{ id: 'f1', content: '', tags: [], createdAt: '', status: 'archived', lesson: 'L' }],
+      successes: [],
+      patterns: [],
+    }
+    const lines = activeMemoryLines(mem)
+    expect(lines.join('\n')).not.toContain('결정')
+    expect(lines.join('\n')).not.toContain('실패')
+    expect(lines.filter((l) => l.startsWith('**'))).toHaveLength(0)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// H — 통합 / write-once 견고성
+// ════════════════════════════════════════════════════════════════════════════
+describe('memory v2 엣지 H — 통합/write-once', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+  })
+
+  it('context() — 손상 memory.json 이어도 크래시 없이 context.md 생성', async () => {
+    const d = tmp()
+    seedRaw(d, '{ broken json ]]')
+    fs.writeFileSync(path.join(d, 'package.json'), JSON.stringify({ name: 't', version: '0.0.0' }), 'utf-8')
+    process.chdir(d)
+    await expect(context()).resolves.not.toThrow()
+    expect(fs.existsSync(path.join(d, '.vhk', 'context.md'))).toBe(true)
+    process.chdir(origCwd)
+    rm(d)
+  })
+
+  it('외부 revert(v2→v1) 후 readMemory 재실행 — .v1.bak write-once 유지, 다시 v2 영구화', () => {
+    const d = tmp()
+    seedV1(d, [{ content: '원본' }])
+    readMemory(d) // 1회: v1→v2, .v1.bak = 원본 v1
+    const bak1 = fs.readFileSync(memPath(d) + '.v1.bak', 'utf-8')
+    fs.writeFileSync(memPath(d), JSON.stringify([{ content: '원본' }]), 'utf-8') // 외부 v1 revert
+    readMemory(d) // 2회: 디스크 v1 → 재마이그레이션, 단 .v1.bak 존재 → write-once 가드
+    const bak2 = fs.readFileSync(memPath(d) + '.v1.bak', 'utf-8')
+    expect(bak2).toBe(bak1) // .v1.bak 무변경
+    expect(readMem(d).schemaVersion).toBe(2) // memory.json 다시 v2
+    rm(d)
+  })
+})

--- a/tests/memory-v2-hardening.test.ts
+++ b/tests/memory-v2-hardening.test.ts
@@ -1,0 +1,625 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  migrateMemory,
+  readMemory,
+  writeMemory,
+  recordLesson,
+  memoryAdd,
+  memoryList,
+  memoryRemove,
+  memoryArchive,
+  memoryMigrate,
+  activeMemoryLines,
+  MEMORY_PATH_REL,
+  type MemoryFileV2,
+} from '../src/commands/memory.js'
+import { context } from '../src/commands/context.js'
+import { findSecretsInLine, filterSevereFindings } from '../src/lib/scan-secrets.js'
+
+// ────────────────────────────────────────────────────────────────────────────
+// 창 C — memory schema v2 회귀/엣지 하드닝 (characterization 안전망).
+// schema v2 는 breaking(v1 평면배열 → v2 4버킷). 로직은 이미 존재 → 이 테스트는
+// "현 동작을 못박는" 것이며 현 구현에서 전부 green 이어야 정상.
+// Windows: 임시디렉토리 정리 시 chdir(origCwd) 를 rmSync 보다 먼저 (EPERM 회피).
+// ────────────────────────────────────────────────────────────────────────────
+
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-memh-'))
+}
+function memPath(d: string): string {
+  return path.join(d, MEMORY_PATH_REL)
+}
+/** v1 평면 배열 시드 (.vhk/memory.json) */
+function seedV1(d: string, arr: unknown[]): void {
+  fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+  fs.writeFileSync(memPath(d), JSON.stringify(arr), 'utf-8')
+}
+/** raw 문자열을 그대로 .vhk/memory.json 에 기록 (손상 입력 시드용) */
+function seedRaw(d: string, raw: string): void {
+  fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+  fs.writeFileSync(memPath(d), raw, 'utf-8')
+}
+function seedV2(d: string, mem: MemoryFileV2): void {
+  fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+  fs.writeFileSync(memPath(d), JSON.stringify(mem, null, 2) + '\n', 'utf-8')
+}
+function seedLearnings(d: string, body: string): void {
+  fs.mkdirSync(path.join(d, 'docs', 'state'), { recursive: true })
+  fs.writeFileSync(path.join(d, 'docs', 'state', 'learnings.md'), body, 'utf-8')
+}
+function readMem(d: string): MemoryFileV2 {
+  return JSON.parse(fs.readFileSync(memPath(d), 'utf-8'))
+}
+function rm(d: string): void {
+  fs.rmSync(d, { recursive: true, force: true })
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// 케이스 1 — 마이그레이션 멱등성 (FS 레벨: 2회 실행해도 무변경/무중복)
+// ════════════════════════════════════════════════════════════════════════════
+describe('memory v2 하드닝 1 — 마이그레이션 멱등성 (FS)', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+  })
+
+  it('memoryMigrate 2회 — 두 번째는 no-op (바이트 동일, failures 중복 흡수 안 함)', async () => {
+    const d = tmp()
+    seedV1(d, [{ content: '결정A' }, { content: '결정B' }])
+    seedLearnings(d, '- [2026-01-01 goal-1] 교훈1.\n- [2026-01-02 goal-2] 교훈2.\n')
+    process.chdir(d)
+
+    await memoryMigrate()
+    const afterFirst = fs.readFileSync(memPath(d), 'utf-8')
+    const mem1 = JSON.parse(afterFirst)
+    expect(mem1.decisions).toHaveLength(2)
+    expect(mem1.failures).toHaveLength(2) // learnings 1회 흡수
+
+    await memoryMigrate() // 이미 v2 → no-op
+    const afterSecond = fs.readFileSync(memPath(d), 'utf-8')
+    expect(afterSecond).toBe(afterFirst) // 바이트 단위 무변경
+    const mem2 = JSON.parse(afterSecond)
+    expect(mem2.decisions).toHaveLength(2) // 중복 없음
+    expect(mem2.failures).toHaveLength(2) // learnings 재흡수 안 함 (4 아님)
+
+    process.chdir(origCwd)
+    rm(d)
+  })
+
+  it('readMemory 2회 — v1 1회 영구화 후 재읽기는 디스크 무변경 (멱등)', () => {
+    const d = tmp()
+    seedV1(d, [{ content: '결정X', tags: ['t'], addedAt: '2026-03-03' }])
+
+    readMemory(d) // 1회: v1 → v2 영구화 (+ .bak/.v1.bak)
+    const afterFirst = fs.readFileSync(memPath(d), 'utf-8')
+    expect(JSON.parse(afterFirst).schemaVersion).toBe(2)
+
+    readMemory(d) // 2회: 디스크 v2 → write 안 함
+    const afterSecond = fs.readFileSync(memPath(d), 'utf-8')
+    expect(afterSecond).toBe(afterFirst)
+
+    rm(d)
+  })
+
+  it('순수 migrateMemory — 이미 v2 면 learnings 무시 (재흡수 0)', () => {
+    const once = migrateMemory([{ content: 'A' }], '- [2026-01-01 g] L1.\n')
+    expect(once.failures).toHaveLength(1)
+    const twice = migrateMemory(once, '- [2026-01-01 g] L1.\n- [2026-01-02 g] L2.\n')
+    expect(twice.failures).toHaveLength(1) // v2 입력이면 새 learnings 도 안 흡수
+    expect(twice.decisions).toHaveLength(1)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 케이스 2 — 손상 v1 입력 복구 (빈 파일 / BOM / 깨진 JSON → 크래시 없음)
+// ════════════════════════════════════════════════════════════════════════════
+describe('memory v2 하드닝 2 — 손상 입력 안전 복구', () => {
+  it('빈 파일 → 크래시 없이 빈 v2 (버킷 전부 빈 배열)', () => {
+    const d = tmp()
+    seedRaw(d, '')
+    let mem: MemoryFileV2 | undefined
+    expect(() => {
+      mem = readMemory(d)
+    }).not.toThrow()
+    expect(mem!.schemaVersion).toBe(2)
+    expect(mem!.decisions).toEqual([])
+    expect(mem!.failures).toEqual([])
+    expect(mem!.successes).toEqual([])
+    expect(mem!.patterns).toEqual([])
+    rm(d)
+  })
+
+  it('공백만 있는 파일 → 크래시 없음', () => {
+    const d = tmp()
+    seedRaw(d, '   \n\t  \n')
+    expect(() => readMemory(d)).not.toThrow()
+    expect(readMemory(d).schemaVersion).toBe(2)
+    rm(d)
+  })
+
+  it('깨진 JSON → 크래시 없이 빈 v2', () => {
+    const d = tmp()
+    seedRaw(d, '{ this is not : valid json ]]')
+    let mem: MemoryFileV2 | undefined
+    expect(() => {
+      mem = readMemory(d)
+    }).not.toThrow()
+    expect(mem!.decisions).toEqual([])
+    rm(d)
+  })
+
+  it('BOM + 유효 v1 배열 → 정상 파싱 (decisions 흡수)', () => {
+    const d = tmp()
+    seedRaw(d, '﻿' + JSON.stringify([{ content: 'BOM 결정' }]))
+    const mem = readMemory(d)
+    expect(mem.decisions).toHaveLength(1)
+    expect(mem.decisions[0].content).toBe('BOM 결정')
+    rm(d)
+  })
+
+  it('BOM + 유효 v2 객체 → v2 로 인식 (마이그레이션·.v1.bak 생성 안 함)', () => {
+    const d = tmp()
+    const v2: MemoryFileV2 = {
+      schemaVersion: 2,
+      decisions: [{ id: 'd1', content: 'x', tags: [], createdAt: '', status: 'active' }],
+      failures: [],
+      successes: [],
+      patterns: [],
+    }
+    seedRaw(d, '﻿' + JSON.stringify(v2, null, 2) + '\n')
+    const mem = readMemory(d)
+    expect(mem.decisions[0].content).toBe('x')
+    expect(fs.existsSync(memPath(d) + '.v1.bak')).toBe(false) // 이미 v2 → 백업 안 함
+    rm(d)
+  })
+
+  it('순수 migrateMemory — null/문자열/객체(비배열) 입력은 빈 v2', () => {
+    expect(migrateMemory(null).decisions).toEqual([])
+    expect(migrateMemory('just a string' as unknown).decisions).toEqual([])
+    expect(migrateMemory({ foo: 'bar' } as unknown).decisions).toEqual([])
+    // 배열이어도 content 가 문자열 아닌 항목은 건너뜀
+    const v2 = migrateMemory([{ content: 'ok' }, { nope: 1 }, { content: 123 }])
+    expect(v2.decisions).toHaveLength(1)
+    expect(v2.decisions[0].content).toBe('ok')
+  })
+
+  it('파일 아예 없음 → 빈 v2 반환 + 디스크에 쓰지 않음', () => {
+    const d = tmp() // .vhk/memory.json 없음
+    const mem = readMemory(d)
+    expect(mem.schemaVersion).toBe(2)
+    expect(mem.decisions).toEqual([])
+    expect(fs.existsSync(memPath(d))).toBe(false) // read 가 빈 파일 만들지 않음
+    rm(d)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 케이스 3 — .v1.bak 원본 write-once 영구 보존
+// ════════════════════════════════════════════════════════════════════════════
+describe('memory v2 하드닝 3 — .v1.bak 원본 보존', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    process.exitCode = 0
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+    process.exitCode = 0
+  })
+
+  it('마이그레이션 후 add/archive 여러 번 — .v1.bak 은 v1 원본 그대로', async () => {
+    const d = tmp()
+    const original = [{ content: '원본1' }, { content: '원본2', tags: ['x'] }]
+    seedV1(d, original)
+    process.chdir(d)
+
+    await memoryMigrate()
+    await memoryAdd('새 결정')
+    await memoryAdd('성공 기록', { type: 'success' })
+    await memoryArchive('1')
+    await memoryRemove('2')
+
+    const v1bak = JSON.parse(fs.readFileSync(memPath(d) + '.v1.bak', 'utf-8'))
+    expect(Array.isArray(v1bak)).toBe(true)
+    expect(v1bak).toEqual(original) // 후속 쓰기들이 절대 못 덮음
+    process.chdir(origCwd)
+    rm(d)
+  })
+
+  it('.v1.bak 이 이미 있으면 write-once 가드로 덮어쓰지 않음', () => {
+    const d = tmp()
+    seedV1(d, [{ content: 'v1 데이터' }])
+    const sentinel = '["SENTINEL_PRE_EXISTING_BAK"]'
+    fs.writeFileSync(memPath(d) + '.v1.bak', sentinel, 'utf-8')
+
+    writeMemory(d, migrateMemory(readMemory(d))) // 마이그레이션 1회 쓰기
+    expect(fs.readFileSync(memPath(d) + '.v1.bak', 'utf-8')).toBe(sentinel) // 무변경
+    rm(d)
+  })
+
+  it('롤링 .bak 은 최신 직전 상태, .v1.bak 은 원본 — 서로 다름', async () => {
+    const d = tmp()
+    seedV1(d, [{ content: '원본만' }])
+    process.chdir(d)
+
+    await memoryMigrate()
+    await memoryAdd('두번째 결정')
+
+    const v1bak = JSON.parse(fs.readFileSync(memPath(d) + '.v1.bak', 'utf-8'))
+    const bak = JSON.parse(fs.readFileSync(memPath(d) + '.bak', 'utf-8'))
+    expect(Array.isArray(v1bak)).toBe(true) // 원본 = v1 평면 배열
+    expect(bak.schemaVersion).toBe(2) // 롤링 = 직전 v2 상태
+    expect(bak.decisions).toHaveLength(1) // add '두번째' 직전 = 결정 1개
+    process.chdir(origCwd)
+    rm(d)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 케이스 4 — learn → failures.lesson 통합 + 중복 흡수 방지
+// ════════════════════════════════════════════════════════════════════════════
+describe('memory v2 하드닝 4 — learn 통합 + 중복 흡수 방지', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+  })
+
+  it('recordLesson 다회 — failures.lesson 누적 + id f1,f2 증가, learnings.md 미생성', () => {
+    const d = tmp()
+    const e1 = recordLesson(d, '교훈 하나', 7)
+    const e2 = recordLesson(d, '교훈 둘') // goalId 없음 → no-goal
+    expect(e1.id).toBe('f1')
+    expect(e2.id).toBe('f2')
+    const mem = readMem(d)
+    expect(mem.failures.map((f) => f.lesson)).toEqual(['교훈 하나', '교훈 둘'])
+    expect(mem.failures[0].tags).toEqual(['goal-7'])
+    expect(mem.failures[1].tags).toEqual(['no-goal'])
+    expect(fs.existsSync(path.join(d, 'docs', 'state', 'learnings.md'))).toBe(false)
+    rm(d)
+  })
+
+  it('vhk learn 호출 → failures.lesson + learnings.md 신규 기록 안 함', async () => {
+    const d = tmp()
+    process.chdir(d)
+    const { learn } = await import('../src/commands/agent.js')
+    await learn('PowerShell 은 && 미지원')
+    const mem = readMem(d)
+    expect(mem.schemaVersion).toBe(2)
+    expect(mem.failures[0].lesson).toBe('PowerShell 은 && 미지원')
+    expect(fs.existsSync(path.join(d, 'docs', 'state', 'learnings.md'))).toBe(false)
+    process.chdir(origCwd)
+    rm(d)
+  })
+
+  it('learnings.md 흡수는 마이그레이션 1회뿐 — 이후 recordLesson 이 재흡수 안 함', () => {
+    const d = tmp()
+    seedV1(d, [{ content: '결정1' }])
+    seedLearnings(d, '- [2026-01-01 goal-1] L1.\n- [2026-01-02 goal-2] L2.\n')
+
+    const m1 = readMemory(d) // 마이그레이션: learnings 2개 흡수
+    expect(m1.failures).toHaveLength(2)
+
+    recordLesson(d, '새 교훈 추가') // failures 3번째
+    const m2 = readMem(d)
+    expect(m2.failures).toHaveLength(3) // 2(흡수) + 1(신규) — 재흡수 시 5가 됨
+    const lessons = m2.failures.map((f) => f.lesson)
+    expect(lessons).toEqual(['L1.', 'L2.', '새 교훈 추가']) // L1/L2 각 1회만
+    rm(d)
+  })
+
+  it('마이그레이션 후 learnings.md 에 항목 추가돼도 재읽기는 흡수 안 함 (v2 디스크)', () => {
+    const d = tmp()
+    seedV1(d, [{ content: '결정' }])
+    seedLearnings(d, '- [2026-01-01 goal-1] 원래교훈.\n')
+
+    readMemory(d) // v1 → v2, 교훈 1개 흡수
+    // 마이그레이션 후 learnings.md 가 더 늘어나는 상황을 모사
+    fs.appendFileSync(path.join(d, 'docs', 'state', 'learnings.md'), '- [2026-02-02 goal-2] 추가교훈.\n', 'utf-8')
+
+    const m = readMemory(d) // 디스크 v2 → learnings 무시
+    expect(m.failures).toHaveLength(1)
+    expect(m.failures[0].lesson).toBe('원래교훈.')
+    rm(d)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 케이스 5 — status 전이 (active→archived) + archive 동작 + 잘못된 전이 거부
+// ════════════════════════════════════════════════════════════════════════════
+describe('memory v2 하드닝 5 — status 전이 / archive', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    process.exitCode = 0
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+    process.exitCode = 0
+  })
+
+  it('active → archived: archive 후 status/archivedAt 설정, 활성 렌더에서 제외', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('보관 대상')
+    await memoryArchive('1')
+    const mem = readMem(d)
+    expect(mem.decisions[0].status).toBe('archived')
+    expect(typeof mem.decisions[0].archivedAt).toBe('string')
+    // activeMemoryLines 는 active 만 — archived 제외
+    expect(activeMemoryLines(mem).join('\n')).not.toContain('보관 대상')
+    process.chdir(origCwd)
+    rm(d)
+  })
+
+  it('잘못된 index (0 / 음수 / 비숫자 / 범위초과) → exit 1, 파일 무변경', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('하나') // v2 생성
+    const before = fs.readFileSync(memPath(d), 'utf-8')
+
+    for (const bad of ['0', '-1', 'abc', '99']) {
+      process.exitCode = 0
+      await memoryArchive(bad)
+      expect(process.exitCode).toBe(1)
+    }
+    // 잘못된 index 는 어떤 쓰기도 유발 안 함
+    expect(fs.readFileSync(memPath(d), 'utf-8')).toBe(before)
+    expect(readMem(d).decisions[0].status).toBe('active')
+    process.chdir(origCwd)
+    rm(d)
+  })
+
+  it('memoryRemove 잘못된 index → exit 1, 삭제 안 함', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('남아야함')
+    await memoryRemove('5')
+    expect(process.exitCode).toBe(1)
+    expect(readMem(d).decisions).toHaveLength(1)
+    process.chdir(origCwd)
+    rm(d)
+  })
+
+  it('resolved 상태(데이터)는 activeMemoryLines 에서 제외, archive 하면 archived 로 전이', async () => {
+    const d = tmp()
+    seedV2(d, {
+      schemaVersion: 2,
+      decisions: [
+        { id: 'd1', content: '활성결정', tags: [], createdAt: '', status: 'active' },
+        { id: 'd2', content: '해결결정', tags: [], createdAt: '', status: 'resolved' },
+      ],
+      failures: [],
+      successes: [],
+      patterns: [],
+    })
+    const mem = readMemory(d)
+    const lines = activeMemoryLines(mem).join('\n')
+    expect(lines).toContain('활성결정')
+    expect(lines).not.toContain('해결결정') // resolved 는 active 렌더 제외
+
+    process.chdir(d)
+    // orderedAll 순서상 d2 는 index 2 — resolved → archived 전이
+    await memoryArchive('2')
+    expect(readMem(d).decisions[1].status).toBe('archived')
+    process.chdir(origCwd)
+    rm(d)
+  })
+
+  it('이미 archived 항목 재-archive → 크래시 없이 archived 유지 (idempotent re-stamp)', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('두번보관')
+    await memoryArchive('1')
+    await memoryArchive('1') // 두 번째
+    const mem = readMem(d)
+    expect(mem.decisions[0].status).toBe('archived')
+    process.chdir(origCwd)
+    rm(d)
+  })
+
+  it('archived 항목 — 기본 목록 숨김, --all 로만 노출 (memoryList 스모크, no throw)', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('활성것')
+    await memoryAdd('보관것')
+    await memoryArchive('2')
+    await expect(memoryList()).resolves.not.toThrow()
+    await expect(memoryList({ all: true })).resolves.not.toThrow()
+    process.chdir(origCwd)
+    rm(d)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 케이스 6 — secret 미포함 (4버킷 어디에도 토큰/API키 안 샘)
+// memory.json 은 .gitignore 대상(로컬 전용). 핵심 불변식: memory 가 env/타 파일에서
+// 시크릿을 자동 흡수하지 않는다 (사용자가 명시 입력하지 않는 한).
+// ════════════════════════════════════════════════════════════════════════════
+describe('memory v2 하드닝 6 — secret 미포함', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+  })
+
+  /** memory.json + 백업 파일 전부를 프로젝트 시크릿 스캐너로 검사 */
+  function scanMemArtifacts(d: string): string[] {
+    const hits: string[] = []
+    for (const suffix of ['', '.bak', '.v1.bak']) {
+      const p = memPath(d) + suffix
+      if (!fs.existsSync(p)) continue
+      const content = fs.readFileSync(p, 'utf-8')
+      content.split('\n').forEach((line, i) => {
+        for (const f of filterSevereFindings(findSecretsInLine(line, p, i + 1))) {
+          hits.push(`${p}:${f.line} ${f.patternId}`)
+        }
+      })
+    }
+    return hits
+  }
+
+  it('정상 입력 후 memory 산출물에 시크릿 패턴 0건 (포맷이 시크릿 만들지 않음)', () => {
+    const d = tmp()
+    seedV1(d, [{ content: 'API 는 tRPC 사용', tags: ['api'] }])
+    readMemory(d) // 마이그레이션 → v2 + 백업들
+    recordLesson(d, '롤백은 백업 먼저', 1)
+    expect(scanMemArtifacts(d)).toEqual([])
+    rm(d)
+  })
+
+  it('환경변수/타 파일의 시크릿을 memory 가 자동 흡수하지 않음', async () => {
+    const d = tmp()
+    const ghToken = 'ghp_' + 'x'.repeat(36) // 가짜(패턴만 일치)
+    const awsKey = 'AKIA' + 'ABCDEFGHIJKLMNOP'
+    // 환경변수 + 프로젝트 파일에 시크릿 심기
+    process.env.VHK_TEST_FAKE_SECRET = ghToken
+    fs.writeFileSync(path.join(d, '.env'), `AWS_KEY=${awsKey}\n`, 'utf-8')
+    seedLearnings(d, '- [2026-01-01 goal-1] 평범한 교훈.\n')
+    seedV1(d, [{ content: '평범한 결정' }])
+    try {
+      process.chdir(d)
+      readMemory(d) // 마이그레이션
+      recordLesson(d, '또 다른 평범한 교훈')
+      await context() // memory 를 렌더하는 경로
+
+      const blob = [
+        fs.readFileSync(memPath(d), 'utf-8'),
+        fs.existsSync(memPath(d) + '.bak') ? fs.readFileSync(memPath(d) + '.bak', 'utf-8') : '',
+        fs.existsSync(memPath(d) + '.v1.bak') ? fs.readFileSync(memPath(d) + '.v1.bak', 'utf-8') : '',
+        fs.readFileSync(path.join(d, '.vhk', 'context.md'), 'utf-8'),
+      ].join('\n')
+      expect(blob).not.toContain(ghToken) // env 시크릿 누출 없음
+      expect(blob).not.toContain(awsKey) // .env 시크릿 누출 없음
+    } finally {
+      delete process.env.VHK_TEST_FAKE_SECRET
+      process.chdir(origCwd)
+      rm(d)
+    }
+  })
+
+  it('[characterization] memoryAdd 는 content 를 verbatim 저장 — redaction 없음 (.gitignore 의존)', async () => {
+    const d = tmp()
+    const secret = 'ghp_' + 'y'.repeat(36)
+    process.chdir(d)
+    await memoryAdd(`토큰 메모: ${secret}`)
+    // 현 구현은 redaction 안 함 → verbatim 저장됨을 못박음 (창 A 판단용 finding 근거)
+    expect(fs.readFileSync(memPath(d), 'utf-8')).toContain(secret)
+    // 동시에 스캐너는 이를 시크릿으로 탐지 (= memory 가 자체 스캔하지 않는다는 갭 증명)
+    const found = filterSevereFindings(findSecretsInLine(secret, memPath(d), 1))
+    expect(found.length).toBeGreaterThan(0)
+    process.chdir(origCwd)
+    rm(d)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 케이스 7 — v1 API 무파괴 회귀 (add / list / remove 기존 동작)
+// ════════════════════════════════════════════════════════════════════════════
+describe('memory v2 하드닝 7 — add/list/remove 무파괴 회귀', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    process.exitCode = 0
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+    process.exitCode = 0
+  })
+
+  it('add 3 → list(스모크) → remove 중간 → 정확히 남음 (id d1,d2,d3)', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('첫째')
+    await memoryAdd('둘째')
+    await memoryAdd('셋째')
+    let mem = readMem(d)
+    expect(mem.decisions.map((e) => e.id)).toEqual(['d1', 'd2', 'd3'])
+    expect(mem.decisions.every((e) => e.status === 'active')).toBe(true)
+
+    await expect(memoryList()).resolves.not.toThrow()
+
+    await memoryRemove('2') // 중간(둘째) 삭제
+    mem = readMem(d)
+    expect(mem.decisions.map((e) => e.content)).toEqual(['첫째', '셋째'])
+    process.chdir(origCwd)
+    rm(d)
+  })
+
+  it('remove 후 nextId 는 잔존 max+1 (id 단조, 충돌 없음)', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('A') // d1
+    await memoryAdd('B') // d2
+    await memoryRemove('1') // d1 삭제 → 남은 [d2]
+    await memoryAdd('C') // max(2)+1 = d3
+    const mem = readMem(d)
+    expect(mem.decisions.map((e) => e.id)).toEqual(['d2', 'd3'])
+    expect(mem.decisions.map((e) => e.content)).toEqual(['B', 'C'])
+    process.chdir(origCwd)
+    rm(d)
+  })
+
+  it('버킷별 id prefix 독립 (decision d / failure f / success s) + orderedAll 순서대로 remove', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('결정', { type: 'decision' })
+    await memoryAdd('실패', { type: 'failure', lesson: 'L' })
+    await memoryAdd('성공', { type: 'success' })
+    let mem = readMem(d)
+    expect(mem.decisions[0].id).toBe('d1')
+    expect(mem.failures[0].id).toBe('f1')
+    expect(mem.successes[0].id).toBe('s1')
+
+    // orderedAll = decisions→failures→successes: index 2 = failure
+    await memoryRemove('2')
+    mem = readMem(d)
+    expect(mem.failures).toHaveLength(0)
+    expect(mem.decisions).toHaveLength(1)
+    expect(mem.successes).toHaveLength(1)
+    process.chdir(origCwd)
+    rm(d)
+  })
+
+  it('빈 메모리에서 remove → exit 1 (크래시 없음)', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryRemove('1')
+    expect(process.exitCode).toBe(1)
+    process.chdir(origCwd)
+    rm(d)
+  })
+
+  it('빈 content add → exit 1, 파일 미생성', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('   ')
+    expect(process.exitCode).toBe(1)
+    expect(fs.existsSync(memPath(d))).toBe(false)
+    process.chdir(origCwd)
+    rm(d)
+  })
+})

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -263,3 +263,72 @@ describe('memory v2 — activeMemoryLines + context/brief 렌더 (회귀)', () =
     fs.rmSync(d, { recursive: true, force: true })
   })
 })
+
+describe('memory v2 — read 경로 마이그레이션 계약 일관성 (어느 명령 먼저든 동일)', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+  })
+
+  function seedV1Project(d: string): void {
+    execFileSync('git', ['init'], { cwd: d, stdio: 'pipe' })
+    fs.writeFileSync(path.join(d, 'package.json'), JSON.stringify({ name: 't', version: '0.0.0' }), 'utf-8')
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    fs.writeFileSync(path.join(d, MEMORY_PATH_REL), JSON.stringify([{ content: 'v1 결정' }]), 'utf-8')
+  }
+  function assertMigrated(d: string): void {
+    const m = JSON.parse(fs.readFileSync(path.join(d, MEMORY_PATH_REL), 'utf-8'))
+    expect(m.schemaVersion).toBe(2) // 디스크에 v2 영구화
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL + '.v1.bak'))).toBe(true) // 원본 보존
+  }
+
+  it('memory list 첫 실행 → 디스크 v2 + .v1.bak', async () => {
+    const d = tmp()
+    seedV1(d, [{ content: 'v1 결정' }])
+    process.chdir(d)
+    await memoryList()
+    assertMigrated(d)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('context 첫 실행 → 디스크 v2 + .v1.bak (memory list 안 거쳐도 동일)', async () => {
+    const d = tmp()
+    seedV1Project(d)
+    process.chdir(d)
+    await context()
+    assertMigrated(d)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('brief 첫 실행 → 디스크 v2 + .v1.bak', async () => {
+    const d = tmp()
+    seedV1Project(d)
+    process.chdir(d)
+    await brief()
+    assertMigrated(d)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('이미 v2 → read 가 파일 변경/.v1.bak 생성 안 함 (멱등)', async () => {
+    const d = tmp()
+    const v2: MemoryFileV2 = { schemaVersion: 2, decisions: [{ id: 'd1', content: 'x', tags: [], createdAt: '', status: 'active' }], failures: [], successes: [], patterns: [] }
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    fs.writeFileSync(path.join(d, MEMORY_PATH_REL), JSON.stringify(v2, null, 2) + '\n', 'utf-8')
+    const before = fs.readFileSync(path.join(d, MEMORY_PATH_REL), 'utf-8')
+    process.chdir(d)
+    await memoryList()
+    expect(fs.readFileSync(path.join(d, MEMORY_PATH_REL), 'utf-8')).toBe(before) // 무변경
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL + '.v1.bak'))).toBe(false) // .v1.bak 미생성
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -15,6 +15,8 @@ import {
   memoryList,
   memoryRemove,
   memoryArchive,
+  memoryResolve,
+  memoryUnarchive,
   memoryMigrate,
   MEMORY_PATH_REL,
   type MemoryFileV2,
@@ -97,6 +99,7 @@ describe('memory v2 — 커맨드 (tmp+chdir)', () => {
   beforeEach(() => {
     origCwd = process.cwd()
     vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
     process.exitCode = 0
   })
   afterEach(() => {
@@ -193,6 +196,185 @@ describe('memory v2 — 커맨드 (tmp+chdir)', () => {
     const bak = JSON.parse(fs.readFileSync(path.join(d, MEMORY_PATH_REL + '.bak'), 'utf-8'))
     expect(bak.schemaVersion).toBe(2)
     process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('손상 memory.json — read 경로(memoryList)가 덮어쓰지 않고 원본 보존 (#1 blocker)', async () => {
+    const d = tmp()
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    const corrupt = '{ "decisions": [ this is not valid json'
+    fs.writeFileSync(path.join(d, MEMORY_PATH_REL), corrupt, 'utf-8')
+    process.chdir(d)
+    await memoryList() // read 경로 — 손상 파일을 빈 v2 로 절대 덮으면 안 됨
+    expect(fs.readFileSync(path.join(d, MEMORY_PATH_REL), 'utf-8')).toBe(corrupt)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('손상 memory.json + .v1.bak 선재 — 반복 read 도 데이터 파괴 안 함 (#1 worst-case)', async () => {
+    const d = tmp()
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    fs.writeFileSync(path.join(d, MEMORY_PATH_REL + '.v1.bak'), JSON.stringify([{ content: '오래된 v1' }]), 'utf-8')
+    const corrupt = '{ broken'
+    fs.writeFileSync(path.join(d, MEMORY_PATH_REL), corrupt, 'utf-8')
+    process.chdir(d)
+    await memoryList()
+    await memoryList() // 두 번째 read 도 파괴 금지(이전엔 .bak 덮어쓰며 영구 손실)
+    expect(fs.readFileSync(path.join(d, MEMORY_PATH_REL), 'utf-8')).toBe(corrupt)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('memoryMigrate — 인식 불가 객체(미래 스키마/수동편집)면 덮어쓰지 않고 중단 (exit 1, 원본 보존)', async () => {
+    const d = tmp()
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    // v1 배열도 v2(schemaVersion:2) 도 아닌 객체 — 미래 v3+ 또는 수동 편집 의심.
+    const future = JSON.stringify({ schemaVersion: 3, somethingNew: [] })
+    fs.writeFileSync(path.join(d, MEMORY_PATH_REL), future, 'utf-8')
+    process.chdir(d)
+    await memoryMigrate()
+    expect(process.exitCode).toBe(1) // 마이그레이션 대상 아님 → 중단
+    expect(fs.readFileSync(path.join(d, MEMORY_PATH_REL), 'utf-8')).toBe(future) // 빈 v2 로 덮지 않음
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL + '.v1.bak'))).toBe(false) // 백업도 안 만듦
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('memoryMigrate — memory.json/learnings 둘 다 없으면 파일 생성 안 함 (거짓 백업 메시지 방지, #3)', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryMigrate()
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL))).toBe(false) // 빈 파일 안 만듦
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('memoryMigrate — learnings 만 있으면 v2 생성하되 .v1.bak 없음 (신규 생성, #3)', async () => {
+    const d = tmp()
+    seedLearnings(d, '- [2026-01-01 goal-1] 교훈만.\n')
+    process.chdir(d)
+    await memoryMigrate()
+    expect(read(d).failures[0].lesson).toBe('교훈만.')
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL + '.v1.bak'))).toBe(false) // 원본 없었으니 백업 없음
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('memoryRemove — 중복 id 여도 위치 기준으로 정확히 삭제 (#D)', async () => {
+    const d = tmp()
+    const v2: MemoryFileV2 = {
+      schemaVersion: 2,
+      decisions: [
+        { id: 'd1', content: 'FIRST', tags: [], createdAt: '', status: 'active' },
+        { id: 'd1', content: 'SECOND', tags: [], createdAt: '', status: 'active' },
+      ],
+      failures: [], successes: [], patterns: [],
+    }
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    fs.writeFileSync(path.join(d, MEMORY_PATH_REL), JSON.stringify(v2, null, 2) + '\n', 'utf-8')
+    process.chdir(d)
+    await memoryRemove('2') // 두 번째(SECOND) 삭제 의도 — id 매칭이면 FIRST 가 지워졌었음
+    const mem = read(d)
+    expect(mem.decisions).toHaveLength(1)
+    expect(mem.decisions[0].content).toBe('FIRST')
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('memoryAdd — 잘못된 --type 거부(exit 1), 저장/입력 유실 없음 (#L)', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('교훈 유실 방지', { type: 'failrue', lesson: '회귀 가드' })
+    expect(process.exitCode).toBe(1)
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL))).toBe(false) // 저장 안 됨
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('memoryResolve → status resolved + resolvedAt (#2 — 이제 도달 가능)', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('해결 대상')
+    await memoryResolve('1')
+    const mem = read(d)
+    expect(mem.decisions[0].status).toBe('resolved')
+    expect(mem.decisions[0].resolvedAt).toBeDefined()
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('memoryUnarchive → archived 를 active 로 복구 (오조작 역전)', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('보관 후 복구')
+    await memoryArchive('1')
+    await memoryUnarchive('1')
+    const mem = read(d)
+    expect(mem.decisions[0].status).toBe('active')
+    expect(mem.decisions[0].archivedAt).toBeUndefined()
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('writeMemory — 원자적 쓰기 후 .tmp 잔여물 없음', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('원자성')
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL + '.tmp'))).toBe(false)
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL))).toBe(true)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('memoryAdd 첫 add(디스크 v1) — 단일 write: .bak 이 v1 원본 (이중 write 제거 #6)', async () => {
+    const d = tmp()
+    seedV1(d, [{ content: 'v1 원본' }])
+    process.chdir(d)
+    await memoryAdd('새 항목')
+    // 단일 write 라 직전 상태(.bak)는 v1 원본 배열. 이중 write 였다면 중간 v2 가 됐을 것.
+    const bak = JSON.parse(fs.readFileSync(path.join(d, MEMORY_PATH_REL + '.bak'), 'utf-8'))
+    expect(Array.isArray(bak)).toBe(true)
+    expect(bak[0].content).toBe('v1 원본')
+    const mem = read(d)
+    expect(mem.schemaVersion).toBe(2)
+    expect(mem.decisions.map((x) => x.content)).toEqual(expect.arrayContaining(['v1 원본', '새 항목']))
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('memoryAdd — 손상 memory.json 위 저장 시도 시 중단(exit 1) + 원본 보존 (#1 mutate-path blocker)', async () => {
+    const d = tmp()
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    const corrupt = '{ "decisions": [ broken'
+    fs.writeFileSync(path.join(d, MEMORY_PATH_REL), corrupt, 'utf-8')
+    process.chdir(d)
+    await memoryAdd('새 결정') // 손상 파일 위에 빈 v2 로 덮으면 안 됨
+    expect(process.exitCode).toBe(1)
+    expect(fs.readFileSync(path.join(d, MEMORY_PATH_REL), 'utf-8')).toBe(corrupt)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('memoryArchive — 손상 memory.json 위 status 전이 시도 시 중단(exit 1) + 원본 보존', async () => {
+    const d = tmp()
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    const corrupt = '{ broken'
+    fs.writeFileSync(path.join(d, MEMORY_PATH_REL), corrupt, 'utf-8')
+    process.chdir(d)
+    await memoryArchive('1')
+    expect(process.exitCode).toBe(1)
+    expect(fs.readFileSync(path.join(d, MEMORY_PATH_REL), 'utf-8')).toBe(corrupt)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('recordLesson — 손상 memory.json 이면 null 반환 + 원본 보존 (learn 중단)', () => {
+    const d = tmp()
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    const corrupt = '{ broken json'
+    fs.writeFileSync(path.join(d, MEMORY_PATH_REL), corrupt, 'utf-8')
+    expect(recordLesson(d, '교훈', 1)).toBeNull()
+    expect(fs.readFileSync(path.join(d, MEMORY_PATH_REL), 'utf-8')).toBe(corrupt)
     fs.rmSync(d, { recursive: true, force: true })
   })
 })

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -1,117 +1,175 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  migrateMemory,
+  readMemory,
+  writeMemory,
+  recordLesson,
+  memoryAdd,
+  memoryList,
+  memoryRemove,
+  memoryArchive,
+  memoryMigrate,
+  MEMORY_PATH_REL,
+  type MemoryFileV2,
+} from '../src/commands/memory.js'
 
-const mockExistsSync = vi.fn()
-const mockReadFileSync = vi.fn()
-const mockWriteFileSync = vi.fn()
-const mockMkdirSync = vi.fn()
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mem-'))
+}
+function seedV1(d: string, arr: unknown[]): void {
+  fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+  fs.writeFileSync(path.join(d, MEMORY_PATH_REL), JSON.stringify(arr), 'utf-8')
+}
+function seedLearnings(d: string, body: string): void {
+  fs.mkdirSync(path.join(d, 'docs', 'state'), { recursive: true })
+  fs.writeFileSync(path.join(d, 'docs', 'state', 'learnings.md'), body, 'utf-8')
+}
+function read(d: string): MemoryFileV2 {
+  return JSON.parse(fs.readFileSync(path.join(d, MEMORY_PATH_REL), 'utf-8'))
+}
 
-vi.mock('node:fs', () => ({
-  existsSync: (...a: unknown[]) => mockExistsSync(...a),
-  readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
-  writeFileSync: (...a: unknown[]) => mockWriteFileSync(...a),
-  mkdirSync: (...a: unknown[]) => mockMkdirSync(...a),
-}))
+describe('memory v2 — migrateMemory (순수)', () => {
+  it('v1 평면 배열 → decisions (status active)', () => {
+    const v2 = migrateMemory([{ content: 'A', addedAt: '2026-01-01', tags: ['x'] }, { content: 'B' }])
+    expect(v2.schemaVersion).toBe(2)
+    expect(v2.decisions).toHaveLength(2)
+    expect(v2.decisions[0]).toMatchObject({ content: 'A', tags: ['x'], status: 'active' })
+    expect(v2.failures).toEqual([])
+  })
+  it('learnings.md 흡수 → failures (lesson, content 비움)', () => {
+    const learnings = '# Learnings\n\n- [2026-05-27 goal-1] 교훈 하나.\n- [2026-05-28 release] 교훈 둘.\n'
+    const v2 = migrateMemory([], learnings)
+    expect(v2.failures).toHaveLength(2)
+    expect(v2.failures[0].content).toBe('')
+    expect(v2.failures[0].lesson).toBe('교훈 하나.')
+    expect(v2.failures[0].tags).toEqual(['goal-1'])
+  })
+  it('이미 v2 면 멱등 (learnings 재흡수 안 함)', () => {
+    const once = migrateMemory([{ content: 'A' }], '- [2026-01-01 goal-1] L.\n')
+    const twice = migrateMemory(once, '- [2026-01-01 goal-1] L.\n')
+    expect(twice.decisions).toHaveLength(1)
+    expect(twice.failures).toHaveLength(1) // 두 번째 호출이 재흡수하지 않음
+  })
+})
 
-describe('memory', () => {
+describe('memory v2 — read/write (fs)', () => {
+  it('readMemory: v1 + learnings 흡수 → v2 (BOM-safe)', () => {
+    const d = tmp()
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    fs.writeFileSync(path.join(d, MEMORY_PATH_REL), '﻿' + JSON.stringify([{ content: 'BOM 결정' }]), 'utf-8')
+    seedLearnings(d, '- [2026-01-01 goal-2] BOM 교훈.\n')
+    const mem = readMemory(d)
+    expect(mem.decisions[0].content).toBe('BOM 결정')
+    expect(mem.failures[0].lesson).toBe('BOM 교훈.')
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+  it('writeMemory: 기존 파일 있으면 .bak 백업', () => {
+    const d = tmp()
+    seedV1(d, [{ content: '원본' }])
+    writeMemory(d, migrateMemory(readMemory(d)))
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL + '.bak'))).toBe(true)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})
+
+describe('memory v2 — recordLesson (learn 통합)', () => {
+  it('교훈 → failures.lesson + learnings.md 신규 기록 안 함', () => {
+    const d = tmp()
+    const entry = recordLesson(d, 'PowerShell 은 && 미지원', 7)
+    expect(entry.lesson).toBe('PowerShell 은 && 미지원')
+    const mem = read(d)
+    expect(mem.failures[0].lesson).toBe('PowerShell 은 && 미지원')
+    expect(mem.failures[0].tags).toEqual(['goal-7'])
+    expect(fs.existsSync(path.join(d, 'docs', 'state', 'learnings.md'))).toBe(false) // learnings.md 미생성
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})
+
+describe('memory v2 — 커맨드 (tmp+chdir)', () => {
+  let origCwd: string
   beforeEach(() => {
-    vi.resetAllMocks()
+    origCwd = process.cwd()
     vi.spyOn(console, 'log').mockImplementation(() => {})
     process.exitCode = 0
   })
   afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
     process.exitCode = 0
   })
 
-  it('모듈을 import 할 수 있다', async () => {
-    const mod = await import('../src/commands/memory.js')
-    expect(mod.memoryAdd).toBeDefined()
-    expect(mod.memoryList).toBeDefined()
-    expect(mod.memoryRemove).toBeDefined()
+  it('memoryAdd --type failure (--why --lesson) → failures 버킷, status active', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('테스트가 변경 미커버', { type: 'failure', why: '테스트 안 짬', lesson: '회귀 가드 먼저' })
+    const mem = read(d)
+    expect(mem.failures).toHaveLength(1)
+    expect(mem.failures[0]).toMatchObject({ why: '테스트 안 짬', lesson: '회귀 가드 먼저', status: 'active' })
+    expect(mem.decisions).toEqual([])
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
   })
 
-  it('memoryAdd — 빈 content면 쓰지 않음 + exitCode=1 (VHK-016 저장실패 비-0)', async () => {
-    const { memoryAdd } = await import('../src/commands/memory.js')
+  it('memoryAdd --type success (--why) → successes', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('롤백 빨랐다', { type: 'success', why: '백업 먼저' })
+    expect(read(d).successes[0]).toMatchObject({ why: '백업 먼저', status: 'active' })
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('memoryAdd 기본 → decisions, 빈 content → exit 1', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('API tRPC')
+    expect(read(d).decisions[0].content).toBe('API tRPC')
     await memoryAdd('')
-    expect(mockWriteFileSync).not.toHaveBeenCalled()
     expect(process.exitCode).toBe(1)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
   })
 
-  it('memoryAdd — 새 content면 .vhk/memory.json에 추가', async () => {
-    mockExistsSync.mockReturnValue(false)
-    const { memoryAdd } = await import('../src/commands/memory.js')
-    await memoryAdd('API는 tRPC 사용', ['decision', 'arch'])
-
-    expect(mockMkdirSync).toHaveBeenCalledWith('.vhk', { recursive: true })
-    const call = mockWriteFileSync.mock.calls[0]
-    expect(String(call[0])).toContain('memory.json')
-    const data = JSON.parse(String(call[1]))
-    expect(data).toHaveLength(1)
-    expect(data[0].content).toBe('API는 tRPC 사용')
-    expect(data[0].tags).toEqual(['decision', 'arch'])
-    expect(data[0].addedAt).toBeDefined()
+  it('memoryArchive → status archived (활성 목록서 제외, 선순환)', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('보관 대상')
+    await memoryArchive('1')
+    const mem = read(d)
+    expect(mem.decisions[0].status).toBe('archived')
+    expect(mem.decisions[0].archivedAt).toBeDefined()
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
   })
 
-  it('memoryAdd — 기존 항목에 append', async () => {
-    mockExistsSync.mockReturnValue(true)
-    mockReadFileSync.mockReturnValue(
-      JSON.stringify([{ content: '기존', addedAt: '2026-01-01', tags: [] }])
-    )
-    const { memoryAdd } = await import('../src/commands/memory.js')
-    await memoryAdd('새 결정')
-
-    const data = JSON.parse(String(mockWriteFileSync.mock.calls[0][1]))
-    expect(data).toHaveLength(2)
-    expect(data[0].content).toBe('기존')
-    expect(data[1].content).toBe('새 결정')
-  })
-
-  it('memoryList — 항목 0이면 안내만, read 호출 X', async () => {
-    mockExistsSync.mockReturnValue(false)
-    const { memoryList } = await import('../src/commands/memory.js')
-    await memoryList()
-    expect(mockReadFileSync).not.toHaveBeenCalled()
-  })
-
-  it('memoryList — 항목 출력', async () => {
-    mockExistsSync.mockReturnValue(true)
-    mockReadFileSync.mockReturnValue(
-      JSON.stringify([
-        { content: 'A', addedAt: '2026-01-01T00:00:00.000Z', tags: [] },
-        { content: 'B', addedAt: '2026-02-01T00:00:00.000Z', tags: ['db'] },
-      ])
-    )
-    const logSpy = vi.spyOn(console, 'log')
-    const { memoryList } = await import('../src/commands/memory.js')
-    await memoryList()
-    const joined = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
-    expect(joined).toContain('A')
-    expect(joined).toContain('B')
-    expect(joined).toContain('db')
-  })
-
-  it('memoryRemove — 유효하지 않은 인덱스면 쓰지 않음', async () => {
-    mockExistsSync.mockReturnValue(true)
-    mockReadFileSync.mockReturnValue(
-      JSON.stringify([{ content: 'A', addedAt: '2026-01-01', tags: [] }])
-    )
-    const { memoryRemove } = await import('../src/commands/memory.js')
-    await memoryRemove('99')
-    expect(mockWriteFileSync).not.toHaveBeenCalled()
-  })
-
-  it('memoryRemove — 유효한 인덱스면 삭제 후 저장', async () => {
-    mockExistsSync.mockReturnValue(true)
-    mockReadFileSync.mockReturnValue(
-      JSON.stringify([
-        { content: 'A', addedAt: '2026-01-01', tags: [] },
-        { content: 'B', addedAt: '2026-02-01', tags: [] },
-      ])
-    )
-    const { memoryRemove } = await import('../src/commands/memory.js')
+  it('memoryRemove → 해당 항목 삭제', async () => {
+    const d = tmp()
+    process.chdir(d)
+    await memoryAdd('지울것')
+    await memoryAdd('남길것')
     await memoryRemove('1')
+    const mem = read(d)
+    expect(mem.decisions).toHaveLength(1)
+    expect(mem.decisions[0].content).toBe('남길것')
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
 
-    const data = JSON.parse(String(mockWriteFileSync.mock.calls[0][1]))
-    expect(data).toHaveLength(1)
-    expect(data[0].content).toBe('B')
+  it('memoryMigrate → v1 파일을 v2 로 재기록 (.bak)', async () => {
+    const d = tmp()
+    seedV1(d, [{ content: '결정1' }])
+    seedLearnings(d, '- [2026-01-01 goal-1] 교훈1.\n')
+    process.chdir(d)
+    await memoryMigrate()
+    const mem = read(d)
+    expect(mem.schemaVersion).toBe(2)
+    expect(mem.decisions[0].content).toBe('결정1')
+    expect(mem.failures[0].lesson).toBe('교훈1.')
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL + '.bak'))).toBe(true)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
   })
 })

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { context } from '../src/commands/context.js'
+import { brief } from '../src/commands/brief.js'
+import { activeMemoryLines } from '../src/commands/memory.js'
 import {
   migrateMemory,
   readMemory,
@@ -169,6 +173,92 @@ describe('memory v2 — 커맨드 (tmp+chdir)', () => {
     expect(mem.decisions[0].content).toBe('결정1')
     expect(mem.failures[0].lesson).toBe('교훈1.')
     expect(fs.existsSync(path.join(d, MEMORY_PATH_REL + '.bak'))).toBe(true)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('.v1.bak = v1 원본 write-once 영구 보존 (후속 add/archive 가 못 덮음) + 롤링 .bak 은 최신', async () => {
+    const d = tmp()
+    seedV1(d, [{ content: '원본 결정' }]) // v1: 1개
+    process.chdir(d)
+    await memoryMigrate() // .v1.bak = v1 원본
+    await memoryAdd('새 결정') // v2 덮어쓰기
+    await memoryAdd('또 결정', { type: 'success' })
+    // .v1.bak 은 v1 평면 배열 원본 그대로
+    const v1bak = JSON.parse(fs.readFileSync(path.join(d, MEMORY_PATH_REL + '.v1.bak'), 'utf-8'))
+    expect(Array.isArray(v1bak)).toBe(true)
+    expect(v1bak).toHaveLength(1)
+    expect(v1bak[0].content).toBe('원본 결정')
+    // 롤링 .bak 은 직전(v2) 상태 — v2 객체
+    const bak = JSON.parse(fs.readFileSync(path.join(d, MEMORY_PATH_REL + '.bak'), 'utf-8'))
+    expect(bak.schemaVersion).toBe(2)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})
+
+describe('memory v2 — activeMemoryLines + context/brief 렌더 (회귀)', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+  })
+
+  it('activeMemoryLines — active decisions/failures/successes 렌더, archived 제외', () => {
+    const mem: MemoryFileV2 = {
+      schemaVersion: 2,
+      decisions: [
+        { id: 'd1', content: '활성 결정', tags: [], createdAt: '', status: 'active' },
+        { id: 'd2', content: '보관 결정', tags: [], createdAt: '', status: 'archived' },
+      ],
+      failures: [{ id: 'f1', content: '', tags: [], createdAt: '', status: 'active', lesson: '교훈X' }],
+      successes: [{ id: 's1', content: '성공Y', tags: [], createdAt: '', status: 'active' }],
+      patterns: [],
+    }
+    const out = activeMemoryLines(mem).join('\n')
+    expect(out).toContain('활성 결정')
+    expect(out).toContain('교훈X')
+    expect(out).toContain('성공Y')
+    expect(out).not.toContain('보관 결정') // archived 제외
+  })
+
+  function seedProject(d: string): void {
+    execFileSync('git', ['init'], { cwd: d, stdio: 'pipe' })
+    fs.writeFileSync(path.join(d, 'package.json'), JSON.stringify({ name: 't', version: '0.0.0' }), 'utf-8')
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    const mem: MemoryFileV2 = {
+      schemaVersion: 2,
+      decisions: [{ id: 'd1', content: 'tRPC 채택 결정', tags: ['api'], createdAt: '2026-01-01', status: 'active' }],
+      failures: [],
+      successes: [],
+      patterns: [],
+    }
+    fs.writeFileSync(path.join(d, MEMORY_PATH_REL), JSON.stringify(mem, null, 2), 'utf-8')
+  }
+
+  it('vhk context → context.md 에 v2 decision 노출', async () => {
+    const d = tmp()
+    seedProject(d)
+    process.chdir(d)
+    await context()
+    const md = fs.readFileSync(path.join(d, '.vhk', 'context.md'), 'utf-8')
+    expect(md).toContain('tRPC 채택 결정')
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('vhk brief → brief.md 에 v2 decision 노출', async () => {
+    const d = tmp()
+    seedProject(d)
+    process.chdir(d)
+    await brief()
+    const md = fs.readFileSync(path.join(d, '.vhk', 'brief.md'), 'utf-8')
+    expect(md).toContain('tRPC 채택 결정')
     process.chdir(origCwd)
     fs.rmSync(d, { recursive: true, force: true })
   })

--- a/tests/nlp-router.test.ts
+++ b/tests/nlp-router.test.ts
@@ -176,6 +176,32 @@ describe('자연어 라우팅', () => {
     expect(routeNaturalLanguage('기억 목록')?.command).toBe('memory')
   })
 
+  it('"기억 마이그레이트" → memory (args migrate), 패키지매니저 migrate 로 안 샘', () => {
+    const r = routeNaturalLanguage('기억 마이그레이트')
+    expect(r?.command).toBe('memory')
+    expect(r?.args).toEqual(['migrate'])
+  })
+
+  it('"메모리 마이그레이션" → memory (args migrate)', () => {
+    const r = routeNaturalLanguage('메모리 마이그레이션')
+    expect(r?.command).toBe('memory')
+    expect(r?.args).toEqual(['migrate'])
+  })
+
+  it('"패키지 매니저 마이그레이트" → migrate (memory 아님)', () => {
+    expect(routeNaturalLanguage('패키지 매니저 마이그레이트')?.command).toBe('migrate')
+  })
+
+  it('"메모리 누수 때문에 pnpm 으로 전환" → migrate (memory 단어가 있어도 pkg 전환 통과)', () => {
+    expect(routeNaturalLanguage('메모리 누수 때문에 pnpm 으로 전환')?.command).toBe('migrate')
+  })
+
+  it('"기억 보관" → 잘못된 memory list 라우팅 안 함 (archive 는 번호 필요 → NL 미지원)', () => {
+    const r = routeNaturalLanguage('기억 보관')
+    const isMemoryList = r?.command === 'memory' && (!r.args || r.args.length === 0)
+    expect(isMemoryList).toBe(false)
+  })
+
   it('"기억 추가해줘" → null (NL 배제)', () => {
     expect(routeNaturalLanguage('기억 추가해줘')).toBeNull()
   })

--- a/tests/state-files.test.ts
+++ b/tests/state-files.test.ts
@@ -4,9 +4,7 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import {
   appendBlocker,
-  appendLearning,
   countActiveBlockers,
-  getRecentLearnings,
   getRecentBlockers,
   getActiveBlockers,
   writeHardStop,
@@ -99,52 +97,8 @@ describe('appendBlocker — Forbidden append-only 보장', () => {
   })
 })
 
-describe('appendLearning + getRecentLearnings', () => {
-  let origCwd: string
-  let dir: string
-  beforeEach(() => {
-    origCwd = process.cwd()
-    dir = tmpProject('learning')
-    process.chdir(dir)
-  })
-  afterEach(() => {
-    process.chdir(origCwd)
-    rmSync(dir, { recursive: true, force: true })
-  })
-
-  it('append-only 누적', () => {
-    appendLearning('A', 1)
-    appendLearning('B', 2)
-    appendLearning('C', 2)
-    const content = readFileSync(LEARNINGS_PATH, 'utf-8')
-    expect(content).toContain('A')
-    expect(content).toContain('B')
-    expect(content).toContain('C')
-    expect(content.indexOf('A')).toBeLessThan(content.indexOf('B'))
-    expect(content.indexOf('B')).toBeLessThan(content.indexOf('C'))
-  })
-
-  it('getRecentLearnings 가 마지막 N건 반환', () => {
-    appendLearning('A')
-    appendLearning('B')
-    appendLearning('C')
-    appendLearning('D')
-    const recent = getRecentLearnings(3)
-    expect(recent).toHaveLength(3)
-    expect(recent[0]).toContain('B')
-    expect(recent[1]).toContain('C')
-    expect(recent[2]).toContain('D')
-  })
-
-  it('파일 없으면 빈 배열', () => {
-    expect(getRecentLearnings(3)).toEqual([])
-  })
-
-  it('SoT 일관성 — appendLearning 은 .vhk/memory.json 에 쓰지 않음 (Forbidden 이중 기록)', () => {
-    appendLearning('learning that should NOT enter memory.json')
-    expect(existsSync(join('.vhk', 'memory.json'))).toBe(false)
-  })
-})
+// NOTE(v2.0): appendLearning/getRecentLearnings 제거 — 교훈 SoT 는 memory v2(tests/memory.test.ts).
+// learnings.md 흡수(읽기 소스) 회귀는 tests/memory.test.ts 의 migrateMemory/readMemory 케이스가 커버.
 
 describe('getRecentBlockers / getActiveBlockers (배치2)', () => {
   let origCwd: string


### PR DESCRIPTION
## 요약

Goal 18(v2.0.0, `b469b4e`) 릴리즈 커밋에서 빠진 **마무리** + 후속 **생명주기 증분**. v2.0.0 은 아직 미머지·미publish 라, publish 전 main 에 머지하면 발행본이 완전체가 된다.

- **빌드** ✓ / **테스트 702개 전부 통과** ✓

## 변경 (그룹 A — v2.0.0 마무리, Goal 18 산출물)

- **learn MCP 툴 등록** (24→25): `vhk learn` CLI 는 릴리즈됐으나 MCP 미노출분 보강
- **appendLearning/getRecentLearnings 제거**: 교훈 단일 SoT = memory v2 `failures.lesson`
  (`learnings.md` 는 v1→v2 마이그레이션 읽기 소스로만 잔존, 신규 기록 경로 없음)
- **`memory migrate` 자연어 라우팅**: "기억 마이그레이트" 가 pnpm `migrate` 로 새지 않도록 우선순위 + 제외 토큰
- **`.gitignore`**: `.vhk/memory.json.*` (`.bak`/`.v1.bak`/`.tmp`) 백업 ignore — v1 평문 누출 방지
- **문서 정합**: `CLAUDE.md` MCP 25 / 테스트 702

## 변경 (그룹 B — 후속 생명주기 증분)

- **`memory resolve <n>` / `memory unarchive <n>`** 서브커맨드: status 모델(`resolved`/`archived`) 조작 명령
  - Goal 18 Completion Check 는 `archive` 만 포함 → 스키마가 약속한 `resolved` 상태를 만드는 명령이 없던 공백을 메움

## 검증

- `pnpm run build` ✓
- `pnpm test` → 74 파일 / **702 tests passed**
- 민감 파일(`.vhk/memory.json`, 백업) 스테이징 누출 0 확인

## 참고

- A/B 가 `memory.ts`·`command-registry`·테스트에 섞여 있어 분리 비용이 커, 일관된 memory-v2 작업 덩어리로 단일 PR 처리(실용 노선).
- 후속: Goal 19(vhk pattern, v2.1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
