### PR TITLE
feat(goal-19): vhk pattern detection v0 — Evolution Loop 도미노 3

### DIFF
--- a/goals/19-pattern.md
+++ b/goals/19-pattern.md
@@ -1,0 +1,62 @@
+---
+vhk_format: 1
+type: goal
+id: 19
+title: 패턴 감지 — pattern detection v0 (반복 실패·성공 → avoid/reinforce 후보) — P1
+status: NOT_STARTED
+priority: P1
+version: v2.1.0
+---
+
+# Goal 19: pattern detection v0 (Evolution Loop 도미노 3)
+
+> 출처: Evolution Loop 로드맵 — `작업→증거(13)→기억(18)→`**`패턴(19)`**`→진화(20)`. 확정 스펙:
+> "active 실패+성공에서 반복 추출 → `avoid`/`reinforce` 후보. 보수적 임계(기본 3회+). **읽기·제안만, 반영 X.** CLI `vhk pattern`."
+> 전제: Goal 18(memory schema v2) 완료 — `patterns[]` 빈 배열 + 최소 타입으로 예약됨. 19 = 그 버킷을 감지로 채움. 적용/evolve 는 Goal 20.
+
+## 현황 (19-A 코드 확인 결과)
+- **patterns 예약됨** = `src/commands/memory.ts:36-40` `PatternEntry { id: string; [key:string]: unknown }` (최소 타입).
+  `emptyV2()`(memory.ts:51) 가 `patterns: []` 초기화. **어디서도 채우지 않음** — 19 가 첫 기록자.
+- **입력 소스 존재** = `failures: FailEntry[]` (`{...MemEntry, why?, lesson?}`, memory.ts:29-32) · `successes: SuccessEntry[]` (`{...MemEntry, why?}`, memory.ts:33-35).
+  `MemEntry`(memory.ts:20-28) = `{ id, content, tags[], createdAt, status, resolvedAt?, archivedAt? }`.
+- **status 선순환** = `'active'|'resolved'|'archived'`(memory.ts:17). `vhk learn`(agent.ts) → `recordLesson`(memory.ts:363) 이 `failures.lesson` 에 active 로 append, `tags:['goal-N'|'no-goal']`.
+- **표시 자리만 있음** = `activeMemoryLines()`(memory.ts:357) 이 `patterns.length>0` 면 "패턴 후보 (patterns): N개 — `vhk pattern`" 안내(현재 항상 0). 명령 자체는 미구현.
+- **읽기/쓰기 계약** = `readMemory(cwd)`(memory.ts:153) / `writeMemory(cwd, mem)`(memory.ts:168, `.bak` 롤링) / `nextId(bucket, mem)`. BOM-safe.
+
+## 동작 (파일·계약)
+- **입력**: `readMemory(cwd)` → `failures` + `successes` 중 **`status==='active'` 만**(`resolved`/`archived` 제외 — 선순환·재제안 방지). decisions/patterns 는 입력 아님.
+  - 신호 텍스트: failure = `lesson ?? content`, success = `content`(+`why` 보조).
+- **감지 v0 (구조/빈도 — ML/LLM/외부 라이브러리 0)**, 버킷별 독립 2축:
+  - **① 태그 군집** — active 항목 태그 빈도. 한 태그가 같은 버킷에서 `≥ 임계` → 후보. (`goal-N`/사용자 태그 포함, `no-goal` 제외.)
+  - **② 키워드 문서빈도** — 신호 텍스트 정규화(소문자·구두점 제거·공백 split, 최소 불용어) → 토큰의 **문서빈도**(서로 다른 항목 수). `≥ 임계` 항목 등장 토큰 → 후보. (한국어 형태소분석 없음 → 제외 범위.)
+  - 임계 기본 **3**(보수적), `--min <n>` 조정. kind: failures→**`avoid`**, successes→**`reinforce`**.
+  - **결정적**: count desc → signal asc 안정 정렬. 동일 입력=동일 출력.
+- **출력 — `PatternEntry` 스키마**(placeholder 대체, 4버킷 일관): `{ id, kind:'avoid'|'reinforce', axis:'tag'|'keyword', signal, count, sources[](기여 entry id), summary(사람용 한 줄 — Goal 20 카드 토대), createdAt, status, tags[](소스 태그 합집합 — v3 스코프 토대) }`.
+- **멱등/병합**: `detect` = 순수 재계산 → 시그니처(`kind:axis:정규화signal`) 병합. 기존 active 동일 시그니처 → count/sources/summary 갱신(중복 push 금지), 신규 → `nextId('pattern',mem)` push. 자동 삭제 없음.
+- **CLI (컨테이너)**: `vhk pattern detect`(`--min`,`--json`) · `list`(`--kind`,`--all`) · `dismiss <n>`(→archived). 별칭 `.alias('패턴')`, `command-registry` `pattern:['detect','list','dismiss']`. NLP 키워드 '패턴/반복/되풀이/버릇/pattern'. `printNextStep()` → `vhk pattern list` · "(Goal 20) `vhk evolve`(나중)".
+- **MCP**: `pattern detect`·`pattern list` 노출(`runVhkCli`, 비대화형). dismiss 후속. secret 미포함(memory 파생 → secure scan 관문).
+
+## 철학
+① 읽기·제안만 — **RULES.md/적용 반영 0**(Goal 20 영역, 안전 1원칙 "자동 학습 OK·자동 적용 금지") ② active 만 입력 — 선순환 닫힘 존중(해결·보관된 실수는 다시 안 운다) ③ 보수적 임계 — 거짓 패턴보다 미탐 선호 ④ 결정적·멱등 — 재실행해도 중복·표류 0 ⑤ v0 구조/빈도 — 의미·ML 은 미래(v3 Hub), 의존성 0 유지 ⑥ Windows 1급·`safeExecFile`(구현 시).
+
+## Completion Check
+- [ ] `PatternEntry` 구체 타입(kind/axis/signal/count/sources/summary/status/tags) — placeholder 대체
+- [ ] `detect`: active failures+successes 2축(태그군집·키워드빈도) 감지 → `avoid`/`reinforce` 후보
+- [ ] 보수적 임계 기본 3(`--min` 조정) · `resolved`/`archived` 입력 제외 검증
+- [ ] 멱등 — 재실행 시 시그니처 병합(중복 patterns 0), 결정적 정렬
+- [ ] `vhk pattern list`(--kind/--all) · `dismiss <n>`(→archived) · 별칭 `패턴` + NLP 라우팅
+- [ ] **반영 0 회귀 가드** — detect 가 RULES.md/memory 외 파일·다른 버킷 무변경
+- [ ] MCP `pattern detect`·`list` 노출(비대화형) · secret 누출 0(secure scan)
+- [ ] vhk goal sync → check-goal-19.mjs 생성 → vhk goal check --id 19 통과
+- [ ] 신규 테스트(감지·임계·멱등·반영0) + 공통 게이트(typecheck+test+build), 기존 회귀 0
+
+## 제외 범위
+- 후보 → 적용/반영(RULES.md), `evolve`, 사람말 카드 [예/아니오/나중에], 기여 실패 `resolved` 닫기 → **Goal 20**.
+- Jaccard 토큰셋 근접중복(재서술 반복 포착) · 의미/임베딩 분석 · 한국어 형태소분석 → 후속(v0=구조/빈도만).
+- `profile.json` 자동학습 · 기억 자동정리(오래된 active archive 제안) → Goal 20 / v2.x.
+- 크로스 프로젝트 패턴 합산 · 글로벌 메모리(`~/.vhk`) · 스코프 규칙 → v3 VHK Hub.
+
+## Mandatory Reading
+- src/commands/memory.ts (PatternEntry placeholder:36-40 · MemEntry/FailEntry/SuccessEntry · readMemory/writeMemory/nextId · activeMemoryLines)
+- goals/18-memory-schema-v2.md (4버킷·status 선순환·learn 통합 — 입력 계약)
+- Notion 🌱 성장 루프 비전(Evolution Loop) · 🚀 릴리즈 로드맵 v2.1.0 Goal 19 확정 스펙(avoid/reinforce·임계 3·반영 X)

