### PR TITLE
fix(goal-19): pattern dismiss/detect NL 라우팅 버그 + dismiss 재제안 수정

### DIFF
--- a/src/commands/pattern.ts
+++ b/src/commands/pattern.ts
@@ -46,7 +46,7 @@ function isActive(e: MemEntry): boolean {
   return e.status !== 'archived' && e.status !== 'resolved'
 }
 
-interface RawCandidate {
+export interface RawCandidate {
   kind: 'avoid' | 'reinforce'
   axis: 'tag' | 'keyword'
   signal: string
@@ -134,14 +134,62 @@ export function detectCandidates(mem: MemoryFileV2, minFreq: number): RawCandida
   return candidates.sort((a, b) => b.count - a.count || a.signal.localeCompare(b.signal))
 }
 
-function nextPatternId(mem: MemoryFileV2): string {
-  const re = /^p(\d+)$/
-  let max = 0
-  for (const p of mem.patterns) {
-    const m = p.id.match(re)
-    if (m) max = Math.max(max, Number(m[1]))
+/**
+ * 순수 reconcile — 후보를 기존 patterns[] 에 멱등 반영(부수효과 없음, 배열만 변형).
+ * - dismiss(보관)된 시그널은 재제안 금지(skip): 사용자가 오탐으로 보관한 것을 존중.
+ *   (이게 없으면 detect 재실행이 archived 패턴을 새 active 로 부활시켜 dismiss 가 무의미해짐.)
+ * - 같은 시그널의 active 패턴이 있으면 갱신, 없으면 신규 추가.
+ */
+export function reconcilePatterns(
+  patterns: PatternEntryV19[],
+  candidates: RawCandidate[],
+  now: string,
+): { added: number; updated: number } {
+  let added = 0
+  let updated = 0
+
+  // 신규 id 채번용 max — 한 번만 스캔하고 증가시킨다(매 push 마다 재스캔 방지).
+  let maxId = 0
+  for (const p of patterns) {
+    const m = p.id.match(/^p(\d+)$/)
+    if (m) maxId = Math.max(maxId, Number(m[1]))
   }
-  return `p${max + 1}`
+
+  for (const c of candidates) {
+    const sig = sigOf(c.kind, c.axis, c.signal)
+    const matches = (pp: PatternEntryV19): boolean =>
+      pp._sig === sig || (pp.kind === c.kind && pp.axis === c.axis && pp.signal === c.signal)
+
+    // dismiss(보관)된 시그널 → 재제안 금지
+    if (patterns.some((p) => matches(p) && p.status === 'archived')) continue
+
+    const existing = patterns.find((p) => matches(p) && p.status !== 'archived')
+    if (existing) {
+      existing._sig = sig // _sig 없는 레거시 엔트리에 백필
+      existing.count = c.count
+      existing.sources = c.sources
+      existing.summary = c.summary
+      existing.tags = c.sourceTags
+      updated++
+    } else {
+      patterns.push({
+        id: `p${++maxId}`,
+        kind: c.kind,
+        axis: c.axis,
+        signal: c.signal,
+        count: c.count,
+        sources: c.sources,
+        summary: c.summary,
+        createdAt: now,
+        status: 'active',
+        tags: c.sourceTags,
+        _sig: sig,
+      })
+      added++
+    }
+  }
+
+  return { added, updated }
 }
 
 export async function patternDetect(opts: { min?: string; json?: boolean } = {}): Promise<void> {
@@ -166,43 +214,9 @@ export async function patternDetect(opts: { min?: string; json?: boolean } = {})
   const candidates = detectCandidates(mem, minFreq)
 
   // Fix #3: _sig 없는 레거시 엔트리도 kind+axis+signal 로 중복 탐색 → 멱등성 보장
+  // dismiss 존중·신규/갱신 판정은 순수 reconcilePatterns 가 담당(테스트 가능).
   const now = new Date().toISOString()
-  let added = 0, updated = 0
-
-  for (const c of candidates) {
-    const sig = sigOf(c.kind, c.axis, c.signal)
-    const existing = mem.patterns.find((p) => {
-      const pp = p as PatternEntryV19
-      const sigMatch = pp._sig === sig
-      const fieldMatch = pp.kind === c.kind && pp.axis === c.axis && pp.signal === c.signal
-      return (sigMatch || fieldMatch) && pp.status !== 'archived'
-    }) as PatternEntryV19 | undefined
-
-    if (existing) {
-      existing._sig = sig  // _sig 없는 레거시 엔트리에 백필
-      existing.count = c.count
-      existing.sources = c.sources
-      existing.summary = c.summary
-      existing.tags = c.sourceTags
-      updated++
-    } else {
-      const entry: PatternEntryV19 = {
-        id: nextPatternId(mem),
-        kind: c.kind,
-        axis: c.axis,
-        signal: c.signal,
-        count: c.count,
-        sources: c.sources,
-        summary: c.summary,
-        createdAt: now,
-        status: 'active',
-        tags: c.sourceTags,
-        _sig: sig,
-      }
-      mem.patterns.push(entry)
-      added++
-    }
-  }
+  const { added, updated } = reconcilePatterns(mem.patterns as PatternEntryV19[], candidates, now)
 
   // Fix #6: 변경이 없으면 writeMemory 스킵 — .bak 슬롯 불필요 소비 방지
   if (added > 0 || updated > 0) {

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -45,6 +45,8 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'verify', '사전점검',
   'review', '검토',
   'mission', '미션',
+  'pattern', '패턴',
+  'evolve', '진화',
   'help',
 ])
 

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -129,6 +129,30 @@ describe('detectNaturalLanguageInput — 서브커맨드 명령 경로 가드 (R
   })
 })
 
