### PR TITLE
docs(goal-20): vhk evolve 설계 spike 등록 + 안전성 게이트 강화

### DIFF
--- a/goals/20-evolve.md
+++ b/goals/20-evolve.md
@@ -28,11 +28,13 @@ patterns[](Goal 19) → rule/check/prompt "후보" 생성 → 사람 승인 → 
 
 ### CLI (컨테이너 — memory/pattern과 동형)
 - `vhk evolve suggest`      # patterns[] → 후보 큐 적재(쓰기=큐만, 본문 반영 X)
-- `vhk evolve list`         # --status pending|approved|rejected|applied
-- `vhk evolve apply <id>`   # diff 출력 → 사람 확인 → 반영 + .bak
-- `vhk evolve reject <id>`  # 기각(archive)
-- `vhk evolve undo <id>`    # 마지막 반영 되돌리기(.bak 복원)
+- `vhk evolve list`         # --status pending|rejected|applied (approved 상태 없음 — 아래 주석)
+- `vhk evolve apply <id>`   # diff 출력 → 사람 TTY 확인(원스텝) → 반영 + .bak
+- `vhk evolve reject <id>`  # 기각(archived)
+- `vhk evolve undo`         # 최근 apply 1건만 undo(.bak 복원) — id 인자 없음(단일 제약)
 - `--json` (suggest/list, CI·MCP용) / alias: `진화` / MCP: suggest·list만 노출
+> **apply = 원스텝**: diff 출력 → 사람이 TTY에서 확인/문구 수정 → 즉시 반영. `approved`는
+> 별도 상태가 아님(two-step approve→apply 없음). status 값: `pending | rejected | applied`만 유효.
 
 ### 후보 저장 (Q1=A + 가드)
 - 위치: 별도 `.vhk/evolve/queue.json` (memory v2 스키마 불변)
@@ -50,7 +52,14 @@ patterns[](Goal 19) → rule/check/prompt "후보" 생성 → 사람 승인 → 
 ### 후보 라이프사이클 (그룹 A)
 - A1 재제안 억제: reject한 후보는 다음 suggest에서 억제(기각 기억)
 - A2 중복 suggest: dedupe 키(패턴id+종류)로 1건 유지
-- A3 반영 후 전이: apply된 패턴 status=applied/resolved(재제안 차단, 18 status 재사용)
+- A3 반영 후 전이: apply 완료 → 큐 항목 status=applied, 소스 패턴 status=archived
+  (재제안 차단 — archived는 18의 선순환 status 재사용. 'applied' 신규 status 추가 불필요)
+- A4 댕글링 참조 가드: apply 실행 전 참조 패턴 id의 현재 status 확인.
+  소스 패턴이 archived이면 archived 원인을 구분해 경고:
+  - dismiss로 archived(queue에 applied 항목 없음) → "소스 패턴이 dismiss됨 — apply 거부"
+  - A3 apply 완료로 archived(queue에 applied 항목 있음) → "이미 반영된 패턴 — apply 거부"
+  어느 경우든 apply 거부. 사용자가 의도하지 않은 중복 반영 방지.
+  구현 시 queue.json에서 동일 patternId 기준 applied 항목 존재 여부로 두 경우를 구분.
 
 ### rule 문구 (그룹 B)
 - B1 템플릿 기반 문구 생성(매직/LLM 금지)
@@ -59,7 +68,18 @@ patterns[](Goal 19) → rule/check/prompt "후보" 생성 → 사람 승인 → 
 
 ### 안전·게이트 (그룹 C)
 - C1 undo 경계: apply=RULES.md append+sync 2단계 → undo=RULES.md .bak 복원→재sync
