### PR TITLE
fix(publish): 발행 전 브랜치/clean 가드 추가 (v2.3.1 오발행 재발 방지)

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -92,9 +92,54 @@ export function gitPostRelease(newVersion: string): GitReleaseResult {
   }
 }
 
+export type PublishPreflightCode = 'wrong-branch' | 'dirty'
+export interface PublishPreflightResult {
+  ok: boolean
+  code?: PublishPreflightCode
+}
+
+/**
+ * 발행 전 안전 점검(순수 판정) — feature 브랜치/미커밋 상태서 발행해 픽스 누락본이
+ * npm latest 로 나가는 사고 방지(v2.3.1 오발행 사례). 브랜치 위반을 dirty 보다 우선 보고.
+ */
+export function evaluatePublishPreflight(
+  branch: string,
+  trackedStatus: string,
+  defaultBranch: string
+): PublishPreflightResult {
+  if (branch !== defaultBranch) return { ok: false, code: 'wrong-branch' }
+  if (trackedStatus.trim()) return { ok: false, code: 'dirty' }
+  return { ok: true }
+}
+
+/**
+ * git 상태를 수집해 발행 전 점검. defaultBranch 는 origin/HEAD 에서 감지(실패 시 'main').
+ * untracked 파일(미커밋 plan 문서 등)은 발행 산출물에 영향 없어 검사 제외(tracked 변경만).
+ */
+export function publishPreflight(): PublishPreflightResult & { branch: string; defaultBranch: string } {
+  const br = safeExecFile('git', ['branch', '--show-current'])
+  const branch = br.ok ? br.out.trim() : ''
+  const head = safeExecFile('git', ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'])
+  const defaultBranch = head.ok ? head.out.trim().split('/').pop() || 'main' : 'main'
+  const st = safeExecFile('git', ['status', '--porcelain', '--untracked-files=no'])
+  const trackedStatus = st.ok ? st.out : ''
+  return { ...evaluatePublishPreflight(branch, trackedStatus, defaultBranch), branch, defaultBranch }
+}
+
 export async function publish(): Promise<void> {
   console.log(chalk.bold('\n📦 ' + t('publish.title')))
   console.log(chalk.gray('─'.repeat(40)))
+
+  // 발행 전 안전 점검 — feature 브랜치/미커밋서 발행해 픽스 누락본이 latest 로 나가는 사고 방지(v2.3.1 사례)
+  const pre = publishPreflight()
+  if (!pre.ok) {
+    const msg =
+      pre.code === 'wrong-branch'
+        ? t('publish.preflightWrongBranch', pre.branch || '(detached)', pre.defaultBranch)
+        : t('publish.preflightDirty')
+    console.log(chalk.red(`\n❌ ${msg}`))
+    return
+  }
 
   if (!existsSync('package.json')) {
     console.log(chalk.red('❌ package.json을 찾을 수 없습니다.'))

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -377,6 +377,11 @@ export const ko = {
     publishing: 'npm 배포 중...',
     publishSuccess: 'npm 배포 성공!',
     publishFailed: 'npm 배포 실패',
+    // 발행 전 안전 가드 — feature 브랜치/미커밋 발행로 픽스 누락본이 latest 로 나가는 사고 방지(v2.3.1 사례)
+    preflightWrongBranch: (branch: string, def: string) =>
+      `발행 중단 — 현재 '${branch}' 브랜치입니다. 발행은 '${def}' 에서만 하세요 (feature 브랜치 발행 → 픽스 누락본이 npm latest 로 나가는 사고 방지). git checkout ${def} && git pull 후 재시도.`,
+    preflightDirty:
+      '발행 중단 — 커밋 안 된 변경이 있습니다. 발행 전 커밋/정리하세요 (untracked 파일은 무시).',
   },
   harness: {
     title: '통합 품질 점검',

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -131,3 +131,90 @@ describe('publish — gitPostRelease (commit 실패 시 tag 미생성)', () => {
     expect(r.warning).toBeUndefined()
   })
 })
+
+describe('evaluatePublishPreflight — 발행 전 브랜치/clean 가드 (2.3.1 오발행 재발 방지)', () => {
+  it('default 브랜치 + clean → ok', async () => {
+    const { evaluatePublishPreflight } = await import('../src/commands/publish.js')
+    expect(evaluatePublishPreflight('main', '', 'main')).toEqual({ ok: true })
+  })
+
+  it('feature 브랜치 → wrong-branch 차단 (이번 2.3.1 오발행 원인)', async () => {
+    const { evaluatePublishPreflight } = await import('../src/commands/publish.js')
+    const r = evaluatePublishPreflight('feat/goal-20-evolve', '', 'main')
+    expect(r.ok).toBe(false)
+    expect(r.code).toBe('wrong-branch')
+  })
+
+  it('tracked 미커밋 변경 → dirty 차단', async () => {
+    const { evaluatePublishPreflight } = await import('../src/commands/publish.js')
+    const r = evaluatePublishPreflight('main', ' M src/x.ts', 'main')
+    expect(r.ok).toBe(false)
+    expect(r.code).toBe('dirty')
+  })
+
+  it('detached HEAD(빈 브랜치) → wrong-branch 차단', async () => {
+    const { evaluatePublishPreflight } = await import('../src/commands/publish.js')
+    expect(evaluatePublishPreflight('', '', 'main').code).toBe('wrong-branch')
+  })
+
+  it('브랜치 위반 우선 — feature + dirty 면 wrong-branch 먼저', async () => {
+    const { evaluatePublishPreflight } = await import('../src/commands/publish.js')
+    expect(evaluatePublishPreflight('feat/x', ' M a', 'main').code).toBe('wrong-branch')
+  })
+
+  it('master 등 다른 default 도 인식 (하드코딩 아님)', async () => {
+    const { evaluatePublishPreflight } = await import('../src/commands/publish.js')
+    expect(evaluatePublishPreflight('master', '', 'master')).toEqual({ ok: true })
+    expect(evaluatePublishPreflight('main', '', 'master').code).toBe('wrong-branch')
+  })
+})
+
+describe('publishPreflight — git 수집 + default 브랜치 추출', () => {
+  const exec = vi.mocked(safeExecFile)
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('origin/HEAD 에서 default 추출 + feature 브랜치 차단', async () => {
+    exec.mockImplementation((_c: string, args: string[]) => {
+      if (args[0] === 'branch') return { ok: true, out: 'feat/x' }
+      if (args[0] === 'symbolic-ref') return { ok: true, out: 'origin/main' }
+      if (args[0] === 'status') return { ok: true, out: '' }
+      return { ok: true, out: '' }
+    })
+    const { publishPreflight } = await import('../src/commands/publish.js')
+    const r = publishPreflight()
+    expect(r.defaultBranch).toBe('main')
+    expect(r.branch).toBe('feat/x')
+    expect(r.ok).toBe(false)
+    expect(r.code).toBe('wrong-branch')
+  })
+
+  it('origin/HEAD 감지 실패 → main fallback + main 이면 통과', async () => {
+    exec.mockImplementation((_c: string, args: string[]) => {
+      if (args[0] === 'branch') return { ok: true, out: 'main' }
+      if (args[0] === 'symbolic-ref') return { ok: false, err: 'no remote', out: '' }
+      if (args[0] === 'status') return { ok: true, out: '' }
+      return { ok: true, out: '' }
+    })
+    const { publishPreflight } = await import('../src/commands/publish.js')
+    const r = publishPreflight()
+    expect(r.defaultBranch).toBe('main')
+    expect(r.ok).toBe(true)
+  })
+
+  it('default 브랜치인데 tracked 변경 있으면 dirty 차단', async () => {
+    exec.mockImplementation((_c: string, args: string[]) => {
+      if (args[0] === 'branch') return { ok: true, out: 'main' }
+      if (args[0] === 'symbolic-ref') return { ok: true, out: 'origin/main' }
+      if (args[0] === 'status') return { ok: true, out: ' M src/x.ts' }
+      return { ok: true, out: '' }
+    })
+    const { publishPreflight } = await import('../src/commands/publish.js')
+    const r = publishPreflight()
+    expect(r.ok).toBe(false)
+    expect(r.code).toBe('dirty')
+  })
+})


### PR DESCRIPTION
## 무엇

`vhk publish` 에 **발행 전 안전 가드** 추가 — feature 브랜치/미커밋 상태서 발행해 픽스 누락본이 npm latest 로 나가는 사고 재발 방지.

## 왜 (실제 사고)

v2.3.1 이 main 체크아웃 없이 `feat/goal-20-evolve` 에서 `vhk publish` 실행돼, **#117(CLAUDE.md 마커)·#118(pattern fix)이 빠진 옛 코드**가 npm latest 로 나감. npm 버전은 immutable 이라 2.3.2 로 재발행해야 했음. 사람 실수에 의존하던 발행 절차에 가드를 박는다.

## 어떻게

- **`evaluatePublishPreflight(branch, trackedStatus, defaultBranch)`** (순수): 현재 브랜치 ≠ default → `wrong-branch`, tracked 미커밋 변경 → `dirty` 차단. 브랜치 위반을 dirty 보다 우선 보고.
- **`publishPreflight()`** (wrapper): `git symbolic-ref refs/remotes/origin/HEAD` 로 default 브랜치 동적 감지(실패 시 `main` fallback — 하드코딩 아님). **untracked 파일은 검사 제외**(미커밋 plan 문서 등 발행 산출물 무관).
- **`publish()` 시작부 배선**: 위반 시 `ko.publish.preflightWrongBranch`/`preflightDirty` 출력 후 중단. inquirer/build/publish 진입 전 차단.

## 검증

- **test 852 pass** (신규 +9: default/feature/dirty/detached/master 인식 · wrapper origin/HEAD 추출 · fallback)
- tsc 0
- **실증**: 현재 `fix/publish-branch-guard` 브랜치서 `publishPreflight()` → `{ ok:false, code:'wrong-branch', branch:'fix/publish-branch-guard', defaultBranch:'main' }` — 정확히 2.3.1 사고 패턴 차단

## 효과

머지 후 다음 발행부터 적용. main 아닌 곳/미커밋 상태 발행을 사전 차단. (이 PR 자체는 코드만 — 재발행 불필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