+describe('detectNaturalLanguageInput — pattern/evolve 라우팅 (회귀: Goal 19/20)', () => {
+  // 실결함: pattern/evolve 가 KNOWN_COMMAND_TOKENS 에 없어서, 옵션 없는 서브커맨드
+  // (vhk pattern dismiss <id>, vhk pattern detect, vhk evolve <sub>)가 NL 라우터로 새서
+  // patternList()/evolveList() 로 둔갑 → dismiss/detect 가 동작하지 않았다.
+  it('vhk pattern dismiss <id> → null (commander 가 dismiss 처리, NL 가로채기 금지)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'pattern', 'dismiss', 'p1'])).toBeNull()
+  })
+  it('vhk pattern detect → null (옵션 없어도 commander)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'pattern', 'detect'])).toBeNull()
+  })
+  it('vhk pattern list → null', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'pattern', 'list'])).toBeNull()
+  })
+  it('vhk 패턴 dismiss <id> → null (한글 컨테이너 + 영문 서브)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '패턴', 'dismiss', 'p1'])).toBeNull()
+  })
+  it('vhk evolve suggest → null', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'evolve', 'suggest'])).toBeNull()
+  })
+  it('vhk evolve apply <id> → null (인자 보존)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'evolve', 'apply', 'r1'])).toBeNull()
+  })
+})
+
 describe('cli NL e2e', () => {
   const bin = path.join(process.cwd(), 'dist', 'index.js')
 

--- a/tests/command-registry.test.ts
+++ b/tests/command-registry.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { program } from '../src/index.js'
 import { CONTAINER_SUBCOMMANDS, CONTAINER_ALIASES } from '../src/lib/command-registry.js'
-import { detectNaturalLanguageInput } from '../src/lib/cli-args.js'
+import { detectNaturalLanguageInput, KNOWN_COMMAND_TOKENS } from '../src/lib/cli-args.js'
 
 // R1 드리프트 가드: commander 정의(index.ts)와 R1 가드의 단일 소스(command-registry)가
 // 따로 놀지 않는지 실제 introspect 로 검증. (주석 grep 이 아니라 코드 구조 검증)
@@ -37,6 +37,27 @@ describe('R1 드리프트 가드 — command-registry 단일 소스', () => {
         CONTAINER_SUBCOMMANDS[name],
         `새 컨테이너 '${name}' 가 command-registry 에 없음 → R1 가드 누락`
       ).toBeDefined()
+    }
+  })
+
+  // 실결함(Goal 19): pattern/evolve 가 registry 에는 있었지만 KNOWN_COMMAND_TOKENS 에 없어서,
+  // 옵션 없는 서브커맨드(vhk pattern dismiss <id>)가 NL 라우터로 새 동작이 깨졌다.
+  // registry 와 KNOWN_COMMAND_TOKENS 가 따로 노는 드리프트를 코드로 막는다.
+  it('모든 컨테이너 명령이 KNOWN_COMMAND_TOKENS 에 있음 (없으면 옵션 없는 서브커맨드가 NL 로 샘)', () => {
+    for (const container of Object.keys(CONTAINER_SUBCOMMANDS)) {
+      expect(
+        KNOWN_COMMAND_TOKENS.has(container),
+        `컨테이너 '${container}' 가 KNOWN_COMMAND_TOKENS 에 없음 → '${container} <sub>' 가 자연어로 둔갑`
+      ).toBe(true)
+    }
+  })
+
+  it('모든 한글 컨테이너 별칭도 KNOWN_COMMAND_TOKENS 에 있음', () => {
+    for (const alias of Object.keys(CONTAINER_ALIASES)) {
+      expect(
+        KNOWN_COMMAND_TOKENS.has(alias),
+        `한글 별칭 '${alias}' 가 KNOWN_COMMAND_TOKENS 에 없음 → 한글 서브커맨드가 자연어로 둔갑`
+      ).toBe(true)
     }
   })
 })

