### PR TITLE
fix(cli): 글로벌/심링크 실행 시 isMainModule realpath 정규화 (2.0.1 버그 → 2.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ## [Unreleased]
 
-(다음 릴리즈 누적 영역)
+### Fixed
+
+- **글로벌/심링크 실행 시 CLI 미동작 가드** (`src/index.ts`) — `isMainModule` 판정을
+  `import.meta.url ↔ pathToFileURL(argv[1])` 단순 비교에서 **realpath 정규화 비교**(`fs.realpathSync`)로 변경.
+  `pnpm link`·글로벌 설치처럼 `process.argv[1]`(심링크)와 실제 모듈 경로가 다르면 main 액션이 안 돌던 문제 해소.
+  vitest import(비-main) 판정은 그대로(realpath 도 불일치) — 테스트 동작 무손상. 다음 릴리즈(2.0.2)에 포함 예정.
 
 ## [2.0.1] - 2026-06-03
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Command, Help } from 'commander'
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath } from 'node:url'
+import fs from 'node:fs'
 import chalk from 'chalk'
 import inquirer from 'inquirer'
 import { detectNaturalLanguageInput } from './lib/cli-args.js'
@@ -685,8 +686,17 @@ program.action(async () => {
 
 // 메인 모듈로 직접 실행될 때만 파싱한다(import 되면 program 만 노출).
 // env 가 아니라 import.meta.url ↔ argv[1] 비교라, VITEST 환경을 물려받은 spawn 자식도 정상 실행.
+const getRealPath = (p: string) => {
+  try {
+    return fs.realpathSync(p)
+  } catch {
+    return p
+  }
+}
+
 const isMainModule =
-  !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+  !!process.argv[1] &&
+  getRealPath(fileURLToPath(import.meta.url)) === getRealPath(process.argv[1])
 
 if (isMainModule) {
   // VHK-014: parseAsync 를 try/catch 로 감싸 unsettled top-level await 경고 제거 +


### PR DESCRIPTION
@
## 버그

발행한 `@byh3071/vhk@2.0.1` 을 `pnpm link`/글로벌 설치로 실행하면 CLI main 액션이 안 돈다.

원인: `isMainModule` 이 `import.meta.url === pathToFileURL(process.argv[1]).href` 로 판정 →
글로벌 bin 은 심링크라 `process.argv[1]`(심링크 경로)와 `import.meta.url`(실제 dist 경로)이 달라 **false** → `if (isMainModule)` 본문(parseAsync) 미실행.

## 픽스

`fs.realpathSync` 로 양쪽을 실경로 정규화 후 비교. 심링크/글로벌 실행에서 일치 → 정상 동작.
- vitest import(비-main) 판정은 그대로(realpath 도 불일치) → **테스트 761 무손상**.
- 미사용 `pathToFileURL` import 제거.

## 검증

- build ✓ / test **761 pass** ✓
- 런타임: `node dist/index.js --version` → `2.0.1` (직접 실행 main 정상)

## 릴리즈

다음 publish 시 **2.0.2** (patch) 로 발행 — `vhk publish` 강제 범프와 정합(2.0.1→2.0.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@