### PR TITLE
fix(sync): CLAUDE.md 사용자 섹션 조용한 드롭 결함 수정 (sentinel 마커)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,7 +2,12 @@
 
 > v1 OUT 기능은 여기에 기록. 범위 수비 필수.
 
-## 배치 1 (확정 — 배치0 적대적 검증서 도출) — CLAUDE.md 사용자 섹션 보존
+## 배치 1 ✅ DONE (브랜치 `fix/claude-md-marker`) — CLAUDE.md 사용자 섹션 보존
+
+> **구현 완료** — `<!-- vhk:rules:start/end -->` sentinel 마커 + 1회 마이그레이션 + 보존/제거 경고
+> (`ko.sync.claudeMigrated`). 순수함수 `buildVhkBlock`/`splitVhkBlock`/`stripLegacyAutogen`/
+> `claudeMdMigration` 분리, `toClaudeMd` 시그니처 유지. 게이트: tsc0·test green(신규 +14)·실
+> CLAUDE.md dry-run e2e·적대적 반례 5종(CRLF/다중마커/손글키섹션/빈입력/코드블록) 통과.
 
 > **확정 결함**(추측 아님). 배치0 R3 자체검증서 medium 으로 확인 — `toClaudeMd` 가 CLAUDE.md
 > 재생성 시 `## 현재 상태` + RULES record 섹션만 보존하고 **비-키 사용자 섹션(예 `## 프로젝트

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -175,42 +175,128 @@ export function toAntigravityRules(sections: RulesSection[], projectName: string
 const CLAUDE_AUTOGEN_BANNER = '> ⚡ 아래 규칙 섹션은 RULES.md에서 자동 생성됨 (vhk sync). 직접 수정 금지.'
 
 /**
- * RULES.md 섹션을 CLAUDE.md 포맷으로 변환
+ * CLAUDE.md 내 vhk 관리 영역 sentinel 마커(안 보이는 HTML 주석).
+ * 마커 **안** = 매 sync 재생성(배너 + RULES 유래 record 섹션). 마커 **밖** = 사용자 영역(보존).
+ * 이전엔 마커가 없어 header + '## 현재 상태' 외 모든 사용자 섹션을 조용히 드롭했음(배치1 결함).
  */
-export function toClaudeMd(sections: RulesSection[], existing: string): string {
-  const recordSections = sections.filter(s =>
-    CLAUDE_MD_KEYS.some(k => s.title.includes(k))
-  )
+const VHK_BLOCK_START = '<!-- vhk:rules:start -->'
+const VHK_BLOCK_END = '<!-- vhk:rules:end -->'
 
-  // 멱등성: 기존 본문에서 이전 자동생성 배너(정확히 일치하는 줄)를 모두 제거 후 정확히 1개만
-  // 재삽입. 이러면 배너가 header/현재상태 어디에 끼었든 누적되지 않고(매 sync drift→백업 churn
-  // 방지), 사용자가 '## 현재 상태'에 직접 쓴 임의 '> ⚡' 인용줄은 배너 문구 전체와 일치하지 않아
-  // 보존된다. (배너 접두만 보던 이전 수정의 사용자-인용줄 절단 회귀를 제거.)
-  const cleaned = existing
-    .split('\n')
-    .filter(line => line.trim() !== CLAUDE_AUTOGEN_BANNER)
-    .join('\n')
-
-  const statusMatch = cleaned.match(/## 현재 상태[\s\S]*?(?=\n## |$)/)
-  const statusSection = statusMatch ? statusMatch[0].trimEnd() : ''
-  const header = cleaned.split('## ')[0].trim()
-
-  const lines = [
-    header,
-    '',
-    statusSection,
-    '',
-    CLAUDE_AUTOGEN_BANNER,
-    '',
-  ]
-
+/** vhk 관리 블록(배너 + record 섹션)을 마커로 감싸 생성. toClaudeMd 가 매 sync 이 형태로 재생성한다. */
+function buildVhkBlock(recordSections: RulesSection[]): string {
+  const lines = [VHK_BLOCK_START, CLAUDE_AUTOGEN_BANNER, '']
   for (const section of recordSections) {
     lines.push(`## ${section.title}`)
     lines.push(section.content)
     lines.push('')
   }
-
+  lines.push(VHK_BLOCK_END)
   return lines.join('\n')