--- a/tests/pattern.test.ts
+++ b/tests/pattern.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { detectCandidates, tokenize, MIN_TAG_FREQ, MIN_KEYWORD_FREQ } from '../src/commands/pattern.js'
+import { detectCandidates, reconcilePatterns, tokenize, MIN_TAG_FREQ, MIN_KEYWORD_FREQ } from '../src/commands/pattern.js'
+import type { RawCandidate, PatternEntryV19 } from '../src/commands/pattern.js'
 import type { MemoryFileV2, FailEntry, SuccessEntry } from '../src/commands/memory.js'
 
 /**
@@ -215,5 +216,73 @@ describe('MIN_TAG_FREQ / MIN_KEYWORD_FREQ 상수', () => {
   it('매직넘버 아님 — 명명 상수 존재', () => {
     expect(MIN_TAG_FREQ).toBe(3)
     expect(MIN_KEYWORD_FREQ).toBe(3)
+  })
+})
+
+// ── reconcilePatterns (멱등 반영 + dismiss 존중) ───────────────────────────────
+
+const NOW = '2026-02-02T00:00:00Z'
+
+function cand(signal: string, count: number, sources: string[]): RawCandidate {
+  return {
+    kind: 'avoid', axis: 'tag', signal, count, sources,
+    summary: `[avoid] 태그 '${signal}' ${count}건 반복`, sourceTags: [signal],
+  }
+}
+
+function pat(id: string, signal: string, status: 'active' | 'archived', count = 2): PatternEntryV19 {
+  return {
+    id, kind: 'avoid', axis: 'tag', signal, count, sources: [],
+    summary: '', createdAt: NOW, status, tags: [], _sig: `avoid:tag:${signal}`,
+  }
+}
+
+describe('reconcilePatterns — 신규/갱신', () => {
+  it('신규 후보 → added, active 패턴 생성 + id 부여', () => {
+    const patterns: PatternEntryV19[] = []
+    const r = reconcilePatterns(patterns, [cand('build', 3, ['f1', 'f2', 'f3'])], NOW)
+    expect(r).toEqual({ added: 1, updated: 0 })
+    expect(patterns).toHaveLength(1)
+    expect(patterns[0].id).toBe('p1')
+    expect(patterns[0].signal).toBe('build')
+    expect(patterns[0].status).toBe('active')
+    expect(patterns[0].count).toBe(3)
+  })
+
+  it('기존 active 동일 시그널 → updated (count 갱신, 신규 생성 안 함)', () => {
+    const patterns: PatternEntryV19[] = [pat('p1', 'build', 'active', 2)]
+    const r = reconcilePatterns(patterns, [cand('build', 5, ['f1', 'f2', 'f3', 'f4', 'f5'])], NOW)
+    expect(r).toEqual({ added: 0, updated: 1 })
+    expect(patterns).toHaveLength(1)
+    expect(patterns[0].count).toBe(5)
+  })
+
+  it('신규 id 는 기존 max+1 (p1,p2 있으면 p3)', () => {
+    const patterns: PatternEntryV19[] = [pat('p1', 'a', 'active'), pat('p2', 'b', 'active')]
+    reconcilePatterns(patterns, [cand('c', 3, ['f1', 'f2', 'f3'])], NOW)
+    expect(patterns.find((p) => p.signal === 'c')?.id).toBe('p3')
+  })
+})
+
+describe('reconcilePatterns — dismiss(보관) 존중 (회귀: 재제안 금지)', () => {
+  // 실결함: dismiss 로 archived 된 시그널을 detect 재실행이 새 active 패턴으로 부활시켰다.
+  it('archived 시그널은 재제안 안 함 (skip — 새 active 안 생김)', () => {
+    const patterns: PatternEntryV19[] = [pat('p1', 'build', 'archived')]
+    const r = reconcilePatterns(patterns, [cand('build', 3, ['f1', 'f2', 'f3'])], NOW)
+    expect(r).toEqual({ added: 0, updated: 0 })
+    expect(patterns).toHaveLength(1)
+    expect(patterns.filter((p) => p.status === 'active')).toHaveLength(0)
+  })
+
+  it('archived 시그널은 다른 active 후보 처리에 영향 없음', () => {
+    const patterns: PatternEntryV19[] = [pat('p1', 'build', 'archived')]
+    const r = reconcilePatterns(
+      patterns,
+      [cand('build', 3, ['f1', 'f2', 'f3']), cand('lint', 3, ['f4', 'f5', 'f6'])],
+      NOW,
+    )
+    expect(r).toEqual({ added: 1, updated: 0 })
+    expect(patterns.find((p) => p.signal === 'lint')?.status).toBe('active')
+    expect(patterns.find((p) => p.signal === 'build')?.status).toBe('archived')
   })
 })


### PR DESCRIPTION
## 요약
SnapContext로 **Goal 19 도그푸딩** 중 발견한 2개 결함 수정.

### 🔴 BUG#1 — `pattern`/`evolve`가 자연어 라우터로 샘
`KNOWN_COMMAND_TOKENS`(cli-args.ts)에 `pattern`/`evolve`가 누락 → 옵션 없는 서브커맨드(`vhk pattern dismiss <id>`, `vhk pattern detect`, `vhk evolve <sub>`)가 Commander 대신 NL 라우터로 가서 `patternList()`/`evolveList()`로 둔갑. **`dismiss`가 아무것도 안 했음.**
→ `pattern`/`evolve`/`패턴`/`진화` 토큰 추가.

### 🔴 BUG#2 — dismiss한 패턴이 재제안됨
`patternDetect`가 dismiss(archived)된 시그널을 active로 못 찾아 **새 패턴으로 부활** → "재제안 안 됨" 약속 위반.
→ reconcile 로직을 순수 함수 `reconcilePatterns`로 추출하고 archived 시그널 skip 추가.

## 재발 방지
`command-registry.test.ts`에 드리프트 가드 추가: 모든 컨테이너 명령/한글 별칭이 `KNOWN_COMMAND_TOKENS`에 존재하는지 검증 (이번 버그를 사전에 잡았을 테스트).

## 테스트
- `tests/cli-args.test.ts`: pattern/evolve 서브커맨드가 Commander로 가는지 회귀
- `tests/command-registry.test.ts`: KNOWN_COMMAND_TOKENS 드리프트 가드 2건
- `tests/pattern.test.ts`: `reconcilePatterns` 신규/갱신/archived-skip 단위 테스트
- 게이트: `pnpm test:run` (829 통과) + `node scripts/check-goal-19.mjs` (✅)

## 참고 (이번 PR 범위 밖, 후속 제안)
keyword 축이 "금지"/"필수" 같은 교훈 명령어를 저신호 패턴으로 잡음 → `tokenize` 한국어 stopword 필터 후속 고려.

🤖 Generated with [Claude Code](https://claude.com/claude-code)