+  - **apply 대화형 강제**: apply 진입 즉시 `ensureInteractive()` 가드 — 비-TTY(MCP·스크립트)면 에러 종료.
+    sync는 apply가 이미 사람 확인을 거친 후 `sync({ yes: true })` 또는 내부 non-interactive 분기로
+    호출(sync 자체의 TTY 프롬프트 중복 방지 + 비-TTY 자동 실행 차단). 이중 프롬프트 금지.
+  - **undo 대화형 강제 + 재sync 비대화형**: undo도 `ensureInteractive()` 가드 필수(apply와 동일).
+    undo 내 RULES.md .bak 복원 후 재sync 호출도 `sync({ yes: true })` 비대화형으로 실행
+    (undo 자체가 TTY 확인 후 진행이므로 재sync 이중 프롬프트 불필요·금지).
+  - **undo 단일 apply 제약(#2 연동)**: .bak은 파일 단위 롤링 단일 백업이므로 직전 apply 1건만 undo 가능.
+    다중 연속 apply 금지 — 2번째 apply 전에 반드시 이전 apply를 undo하거나 유지 결정해야 함.
+    구현에서 queue.json에 `appliedAt` + RULES.md 스냅샷 경로를 기록해 per-id 복원 가능하게 할 수도
+    있으나 v0는 "최근 apply 1건만 undo" 제약을 테스트·문서에 명시 필수.
 - C2 자동적용 금지 게이트: evolve가 AGENTS/CLAUDE 직접 write하는 코드 없는지 grep 게이트
+  (evolve.ts 구현 후 게이트가 해당 파일을 스캔하도록 check-goal-20.mjs 업데이트 필수)
 - HARD_STOP 체크 / apply·undo는 대화형(MCP·비대화형 차단)
 
 ## 수용 기준 (구현 단계 기준, 지금은 문서화만)
@@ -73,6 +93,9 @@ patterns[](Goal 19) → rule/check/prompt "후보" 생성 → 사람 승인 → 
 - suggest 매핑(avoid→rule 후보) 결정성
 - dedupe/재제안 억제
 - apply 승인·diff 가드 / undo 복원
+- **다중 apply 블로킹**: apply 후 2번째 apply 시도 시 에러 반환 (단일 apply 제약 시행)
+- undo → apply 후 재apply 가능 확인(undo로 단일 제약 해제)
+- A4 댕글링 가드: dismiss된 패턴 참조 큐 항목 apply 시도 → 거부 확인
 - 중복 룰 감지
 
 ## 의존·후속

--- a/goals/20-evolve.md
+++ b/goals/20-evolve.md
@@ -1,0 +1,86 @@
+---
+vhk_format: 1
+type: goal
+id: 20
+title: vhk evolve — Evolution Loop 도미노 4 (패턴→룰 후보→사람 승인→반영)
+status: NOT_STARTED
+priority: P1
+version: v2.2.0
+depends_on:
+  - goal-18-memory-schema-v2
+  - goal-19-pattern
+leads_to: v3-vhk-hub
+---
+
+# Goal 20 — vhk evolve
+
+## 목적
+patterns[](Goal 19) → rule/check/prompt "후보" 생성 → 사람 승인 → diff + 반영 + undo.
+성장 루프 도미노 4번(진화). 18(기억)·19(패턴) 위에 선다.
+
+## 비목적 (v0 제외)
+- 자동 적용 금지(1원칙: 자동 학습 OK, 자동 적용 금지)
+- 크로스-프로젝트 공유(= v3 VHK Hub)
+- ML/LLM 기반 후보 생성(규칙·템플릿 기반만)
+- check/prompt 후보, profile.json 연계 → v0.1+
+
+## 설계 결정 (동결)
+
+### CLI (컨테이너 — memory/pattern과 동형)
+- `vhk evolve suggest`      # patterns[] → 후보 큐 적재(쓰기=큐만, 본문 반영 X)
+- `vhk evolve list`         # --status pending|approved|rejected|applied
+- `vhk evolve apply <id>`   # diff 출력 → 사람 확인 → 반영 + .bak
+- `vhk evolve reject <id>`  # 기각(archive)
+- `vhk evolve undo <id>`    # 마지막 반영 되돌리기(.bak 복원)
+- `--json` (suggest/list, CI·MCP용) / alias: `진화` / MCP: suggest·list만 노출
+
+### 후보 저장 (Q1=A + 가드)
+- 위치: 별도 `.vhk/evolve/queue.json` (memory v2 스키마 불변)
+- 가드1: patterns[]를 복사하지 말고 id로 "참조만"(이중 SoT 금지)
+- 가드2: queue는 "기억"이 아니라 "워크플로 상태"임을 문서·게이트에 명시
+  (18 금지문구 게이트가 queue.json 오탐 안 하게 예외 처리)
+
+### 반영 타깃 (Q2=A)
+- v0는 rule 후보만 → RULES.md append → vhk sync 재생성
+- check/prompt는 v0.1+
+
+### 트리거 (Q3=A)
+- 수동 `vhk evolve suggest`만. pattern detect 자동 체이닝 안 함.
+
+### 후보 라이프사이클 (그룹 A)
+- A1 재제안 억제: reject한 후보는 다음 suggest에서 억제(기각 기억)
+- A2 중복 suggest: dedupe 키(패턴id+종류)로 1건 유지
+- A3 반영 후 전이: apply된 패턴 status=applied/resolved(재제안 차단, 18 status 재사용)
+
+### rule 문구 (그룹 B)
+- B1 템플릿 기반 문구 생성(매직/LLM 금지)
+- B2 후보=초안, apply 직전 사람이 문구 수정 가능
+- B3 RULES.md 중복 룰 append 전 감지
+
+### 안전·게이트 (그룹 C)
+- C1 undo 경계: apply=RULES.md append+sync 2단계 → undo=RULES.md .bak 복원→재sync
+- C2 자동적용 금지 게이트: evolve가 AGENTS/CLAUDE 직접 write하는 코드 없는지 grep 게이트
+- HARD_STOP 체크 / apply·undo는 대화형(MCP·비대화형 차단)
+
+## 수용 기준 (구현 단계 기준, 지금은 문서화만)
+- suggest 결정적: 같은 patterns[] → 같은 후보(단위 테스트)
+- diff 없이/미승인 반영 시 에러로 차단(테스트)
+- undo가 .bak 정확 복원(테스트)
+- 자동 적용 경로 코드에 없음(grep 게이트)
+- build/test/check-meta + goal check --id 20 통과
+
+## 테스트 계획
+- suggest 매핑(avoid→rule 후보) 결정성
+- dedupe/재제안 억제
+- apply 승인·diff 가드 / undo 복원
+- 중복 룰 감지
+
+## 의존·후속
+- ⬅ Goal 19 patterns[] 포맷 = 입력 계약(19 안정화 후 구현)
+- ➡ Goal 20까지 = 프로젝트별 v2 루프 완성 → 위층 v3 VHK Hub
+
+## Mandatory Reading
+- goals/19-pattern.md (PatternEntryV19 스키마 · patterns[] 포맷 · avoid/reinforce)
+- src/commands/pattern.ts (PatternEntryV19 런타임 타입)
+- goals/18-memory-schema-v2.md (status 선순환 · loadForMutation 계약)
+- RULES.md (반영 타깃 파일 구조 확인)

--- a/scripts/check-goal-20.mjs
+++ b/scripts/check-goal-20.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// scripts/check-goal-20.mjs — Goal 20: vhk evolve (설계 등록 단계)
+// 현재는 문서 등록 + 기본 게이트만. 구현 단계에서 고유 검증 추가.
+//
+// Env: VHK_GATES_SKIP_DEEP=1 → test + build 스킵
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 20 gate.')
+  process.exit(1)
+}
+
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+const pkg = existsSync('package.json') ? JSON.parse(readFileSync('package.json', 'utf-8').replace(/^﻿/, '')) : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 20] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// 공통 게이트
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 20 고유 검증 (설계 등록 단계) ──────────────────────────────────
+const g20 = read('goals/20-evolve.md') ?? ''
+must(g20.includes('id: 20'), 'goals/20-evolve.md: id: 20')
+must(g20.includes('status: NOT_STARTED'), 'goals/20-evolve.md: status NOT_STARTED')
+must(g20.includes('version: v2.2.0'), 'goals/20-evolve.md: version v2.2.0')
+must(g20.includes('depends_on'), 'goals/20-evolve.md: depends_on 선언')
+must(g20.includes('goal-19-pattern'), 'goals/20-evolve.md: goal-19-pattern 의존')
+must(g20.includes('vhk evolve suggest') && g20.includes('vhk evolve apply'), 'CLI 설계 결정 포함')
+must(g20.includes('자동 적용 금지'), '자동 적용 금지 원칙 명시')
+must(g20.includes('queue.json'), '.vhk/evolve/queue.json 저장 위치 명시')
+
+// Goal 19 의존 코드 존재 확인
+must(existsSync('goals/19-pattern.md'), 'goals/19-pattern.md 존재 (Goal 20 의존)')
+must(existsSync('src/commands/pattern.ts'), 'src/commands/pattern.ts 존재 (Goal 20 입력)')
+
+// 구현 금지 체크 (이 단계에서는 evolve.ts 없어야 함)
+must(!existsSync('src/commands/evolve.ts'), 'src/commands/evolve.ts 미구현 (설계 단계, 구현은 Goal 19 머지 후)')
+
+// 자동 적용 경로 없음 (설계 단계에서도 grep 확인)
+const ptTxt = read('src/commands/pattern.ts') ?? ''
+must(!/AGENTS\.md|CLAUDE\.md/.test(ptTxt) || !/writeFileSync|appendFileSync/.test(ptTxt), 'pattern.ts 가 AGENTS/CLAUDE 직접 write 안 함')
+
+if (pass) { console.log('✅ goal 20 gate passes'); process.exit(0) }
+console.log('❌ goal 20 gate failed'); process.exit(1)