--- a/scripts/check-goal-19.mjs
+++ b/scripts/check-goal-19.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// scripts/check-goal-19.mjs — Goal 19: pattern detection v0
+// 기본 게이트 = typecheck + test + build. goal 19 고유 검증 포함.
+//
+// Env: VHK_GATES_SKIP_DEEP=1 → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 19 gate.')
+  process.exit(1)
+}
+
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+const pkg = existsSync('package.json') ? JSON.parse(readFileSync('package.json', 'utf-8').replace(/^﻿/, '')) : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 19] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// 공통 게이트
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 19 고유 검증 (pattern detection v0) ──────────────────────────────
+const pt = read('src/commands/pattern.ts') ?? ''
+must(/export function detectCandidates/.test(pt), 'detectCandidates 순수 함수 export')
+must(/export const MIN_TAG_FREQ/.test(pt) && /export const MIN_KEYWORD_FREQ/.test(pt), '명명 상수 MIN_TAG_FREQ / MIN_KEYWORD_FREQ (매직넘버 금지)')
+must(/export function tokenize/.test(pt), 'tokenize export')
+must(/export async function patternDetect/.test(pt) && /export async function patternList/.test(pt) && /export async function patternDismiss/.test(pt), 'patternDetect / patternList / patternDismiss export')
+must(/printNextStep/.test(pt), 'printNextStep() 패턴 사용')
+must(!/process\.exit\s*\(/.test(pt), 'process.exit() 금지 (MCP 핸들러 정책)')
+must(!/execSync/.test(pt), 'execSync 금지 — safeExecFile 사용')
+must(/PatternEntryV19/.test(pt), 'PatternEntryV19 구체 스키마 정의')
+must(/avoid/.test(pt) && /reinforce/.test(pt), 'avoid / reinforce kind')
+must(/axis.*tag.*keyword|tag.*axis|keyword.*axis/.test(pt), 'axis tag/keyword 2축')
+must(/_sig/.test(pt), '멱등 병합 시그니처 _sig')
+must(/status.*archived|archived.*status/.test(pt), 'dismiss = archived (하드 삭제 금지)')
+
+// NLP 라우터에 pattern 추가됐는지
+const nr = read('src/lib/nlp-router.ts') ?? ''
+must(/'pattern'/.test(nr), "NlpCommand 에 'pattern' 추가")
+must(/패턴|반복|되풀이|pattern/.test(nr), 'NLP 키워드 pattern 등록')
+
+// command-registry 등록
+const cr = read('src/lib/command-registry.ts') ?? ''
+must(/pattern.*detect.*list.*dismiss|detect.*list.*dismiss/.test(cr), 'command-registry 에 pattern 서브커맨드 등록')
+
+// MCP 등록
+const srv = read('src/mcp/server.ts') ?? ''
+must(/pattern-detect/.test(srv) && /pattern-list/.test(srv), 'MCP pattern-detect + pattern-list 등록')
+must(!/process\.exit/.test(srv.slice(srv.indexOf('pattern-detect'))), 'MCP 핸들러 process.exit() 금지 (runVhkCli 위임)')
+
+// 테스트 존재
+must(existsSync('tests/pattern.test.ts'), 'tests/pattern.test.ts 존재')
+
+// 반영 0 — RULES.md 미변경 (패턴 읽기·제안만, 반영 = Goal 20)
+const rules = read('RULES.md') ?? ''
+must(!/patternDetect|패턴.*반영|pattern.*apply/.test(rules), 'RULES.md 에 패턴 반영 코드 없음 (Goal 20 영역)')
+
+if (pass) { console.log('✅ goal 19 gate passes'); process.exit(0) }
+console.log('❌ goal 19 gate failed'); process.exit(1)

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -123,14 +123,23 @@ export function migrateMemory(rawMemory: unknown, rawLearnings?: string): Memory
 
 // ── fs 경계 (impure) ──
 
-function readRaw(cwd: string): unknown {
+type RawResult = { kind: 'missing' } | { kind: 'parsed'; value: unknown } | { kind: 'error' }
+
+function readRaw(cwd: string): RawResult {
   const p = join(cwd, MEMORY_PATH_REL)
-  if (!existsSync(p)) return null
+  if (!existsSync(p)) return { kind: 'missing' }
   try {
-    return readJsonFile<unknown>(p)
+    return { kind: 'parsed', value: readJsonFile<unknown>(p) }
   } catch {
-    return null
+    return { kind: 'error' }
   }
+}
+
+function warnUnreadable(cwd: string): void {
+  const p = join(cwd, MEMORY_PATH_REL)
+  console.error(chalk.red(`\n⚠️  ${MEMORY_PATH_REL} 를 읽을 수 없습니다 (손상/부분 쓰기 의심).`))
+  console.error(chalk.yellow(`   덮어쓰지 않고 빈 메모리로 진행합니다 — 원본 보존됨.`))
+  console.error(chalk.dim(`   확인/복구: ${p}  (백업: ${p}.bak)`))
 }
 
 // learnings.md 는 JSON 이 아니라 텍스트 — BOM-safe 로 읽되 JSON.parse 안 함.
@@ -149,14 +158,36 @@ function readLearningsRaw(cwd: string): string | undefined {
  * **계약 일관성**: 디스크가 v1 이면 read 경로(memory list / context / brief 등)에서도 1회 실제
  * 마이그레이션을 영구화(v2 write + .v1.bak) — 어느 명령으로 첫 실행해도 동일 결과.
  * 멱등: 이미 v2 면 no-op(재흡수·재기록 없음). 파일이 아예 없으면 빈 v2 만 반환(쓰지 않음).
+ * 손상 파일(파싱 불가): 경고 출력 후 빈 v2 반환 — **절대 덮어쓰지 않음**(원본 보존).
  */
 export function readMemory(cwd: string = process.cwd()): MemoryFileV2 {
   const raw = readRaw(cwd)
-  if (isV2(raw)) return normalizeV2(raw)
-  const v2 = migrateMemory(raw, readLearningsRaw(cwd))
-  // 디스크에 v1 파일이 실재할 때만 영구화(없는데 read 하면서 빈 파일 만들지 않음).
-  if (existsSync(join(cwd, MEMORY_PATH_REL))) writeMemory(cwd, v2)
+  if (raw.kind === 'error') {
+    warnUnreadable(cwd)
+    return emptyV2()  // 손상 파일은 쓰지 않음
+  }
+  const value = raw.kind === 'parsed' ? raw.value : null
+  if (isV2(value)) return normalizeV2(value as MemoryFileV2)
+  const v2 = migrateMemory(value, readLearningsRaw(cwd))
+  // v1 파일이 실재할 때만 영구화(없는데 read 하면서 빈 파일 만들지 않음).
+  if (raw.kind === 'parsed') writeMemory(cwd, v2)
   return v2
+}
+
+/**
+ * 변경(mutating) 커맨드용 로더 — 손상 파일이면 `{ ok: false }` 반환해 호출자가 abort.
+ * `readMemory` 는 write 를 트리거하지 않는 read-only 경로에 사용.
+ * 이 함수는 write 전 안전 확인 용도로 pattern/memory mutating 커맨드가 호출.
+ */
+export function loadForMutation(cwd: string): { ok: true; mem: MemoryFileV2 } | { ok: false } {
+  const raw = readRaw(cwd)
+  if (raw.kind === 'error') {
+    warnUnreadable(cwd)
+    return { ok: false }
+  }
+  const value = raw.kind === 'parsed' ? raw.value : null
+  if (isV2(value)) return { ok: true, mem: normalizeV2(value as MemoryFileV2) }
+  return { ok: true, mem: migrateMemory(value, readLearningsRaw(cwd)) }
 }
 
 /**
@@ -170,7 +201,9 @@ export function writeMemory(cwd: string, mem: MemoryFileV2): void {
   mkdirSync(join(cwd, '.vhk'), { recursive: true })
   if (existsSync(p)) {
     // 마이그레이션 순간(디스크가 v1)에 v1 원본을 write-once 보존.
-    if (!isV2(readRaw(cwd)) && !existsSync(p + '.v1.bak')) {
+    const curRaw = readRaw(cwd)
+    const curValue = curRaw.kind === 'parsed' ? curRaw.value : null
+    if (!isV2(curValue) && !existsSync(p + '.v1.bak')) {
       try {
         copyFileSync(p, p + '.v1.bak')
       } catch {
@@ -317,11 +350,12 @@ export async function memoryArchive(indexStr: string): Promise<void> {
 export async function memoryMigrate(): Promise<void> {
   const cwd = process.cwd()
   const raw = readRaw(cwd)
-  if (isV2(raw)) {
+  const rawValue = raw.kind === 'parsed' ? raw.value : null
+  if (isV2(rawValue)) {
     console.log(chalk.dim('  이미 memory schema v2 입니다 — 변경 없음(멱등).'))
     return
   }
-  const v2 = migrateMemory(raw, readLearningsRaw(cwd))
+  const v2 = migrateMemory(rawValue, readLearningsRaw(cwd))
   writeMemory(cwd, v2)
   console.log(chalk.green('\n✅ memory.json v1 → v2 마이그레이션 완료 (.v1.bak 원본 영구 백업)'))
   console.log(

--- a/src/commands/pattern.ts
+++ b/src/commands/pattern.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
-import { readMemory, writeMemory, type MemoryFileV2, type MemEntry, type FailEntry, type PatternEntry } from './memory.js'
+import { loadForMutation, readMemory, writeMemory, type MemoryFileV2, type MemEntry, type FailEntry, type PatternEntry } from './memory.js'
 
 /**
  * Goal 19: pattern detection v0 — active failures/successes 에서 반복 패턴 감지.
@@ -75,7 +75,10 @@ export function detectCandidates(mem: MemoryFileV2, minFreq: number): RawCandida
     // 축1: 태그 군집
     const tagMap = new Map<string, string[]>()
     for (const e of active) {
-      for (const tag of e.tags) {
+      // Fix #7: null guard on e.tags
+      const uniqueTags = new Set(e.tags ?? [])
+      for (const tag of uniqueTags) {
+        // Fix #2: Set(e.tags) — 같은 항목 내 중복 태그로 인한 count 팽창 방지
         if (tag === 'no-goal') continue
         if (!tagMap.has(tag)) tagMap.set(tag, [])
         tagMap.get(tag)!.push(e.id)
@@ -83,8 +86,10 @@ export function detectCandidates(mem: MemoryFileV2, minFreq: number): RawCandida
     }
     for (const [tag, sources] of tagMap) {
       if (sources.length >= minFreq) {
-        const involved = active.filter((e) => sources.includes(e.id))
-        const sourceTags = [...new Set(involved.flatMap((e) => e.tags))]
+        // Fix efficiency: Set for O(1) lookup instead of O(n) includes
+        const sourceSet = new Set(sources)
+        const involved = active.filter((e) => sourceSet.has(e.id))
+        const sourceTags = [...new Set(involved.flatMap((e) => e.tags ?? []))]
         candidates.push({
           kind, axis: 'tag', signal: tag, count: sources.length, sources,
           summary: `[${kind}] 태그 '${tag}' ${sources.length}건 반복`,
@@ -107,8 +112,8 @@ export function detectCandidates(mem: MemoryFileV2, minFreq: number): RawCandida
     for (const [tok, sourceSet] of tokenMap) {
       if (sourceSet.size >= minFreq) {
         const sources = [...sourceSet]
-        const involved = active.filter((e) => sources.includes(e.id))
-        const sourceTags = [...new Set(involved.flatMap((e) => e.tags))]
+        const involved = active.filter((e) => sourceSet.has(e.id))
+        const sourceTags = [...new Set(involved.flatMap((e) => e.tags ?? []))]
         candidates.push({
           kind, axis: 'keyword', signal: tok, count: sourceSet.size, sources,
           summary: `[${kind}] 키워드 '${tok}' ${sourceSet.size}건 문서`,
@@ -148,10 +153,19 @@ export async function patternDetect(opts: { min?: string; json?: boolean } = {})
   }
 
   const cwd = process.cwd()
-  const mem = readMemory(cwd)
+
+  // Fix #1: loadForMutation 으로 교체 — 손상 파일 시 abort(데이터 소실 방지)
+  const loaded = loadForMutation(cwd)
+  if (!loaded.ok) {
+    console.log(chalk.red('❌ memory.json 손상 의심 — 감지 중단 (원본 보존). 백업 확인 후 재시도하세요.'))
+    process.exitCode = 1
+    return
+  }
+  const mem = loaded.mem
+
   const candidates = detectCandidates(mem, minFreq)
 
-  // 멱등 병합: 동일 시그니처 active 패턴은 갱신, 신규는 push.
+  // Fix #3: _sig 없는 레거시 엔트리도 kind+axis+signal 로 중복 탐색 → 멱등성 보장
   const now = new Date().toISOString()
   let added = 0, updated = 0
 
@@ -159,10 +173,13 @@ export async function patternDetect(opts: { min?: string; json?: boolean } = {})
     const sig = sigOf(c.kind, c.axis, c.signal)
     const existing = mem.patterns.find((p) => {
       const pp = p as PatternEntryV19
-      return pp._sig === sig && pp.status !== 'archived'
+      const sigMatch = pp._sig === sig
+      const fieldMatch = pp.kind === c.kind && pp.axis === c.axis && pp.signal === c.signal
+      return (sigMatch || fieldMatch) && pp.status !== 'archived'
     }) as PatternEntryV19 | undefined
 
     if (existing) {
+      existing._sig = sig  // _sig 없는 레거시 엔트리에 백필
       existing.count = c.count
       existing.sources = c.sources
       existing.summary = c.summary
@@ -187,7 +204,10 @@ export async function patternDetect(opts: { min?: string; json?: boolean } = {})
     }
   }
 
-  writeMemory(cwd, mem)
+  // Fix #6: 변경이 없으면 writeMemory 스킵 — .bak 슬롯 불필요 소비 방지
+  if (added > 0 || updated > 0) {
+    writeMemory(cwd, mem)
+  }
 
   if (opts.json) {
     const active = mem.patterns.filter((p) => (p as PatternEntryV19).status !== 'archived')
@@ -266,7 +286,16 @@ export async function patternDismiss(idStr: string): Promise<void> {
   }
 
   const cwd = process.cwd()
-  const mem = readMemory(cwd)
+
+  // Fix #5: loadForMutation — 손상 파일 시 명시적 abort + 정확한 오류 메시지
+  const loaded = loadForMutation(cwd)
+  if (!loaded.ok) {
+    console.log(chalk.red('❌ memory.json 손상 의심 — dismiss 중단 (원본 보존).'))
+    process.exitCode = 1
+    return
+  }
+  const mem = loaded.mem
+
   const pattern = mem.patterns.find((p) => p.id === idStr.trim()) as PatternEntryV19 | undefined
 
   if (!pattern) {

--- a/src/commands/pattern.ts
+++ b/src/commands/pattern.ts
@@ -1,0 +1,294 @@
+import chalk from 'chalk'
+import { t } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+import { readMemory, writeMemory, type MemoryFileV2, type MemEntry, type FailEntry, type PatternEntry } from './memory.js'
+
+/**
+ * Goal 19: pattern detection v0 — active failures/successes 에서 반복 패턴 감지.
+ * 2축(태그 군집 + 키워드 문서빈도), 순수 빈도 카운팅(ML/외부 라이브러리 0).
+ * patterns[] 는 Goal 18 이 예약한 빈 버킷 — 여기서 처음 채움.
+ * 읽기·제안만. RULES.md/파일 반영은 Goal 20.
+ */
+
+export const MIN_TAG_FREQ = 3
+export const MIN_KEYWORD_FREQ = 3
+
+const STOPWORDS = new Set(['the', 'a', 'an', 'is', 'are', 'and', 'or', 'in', 'on', 'at', 'to', 'for', 'of', 'with', 'it', 'was', 'be'])
+
+/** 신호 텍스트 정규화 → 토큰 배열 (소문자·구두점 제거·최소 불용어). */
+export function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^가-힣a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter((tok) => tok.length >= 2 && !STOPWORDS.has(tok))
+}
+
+/** PatternEntry 구체 스키마 (Goal 19 채움). */
+export interface PatternEntryV19 extends PatternEntry {
+  kind: 'avoid' | 'reinforce'
+  axis: 'tag' | 'keyword'
+  signal: string
+  count: number
+  sources: string[]
+  summary: string
+  createdAt: string
+  status: 'active' | 'archived'
+  tags: string[]
+  _sig: string
+}
+
+function sigOf(kind: 'avoid' | 'reinforce', axis: 'tag' | 'keyword', signal: string): string {
+  return `${kind}:${axis}:${signal}`
+}
+
+function isActive(e: MemEntry): boolean {
+  return e.status !== 'archived' && e.status !== 'resolved'
+}
+
+interface RawCandidate {
+  kind: 'avoid' | 'reinforce'
+  axis: 'tag' | 'keyword'
+  signal: string
+  count: number
+  sources: string[]
+  summary: string
+  sourceTags: string[]
+}
+
+/**
+ * 순수 감지 함수 — fs·Date 부수효과 없음(테스트 가능).
+ * 축1: 태그 군집(같은 버킷 내 태그 빈도 ≥ minFreq → 후보, no-goal 제외).
+ * 축2: 키워드 문서빈도(서로 다른 항목 수 ≥ minFreq → 후보).
+ * 정렬: count desc → signal asc(결정적).
+ */
+export function detectCandidates(mem: MemoryFileV2, minFreq: number): RawCandidate[] {
+  const candidates: RawCandidate[] = []
+
+  function processBucket(
+    entries: MemEntry[],
+    kind: 'avoid' | 'reinforce',
+    getText: (e: MemEntry) => string,
+  ): void {
+    const active = entries.filter(isActive)
+
+    // 축1: 태그 군집
+    const tagMap = new Map<string, string[]>()
+    for (const e of active) {
+      for (const tag of e.tags) {
+        if (tag === 'no-goal') continue
+        if (!tagMap.has(tag)) tagMap.set(tag, [])
+        tagMap.get(tag)!.push(e.id)
+      }
+    }
+    for (const [tag, sources] of tagMap) {
+      if (sources.length >= minFreq) {
+        const involved = active.filter((e) => sources.includes(e.id))
+        const sourceTags = [...new Set(involved.flatMap((e) => e.tags))]
+        candidates.push({
+          kind, axis: 'tag', signal: tag, count: sources.length, sources,
+          summary: `[${kind}] 태그 '${tag}' ${sources.length}건 반복`,
+          sourceTags,
+        })
+      }
+    }
+
+    // 축2: 키워드 문서빈도
+    const tokenMap = new Map<string, Set<string>>()
+    for (const e of active) {
+      const text = getText(e)
+      if (!text) continue
+      const unique = new Set(tokenize(text))
+      for (const tok of unique) {
+        if (!tokenMap.has(tok)) tokenMap.set(tok, new Set())
+        tokenMap.get(tok)!.add(e.id)
+      }
+    }
+    for (const [tok, sourceSet] of tokenMap) {
+      if (sourceSet.size >= minFreq) {
+        const sources = [...sourceSet]
+        const involved = active.filter((e) => sources.includes(e.id))
+        const sourceTags = [...new Set(involved.flatMap((e) => e.tags))]
+        candidates.push({
+          kind, axis: 'keyword', signal: tok, count: sourceSet.size, sources,
+          summary: `[${kind}] 키워드 '${tok}' ${sourceSet.size}건 문서`,
+          sourceTags,
+        })
+      }
+    }
+  }
+
+  const failText = (e: MemEntry): string => {
+    const f = e as FailEntry
+    return f.lesson ?? f.content ?? ''
+  }
+
+  processBucket(mem.failures, 'avoid', failText)
+  processBucket(mem.successes, 'reinforce', (e) => e.content ?? '')
+
+  return candidates.sort((a, b) => b.count - a.count || a.signal.localeCompare(b.signal))
+}
+
+function nextPatternId(mem: MemoryFileV2): string {
+  const re = /^p(\d+)$/
+  let max = 0
+  for (const p of mem.patterns) {
+    const m = p.id.match(re)
+    if (m) max = Math.max(max, Number(m[1]))
+  }
+  return `p${max + 1}`
+}
+
+export async function patternDetect(opts: { min?: string; json?: boolean } = {}): Promise<void> {
+  const minFreq = opts.min !== undefined ? parseInt(opts.min, 10) : MIN_TAG_FREQ
+  if (!Number.isFinite(minFreq) || minFreq < 1) {
+    console.log(chalk.red('❌ --min 은 1 이상의 정수여야 합니다.'))
+    process.exitCode = 1
+    return
+  }
+
+  const cwd = process.cwd()
+  const mem = readMemory(cwd)
+  const candidates = detectCandidates(mem, minFreq)
+
+  // 멱등 병합: 동일 시그니처 active 패턴은 갱신, 신규는 push.
+  const now = new Date().toISOString()
+  let added = 0, updated = 0
+
+  for (const c of candidates) {
+    const sig = sigOf(c.kind, c.axis, c.signal)
+    const existing = mem.patterns.find((p) => {
+      const pp = p as PatternEntryV19
+      return pp._sig === sig && pp.status !== 'archived'
+    }) as PatternEntryV19 | undefined
+
+    if (existing) {
+      existing.count = c.count
+      existing.sources = c.sources
+      existing.summary = c.summary
+      existing.tags = c.sourceTags
+      updated++
+    } else {
+      const entry: PatternEntryV19 = {
+        id: nextPatternId(mem),
+        kind: c.kind,
+        axis: c.axis,
+        signal: c.signal,
+        count: c.count,
+        sources: c.sources,
+        summary: c.summary,
+        createdAt: now,
+        status: 'active',
+        tags: c.sourceTags,
+        _sig: sig,
+      }
+      mem.patterns.push(entry)
+      added++
+    }
+  }
+
+  writeMemory(cwd, mem)
+
+  if (opts.json) {
+    const active = mem.patterns.filter((p) => (p as PatternEntryV19).status !== 'archived')
+    console.log(JSON.stringify(active, null, 2))
+    return
+  }
+
+  console.log(chalk.bold('\n🔍 ' + t('pattern.detectTitle')))
+  console.log(chalk.gray('─'.repeat(40)))
+  console.log(chalk.dim(`  임계: ${minFreq}회 이상 · active failures+successes 입력`))
+  console.log(chalk.dim(`  후보: ${candidates.length}개 감지 (추가 ${added} / 갱신 ${updated})`))
+
+  const active = mem.patterns.filter((p) => (p as PatternEntryV19).status !== 'archived') as PatternEntryV19[]
+  if (active.length === 0) {
+    console.log(chalk.yellow('\n📭 임계 이상 반복 패턴이 없습니다.'))
+    console.log(chalk.gray(`   failures/successes 가 ${minFreq}개 이상 쌓이면 감지됩니다.`))
+    console.log(chalk.gray('   --min N 으로 임계를 낮출 수 있습니다.'))
+    return
+  }
+
+  console.log(chalk.cyan(`\n패턴 후보 ${active.length}개:\n`))
+  for (const p of active.slice(0, 20)) {
+    const icon = p.kind === 'avoid' ? '⚠️ ' : '✅'
+    console.log(`  [${p.id}] ${icon} (${p.kind}/${p.axis}) "${p.signal}" — ${p.count}건`)
+    const preview = p.sources.slice(0, 5).join(', ') + (p.sources.length > 5 ? ` 외 ${p.sources.length - 5}건` : '')
+    console.log(chalk.dim(`      근거: ${preview}`))
+    console.log(chalk.dim(`      ${p.summary}`))
+  }
+
+  printNextStep({
+    message: `패턴 감지 완료! ${active.length}개 후보.`,
+    command: 'vhk pattern list',
+    cursorHint: '패턴 목록 보여줘',
+    alternative: '(Goal 20) vhk evolve — 다음 단계에서 반영',
+  })
+}
+
+export async function patternList(opts: { kind?: string; all?: boolean; json?: boolean } = {}): Promise<void> {
+  console.log(chalk.bold('\n🔍 ' + t('pattern.listTitle')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  const mem = readMemory(process.cwd())
+  let patterns = mem.patterns as PatternEntryV19[]
+
+  if (!opts.all) patterns = patterns.filter((p) => p.status !== 'archived')
+  if (opts.kind === 'avoid' || opts.kind === 'reinforce') {
+    patterns = patterns.filter((p) => p.kind === opts.kind)
+  }
+
+  if (opts.json) {
+    console.log(JSON.stringify(patterns, null, 2))
+    return
+  }
+
+  if (patterns.length === 0) {
+    console.log(chalk.yellow('\n📭 표시할 패턴이 없습니다.'))
+    console.log(chalk.gray('   vhk pattern detect 로 감지 먼저 실행하세요.'))
+    return
+  }
+
+  console.log(chalk.cyan(`\n${patterns.length}개${opts.all ? ' (보관 포함)' : ' (활성)'}:\n`))
+  for (const p of patterns) {
+    const icon = p.kind === 'avoid' ? '⚠️ ' : '✅'
+    const archived = p.status === 'archived' ? '📦 ' : ''
+    console.log(`  [${p.id}] ${archived}${icon} (${p.kind}/${p.axis}) "${p.signal}" — ${p.count}건`)
+    if (p.summary) console.log(chalk.dim(`      ${p.summary}`))
+    if (p.tags?.length) console.log(chalk.blue(`      🏷️  ${p.tags.join(', ')}`))
+  }
+}
+
+export async function patternDismiss(idStr: string): Promise<void> {
+  if (!idStr?.trim()) {
+    console.log(chalk.red('❌ 패턴 id 를 입력해주세요. 예: vhk pattern dismiss p1'))
+    process.exitCode = 1
+    return
+  }
+
+  const cwd = process.cwd()
+  const mem = readMemory(cwd)
+  const pattern = mem.patterns.find((p) => p.id === idStr.trim()) as PatternEntryV19 | undefined
+
+  if (!pattern) {
+    console.log(chalk.red(`❌ 패턴 '${idStr}' 를 찾을 수 없습니다.`))
+    console.log(chalk.gray('   vhk pattern list --all 로 목록 확인.'))
+    process.exitCode = 1
+    return
+  }
+
+  if (pattern.status === 'archived') {
+    console.log(chalk.dim(`  이미 보관된 패턴입니다 — 변경 없음: ${pattern.id}`))
+    return
+  }
+
+  pattern.status = 'archived'
+  writeMemory(cwd, mem)
+  console.log(chalk.green(`\n📦 패턴 dismiss(보관)됨: [${pattern.id}] ${pattern.summary ?? pattern.signal}`))
+  console.log(chalk.dim('   오탐으로 판단. detect 재실행 시 재제안 안 됨.'))
+
+  printNextStep({
+    message: '패턴 dismiss 완료!',
+    command: 'vhk pattern list',
+    cursorHint: '남은 패턴 보여줘',
+  })
+}

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -413,6 +413,11 @@ export const ko = {
     learnTitle: '🧠 Learning 기록',
     resumeTitle: '▶️  HARD_STOP 해제',
   },
+  pattern: {
+    detectTitle: '패턴 감지',
+    listTitle: '패턴 목록',
+    dismissTitle: '패턴 dismiss',
+  },
 } as const
 
 type KoValue = string | ((...args: never[]) => string)

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,7 @@ async function guardCliDefer(
 import { cloudPush, cloudPull } from './commands/cloud.js'
 import { goalCheck, goalDone, goalInit, goalList, goalNext, goalSync } from './commands/goal.js'
 import { blocker, learn, resume } from './commands/agent.js'
+import { patternDetect, patternList, patternDismiss } from './commands/pattern.js'
 
 const program = new Command()
 const defaultHelp = new Help()
@@ -142,6 +143,7 @@ const KO_ALIASES: Record<string, string> = {
   blocker: '블로커',
   learn: '교훈',
   resume: '재개',
+  pattern: '패턴',
 }
 
 program
@@ -610,6 +612,35 @@ program
   .option('--confirm', '사람 확인 — 자동 호출 금지 (Forbidden 위반)')
   .description('.vhk/HARD_STOP 해제 (사용자가 사유 확인 후 --confirm 필요)')
   .action(async (opts: { confirm?: boolean }) => { await guardCliDefer('resume', opts?.confirm === true, () => resume(opts)) })
+
+const patternCmd = program
+  .command('pattern')
+  .alias('패턴')
+  .description('반복 패턴 감지·목록·dismiss (avoid/reinforce 후보) — Goal 19')
+  .action(async () => { await patternList() })
+
+patternCmd
+  .command('detect')
+  .alias('감지')
+  .option('--min <n>', '임계 횟수 (기본 3)', '3')
+  .option('--json', 'JSON 출력 (CI/MCP용)')
+  .description('active failures+successes 2축 분석 → patterns[] 갱신')
+  .action(async (opts: { min?: string; json?: boolean }) => { await patternDetect(opts) })
+
+patternCmd
+  .command('list')
+  .alias('목록')
+  .option('--kind <kind>', 'avoid|reinforce 필터')
+  .option('--all', '보관(archived) 포함')
+  .option('--json', 'JSON 출력 (CI/MCP용)')
+  .description('패턴 후보 목록 (기본 활성)')
+  .action(async (opts: { kind?: string; all?: boolean; json?: boolean }) => { await patternList(opts) })
+
+patternCmd
+  .command('dismiss <id>')
+  .alias('보관')
+  .description('오탐 패턴 dismiss (→archived, 재제안 안 됨)')
+  .action(async (id: string) => { await patternDismiss(id) })
 
 program.on('command:*', async (operands: string[]) => {
   const unknown = operands[0] ?? ''

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -16,6 +16,7 @@ export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
   env: ['check'],
   mode: ['lite', 'standard', 'strict'],
   mission: ['set', 'check', 'clear'],
+  pattern: ['detect', 'list', 'dismiss'],
 }
 
 /** 한국어 별칭 → 영문 컨테이너 명령. 별칭도 같은 서브커맨드 집합을 공유한다. */
@@ -29,4 +30,5 @@ export const CONTAINER_ALIASES: Record<string, string> = {
   환경변수: 'env',
   모드: 'mode',
   미션: 'mission',
+  패턴: 'pattern',
 }

--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -64,7 +64,7 @@ function normalize(input: string): string {
 /** 자연어 → 명령 매칭용 키워드 (부분 문자열) */
 export const NLP_KEYWORDS: Partial<Record<NlpCommand, readonly string[]>> = {
   save: ['저장', '세이브', '커밋', '올려', '올리기', '푸시', 'push', 'commit'],
-  pattern: ['패턴', '반복', '되풀이', '버릇', 'pattern'],
+  pattern: ['패턴', '되풀이', '버릇', 'pattern'],
   undo: ['되돌려', '되돌리기', '취소', '원래대로', '롤백', '리셋', 'reset', 'rollback'],
   status: ['상태', '현황', '어떻게', '어때', '지금'],
   diff: ['변경', '바뀐', '뭐바뀜', '바뀌었', '차이', '달라진', '수정된'],
@@ -364,7 +364,7 @@ const RULES: NlpRule[] = [
   },
   {
     command: 'pattern',
-    explanation: '반복 패턴 감지·목록 (vhk pattern)',
+    explanation: '패턴 후보 목록 (vhk pattern list) — 감지는 vhk pattern detect 직접 실행',
     confidence: 'high',
     test: t => matchesKeywords(t, 'pattern') || /^pattern$/.test(t),
   },

--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -38,6 +38,7 @@ export type NlpCommand =
   | 'verify'
   | 'review'
   | 'mission'
+  | 'pattern'
 
 export type NlpConfidence = 'high' | 'low'
 
@@ -63,6 +64,7 @@ function normalize(input: string): string {
 /** 자연어 → 명령 매칭용 키워드 (부분 문자열) */
 export const NLP_KEYWORDS: Partial<Record<NlpCommand, readonly string[]>> = {
   save: ['저장', '세이브', '커밋', '올려', '올리기', '푸시', 'push', 'commit'],
+  pattern: ['패턴', '반복', '되풀이', '버릇', 'pattern'],
   undo: ['되돌려', '되돌리기', '취소', '원래대로', '롤백', '리셋', 'reset', 'rollback'],
   status: ['상태', '현황', '어떻게', '어때', '지금'],
   diff: ['변경', '바뀐', '뭐바뀜', '바뀌었', '차이', '달라진', '수정된'],
@@ -359,6 +361,12 @@ const RULES: NlpRule[] = [
     test: t =>
       /^출시$|출시\s*해|^publish$|퍼블리시|npm\s*(배포|출시)|버전\s*올|^릴리즈$|^release$/.test(t) &&
       !/체크|준비|회고/.test(t),
+  },
+  {
+    command: 'pattern',
+    explanation: '반복 패턴 감지·목록 (vhk pattern)',
+    confidence: 'high',
+    test: t => matchesKeywords(t, 'pattern') || /^pattern$/.test(t),
   },
   // NLP 규칙은 한국어 표현만 매칭. 영문 `goal <sub>` 은 commander 가 직접 처리하도록
   // 가로채기 금지 — vhk goal list / next / check / done 그대로 동작.

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -37,6 +37,7 @@ import { mode } from '../commands/mode.js'
 import { verify } from '../commands/verify.js'
 import { review } from '../commands/review.js'
 import { missionShow } from '../commands/mission.js'
+import { patternList } from '../commands/pattern.js'
 import { runGuarded } from './safety-guard.js'
 import { NL_GUARDED_ACTIONS } from './risk-policy.js'
 
@@ -135,6 +136,8 @@ export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<
       return review()
     case 'mission':
       return missionShow()
+    case 'pattern':
+      return patternList()
   }
 }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -680,6 +680,40 @@ export function createVhkMcpServer(): McpServer {
     async () => runVhkCli(['mcp-init'], 'mcp-init')
   )
 
+  // ─── pattern-detect ──────────────────────────────────────
+  server.registerTool(
+    'pattern-detect',
+    {
+      description: 'active failures+successes 2축 분석 → avoid/reinforce 후보 감지 · patterns[] 갱신 (Goal 19)',
+      inputSchema: {
+        min: z.number().int().min(1).optional().describe('임계 횟수 (기본 3)'),
+      },
+    },
+    async ({ min }) => {
+      const args = ['pattern', 'detect', '--json']
+      if (min !== undefined) args.push('--min', String(min))
+      return runVhkCli(args, 'pattern detect')
+    }
+  )
+
+  // ─── pattern-list ────────────────────────────────────────
+  server.registerTool(
+    'pattern-list',
+    {
+      description: '패턴 후보 목록 조회 (avoid/reinforce · 활성 기본) — Goal 19',
+      inputSchema: {
+        kind: z.enum(['avoid', 'reinforce']).optional().describe('종류 필터'),
+        all: z.boolean().optional().describe('보관(archived) 포함'),
+      },
+    },
+    async ({ kind, all }) => {
+      const args = ['pattern', 'list', '--json']
+      if (kind) args.push('--kind', kind)
+      if (all) args.push('--all')
+      return runVhkCli(args, 'pattern list')
+    }
+  )
+
   return server
 }
 

--- a/tests/pattern.test.ts
+++ b/tests/pattern.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest'
+import { detectCandidates, tokenize, MIN_TAG_FREQ, MIN_KEYWORD_FREQ } from '../src/commands/pattern.js'
+import type { MemoryFileV2, FailEntry, SuccessEntry } from '../src/commands/memory.js'
+
+/**
+ * Goal 19: pattern detection v0 단위 테스트.
+ * 순수 함수(detectCandidates, tokenize) 만 테스트 — fs/Date 부수효과 없음.
+ * 결정적 입력 → 결정적 출력. ML/외부 라이브러리 0.
+ */
+
+function emptyMem(): MemoryFileV2 {
+  return { schemaVersion: 2, decisions: [], failures: [], successes: [], patterns: [] }
+}
+
+function fail(id: string, tags: string[], lesson: string): FailEntry {
+  return { id, content: '', tags, createdAt: '2026-01-01T00:00:00Z', status: 'active', lesson }
+}
+
+function success(id: string, tags: string[], content: string): SuccessEntry {
+  return { id, content, tags, createdAt: '2026-01-01T00:00:00Z', status: 'active' }
+}
+
+// ── tokenize ──────────────────────────────────────────────────────────────────
+
+describe('tokenize', () => {
+  it('소문자 변환 + 구두점 제거', () => {
+    const tokens = tokenize('Hello, World!')
+    expect(tokens).toContain('hello')
+    expect(tokens).toContain('world')
+  })
+
+  it('한국어 토큰 포함', () => {
+    const tokens = tokenize('타입스크립트 오류 발생')
+    expect(tokens).toContain('타입스크립트')
+    expect(tokens).toContain('오류')
+  })
+
+  it('불용어 제거', () => {
+    const tokens = tokenize('the quick brown fox')
+    expect(tokens).not.toContain('the')
+    expect(tokens).toContain('quick')
+  })
+
+  it('2자 미만 토큰 제거', () => {
+    const tokens = tokenize('a b cd ef')
+    expect(tokens).not.toContain('a')
+    expect(tokens).not.toContain('b')
+    expect(tokens).toContain('cd')
+    expect(tokens).toContain('ef')
+  })
+})
+
+// ── detectCandidates ─────────────────────────────────────────────────────────
+
+describe('detectCandidates — 태그 군집 (축1)', () => {
+  it('임계 이상 동일 태그 → avoid 후보', () => {
+    const mem = emptyMem()
+    mem.failures = [
+      fail('f1', ['build'], '빌드 실패'),
+      fail('f2', ['build'], '타입 오류'),
+      fail('f3', ['build'], '컴파일 실패'),
+    ]
+    const candidates = detectCandidates(mem, 3)
+    const tagCand = candidates.filter(c => c.axis === 'tag' && c.signal === 'build')
+    expect(tagCand).toHaveLength(1)
+    expect(tagCand[0].kind).toBe('avoid')
+    expect(tagCand[0].count).toBe(3)
+    expect(tagCand[0].sources).toEqual(['f1', 'f2', 'f3'])
+  })
+
+  it('임계 미달 태그 → 감지 안 됨', () => {
+    const mem = emptyMem()
+    mem.failures = [
+      fail('f1', ['auth'], '로그인 실패'),
+      fail('f2', ['auth'], '토큰 만료'),
+    ]
+    const candidates = detectCandidates(mem, 3)
+    expect(candidates.filter(c => c.signal === 'auth')).toHaveLength(0)
+  })
+
+  it('no-goal 태그 제외', () => {
+    const mem = emptyMem()
+    mem.failures = [
+      fail('f1', ['no-goal'], '교훈1'),
+      fail('f2', ['no-goal'], '교훈2'),
+      fail('f3', ['no-goal'], '교훈3'),
+    ]
+    const candidates = detectCandidates(mem, 3)
+    expect(candidates.filter(c => c.signal === 'no-goal')).toHaveLength(0)
+  })
+
+  it('successes → reinforce 후보', () => {
+    const mem = emptyMem()
+    mem.successes = [
+      success('s1', ['tdd'], 'TDD로 버그 없음'),
+      success('s2', ['tdd'], '테스트 커버리지 높음'),
+      success('s3', ['tdd'], '리팩토링 용이'),
+    ]
+    const candidates = detectCandidates(mem, 3)
+    const tagCand = candidates.filter(c => c.axis === 'tag' && c.signal === 'tdd')
+    expect(tagCand).toHaveLength(1)
+    expect(tagCand[0].kind).toBe('reinforce')
+    expect(tagCand[0].count).toBe(3)
+  })
+})
+
+describe('detectCandidates — 키워드 문서빈도 (축2)', () => {
+  it('공통 키워드 3건 이상 → 후보', () => {
+    const mem = emptyMem()
+    mem.failures = [
+      fail('f1', [], '타입스크립트 오류 발생'),
+      fail('f2', [], '타입스크립트 컴파일 문제'),
+      fail('f3', [], '타입스크립트 빌드 실패'),
+    ]
+    const candidates = detectCandidates(mem, 3)
+    const kwCand = candidates.filter(c => c.axis === 'keyword' && c.signal === '타입스크립트')
+    expect(kwCand).toHaveLength(1)
+    expect(kwCand[0].kind).toBe('avoid')
+    expect(kwCand[0].count).toBe(3)
+  })
+
+  it('한 항목에 같은 단어 여러 번 → 문서빈도는 1로 계산', () => {
+    const mem = emptyMem()
+    mem.failures = [
+      fail('f1', [], '오류 오류 오류'),
+      fail('f2', [], '오류가 발생했음'),
+    ]
+    const candidates = detectCandidates(mem, 3)
+    const kwCand = candidates.filter(c => c.axis === 'keyword' && c.signal === '오류')
+    // 2건 → 임계 3 미달
+    expect(kwCand).toHaveLength(0)
+  })
+})
+
+describe('detectCandidates — active 만 처리', () => {
+  it('archived 항목은 감지 제외', () => {
+    const mem = emptyMem()
+    mem.failures = [
+      { ...fail('f1', ['env'], '환경변수 오류'), status: 'archived' },
+      { ...fail('f2', ['env'], '환경변수 문제'), status: 'archived' },
+      { ...fail('f3', ['env'], '환경변수 누락'), status: 'archived' },
+    ]
+    const candidates = detectCandidates(mem, 3)
+    expect(candidates.filter(c => c.signal === 'env')).toHaveLength(0)
+  })
+
+  it('resolved 항목은 감지 제외', () => {
+    const mem = emptyMem()
+    mem.failures = [
+      { ...fail('f1', ['goal-1'], '교훈'), status: 'resolved' },
+      { ...fail('f2', ['goal-1'], '교훈'), status: 'resolved' },
+      { ...fail('f3', ['goal-1'], '교훈'), status: 'resolved' },
+    ]
+    const candidates = detectCandidates(mem, 3)
+    expect(candidates.filter(c => c.signal === 'goal-1')).toHaveLength(0)
+  })
+})
+
+describe('detectCandidates — 정렬·결정성', () => {
+  it('동일 입력 → 동일 순서(count desc, signal asc)', () => {
+    const mem = emptyMem()
+    mem.failures = [
+      fail('f1', ['auth', 'build'], '오류1'),
+      fail('f2', ['auth', 'build'], '오류2'),
+      fail('f3', ['auth', 'build'], '오류3'),
+      fail('f4', ['auth'], '오류4'),
+      fail('f5', ['auth'], '오류5'),
+      fail('f6', ['auth'], '오류6'),
+      fail('f7', ['auth'], '오류7'),
+    ]
+    const r1 = detectCandidates(mem, 3)
+    const r2 = detectCandidates(mem, 3)
+    expect(r1.map(c => `${c.axis}:${c.signal}`)).toEqual(r2.map(c => `${c.axis}:${c.signal}`))
+  })
+
+  it('count 높은 것이 먼저', () => {
+    const mem = emptyMem()
+    mem.failures = [
+      fail('f1', ['rare'], '오류'),
+      fail('f2', ['rare'], '오류'),
+      fail('f3', ['rare'], '오류'),
+      fail('f4', ['common', 'rare'], '오류'),
+      fail('f5', ['common', 'rare'], '오류'),
+      fail('f6', ['common', 'rare'], '오류'),
+      fail('f7', ['common'], '오류'),
+    ]
+    const tagCands = detectCandidates(mem, 3).filter(c => c.axis === 'tag')
+    // common: 4건, rare: 6건 → rare 먼저
+    expect(tagCands[0].count).toBeGreaterThanOrEqual(tagCands[1]?.count ?? 0)
+  })
+})
+
+describe('detectCandidates — --min 임계 조정', () => {
+  it('--min 2 → 2건 이상에서 감지', () => {
+    const mem = emptyMem()
+    mem.failures = [
+      fail('f1', ['deploy'], '오류1'),
+      fail('f2', ['deploy'], '오류2'),
+    ]
+    const candidates = detectCandidates(mem, 2)
+    expect(candidates.filter(c => c.signal === 'deploy')).toHaveLength(1)
+  })
+
+  it('--min 5 → 4건으로는 미탐', () => {
+    const mem = emptyMem()
+    mem.failures = Array.from({ length: 4 }, (_, i) =>
+      fail(`f${i + 1}`, ['net'], `오류${i + 1}`)
+    )
+    const candidates = detectCandidates(mem, 5)
+    expect(candidates.filter(c => c.signal === 'net')).toHaveLength(0)
+  })
+})
+
+describe('MIN_TAG_FREQ / MIN_KEYWORD_FREQ 상수', () => {
+  it('매직넘버 아님 — 명명 상수 존재', () => {
+    expect(MIN_TAG_FREQ).toBe(3)
+    expect(MIN_KEYWORD_FREQ).toBe(3)
+  })
+})


### PR DESCRIPTION
## Summary
- Goal 19: vhk pattern detection v0 (Evolution Loop 도미노 3)
- active failures+successes 2축(태그군집·키워드빈도) 감지 → patterns[] 갱신
- detect/list/dismiss CLI + MCP pattern-detect/pattern-list + 단위 테스트 703 pass

## Changes
- src/commands/pattern.ts: detectCandidates/patternDetect/List/Dismiss, PatternEntryV19
- src/commands/memory.ts: readRaw 판별합집합 + loadForMutation export
- src/lib/nlp-router.ts: NlpCommand+pattern, 키워드, rule
- src/lib/command-registry.ts: pattern 서브커맨드 + 별칭
- src/index.ts: pattern 컨테이너 커맨드 등록
- src/mcp/server.ts: pattern-detect + pattern-list
- tests/pattern.test.ts: 단위 테스트
- scripts/check-goal-19.mjs: goal 게이트

## Code Review Fixes (8개)
- loadForMutation으로 손상파일 데이터소실 방지 (#1 치명)
- tagMap 중복태그 Set dedup (#2), _sig 레거시 멱등성 (#3)
- NLP '반복' 오탐 제거 (#4), writeMemory 조건부 (#6)
- null guard (#7), explanation 정정 (#8)

## Test plan
- pnpm build pass
- pnpm test 703 pass (회귀 0)
- scripts/check-goal-19.mjs 20/20 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)