### PR TITLE
docs+rules: v2 교훈 패턴 3건 + Notion Dev Log 적재 규칙 템플릿화

### DIFF
--- a/docs/patterns/auth-npm-scoped-publish-404.md
+++ b/docs/patterns/auth-npm-scoped-publish-404.md
@@ -1,0 +1,73 @@
+---
+패턴명: scoped npm publish E404 = 인증 실패 (401 아닌 404)
+카테고리: auth
+출처프로젝트: VHK (vhk-cli)
+태그: [npm, publish, scoped-package, auth, 404, registry, 2FA]
+발견일: 2026-06-03
+출처DevLog: Notion Dev Log `vhk-pattern-npm-scoped-404-auth` (https://app.notion.com/p/3749740ab07281989d45eb0a9b681191)
+---
+
+# 패턴: scoped npm publish 가 E404 면 십중팔구 인증 실패
+
+## 증상
+
+이미 npmjs 에 **공개 존재하는** scoped 패키지(`@scope/pkg`)를 `npm publish` 하는데 404 가 뜬다.
+
+```text
+npm error code E404
+npm error 404 Not Found - PUT https://registry.npmjs.org/@byh3071%2fvhk
+npm error 404 The requested resource '@byh3071/vhk@2.0.2' could not be found
+npm error 404  or you do not have permission to access it.
+```
+
+함정: 직전에 같은 패키지의 **다른 버전 발행은 성공**했는데도 다음 버전에서 404. "패키지가 없나?" "레지스트리가 잘못됐나?" 로 오진하기 쉽다.
+
+## 원인
+
+npm 레지스트리는 **scoped 패키지의 인증 부재/무효를 존재 은폐를 위해 401 이 아니라 404 로 반환**한다(권한 없는 사용자에게 비공개 패키지의 존재 여부를 누설하지 않으려는 설계). 즉 `404 PUT` = "패키지 없음"이 아니라 대부분 "**자격증명이 거부됨**".
+
+확인 신호:
+
+```powershell
+npm whoami        # → E401 Unauthorized 이면 인증 깨진 것
+npm view @scope/pkg version   # 익명 읽기는 됨(패키지는 공개 존재) → 404 는 auth 문제 확정
+```
+
+흔한 트리거: **웹 인증(`npm login --auth-type=web`)은 `.npmrc` 의 영속 토큰을 갱신한다는 보장이 없다.** 한 번은 그 세션으로 발행되지만, `.npmrc` 에 남은 **만료/무효 토큰**이 그대로라 다음 publish 에서 다시 거부된다. (`.npmrc` 에 `_authToken` 라인이 "있어도" 무효일 수 있음 — 존재 ≠ 유효.)
+
+## 해결
+
+```powershell
+# 1. 인증 상태부터 확인 (버전/레지스트리 의심 금지)
+npm whoami                 # E401 이면 ↓
+# 2. 재로그인 (2FA 면 OTP/웹 인증)
+npm login                  # 또는 npm login --auth-type=legacy (장기 토큰 .npmrc 저장)
+npm whoami                 # 본인 아이디 떠야 성공
+# 3. 재발행
+npm publish --access public
+```
+
+반복 발행 패키지/CI 는 npmjs.com 에서 **Granular Access Token**(publish 권한) 발급해 `.npmrc` 에 저장하면 안정적(단 토큰은 2FA 를 우회하므로 보안 트레이드오프 — 비밀로 관리).
+
+## 핵심 원리
+
+**404 ≠ "없음".** 인증·인가 계층이 존재 은폐를 위해 404 로 응답하는 API 가 있다(npm scoped, GitHub private repo 등). 외부 레지스트리가 404 를 주면 **자원 부재보다 자격증명을 먼저 의심**한다.
+
+## 적용 조건
+
+- ✅ scoped npm 패키지(`@scope/pkg`) publish 가 E404
+- ✅ 웹 인증/OTP 로 한 번 발행 후 다음 발행이 실패
+- ✅ CI 에서 npm publish 가 간헐적 404 (토큰 만료)
+- ❌ 정말 미발행 버전을 **install** 하려다 404 (그건 진짜 부재일 수 있음 — publish PUT 404 와 구분)
+- ⚠️ 같은 버전 재발행이면 403/409(중복)지 404 아님 — 버전은 항상 신규여야
+
+## 재발 방지
+
+- **publish 전 항상 `npm whoami`** (인증 체크를 발행 스크립트 prepublish 단계에 넣는 것도 고려)
+- 404 떴을 때 디버그 순서: ① `npm whoami` ② `npm view <pkg>`(익명 읽기) ③ 그 다음에야 버전/레지스트리
+
+## 참고
+
+- VHK v2.0.2 발행 시 첫 시도 E404 → `npm login` 재인증 후 성공.
+- 멀티에이전트 진단 종합본이 재인증 *후* 실행돼 "전파 지연"으로 오판한 사례 — 도구 출력도 타임라인 혼동 가능, 직접 검증 필요.
+- 관련 패턴: [build-release-tool-forced-version-bump.md](./build-release-tool-forced-version-bump.md), [ux-publish-stdio-inherit.md](./ux-publish-stdio-inherit.md)

--- a/docs/patterns/build-release-tool-forced-version-bump.md
+++ b/docs/patterns/build-release-tool-forced-version-bump.md
@@ -1,0 +1,67 @@
+---
+패턴명: 릴리즈 CLI 강제 버전 범프 — pre-set 버전 발행 불가
+카테고리: build
+출처프로젝트: VHK (vhk-cli)
+태그: [npm, publish, release, semver, version-bump, CLI]
+발견일: 2026-06-03
+출처DevLog: Notion Dev Log `vhk-pattern-release-tool-forced-bump` (https://app.notion.com/p/3749740ab07281188c98d69637e278ed)
+---
+
+# 패턴: 릴리즈 CLI 가 버전을 항상 범프하면 pre-set 버전을 발행 못 한다
+
+## 증상
+
+릴리즈 PR 에서 `package.json` 버전을 목표값(예: `2.0.0`)으로 **미리** 올려두고 머지한 뒤, 릴리즈 CLI(`vhk publish`, 유사 도구)로 발행하면 — npm 에 **`2.0.0` 이 아니라 `2.0.1` 이 올라간다.**
+
+```text
+📌 현재 버전: v2.0.0
+? 버전을 어떻게 올릴까요? 🔧 patch (2.0.1)   ← "그대로 발행" 선택지가 없음
+🆕 새 버전: v2.0.1
+```
+
+결과: npm 발행 이력이 `1.9.0 → 2.0.1` 로 점프, **`2.0.0` 은 영영 공백.** CHANGELOG `[2.0.0]`·수동 git tag `v2.0.0` 과 불일치 잔재 발생.
+
+## 원인
+
+릴리즈 CLI 가 발행 절차에 **버전 범프를 강제**(patch/minor/major 중 택1)하도록 설계됨. `package.json` 이 이미 목표 버전(npm 미발행 상태)이어도 "**현재 버전 그대로 발행**" 옵션이 없어서, 가장 작은 patch 범프가 적용되며 의도한 버전을 건너뛴다.
+
+```
+의도: package.json=2.0.0(미발행) → publish → npm 2.0.0
+현실: package.json=2.0.0 → publish(강제 patch) → npm 2.0.1, 2.0.0 공백
+```
+
+기능상으로는 무해하다(major=2 가 breaking 신호 역할). 하지만 **버전 번호 일관성**(npm ↔ CHANGELOG ↔ git tag)이 깨진다.
+
+## 해결
+
+**릴리즈 PR 에서 `package.json` 버전을 미리 올리지 않는다.** 직전 발행 버전을 그대로 두고, `vhk publish` 의 major/minor/patch 선택이 **곧 발행 버전이 되게** 한다.
+
+```
+권장: package.json=1.9.0 유지 → publish 시 major 선택 → npm 2.0.0
+```
+
+- breaking 릴리즈 → publish 시 `major`
+- 기능 추가 → `minor`, 버그픽스 → `patch`
+- CHANGELOG/태그는 **발행 후** 실제 발행 버전에 맞춰 기록(발행 전 박제 금지)
+
+(향후 개선) 릴리즈 CLI 에 "현재 버전 그대로 발행(no bump)" 옵션 추가하면 pre-set 워크플로도 지원 가능.
+
+## 핵심 원리
+
+**버전을 정하는 주체는 하나여야 한다.** 릴리즈 PR(파일 편집)과 publish CLI(범프) 둘 다 버전을 만지면 충돌 → 한쪽이 의도를 덮는다. 범프를 CLI 가 강제한다면 파일 쪽은 버전을 건드리지 말 것(단일 SoT).
+
+## 적용 조건
+
+- ✅ 버전 범프를 강제하는 릴리즈 CLI(`npm version` 래핑류) 사용 시
+- ✅ 메이저/특정 버전을 의도적으로 찍고 싶을 때
+- ❌ CLI 가 "현재 버전 발행" 또는 "버전 직접 입력"을 지원하면 해당 없음
+- ⚠️ 이미 잘못 발행했으면 되돌리기 어려움(npm 은 하위 버전 재발행해도 latest 안 바뀜) → 수용하고 잔재(CHANGELOG/tag)만 정합
+
+## 검증
+
+릴리즈 후: `npm view <pkg> versions` 로 의도한 버전이 실제 올라갔는지, `git tag` 와 CHANGELOG 헤딩이 일치하는지 확인.
+
+## 참고
+
+- VHK v2.0.0 → 실제 npm 발행은 2.0.1(이후 심링크 픽스로 2.0.2). CHANGELOG `[2.0.0]`→`[2.0.1]` 정합 + 거짓 `v2.0.0` 태그 삭제로 사후 수습.
+- 관련 패턴: [auth-npm-scoped-publish-404.md](./auth-npm-scoped-publish-404.md)

--- a/docs/patterns/env-bash-tool-vs-powershell-heredoc.md
+++ b/docs/patterns/env-bash-tool-vs-powershell-heredoc.md
@@ -1,0 +1,80 @@
+---
+패턴명: Bash 툴에서 PowerShell here-string @'...'@ 사용 → 명령 인자 오염
+카테고리: env
+출처프로젝트: VHK (vhk-cli)
+태그: [bash, PowerShell, here-string, heredoc, git-commit, shell, AI-agent]
+발견일: 2026-06-03
+출처DevLog: Notion Dev Log `vhk-til-bash-tool-pwsh-heredoc` (https://app.notion.com/p/3749740ab0728199a91df50f5f0b586d)
+---
+
+# 패턴: 셸 종류와 쿼팅 문법 불일치 — bash 에서 PowerShell here-string 쓰면 인자 오염
+
+## 증상
+
+Windows(PowerShell 기본 환경)에서 작업하던 흐름대로 멀티라인 `git commit` 을 **bash 셸**에 PowerShell here-string `@'...'@` 로 넣었더니, 커밋 메시지가 깨졌다.
+
+```text
+$ git log -1 --format='%B'
+@                       ← subject 가 @ 한 글자
+fix(cli): 글로벌/심링크 ...
+...본문...
+@                       ← 끝에 @ 또 붙음
+```
+
+`git log --oneline` 에 `@ fix(cli): ...` 처럼 보이고, 실제 의도한 제목은 본문으로 밀린다.
+
+## 원인
+
+**환경이 "PowerShell"이라도, 에이전트의 Bash 툴은 실제 `bash` 를 실행한다.** PowerShell here-string `@'...'@` 는 PowerShell 전용 문법 — bash 에는 그런 구문이 없다.
+
+```bash
+# bash 입장에서 이건 here-string 이 아니라:
+git commit -m @'
+fix(cli): ...
+'@
+#   -m 의 값 = "@\nfix(cli): ...\n"  (@ 는 그냥 리터럴 문자)
+#   끝의 '@ = 닫는 작은따옴표(@'...') + 리터럴 @
+```
+
+→ 커밋 subject 가 `@`, 본문 끝에 `@` 가 붙는다.
+
+## 해결
+
+**셸 종류에 맞는 쿼팅을 쓴다.**
+
+- **Bash 툴** 멀티라인 커밋 → 다중 `-m` 플래그(heredoc 회피가 글로벌 규칙일 때):
+
+```bash
+git commit -m "fix(cli): isMainModule realpath 정규화" \
+           -m "심링크/글로벌 실행에서 main 미동작 픽스. 761 pass." \
+           -m "Co-Authored-By: ..."
+```
+
+- **진짜 PowerShell here-string** 이 필요하면 → **PowerShell 툴**로 실행:
+
+```powershell
+git commit -m @'
+fix(cli): ...
+본문 ...
+'@
+```
+
+## 핵심 원리
+
+**도구(셸 실행기)와 문법은 짝이다.** "내 환경은 PowerShell"이라는 사실과 "지금 호출하는 툴이 무엇을 실행하는가"는 다른 차원 — 후자가 인자 파싱을 결정한다. 멀티라인/특수문자 인자를 넘기기 전에 *이 호출이 bash 인가 pwsh 인가*부터 확인.
+
+## 적용 조건
+
+- ✅ Windows + AI 에이전트(Claude Code 등)에서 bash 툴과 PowerShell 툴을 둘 다 쓰는 경우
+- ✅ 커밋 메시지·PR 본문 등 멀티라인 문자열을 native 명령에 넘길 때
+- ❌ 단일 라인 + 특수문자 없는 인자(셸 무관하게 안전)
+- ⚠️ 이미 잘못 커밋했고 **머지된 히스토리**면, subject 의 `@` 같은 cosmetic 결함은 `force-push` 위험(발산) > 이득 → 방치가 정답. 머지 전이면 `git commit --amend` 로 정정.
+
+## 검증
+
+커밋 직후 `git log -1 --format='%s'`(subject 만) 로 의도한 제목이 첫 줄인지 확인. `@` 나 따옴표 잔재가 보이면 amend(미머지 한정).
+
+## 참고
+
+- VHK v2.0.1 잔재 정리 중 커밋 2건(`c2796ee`·`c588f06`) subject 오염 — 이미 main 머지돼 방치(코드/CHANGELOG 내용은 정상).
+- 관련 패턴: [env-windows-cmd-shim-node20.md](./env-windows-cmd-shim-node20.md) — Windows 셸/실행 호환 시리즈

--- a/src/templates/rules-md.ts
+++ b/src/templates/rules-md.ts
@@ -33,5 +33,8 @@ export function RULES_MD_TEMPLATE(name: string, description: string, stack: stri
     '## 기록 규칙',
     '- 세션 종료 시 docs/log/YYYY-MM-DD-{작업명}.md 생성',
     '- 기술 선택 시 docs/adr/ADR-{번호}-{제목}.md 생성',
+    '- 기능 완성 / 에러 해결 / ADR / 세션 종료 시 Notion "바이브코딩 Dev Log" DB에 1행 적재 (Notion MCP)',
+    '- 적재 직전 Dev Log DB 상단 "AI 적재 규칙" 콜아웃 확인 — 제목: (YYYY-MM-DD) 프로젝트명 - 제목',
+    '- 태그는 기존 옵션만 사용, 같은 작업 중복 적재 금지(SoT Key)',
   ].join('\n')
 }


### PR DESCRIPTION
## 무엇

본 세션(Goal 18 v2.0.0~2.0.2 릴리즈) 교훈의 역전파 2종.

### docs(patterns) — 범용 패턴 파일 3건
- `auth-npm-scoped-publish-404` — scoped npm publish E404 = 인증 실패 (404 != 없음, whoami 먼저)
- `build-release-tool-forced-version-bump` — 릴리즈 CLI 강제 범프 → pre-set 버전 발행 불가
- `env-bash-tool-vs-powershell-heredoc` — bash 툴에 PS here-string 금지 (커밋 메시지 오염)

각 파일 출처DevLog = Notion 바이브코딩 Dev Log 엔트리 링크(양방향 추적). 패턴사전 DB 직접주입 안 함(글로벌 규칙: 자동화 도우미 등록).

### feat(rules) — RULES 템플릿
신규 프로젝트 RULES.md 에 Notion Dev Log 적재 규칙 3줄(기능완성/에러/ADR/세션종료 시 1행 적재, 태그 기존옵션, SoT Key 중복방지).

## 검증
build OK / 761 pass 무회귀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)