+}
+
+/**
+ * 마커 쌍을 찾아 바깥(before/after = 사용자 영역)을 분리. 마커 없거나 훼손(start/end 누락·역전)이면
+ * null → 호출부가 마이그레이션 경로(stripLegacyAutogen)로 폴백.
+ */
+function splitVhkBlock(existing: string): { before: string; after: string } | null {
+  const start = existing.indexOf(VHK_BLOCK_START)
+  const end = existing.indexOf(VHK_BLOCK_END)
+  if (start === -1 || end === -1 || end < start) return null
+  return {
+    before: existing.slice(0, start),
+    after: existing.slice(end + VHK_BLOCK_END.length),
+  }
+}
+
+/**
+ * 마이그레이션(마커 없는 기존 CLAUDE.md): 옛 자동생성(배너 줄 + CLAUDE_MD_KEYS 매칭 `## ` 섹션)만
+ * 제거하고 사용자 콘텐츠(헤더 + 비-키 섹션 = '## 현재 상태'·'## 프로젝트 정보' 등)는 원래 순서로 보존.
+ * - 배너는 **정확히 일치하는 줄**만 제거 → 사용자가 직접 쓴 '> ⚡' 인용줄은 보존(절단 회귀 방지).
+ * - "사용자 섹션 vs RULES서 삭제된 스테일 vhk 섹션"을 구분 못 하므로, 키 매칭 섹션은 옛 자동생성으로
+ *   간주해 제거하고 RULES 유래 record 로 재생성한다(스테일 규칙이 유령으로 남아 단일출처 깨지는 것 방지).
+ * @returns cleaned 보존된 사용자 콘텐츠, removed 제거된 옛 자동생성 섹션 제목, preserved 보존된 사용자 섹션 제목
+ */
+function stripLegacyAutogen(existing: string): { cleaned: string; removed: string[]; preserved: string[] } {
+  // 배너 줄 + 훼손돼 split 에 안 잡힌 잔존 마커 줄(start/end)도 청소 — 폴백 출력에 마커가 새지 않아 멱등 유지.
+  // 사용자가 직접 쓴 '> ⚡' 인용줄은 배너 문구 전체와 불일치해 보존된다.
+  const lines = existing
+    .split('\n')
+    .filter(line => {
+      const t = line.trim()
+      return t !== CLAUDE_AUTOGEN_BANNER && t !== VHK_BLOCK_START && t !== VHK_BLOCK_END
+    })
+
+  const headerLines: string[] = []
+  const blocks: { title: string; body: string[] }[] = []
+  let cur: { title: string; body: string[] } | null = null
+  for (const line of lines) {
+    if (line.startsWith('## ')) {
+      if (cur) blocks.push(cur)
+      cur = { title: line.slice(3).trim(), body: [line] }
+    } else if (cur) {
+      cur.body.push(line)
+    } else {
+      headerLines.push(line)
+    }
+  }
+  if (cur) blocks.push(cur)
+
+  const removed: string[] = []
+  const preserved: string[] = []
+  const keptBodies: string[] = []
+  for (const b of blocks) {
+    if (CLAUDE_MD_KEYS.some(k => b.title.includes(k))) {
+      removed.push(b.title) // 옛 자동생성 → record 로 재생성
+    } else {
+      preserved.push(b.title) // 사용자 섹션 → 보존
+      keptBodies.push(b.body.join('\n').trimEnd())
+    }
+  }
+
+  const header = headerLines.join('\n').trim()
+  const cleaned = [header, ...keptBodies].filter(Boolean).join('\n\n')
+  return { cleaned, removed, preserved }
+}
+
+/** 마이그레이션 시 보존/제거 섹션 집계 — syncCore 가 result 로 노출하고 호출부가 경고 출력. */
+export interface ClaudeMdMigration {
+  migrated: boolean
+  removed: string[]
+  preserved: string[]
+}
+
+/**
+ * 기존 CLAUDE.md 가 마커 없는(=마이그레이션 대상) 상태인지와 보존/제거 섹션을 계산.
+ * 마커가 이미 있으면 migrated=false(추가 작업 없음). toClaudeMd 와 동일 분기 로직을 공유한다.
+ */
+export function claudeMdMigration(existing: string): ClaudeMdMigration {
+  if (splitVhkBlock(existing)) return { migrated: false, removed: [], preserved: [] }
+  const { removed, preserved } = stripLegacyAutogen(existing)
+  return { migrated: true, removed, preserved }
+}
+
+/**
+ * RULES.md 섹션을 CLAUDE.md 포맷으로 변환. vhk 영역만 sentinel 마커로 감싸 재생성하고
+ * 마커 밖(사용자 섹션)은 보존. 마커가 없으면 1회 마이그레이션(옛 자동생성만 제거 + 사용자 섹션 보존).
+ * 멱등: 마이그레이션 출력에 마커가 박히므로 재호출 시 마커 경로로 동일 결과를 낸다.
+ */
+export function toClaudeMd(sections: RulesSection[], existing: string): string {
+  const recordSections = sections.filter(s =>
+    CLAUDE_MD_KEYS.some(k => s.title.includes(k))
+  )
+  const vhkBlock = buildVhkBlock(recordSections)
+
+  const split = splitVhkBlock(existing)
+  if (split) {
+    // 마커 영역만 교체, 바깥(사용자 영역) 보존 → 멱등
+    const before = split.before.replace(/\s+$/, '')
+    const after = split.after.replace(/^\s+/, '').replace(/\s+$/, '')
+    return [before, vhkBlock, after].filter(s => s.length > 0).join('\n\n') + '\n'
+  }
+
+  // 마이그레이션 — 마커 없는 기존 CLAUDE.md: 사용자 섹션 보존 + 마커블록 재조립
+  const { cleaned } = stripLegacyAutogen(existing)
+  return [cleaned, vhkBlock].filter(s => s.length > 0).join('\n\n') + '\n'
 }
 
 /**
@@ -306,6 +392,8 @@ export interface SyncPlanItem {
   exists: boolean
   /** 기존 파일이 RULES.md 생성본과 다름(=수작업 수정 가능성). 정규화 비교(거짓 드리프트 방지). */
   drift: boolean
