### PR TITLE
chore(state): v2.0.2 발행 후 상태 문서 갱신 (CLAUDE.md + next-task.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,16 +13,16 @@ tags: [process, documentation]
 
 - **레포:** <https://github.com/byh3071-cpu/vhk> (public)
 - **npm:** @byh3071/vhk (public, scoped)
-- **버전:** v2.0.0 (package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
+- **버전:** v2.0.2 (npm latest. package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
 - **MCP tool:** 25 (Goal 0 24 + `learn` v2.0 쓰기 도구)
-- **테스트:** 702 pass (vitest)
+- **테스트:** 761 pass (vitest)
 - **패키지 매니저:** pnpm
 
 ## 현재 상태
 
-- **Phase:** Phase 5 이후 — Goal 18(memory schema v2, Evolution Loop 도미노 2) DONE → v2.0.0 릴리즈 PR (breaking). 다음 = Goal 19(vhk pattern).
+- **Phase:** Phase 5 이후 — Goal 18(memory schema v2, Evolution Loop 도미노 2) DONE → **npm v2.0.2 발행 완료**(breaking, learn MCP 툴 25 + 심링크 픽스 포함). 등록 goal 0~18 전부 DONE. 다음 = Goal 19(vhk pattern).
 - **블로커:** 없음
-- **다음 액션:** Goal 19(vhk pattern, v2.1.0), 20(vhk evolve, v2.2.0). publish 는 사람(2FA OTP).
+- **다음 액션:** Goal 19(vhk pattern, v2.1.0 — 설계 spike `feat/goal-19-pattern-spike` 브랜치, main 미머지), 20(vhk evolve, v2.2.0). publish 는 사람(2FA OTP).
 - **마지막 업데이트:** 2026-06-03
 
 > **기억 SoT (v2):** 교훈·결정·실패·성공은 `vhk memory`(memory v2 4버킷, `vhk learn`→`failures.lesson`). `docs/state/learnings.md` 는 v2 마이그레이션으로 흡수·신규기록 중단(분리 폐지).

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -1,10 +1,12 @@
 # Next Task
 
-_Auto-updated 2026-06-02T15:52:17.916Z via `vhk goal next`._
+_Updated 2026-06-03 — Goal 18(memory schema v2) DONE + npm v2.0.2 발행. 등록된 goal(0~18) 전부 완료._
 
 ```
-TASK: Goal 18 — 기억 구조화 — memory schema v2 (4버킷 + learn 통합) — P1
-  status: NOT_STARTED
-  priority: P1
-  file: goals\18-memory-schema-v2.md
+✅ ALL REGISTERED GOALS DONE (0~18)
+
+다음 = Goal 19 — vhk pattern (패턴 감지, v2.1.0)
+  status: 설계 spike (feat/goal-19-pattern-spike 브랜치, main 미머지)
+  action: goals/19-*.md 를 main 에 등록 → `vhk goal next` 재실행 시 자동 추적 재개
+  이후: Goal 20 — vhk evolve (v2.2.0)
 ```


### PR DESCRIPTION
## 무엇
v2.0.2 발행 반영 안 된 stale 상태 문서 정정.

- **CLAUDE.md**: 버전 v2.0.0→v2.0.2, 테스트 702→761, Phase=npm v2.0.2 발행 완료, 다음 액션=Goal 19(설계 spike 미머지)
- **next-task.md**: Goal 18 NOT_STARTED 박제 → 0~18 전부 DONE + Goal 19 안내 (`vhk goal next` 가 전부완료 시 파일 미갱신이라 수동 정정)

## 맥락
docs(자잘한 정리): 이슈 #14(start MCP stdin) close 완료(start MCP 미노출로 해결). #38(RFC 0001)은 의도적 오픈 토론 이슈라 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)