--- a/scripts/check-goal-20.mjs
+++ b/scripts/check-goal-20.mjs
@@ -28,8 +28,11 @@ if (existsSync('.vhk/HARD_STOP')) {
   process.exit(1)
 }
 
-const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
-const pkg = existsSync('package.json') ? JSON.parse(readFileSync('package.json', 'utf-8').replace(/^﻿/, '')) : {}
+// Fix #6+잔존#3: BOM-safe 읽기 — 모든 readFile에 적용(check-goal-18 동일 패턴)
+const stripBomStr = (t) => t.charCodeAt(0) === 0xfeff ? t.slice(1) : t
+const read = (p) => existsSync(p) ? stripBomStr(readFileSync(p, 'utf-8')) : null
+const readJson = (p) => { const t = stripBomStr(readFileSync(p, 'utf-8')); return JSON.parse(t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
 const scripts = pkg.scripts ?? {}
 const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
 const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
@@ -49,13 +52,28 @@ if (!skipDeep) {
 // ─── goal 20 고유 검증 (설계 등록 단계) ──────────────────────────────────
 const g20 = read('goals/20-evolve.md') ?? ''
 must(g20.includes('id: 20'), 'goals/20-evolve.md: id: 20')
-must(g20.includes('status: NOT_STARTED'), 'goals/20-evolve.md: status NOT_STARTED')
+// Fix #4: status 직접 고정 금지 — 유효한 값이면 통과(NOT_STARTED·IN_PROGRESS·DONE·BLOCKED 모두 허용)
+const VALID_GOAL_STATUSES = ['NOT_STARTED', 'IN_PROGRESS', 'DONE', 'BLOCKED']
+must(VALID_GOAL_STATUSES.some(s => g20.includes('status: ' + s)), 'goals/20-evolve.md: 유효한 status 값')
 must(g20.includes('version: v2.2.0'), 'goals/20-evolve.md: version v2.2.0')
 must(g20.includes('depends_on'), 'goals/20-evolve.md: depends_on 선언')
 must(g20.includes('goal-19-pattern'), 'goals/20-evolve.md: goal-19-pattern 의존')
 must(g20.includes('vhk evolve suggest') && g20.includes('vhk evolve apply'), 'CLI 설계 결정 포함')
 must(g20.includes('자동 적용 금지'), '자동 적용 금지 원칙 명시')
 must(g20.includes('queue.json'), '.vhk/evolve/queue.json 저장 위치 명시')
+// Fix #1 + 잔존#4 + G5 fix: 단어 존재가 아닌 구체 구문으로 의미 검증
+must(g20.includes('ensureInteractive()') && g20.includes('가드'), 'C1: apply/undo ensureInteractive() 가드 명시')
+// G5: 'sync({ yes: true })' 또는 '비대화형 분기' 구체 문구 체크 — "비대화형" 단독 단어보다 강한 검증
+must(g20.includes('sync({ yes: true })') || g20.includes('non-interactive 분기'), 'C1: sync 비대화형 호출 구체 방식 명시')
+must(g20.includes('undo') && g20.includes('재sync') && g20.includes('비대화형'), 'C1: undo 재sync 비대화형 호출 명시')
+// G1 fix: 단순 단어 공존이 아닌 구체적 복합 구문 체크
+must(g20.includes('1건만 undo') || g20.includes('단일 apply 제약'), 'C1: undo 단일 apply 제약 구문 명시')
+// G2 fix: negative check → positive check (설명 문맥에서 false positive 방지)
+must(g20.includes('pending|rejected|applied'), 'CLI: list status pending|rejected|applied (approved 없음)')
+must(g20.includes('원스텝') || g20.includes('one-step'), 'apply 원스텝 명시')
+// Fix #5 + 잔존#5: A4 가드 + dismiss vs apply-completed 구분 명시 확인
+must(g20.includes('A4') && g20.includes('archived') && g20.includes('apply 거부'), 'A4: 댕글링 참조 가드 명시')
+must(g20.includes('dismiss로 archived') || g20.includes('dismiss됨'), 'A4: dismiss vs apply-completed archived 구분 명시')
 
 // Goal 19 의존 코드 존재 확인
 must(existsSync('goals/19-pattern.md'), 'goals/19-pattern.md 존재 (Goal 20 의존)')
@@ -64,9 +82,14 @@ must(existsSync('src/commands/pattern.ts'), 'src/commands/pattern.ts 존재 (Goa
 // 구현 금지 체크 (이 단계에서는 evolve.ts 없어야 함)
 must(!existsSync('src/commands/evolve.ts'), 'src/commands/evolve.ts 미구현 (설계 단계, 구현은 Goal 19 머지 후)')
 
-// 자동 적용 경로 없음 (설계 단계에서도 grep 확인)
-const ptTxt = read('src/commands/pattern.ts') ?? ''
-must(!/AGENTS\.md|CLAUDE\.md/.test(ptTxt) || !/writeFileSync|appendFileSync/.test(ptTxt), 'pattern.ts 가 AGENTS/CLAUDE 직접 write 안 함')
+// C2 자동 적용 경로 없음.
+// G3 fix: existsSync 기반 파일 선택 — content falsy(빈 파일)와 파일 없음을 구분.
+// evolve.ts 구현 시 이 게이트가 evolve.ts로 자동 전환됨 (existsSync 기반).
+const evolveExists = existsSync('src/commands/evolve.ts')
+const c2Target = evolveExists ? (read('src/commands/evolve.ts') ?? '') : (read('src/commands/pattern.ts') ?? '')
+const c2Label = evolveExists ? 'evolve.ts' : 'pattern.ts'
+must(!(/AGENTS\.md|CLAUDE\.md/.test(c2Target) && /writeFileSync|appendFileSync/.test(c2Target)),
+     c2Label + ' 가 AGENTS/CLAUDE 직접 write 안 함 (C2 자동적용 금지)')
 
 if (pass) { console.log('✅ goal 20 gate passes'); process.exit(0) }
 console.log('❌ goal 20 gate failed'); process.exit(1)


### PR DESCRIPTION
## Summary
- Goal 20 설계 등록 전용 (docs + gate script, 코드 변경 없음)
- goals/20-evolve.md: CLI 5커맨드·queue.json·apply원스텝·undo단일제약·A4댕글링가드·C1안전가드
- scripts/check-goal-20.mjs: 설계 단계 게이트 (20/20 항목)

## Code Review + Adversarial Fixes (11개)
- C1 apply/undo ensureInteractive() + sync non-interactive 명시
- undo 단일 apply 제약 + id 인자 제거
- approved 상태 제거 → pending|rejected|applied 원스텝 apply
- A4 댕글링 참조 가드 + dismiss vs apply-completed 구분
- Gate: status 하드코딩 제거, BOM-safe stripBomStr(), existsSync C2, positive check

## Test plan
- [x] pnpm test 778 pass
- [x] goal 19 gate pass
- [x] goal 20 gate 20/20 pass
- [x] 3차 적대적 검증 완료 — 잔존 이슈 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)