+  /** CLAUDE.md 전용 — 마커 없는 기존 파일을 마이그레이션할 때 보존/제거 섹션 집계(조용한 드롭 방지 경고용). */
+  migration?: ClaudeMdMigration
 }
 
 export interface SyncResult {
@@ -319,6 +407,8 @@ export interface SyncResult {
   plan: SyncPlanItem[]
   /** ③ 어느 타깃에도 매핑 안 돼 산출물에서 빠지는 섹션 제목 — 조용히 버리지 않게 호출자에 노출. */
   unmapped: string[]
+  /** CLAUDE.md 마커 마이그레이션 집계 — migrated=true 면 호출자가 보존/제거 섹션 경고를 출력. */
+  claudeMigration?: ClaudeMdMigration
 }
 
 /**
@@ -358,6 +448,8 @@ export function buildSyncPlan(
     doneMessage: ko.sync.claudeDone,
     exists: claudeExists,
     drift: claudeDrift,
+    // 기존 CLAUDE.md 가 있을 때만 마이그레이션 집계(첫 생성은 마이그레이션 아님). 추가 I/O 0 — 이미 읽은 existingClaude 재사용.
+    migration: claudeExists ? claudeMdMigration(existingClaude) : undefined,
   })
   return plan
 }
@@ -381,6 +473,8 @@ export async function syncCore(
   // ③ 실제 누락 발생 지점(섹션 → 타깃 매핑)에서 미매칭 섹션을 집계해 결과에 노출.
   // 콘솔 출력은 호출자(sync()/MCP)가 result.unmapped 로 한다(syncCore 는 순수 seam 유지).
   const unmapped = findUnmappedSections(sections)
+  // CLAUDE.md 마커 마이그레이션 집계(있으면) — 호출자가 보존/제거 섹션 경고에 사용. 추가 I/O 없음(plan 재사용).
+  const claudeMigration = plan.find((p) => p.path === 'CLAUDE.md')?.migration
 
   // --dry-run — 어떤 디스크 변경도 하지 않는다(백업·쓰기·마커 전부 생략)
   if (opts.dryRun) {
@@ -394,6 +488,7 @@ export async function syncCore(
       truncated: [],
       plan,
       unmapped,
+      claudeMigration,
     }
   }
 
@@ -436,7 +531,7 @@ export async function syncCore(
   fs.writeFileSync(path.join(rootDir, SYNCED_MARKER_REL), new Date().toISOString() + '\n', 'utf-8')
   ensureVhkIgnored(rootDir, '.synced')
 
-  return { dryRun: false, firstSync, backupId, backedUp, written, skipped, truncated, plan, unmapped }
+  return { dryRun: false, firstSync, backupId, backedUp, written, skipped, truncated, plan, unmapped, claudeMigration }
 }
 
 export async function sync(opts: SyncOptions = {}): Promise<void> {
@@ -491,6 +586,15 @@ export async function sync(opts: SyncOptions = {}): Promise<void> {
       chalk.yellow(
         `  ⚠️  ${result.unmapped.length}개 섹션이 어느 타깃에도 매핑 안 돼 산출물에서 제외됨: ${result.unmapped.join(', ')}` +
           `\n     (코딩 규칙/기술 스택/커밋/기록 등 표준 제목을 쓰거나, 이 섹션은 RULES.md 에만 보존됩니다.)`
+      )
+    )
+  }
+
+  // 배치1 — 마커 없는 기존 CLAUDE.md 를 마커 형식으로 1회 정리. 보존/교체 섹션을 안내(조용한 드롭 방지).
+  if (result.claudeMigration?.migrated) {
+    console.log(
+      chalk.cyan(
+        `  ${ko.sync.claudeMigrated(result.claudeMigration.preserved, result.claudeMigration.removed)}`
       )
     )
   }

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -257,6 +257,16 @@ export const ko = {
       `  ${drift ? '✏️  변경됨' : '·  동일'} : ${p}`,
     nonTtyAuto: (n: number, id: string) =>
       `🤖 비대화형(CI/에이전트) — ${n}개 백업 후 진행. 복원: vhk restore ${id}`,
+    // 배치1 — CLAUDE.md 를 vhk 마커(<!-- vhk:rules:start/end -->) 형식으로 1회 정리할 때의 안내.
+    // 사용자 섹션은 보존, RULES.md 기준 옛 자동생성 섹션만 재생성 교체(조용한 드롭 방지).
+    claudeMigrated: (preserved: string[], removed: string[]) =>
+      `ℹ️  CLAUDE.md 를 vhk 마커 형식으로 정리했어요 — 마커 밖 사용자 섹션은 보존됩니다.` +
+      (preserved.length
+        ? `\n     보존된 사용자 섹션 ${preserved.length}개: ${preserved.join(', ')}`
+        : '') +
+      (removed.length
+        ? `\n     RULES.md 기준으로 재생성·교체된 옛 자동생성 섹션 ${removed.length}개: ${removed.join(', ')} (필요 시 .vhk/backups 에서 복구)`
+        : ''),
   },
   restore: {
     title: '🛟 백업 복원',

--- a/tests/sync-guard.test.ts
+++ b/tests/sync-guard.test.ts
@@ -8,8 +8,10 @@ import {
   parseRulesMd,
   deriveProjectName,
   toClaudeMd,
+  claudeMdMigration,
 } from '../src/commands/sync.js'
 import { listBackups } from '../src/lib/backup.js'
+import { ko } from '../src/i18n/ko.js'
 
 const RULES = `# 데모 — Rules
 
@@ -211,5 +213,165 @@ describe('toClaudeMd — 멱등성 + 사용자 콘텐츠 보존 (라운드2 회�
     expect(out).toContain('사용자가 직접 쓴 강조 메모')
     expect(out).toContain('다음 액션')
     expect(toClaudeMd(sections, out)).toBe(out) // 보존하면서도 멱등
+  })
+})
+
+describe('toClaudeMd — 마커 기반 사용자 섹션 보존 (배치1: 사용자 섹션 조용한 드롭 결함)', () => {
+  const sections = parseRulesMd(RULES) // [코딩 규칙, 기록 규칙] → record=[기록 규칙]
+  const name = deriveProjectName(RULES)
+
+  it('마이그레이션: 마커 없는 CLAUDE.md 의 비-키 사용자 섹션(`## 프로젝트 정보`)을 드롭하지 않고 보존', () => {
+    const existing = `# 기록 규칙 (${name})\n\n## 프로젝트 정보\n- repo: x\n\n## 현재 상태\n- **Phase:** P5\n\n## 기록 규칙\n- 옛 자동생성\n`
+    const out = toClaudeMd(sections, existing)
+    // 결함: 기존 toClaudeMd 는 header + 현재 상태 + record 만 보존하고 `## 프로젝트 정보` 를 조용히 드롭
+    expect(out).toContain('## 프로젝트 정보')
+    expect(out).toContain('repo: x')
+    // 현재 상태도 여전히 보존
+    expect(out).toContain('## 현재 상태')
+    // RULES 유래 record 섹션은 재생성
+    expect(out).toContain('## 기록 규칙')
+    // 마이그레이션 출력엔 마커가 박혀 다음 sync 부터 마커 경로
+    expect(out).toContain('<!-- vhk:rules:start -->')
+    expect(out).toContain('<!-- vhk:rules:end -->')
+  })
+
+  it('마이그레이션도 멱등 — 재호출 시 바이트 동일', () => {
+    const a = toClaudeMd(sections, `# 기록 규칙 (${name})\n\n## 프로젝트 정보\n- x\n\n## 현재 상태\n- P5\n`)
+    expect(toClaudeMd(sections, a)).toBe(a)
+  })
+
+  it('CRLF(\\r\\n) 입력도 멱등 + 사용자 섹션 보존 (Windows CLAUDE.md 회귀)', () => {
+    const crlf = `# 기록 규칙 (${name})\r\n\r\n## 프로젝트 정보\r\n- x\r\n\r\n## 현재 상태\r\n- P5\r\n`
+    const a = toClaudeMd(sections, crlf)
+    expect(a).toContain('## 프로젝트 정보')
+    expect(toClaudeMd(sections, a)).toBe(a) // 배너/마커 trim 비교가 \r 흡수 → 누적 없음
+  })
+
+  it('마커 밖 before/after 사용자 콘텐츠 보존 + 마커 안만 교체', () => {
+    const migrated = toClaudeMd(sections, `# 기록 규칙 (${name})\n\n## 프로젝트 정보\n- repo: x\n\n## 현재 상태\n- P5\n`)
+    // 사용자가 마커 뒤에 새 섹션 추가
+    const edited = migrated.trimEnd() + '\n\n## 사람이 마커 뒤에 추가\n- 메모\n'
+    const out = toClaudeMd(sections, edited)
+    expect(out).toContain('## 프로젝트 정보') // before(마커 앞) 보존
+    expect(out).toContain('## 사람이 마커 뒤에 추가') // after(마커 뒤) 보존
+    expect(out).toContain('## 기록 규칙') // 마커 안 record 재생성
+    expect((out.match(/⚡ 아래 규칙 섹션은/g) || []).length).toBe(1) // 배너 누적 없음
+  })
+
+  it('RULES 에서 record 섹션이 사라지면 마커 안에서도 제거 (스테일 유령 방지)', () => {
+    const withRecord = toClaudeMd(sections, `# 기록 규칙 (${name})\n\n## 현재 상태\n- P5\n`)
+    expect(withRecord).toContain('## 기록 규칙')
+    const noRecord = parseRulesMd(`# 데모 — Rules\n\n## 코딩 규칙\n- a\n`) // 기록 규칙 제거됨
+    const out = toClaudeMd(noRecord, withRecord)
+    expect(out).not.toContain('## 기록 규칙') // 마커 안 스테일 제거
+    expect(out).toContain('## 현재 상태') // 사용자 영역 보존
+  })
+
+  it('마커 훼손(end 누락) → 마이그레이션 폴백, 사용자 섹션 드롭 안 함', () => {
+    const broken = `# 기록 규칙 (${name})\n\n## 프로젝트 정보\n- repo: x\n\n<!-- vhk:rules:start -->\n> ⚡ 아래 규칙 섹션은 RULES.md에서 자동 생성됨 (vhk sync). 직접 수정 금지.\n\n## 기록 규칙\n- 옛것\n` // end 마커 없음
+    const out = toClaudeMd(sections, broken)
+    expect(out).toContain('## 프로젝트 정보') // 폴백서도 사용자 섹션 보존
+    expect(out).toContain('<!-- vhk:rules:end -->') // 정상 마커쌍 재생성
+    expect(toClaudeMd(sections, out)).toBe(out) // 복구 후 멱등
+  })
+})
+
+describe('claudeMdMigration — 마이그레이션 보존/제거 집계 (경고용)', () => {
+  const name = deriveProjectName(RULES)
+
+  it('마커 없으면 migrated=true + preserved(사용자)/removed(키 섹션) 집계', () => {
+    const r = claudeMdMigration(`# 기록 규칙 (${name})\n\n## 프로젝트 정보\n- x\n\n## 현재 상태\n- P5\n\n## 작업 로그\n- 옛것\n`)
+    expect(r.migrated).toBe(true)
+    expect(r.preserved).toEqual(expect.arrayContaining(['프로젝트 정보', '현재 상태']))
+    expect(r.removed).toContain('작업 로그') // '로그' 키 매칭 → 옛 자동생성 간주 제거
+  })
+
+  it('마커 이미 있으면 migrated=false (재작업·경고 없음)', () => {
+    const sections = parseRulesMd(RULES)
+    const withMarker = toClaudeMd(sections, `# 기록 규칙 (${name})\n\n## 현재 상태\n- P5\n`)
+    expect(claudeMdMigration(withMarker).migrated).toBe(false)
+  })
+})
+
+describe('syncCore — CLAUDE.md 마이그레이션 경고 노출 (배치1, 조용한 드롭 방지)', () => {
+  it('마커 없는 기존 CLAUDE.md → result.claudeMigration.migrated=true + 보존 섹션 노출', async () => {
+    fs.writeFileSync(
+      path.join(dir, 'CLAUDE.md'),
+      `# 기록 규칙 (데모)\n\n## 프로젝트 정보\n- repo: x\n\n## 현재 상태\n- P5\n`,
+      'utf-8'
+    )
+    const r = await syncCore(dir, { dryRun: true }, alwaysYes)
+    expect(r.claudeMigration?.migrated).toBe(true)
+    expect(r.claudeMigration?.preserved).toContain('프로젝트 정보')
+  })
+
+  it('이미 마커 있는(=마이그레이션 완료) CLAUDE.md → migrated=false', async () => {
+    const sections = parseRulesMd(read('RULES.md'))
+    const migrated = toClaudeMd(sections, `# 기록 규칙 (데모)\n\n## 현재 상태\n- P5\n`)
+    fs.writeFileSync(path.join(dir, 'CLAUDE.md'), migrated, 'utf-8')
+    const r = await syncCore(dir, { dryRun: true }, alwaysYes)
+    expect(r.claudeMigration?.migrated).toBe(false)
+  })
+
+  it('CLAUDE.md 자체가 없으면 claudeMigration 없음(마이그레이션 비대상)', async () => {
+    const r = await syncCore(dir, { dryRun: true }, alwaysYes)
+    expect(r.claudeMigration?.migrated).toBeFalsy()
+  })
+
+  // BACKLOG 배치1 게이트 — 실제 vhk CLAUDE.md 유사 구조(frontmatter + 다수 비-키 섹션) 보존 e2e
+  it('실 CLAUDE.md 구조(frontmatter + 다수 사용자 섹션) → 모든 비-키 섹션 + frontmatter 보존', async () => {
+    const real = `---
+id: claude-md-vhk
+tags: [process, documentation]
+---
+
+# 기록 규칙 (vhk)
+
+> 이 파일은 기록/운영 전용. 코딩/디자인 → .cursorrules 참조.
+
+## 프로젝트 정보
+- repo: x
+
+## 현재 상태
+- Phase: P5
+
+## 코딩 컨벤션
+- execSync 금지
+
+## MCP 모드 규칙
+- handler 내부 process.exit() 금지
+
+## Safety — HARD_STOP
+- .vhk/HARD_STOP 확인
+
+## Stability Gates
+- build && test 통과 필수
+`
+    fs.writeFileSync(path.join(dir, 'CLAUDE.md'), real, 'utf-8')
+    const r = await syncCore(dir, { dryRun: true }, alwaysYes)
+    const claudeNew = r.plan.find((p) => p.path === 'CLAUDE.md')!.newContent
+    for (const sec of ['프로젝트 정보', '현재 상태', '코딩 컨벤션', 'MCP 모드 규칙', 'Safety — HARD_STOP', 'Stability Gates']) {
+      expect(claudeNew).toContain(`## ${sec}`)
+    }
+    expect(claudeNew).toContain('id: claude-md-vhk') // frontmatter 보존
+    expect(claudeNew).toContain('handler 내부 process.exit() 금지') // 본문 보존
+    expect(r.claudeMigration?.migrated).toBe(true)
+    expect(r.claudeMigration?.preserved).toEqual(
+      expect.arrayContaining(['프로젝트 정보', '코딩 컨벤션', 'MCP 모드 규칙', 'Safety — HARD_STOP', 'Stability Gates'])
+    )
+  })
+})
+
+describe('ko.sync.claudeMigrated — 마이그레이션 경고 문구', () => {
+  it('보존/제거 섹션을 문구에 반영', () => {
+    const msg = ko.sync.claudeMigrated(['프로젝트 정보', '현재 상태'], ['작업 로그'])
+    expect(msg).toContain('보존')
+    expect(msg).toContain('프로젝트 정보')
+    expect(msg).toContain('작업 로그')
+  })
+
+  it('제거 0이면 교체 줄 생략(노이즈 0)', () => {
+    const msg = ko.sync.claudeMigrated(['프로젝트 정보'], [])
+    expect(msg).not.toContain('교체')
   })
 })


### PR DESCRIPTION
## 무엇

`vhk sync` 의 `toClaudeMd` 가 CLAUDE.md 재생성 시 **비-키 사용자 섹션(`## 프로젝트 정보` 등)을 조용히 드롭**하던 확정 결함 수정 (BACKLOG 배치1).

## 왜

기존 `toClaudeMd` 는 `header` + `## 현재 상태` + RULES record 섹션만 보존 → 사용자가 CLAUDE.md 에 직접 쓴 다른 섹션은 모두 누락. 비대화형(에이전트/CI) 무경고 드롭. 실제 vhk CLAUDE.md 에도 `## 프로젝트 정보`·`## 코딩 컨벤션`·`## Safety — HARD_STOP` 등 존재 → 도그푸딩 직접 타격(백업으로 복구는 가능하나 무경고).

## 어떻게

- vhk 관리 영역(배너 + record)을 `<!-- vhk:rules:start -->` … `<!-- vhk:rules:end -->` sentinel 마커(안 보이는 HTML 주석)로 감싸 재생성, **마커 밖 사용자 섹션은 보존**
- 마커 없는 기존 CLAUDE.md 는 **1회 마이그레이션**: 옛 자동생성(배너 + `CLAUDE_MD_KEYS` 매칭 섹션)만 제거, 사용자 섹션 보존, 마커블록 재조립. 출력에 마커가 박혀 다음 sync 부터 멱등
- 순수함수 `buildVhkBlock` / `splitVhkBlock` / `stripLegacyAutogen` / `claudeMdMigration` 분리. **`toClaudeMd` 시그니처 유지**(GA 안정성)
- `syncCore.claudeMigration` 노출 → `sync()` 가 `ko.sync.claudeMigrated` 로 보존/제거 섹션을 경고 (조용한 드롭 방지, `unmapped` 경고와 동형 패턴)
- 추가 I/O 0 — `buildSyncPlan` 이 이미 읽은 `existingClaude` 재사용

## 검증

- **tsc 0**, 전체 **test 830 green** (신규 +14: 마커 멱등 · 마이그레이션 보존 · before/after 보존 · RULES 스테일 record 제거 · 마커 훼손 폴백 · CRLF 멱등 · 실 CLAUDE.md(frontmatter+다수 섹션) dry-run e2e · 경고 문구)
- **적대적 반례 5종 실행 검증** 전부 통과: ① CRLF 멱등 ② 마커 텍스트 오염(after) ③ 손글 키섹션 드롭+경고 ④ 빈입력·마커훼손 폴백 ⑤ 코드블록 들여쓰기 보존
- 기존 4개 멱등성 회귀 테스트(배너 1개 수렴, 사용자 `> ⚡` 인용줄 보존) 유지

## 알려진 트레이드오프 (BACKLOG 의도)

- 사용자가 CLAUDE.md 에 직접 쓴 **키매칭 섹션**(예 손글 `## ADR`, RULES.md 엔 없음)은 마이그레이션 시 제거됨 — 단 `removed` 경고로 **노출** + `.vhk/backups` 복구 가능(조용한 손실 아님). "사용자 섹션 vs RULES서 삭제된 스테일 vhk 섹션" 구분 불가에서 오는 의도된 트레이드오프(단일출처 유지). 기존 동작과 동일하며 비-키 섹션 보존은 순수 개선
- 코드펜스 내 `## `·마커 문자열 파서는 범위 OUT (별도 latent, 마이그레이션 1회 후 마커로 보호됨)

## 범위

`src/commands/sync.ts` · `src/i18n/ko.ts` · `BACKLOG.md` · `tests/sync-guard.test.ts` 만 변경 — evolve 라인(`pattern.ts`/`evolve.ts`/`queue.json`)과 파일 미충돌.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
