### PR TITLE
feat(work): vhk work / work handoff — AI 세션 이어받기·인수인계

### DIFF
--- a/.vhk/.gitignore
+++ b/.vhk/.gitignore
@@ -1,1 +1,3 @@
 reports/
+work-prompt.md
+handoff-prompt.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ## [Unreleased]
 
-_다음 릴리즈 예정 항목 없음 — 최근 변경은 아래 버전 기록 참조._
+### Added
+
+- **`vhk work` / `vhk work handoff`** (`src/commands/work.ts`) — AI 작업 세션 이어받기/인수인계. Claude CLI 세션 기억이 휘발돼도 repo 파일(CLAUDE.md·next-task.md) + VHK 상태로 빠르게 이어가도록, 상태를 수집해 "시작/중단 정리 프롬프트"를 만들고 클립보드에 복사한다.
+  - `work` — git status + active goal + `.vhk/context.md` 갱신 → 시작 프롬프트(CLAUDE.md 1순위·AGENTS.md는 Codex/보조 참고) 생성·복사.
+  - `work handoff` — git status 수집 → 완료/미완료 분리·테스트 기록·next-task 갱신·커밋 판단을 요청하는 인수인계 프롬프트 생성·복사.
+  - **안전 1원칙**: CLI는 상태 수집 + 프롬프트 준비만. 커밋/stash/reset/goal done/파일 삭제 0. HARD_STOP 활성 시 즉시 중단. 별칭 `작업`/`인수인계`, NLP `작업 시작`·`인수인계`.
+- **`src/lib/clipboard.ts`** — 외부 의존성 0 클립보드 헬퍼. Windows는 PowerShell `Set-Clipboard`에 base64(UTF-8) 전달(한글 보존), mac `pbcopy`, linux `wl-copy`/`xclip`/`xsel`. 실패 시 `.vhk/work-prompt.md` 사본 + 화면 출력 폴백.
 
 ## [2.3.0] - 2026-06-04
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ tags: [process, documentation]
 - **npm:** @byh3071/vhk (public, scoped)
 - **버전:** v2.3.2 (npm latest. package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
 - **MCP tool:** 29 (Goal 0 24 + `learn` v2.0 쓰기 도구 + `pattern-detect` + `pattern-list` v2.1 + `evolve-suggest` + `evolve-list` v2.2)
-- **테스트:** 852 pass (vitest)
+- **테스트:** 868 pass (vitest)
 - **패키지 매니저:** pnpm
 
 ## 현재 상태
@@ -23,6 +23,7 @@ tags: [process, documentation]
 - **Phase:** 등록 goal 0~20 전부 DONE. CLAUDE.md sentinel marker(#117)·pattern dismiss/detect 누수(#118) 픽스 + publish 브랜치/clean 가드(#119) main 머지, **v2.3.2 발행 완료**. npm 2.3.1 은 오발행(`feat/goal-20-evolve` 서 발행 → 픽스 누락) → deprecate 처리됨(unpublish 금지·immutable).
 - **블로커:** 없음
 - **다음 액션:** 없음(vhk 발행 라인 종료). 별개 라인 = Goal 19 도그푸딩 → 20(다른 세션). ⚠️ publish 는 항상 `main` 에서만(가드 #119 가 feature 브랜치/미커밋 발행 차단).
+- **진행 중(미발행):** `vhk work` / `vhk work handoff` — AI 세션 이어받기/인수인계 기능(`src/commands/work.ts` + `src/lib/clipboard.ts`). CLI는 수집·프롬프트만, 커밋/done 0. [Unreleased] 상태, 버전 범프·발행 대기.
 - **마지막 업데이트:** 2026-06-05
 
 > **기억 SoT (v2):** 교훈·결정·실패·성공은 `vhk memory`(memory v2 4버킷, `vhk learn`→`failures.lesson`). `docs/state/learnings.md` 는 v2 마이그레이션으로 흡수·신규기록 중단(분리 폐지).

--- a/docs/context/agent-compact.md
+++ b/docs/context/agent-compact.md
@@ -12,6 +12,9 @@
 - 해제는 `vhk resume --confirm` (사람만). 자동 호출 금지.
 - 블로커 3건 누적 시 HARD_STOP 자동 생성.
 
+## 세션 이어받기
+- 시작/이어하기: `vhk work` (시작 프롬프트 생성·클립보드 복사). 중단 시: `vhk work handoff` (인수인계 프롬프트). CLI는 수집·프롬프트만, 커밋/done은 사람 승인.
+
 ## 작업 원칙
 - **active goal 만 작업** (`vhk goal next` 가 고른 첫 NOT_STARTED / IN_PROGRESS).
 - 사용자 변경 **revert 금지**. `git status --short` 먼저 확인, 기존 수정 보존, 최소 범위 패치.

--- a/docs/log/2026-06-05-vhk-work-session-handoff.md
+++ b/docs/log/2026-06-05-vhk-work-session-handoff.md
@@ -1,0 +1,86 @@
+---
+date: 2026-06-05
+project: VHK
+version: Unreleased (버전 범프·발행 대기)
+type: 세션로그
+---
+
+# 2026-06-05 — `vhk work` / `vhk work handoff` (AI 작업 세션 이어받기·인수인계)
+
+## 요약
+
+Claude CLI/Claude Code 가 컴퓨터 재시작으로 **세션 대화 기억이 휘발돼도**, repo 파일(CLAUDE.md·
+next-task.md)과 VHK 상태로 빠르게 이어가도록 하는 진입점 2개를 CLI 제품 기능으로 추가.
+**CLI 는 상태 수집 + Claude 에게 줄 프롬프트 준비만** 하고, 실제 판단·개발·커밋은 Claude 가 한다.
+PowerShell 개인 함수가 아니라 VHK CLI 명령으로 넣어 PC-독립 제품 가치로 만듦.
+
+- `vhk work` — 작업 시작/이어하기. git status + active goal + `.vhk/context.md` 갱신 → "시작 프롬프트" 생성 → 클립보드 복사.
+- `vhk work handoff` — 중단 정리. git status 수집 → "인수인계 프롬프트"(완료/미완료 분리·테스트 기록·next-task 갱신·커밋 판단 요청) 생성 → 클립보드 복사.
+
+별칭 `작업`/`인수인계`. 자연어 `이어서 작업`·`이어하기`·`인수인계` 라우팅. 1차는 **CLI 전용**(MCP 노출은 2차).
+
+## 왜 (배경)
+
+- 사용자는 비개발자. Claude Code 가 메인 엔진, Codex 보조. 세션 기억 휘발 시 "어디까지 했지"를 사람이 매번 설명하는 비효율.
+- VHK 는 이미 기억을 파일에 둠: `CLAUDE.md`(메인 규칙·1순위) · `AGENTS.md`(Codex/보조 에이전트 참고) · `docs/context/agent-compact.md`(빠른 요약) · `docs/state/next-task.md`(다음 작업) · `.vhk/`(HARD_STOP·memory·context).
+- 빠진 것 = **흩어진 상태를 한 번에 모아 Claude 에게 줄 시작/인계 프롬프트로 만드는 진입점**. 그걸 채움.
+- 이름: `vhk resume --confirm` 은 HARD_STOP 해제 전용이라 충돌 회피 → `vhk work` 채택. `vhk start`(새 프로젝트 마법사)와도 별개.
+
+## 무엇을 만들었나
+
+### 신규 파일
+
+- **`src/commands/work.ts`** — 핵심. `work()` / `workHandoff()` + 프롬프트 빌더(`buildStartPrompt`/`buildHandoffPrompt`, 테스트 위해 export).
+  - 재사용 헬퍼 조합: `isHardStopActive`/`readHardStopReason`([src/lib/state-files.ts](../../src/lib/state-files.ts)), `listGoals`([src/lib/goal-frontmatter.ts](../../src/lib/goal-frontmatter.ts)) + `selectActiveId`([src/commands/goal.ts](../../src/commands/goal.ts)), `context({compact:true})`([src/commands/context.ts](../../src/commands/context.ts)), `safeExecFile`로 `git status --short`([src/lib/exec.ts](../../src/lib/exec.ts)), `printNextStep`([src/lib/next-step.ts](../../src/lib/next-step.ts)).
+  - `refreshContextQuietly()` — `context()` 자체 콘솔 출력(헤더·printNextStep)이 work 흐름에 끼지 않게 `console.log` 를 잠시 억제 후 finally 복원.
+  - `emitPrompt()` — 클립보드 복사 + 항상 `.vhk/work-prompt.md`·`.vhk/handoff-prompt.md` 사본 저장. 실패 시 화면에 프롬프트 전문 출력(폴백).
+- **`src/lib/clipboard.ts`** — 외부 의존성 0 클립보드. `copyToClipboard(text): boolean`.
+  - Windows: `powershell Set-Clipboard` 에 base64(UTF-8)를 **stdin 경유** 전달(한글 보존 + 명령줄 32K 한계 우회).
+  - mac `pbcopy`, linux `wl-copy`→`xclip`→`xsel`. 어느 것도 실패하면 false → 호출자가 파일/화면 폴백.
+- **`tests/work.test.ts`** (work/handoff 동작·프롬프트 내용·HARD_STOP 중단·폴백·git mutation 미호출) + **`tests/clipboard.test.ts`** (spawnSync mock 성공/실패/ENOENT/throw 분기).
+
+### 수정 파일 (명령 등록은 4곳 정합 필수 — drift 가드가 강제)
+
+- **`src/index.ts`** — `import { work, workHandoff }`, `KO_ALIASES.work='작업'`, `program.command('work').alias('작업')` + `.command('handoff').alias('인수인계')` (goal 서브명령 패턴).
+- **`src/lib/nlp-router.ts`** — `NlpCommand` 에 `'work'`, `NLP_KEYWORDS.work=['이어서','이어하기','work']`, RULES 2개(handoff 먼저, 그다음 work 기본; work 기본 test 가 `matchesKeywords` 도 호출).
+- **`src/lib/nlp-run.ts`** — `dispatchNlpRoute` switch 에 `case 'work'`(args[0]==='handoff' → workHandoff, 아니면 work).
+- **`src/lib/command-registry.ts`** — `CONTAINER_SUBCOMMANDS.work=['handoff']` + `CONTAINER_ALIASES.작업='work'` (R1 드리프트 가드 단일 소스).
+- **`src/lib/cli-args.ts`** — `KNOWN_COMMAND_TOKENS` 에 `'work','작업'` (없으면 `work handoff` 가 자연어로 둔갑).
+- **`src/i18n/ko.ts`** — `ko.work.workTitle`/`handoffTitle`.
+
+### 문서·기타
+
+- `CHANGELOG.md` [Unreleased] Added · `CLAUDE.md`(테스트 852→868, 현재 상태에 진행중 명시) · `docs/context/agent-compact.md`("세션 이어받기" 섹션) · `.vhk/.gitignore`(`work-prompt.md`/`handoff-prompt.md` 추적 제외).
+
+## 흐름 (실제 사용)
+
+```
+시작:   PowerShell 에서  vhk work       → 프롬프트 클립보드 복사 → claude → Ctrl+V → 이어서 작업
+중단:   vhk work handoff               → 인수인계 프롬프트 복사 → claude → Ctrl+V → Claude 가 정리·next-task 갱신
+```
+
+## 안전 원칙 (전부 코드 반영·검증)
+
+- `.vhk/HARD_STOP` 활성 시 두 명령 모두 즉시 중단(작업 전).
+- git 은 `status --short` 읽기만 — commit/stash/reset/add/checkout/clean 0.
+- 자동 커밋·자동 `vhk goal done` 0. 테스트 통과/완료 판정은 CLI 가 안 함 → Claude 가 판단(프롬프트에 "테스트 전 완료 금지" 명시).
+- CLI 는 수집·프롬프트 준비만. 실제 판단·개발은 Claude.
+
+## 검증
+
+- 타입체크 `tsc --noEmit` 0 · 빌드 `tsup` OK · 테스트 **868 pass**(852 + 신규 16).
+- E2E: `vhk work`/`vhk work handoff` 출력 + 클립보드 복사 성공. `Get-Clipboard` 로 한글 보존 확인.
+- 자연어 `이어서 작업`→work, `인수인계`→work handoff, `이어하기`(단독)→work.
+- 적대 리뷰(cavecrew-reviewer + 직접): 심각 버그 0. LOW 2건 발견·수정 — ① clipboard base64 32K 한계 → stdin 경유로 우회, ② NLP_KEYWORDS.work 죽은 데이터 → work 기본 규칙 test 에 `matchesKeywords` 추가.
+
+## 교훈
+
+- **신규 명령 등록은 4곳 정합 필수**: `index.ts` + `nlp-router.ts`(+`nlp-run.ts`) + `command-registry.ts` + `cli-args.ts`. 컨테이너(서브커맨드 보유) 명령은 누락 시 `command-registry.test.ts` 드리프트 가드가 실패시켜 R1(자연어가 명령 가로채기) 재발을 사전 차단.
+- **Windows 클립보드 한글**: `clip.exe` 는 콘솔 코드페이지로 한글 깨짐 → PowerShell `Set-Clipboard` + base64(UTF-8) **stdin 경유**가 안전(한글 보존 + 32K 우회).
+- **재사용 함수의 콘솔 출력 격리**: 통짜 함수(`context()`)를 흐름 중간에 부르면 그 출력(헤더·printNextStep)이 섞임 → `console.log` 임시 억제 + finally 복원.
+
+## 다음 액션
+
+- (사람) 커밋 — `main` 직접 금지, feature 브랜치 권장. `.vhk/context.md`(기존부터 untracked)는 제외하고 work 관련 파일만 add.
+- 버전 범프 + 발행은 별도 라인 — 항상 `main` 에서만, 2FA 사람이.
+- 2차: MCP tool 노출(`work` — TTY 없어 클립보드 스킵·텍스트만 반환), `work handoff --check`(원할 때만 goal check 실행), 프롬프트 커스터마이즈(`.vhk/work-template.md`).

--- a/src/commands/work.ts
+++ b/src/commands/work.ts
@@ -1,0 +1,223 @@
+import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import chalk from 'chalk'
+import { ko } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+import { safeExecFile } from '../lib/exec.js'
+import { isHardStopActive, readHardStopReason } from '../lib/state-files.js'
+import { listGoals } from '../lib/goal-frontmatter.js'
+import { selectActiveId } from './goal.js'
+import { context } from './context.js'
+import { copyToClipboard } from '../lib/clipboard.js'
+
+const VHK_DIR = '.vhk'
+
+// vhk work / vhk work handoff — AI 작업 세션 시작/인수인계.
+// 핵심 원칙: CLI 는 "상태 수집 + Claude 에게 줄 프롬프트 준비" 만 한다.
+// 실제 판단·개발·커밋은 Claude 가 한다. 커밋/stash/reset/goal done/파일 삭제는 절대 안 한다.
+
+// git status --short — safeExecFile 래퍼라 비-git/실패 시 throw 없이 '' 반환(읽기 전용).
+function gitShort(): string {
+  const r = safeExecFile('git', ['status', '--short'])
+  return r.ok ? r.out.trim() : ''
+}
+
+// 현재 폴더가 VHK 프로젝트인지 — CLAUDE.md / .vhk / goals 중 하나라도 있으면 인정.
+function ensureVhkProject(): boolean {
+  if (existsSync('CLAUDE.md') || existsSync(VHK_DIR) || existsSync('goals')) return true
+  console.log(chalk.yellow('  ⚠️ 여기는 VHK 프로젝트 폴더가 아닌 것 같아요.'))
+  console.log(chalk.dim('  VHK 프로젝트 폴더에서 실행하거나, vhk start 로 새로 시작하세요.'))
+  return false
+}
+
+// HARD_STOP 가드 — 활성이면 사유 출력 후 false(작업 중단). 자동 해제는 절대 안 함.
+function passHardStop(): boolean {
+  if (!isHardStopActive()) {
+    console.log(chalk.green('  ✅ HARD_STOP 없음'))
+    return true
+  }
+  console.log(chalk.red.bold('\n🛑 HARD STOP 활성 (.vhk/HARD_STOP) — 자동화를 중단합니다.'))
+  const reason = readHardStopReason()
+  if (reason) console.log(chalk.red(`   사유: ${reason.replace(/\s*\n\s*/g, ' ')}`))
+  console.log(chalk.yellow('   해제는 사람이 직접: vhk resume --confirm'))
+  return false
+}
+
+// active goal 한 줄 ("Goal N — 제목" / 또는 안내 문구).
+function activeGoalLine(): string {
+  const goals = listGoals('goals')
+  if (goals.length === 0) return '정의된 goal 없음'
+  const id = selectActiveId(goals)
+  if (id === null) return '모든 goal 완료됨'
+  const g = goals.find((x) => x.frontmatter.id === id)
+  if (!g) return '정의된 goal 없음'
+  return `Goal ${id} — ${g.frontmatter.title ?? '(untitled)'}`
+}
+
+// 변경 파일 목록을 화면에 들여쓰기 출력 (없으면 "변경 없음").
+function printGit(git: string): void {
+  if (!git) {
+    console.log(chalk.dim('   (변경된 파일 없음 — 깨끗한 상태)'))
+    return
+  }
+  for (const line of git.split(/\r?\n/)) console.log(`   ${line}`)
+}
+
+// 시작 프롬프트 — Claude CLI 에 붙여넣을 텍스트. (테스트 위해 export)
+export function buildStartPrompt(git: string, goalLine: string): string {
+  const gitBlock = git || '(변경 없음)'
+  return [
+    '당신은 VHK 프로젝트의 작업 파트너입니다. 나는 비개발자입니다.',
+    '',
+    '[규칙 우선순위]',
+    '1. CLAUDE.md 를 1순위 규칙으로 읽고 그대로 따르세요. (충돌 시 CLAUDE.md 우선)',
+    '2. AGENTS.md 는 Codex/보조 에이전트용 참고 규칙입니다. 당신은 참고만 하세요.',
+    '3. docs/state/next-task.md 와 .vhk/context.md 를 읽고 그 기준으로 이어서 작업하세요.',
+    '',
+    '[지금 상태 — 자동 수집됨]',
+    '- 변경된 파일 (git status --short):',
+    gitBlock,
+    '- 현재 목표 (active goal):',
+    goalLine,
+    '',
+    '[해주세요]',
+    '1. 먼저 현재 상태를 비개발자가 알아듣게 쉽게 요약해 주세요.',
+    '2. 그다음 할 일을 3단계 이하로 말하고 진행하세요.',
+    '3. 테스트가 통과하기 전에는 완료(done) 처리하지 마세요.',
+    '4. 자동 커밋이나 vhk goal done 은 내가 승인하기 전에는 하지 마세요.',
+    '모든 응답은 한국어로.',
+  ].join('\n')
+}
+
+// 인수인계(중단 정리) 프롬프트 — Claude CLI 에 붙여넣을 텍스트. (테스트 위해 export)
+export function buildHandoffPrompt(git: string): string {
+  const gitBlock = git || '(변경 없음)'
+  return [
+    '당신은 VHK 프로젝트의 작업 파트너입니다. 오늘은 여기서 작업을 중단하고 컴퓨터를 꺼야 합니다.',
+    '다음 세션이 이어받을 수 있게 정리해 주세요.',
+    '',
+    '[가장 먼저] CLAUDE.md 를 1순위 규칙으로 읽으세요. AGENTS.md 는 Codex/보조용 참고만.',
+    '',
+    '[지금 상태 — 자동 수집됨]',
+    '- 변경된 파일 (git status --short):',
+    gitBlock,
+    '',
+    '[해주세요 — 정리만, 새 개발 시작 금지]',
+    '1. 현재 변경사항을 확인하고, 완료된 일 / 미완료된 일로 나눠 한국어로 정리해 주세요.',
+    "2. 테스트를 실행했는지/안 했는지, 결과가 어땠는지 명확히 기록해 주세요. (안 돌렸으면 '미실행')",
+    '3. docs/state/next-task.md 를 지금 상태에 맞게 업데이트해 주세요. (다음 사람이 이어받을 지점 명확히)',
+    '4. 지금 커밋 가능한 상태인지 판단해 주세요. (이유 설명)',
+    '5. 완료(done) 처리하면 안 되는 상태라면 정리 맨 위에 굵게 표시해 주세요.',
+    '',
+    '[금지] 직접 git commit / git stash / git reset / vhk goal done 실행 금지. 파일 되돌리기·삭제 금지.',
+    '모든 응답은 한국어로.',
+  ].join('\n')
+}
+
+// 프롬프트를 클립보드에 복사 + 항상 .vhk/<fileName> 사본 저장.
+// 클립보드 실패 시 화면에 프롬프트 전문 출력(사용자가 직접 복사).
+function emitPrompt(prompt: string, fileName: string, label: string): void {
+  let savedPath = ''
+  try {
+    mkdirSync(VHK_DIR, { recursive: true })
+    savedPath = join(VHK_DIR, fileName)
+    writeFileSync(savedPath, prompt, 'utf-8')
+  } catch {
+    savedPath = ''
+  }
+
+  const copied = copyToClipboard(prompt)
+  if (copied) {
+    console.log(chalk.green(`\n📋 Claude에게 줄 '${label}'을 클립보드에 복사했습니다! ✅`))
+    if (savedPath) console.log(chalk.dim(`   (사본 저장: ${savedPath})`))
+  } else {
+    console.log(chalk.yellow(`\n⚠️ 클립보드 복사에 실패했어요 — 아래 프롬프트를 직접 복사하세요:`))
+    if (savedPath) console.log(chalk.dim(`   (파일로도 저장됨: ${savedPath} — 열어서 복사 가능)`))
+    console.log(chalk.gray('────────────────────────────────────────'))
+    console.log(prompt)
+    console.log(chalk.gray('────────────────────────────────────────'))
+  }
+}
+
+// .vhk/context.md 를 조용히 갱신한다. context() 자체 콘솔 출력(헤더·printNextStep)이
+// work 흐름 중간에 끼면 비개발자가 혼란하므로 console.log 를 잠시 억제하고 호출.
+async function refreshContextQuietly(): Promise<boolean> {
+  const origLog = console.log
+  console.log = () => {}
+  try {
+    await context({ compact: true })
+    return true
+  } catch {
+    return false
+  } finally {
+    console.log = origLog
+  }
+}
+
+export async function work(): Promise<void> {
+  console.log(chalk.bold(`\n${ko.work.workTitle}`))
+  console.log(chalk.gray('─'.repeat(40)))
+  if (!ensureVhkProject()) return
+  if (!passHardStop()) return
+
+  const git = gitShort()
+  console.log('')
+  console.log(chalk.cyan('📋 변경된 파일'))
+  printGit(git)
+
+  console.log('')
+  console.log(chalk.cyan('📖 규칙'))
+  console.log('   · CLAUDE.md 가 1순위 규칙입니다.')
+  console.log(chalk.dim('   · AGENTS.md 는 Codex/보조 에이전트용 참고 규칙입니다.'))
+
+  const goalLine = activeGoalLine()
+  console.log('')
+  console.log(chalk.cyan(`🎯 현재 목표: ${goalLine}`))
+
+  const refreshed = await refreshContextQuietly()
+  console.log(chalk.dim(refreshed ? '⚙️  .vhk/context.md 갱신됨' : '⚙️  .vhk/context.md 갱신 생략(건너뜀)'))
+
+  // docs/state/next-task.md 핵심을 보여준다(있으면).
+  const nextTaskPath = join('docs', 'state', 'next-task.md')
+  if (existsSync(nextTaskPath)) {
+    try {
+      const lines = readFileSync(nextTaskPath, 'utf-8').split(/\r?\n/).slice(0, 12)
+      console.log('')
+      console.log(chalk.cyan('📝 다음 할 일 (next-task.md)'))
+      for (const l of lines) console.log(chalk.dim(`   ${l}`))
+    } catch {
+      /* 읽기 실패 → 생략 */
+    }
+  }
+
+  const prompt = buildStartPrompt(git, goalLine)
+  emitPrompt(prompt, 'work-prompt.md', '시작 프롬프트')
+
+  printNextStep({
+    message: '터미널에서 claude 를 실행한 뒤, Ctrl+V 로 붙여넣고 Enter 하세요.',
+    command: 'claude',
+  })
+}
+
+export async function workHandoff(): Promise<void> {
+  console.log(chalk.bold(`\n${ko.work.handoffTitle}`))
+  console.log(chalk.gray('─'.repeat(40)))
+  if (!ensureVhkProject()) return
+  if (!passHardStop()) return
+
+  const git = gitShort()
+  console.log('')
+  console.log(chalk.cyan('📋 바뀐 파일'))
+  printGit(git)
+
+  const prompt = buildHandoffPrompt(git)
+  emitPrompt(prompt, 'handoff-prompt.md', '중단 정리 프롬프트')
+
+  console.log('')
+  console.log(chalk.dim('💡 이 명령은 커밋·삭제를 절대 하지 않습니다. 정리·판단은 Claude 가 합니다.'))
+
+  printNextStep({
+    message: '터미널에서 claude 를 실행한 뒤, Ctrl+V 로 붙여넣고 Enter 하세요.',
+    command: 'claude',
+  })
+}

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -428,6 +428,10 @@ export const ko = {
     learnTitle: '🧠 Learning 기록',
     resumeTitle: '▶️  HARD_STOP 해제',
   },
+  work: {
+    workTitle: '🚀 vhk work — 작업 시작/이어하기',
+    handoffTitle: '⏸️  vhk work handoff — 중단 정리',
+  },
   pattern: {
     detectTitle: '패턴 감지',
     listTitle: '패턴 목록',

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { update } from './commands/update.js'
 import { context, contextShow } from './commands/context.js'
 import { memoryAdd, memoryList, memoryRemove, memoryArchive, memoryResolve, memoryUnarchive, memoryMigrate, type MemBucket } from './commands/memory.js'
 import { brief } from './commands/brief.js'
+import { work, workHandoff } from './commands/work.js'
 import { start } from './commands/start.js'
 import { mode } from './commands/mode.js'
 import { verify } from './commands/verify.js'
@@ -147,6 +148,7 @@ const KO_ALIASES: Record<string, string> = {
   resume: '재개',
   pattern: '패턴',
   evolve: '진화',
+  work: '작업',
 }
 
 program
@@ -566,6 +568,19 @@ program
   .alias('브리핑')
   .description('프로젝트 상태 요약 보고서 생성 (.vhk/brief.md)')
   .action(async () => { await brief() })
+
+// AI 작업 세션 이어받기/인수인계 — 상태 수집 + Claude 에게 줄 프롬프트를 클립보드에 복사.
+const workCmd = program
+  .command('work')
+  .alias('작업')
+  .description('AI 작업 시작/이어하기 — 시작 프롬프트 생성 후 클립보드 복사')
+  .action(async () => { await work() })
+
+workCmd
+  .command('handoff')
+  .alias('인수인계')
+  .description('작업 중단 정리 — 인수인계 프롬프트 생성 후 클립보드 복사')
+  .action(async () => { await workHandoff() })
 
 const goalCmd = program
   .command('goal')

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -47,6 +47,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'mission', '미션',
   'pattern', '패턴',
   'evolve', '진화',
+  'work', '작업',
   'help',
 ])
 

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,45 @@
+import { spawnSync } from 'node:child_process'
+
+// 외부 의존성 없이 OS 기본 도구로 클립보드에 복사한다.
+// 성공 시 true, 어떤 경로도 실패하면 false (호출자가 화면/파일 폴백 책임).
+// safeExecFile(exec.ts) 은 stdin(input) 을 지원하지 않으므로 spawnSync 를 직접 쓴다.
+export function copyToClipboard(text: string): boolean {
+  try {
+    if (process.platform === 'win32') return copyWin32(text)
+    if (process.platform === 'darwin') return runWithInput('pbcopy', [], text)
+    // linux/기타 — 사용 가능한 첫 도구 (Wayland → X11 순)
+    return (
+      runWithInput('wl-copy', [], text) ||
+      runWithInput('xclip', ['-selection', 'clipboard'], text) ||
+      runWithInput('xsel', ['--clipboard', '--input'], text)
+    )
+  } catch {
+    return false
+  }
+}
+
+// Windows: clip.exe 는 입력을 콘솔 코드페이지로 해석해 한글이 깨지기 쉽다.
+// 대신 PowerShell Set-Clipboard 에 텍스트를 base64(UTF-8)로 안전 전달한다.
+// base64 는 ASCII 라 따옴표·개행 인자 오염이 없고, 한글은 UTF-8 바이트로 보존된다.
+// base64 는 -Command 인자가 아니라 stdin 으로 흘려보낸다 — 명령줄 32K 길이 한계를 우회
+// (변경 파일 수백 개로 프롬프트가 커져도 복사 성공). Set-Clipboard 는 Windows PowerShell 5.1+ 내장.
+function copyWin32(text: string): boolean {
+  const b64 = Buffer.from(text, 'utf8').toString('base64')
+  const psScript =
+    '$b=[Console]::In.ReadToEnd();' +
+    '$t=[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($b));' +
+    'Set-Clipboard -Value $t'
+  const r = spawnSync(
+    'powershell',
+    ['-NoProfile', '-NonInteractive', '-Command', psScript],
+    { input: b64, encoding: 'utf8', windowsHide: true }
+  )
+  return r.status === 0 && !r.error
+}
+
+// stdin 으로 텍스트를 흘려보내는 클립보드 도구(pbcopy/xclip/xsel/wl-copy) 호출.
+// 명령이 없으면(ENOENT) r.error 가 설정된다 → status 0 + error 없음만 성공으로 본다.
+function runWithInput(cmd: string, args: string[], input: string): boolean {
+  const r = spawnSync(cmd, args, { input, encoding: 'utf8' })
+  return r.status === 0 && !r.error
+}

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -18,6 +18,7 @@ export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
   mission: ['set', 'check', 'clear'],
   pattern: ['detect', 'list', 'dismiss'],
   evolve: ['suggest', 'list', 'apply', 'reject', 'undo'],
+  work: ['handoff'],
 }
 
 /** 한국어 별칭 → 영문 컨테이너 명령. 별칭도 같은 서브커맨드 집합을 공유한다. */
@@ -33,4 +34,5 @@ export const CONTAINER_ALIASES: Record<string, string> = {
   미션: 'mission',
   패턴: 'pattern',
   진화: 'evolve',
+  작업: 'work',
 }

--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -40,6 +40,7 @@ export type NlpCommand =
   | 'mission'
   | 'pattern'
   | 'evolve'
+  | 'work'
 
 export type NlpConfidence = 'high' | 'low'
 
@@ -70,6 +71,7 @@ export const NLP_KEYWORDS: Partial<Record<NlpCommand, readonly string[]>> = {
   undo: ['되돌려', '되돌리기', '취소', '원래대로', '롤백', '리셋', 'reset', 'rollback'],
   status: ['상태', '현황', '어떻게', '어때', '지금'],
   diff: ['변경', '바뀐', '뭐바뀜', '바뀌었', '차이', '달라진', '수정된'],
+  work: ['이어서', '이어하기', 'work'],
 }
 
 function matchesKeywords(text: string, command: NlpCommand): boolean {
@@ -426,6 +428,20 @@ const RULES: NlpRule[] = [
     confidence: 'high',
     args: ['sync'],
     test: t => /(게이트|목표).*(스크립트|동기화)|체크\s*스크립트\s*(생성|만들)/.test(t),
+  },
+  // work — handoff(인수인계)를 먼저 평가(더 구체적), 그다음 작업 시작/이어하기.
+  {
+    command: 'work',
+    explanation: '작업 중단 정리 프롬프트 (vhk work handoff)',
+    confidence: 'high',
+    args: ['handoff'],
+    test: t => /인수인계|핸드오프|handoff|작업\s*(넘기|넘겨|전달|마무리)|중단\s*정리/.test(t),
+  },
+  {
+    command: 'work',
+    explanation: '작업 시작/이어하기 프롬프트 (vhk work)',
+    confidence: 'high',
+    test: t => matchesKeywords(t, 'work') || /작업\s*(시작|이어|이어서|계속)|이어서\s*(작업|하자|할래)|^work$/.test(t),
   },
 ]
 

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -29,6 +29,7 @@ import { update } from '../commands/update.js'
 import { context, contextShow } from '../commands/context.js'
 import { memoryList, memoryMigrate } from '../commands/memory.js'
 import { brief } from '../commands/brief.js'
+import { work, workHandoff } from '../commands/work.js'
 import { start } from '../commands/start.js'
 import { goalCheck, goalDone, goalList, goalNext, goalSync } from '../commands/goal.js'
 import { cloudPush, cloudPull } from '../commands/cloud.js'
@@ -142,6 +143,10 @@ export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<
       return patternList()
     case 'evolve':
       return evolveList()
+    case 'work': {
+      if (route.args?.[0] === 'handoff') return workHandoff()
+      return work()
+    }
   }
 }
 

--- a/tests/clipboard.test.ts
+++ b/tests/clipboard.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// spawnSync 를 mock — 실제 클립보드 도구 spawn 없이 분기만 검증.
+const mockSpawnSync = vi.fn()
+vi.mock('node:child_process', () => ({
+  spawnSync: (...a: unknown[]) => mockSpawnSync(...a),
+}))
+
+const origPlatform = process.platform
+function setPlatform(p: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: p, configurable: true })
+}
+
+describe('copyToClipboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  afterEach(() => {
+    setPlatform(origPlatform)
+  })
+
+  it('win32 — Set-Clipboard 성공(status 0) 시 true', async () => {
+    setPlatform('win32')
+    mockSpawnSync.mockReturnValue({ status: 0, error: undefined })
+    const { copyToClipboard } = await import('../src/lib/clipboard.js')
+    expect(copyToClipboard('안녕하세요 hello')).toBe(true)
+    // powershell 로 호출됐는지 + base64 인자 전달 확인
+    expect(mockSpawnSync).toHaveBeenCalledTimes(1)
+    expect(mockSpawnSync.mock.calls[0][0]).toBe('powershell')
+  })
+
+  it('win32 — 비0 exit 시 false', async () => {
+    setPlatform('win32')
+    mockSpawnSync.mockReturnValue({ status: 1, error: undefined })
+    const { copyToClipboard } = await import('../src/lib/clipboard.js')
+    expect(copyToClipboard('x')).toBe(false)
+  })
+
+  it('win32 — 명령 없음(error 설정) 시 false', async () => {
+    setPlatform('win32')
+    mockSpawnSync.mockReturnValue({ status: null, error: new Error('ENOENT') })
+    const { copyToClipboard } = await import('../src/lib/clipboard.js')
+    expect(copyToClipboard('x')).toBe(false)
+  })
+
+  it('linux — 첫 도구 실패 시 다음 도구를 시도', async () => {
+    setPlatform('linux')
+    mockSpawnSync
+      .mockReturnValueOnce({ status: 1, error: new Error('no wl-copy') }) // wl-copy 실패
+      .mockReturnValueOnce({ status: 0, error: undefined }) // xclip 성공
+    const { copyToClipboard } = await import('../src/lib/clipboard.js')
+    expect(copyToClipboard('x')).toBe(true)
+    expect(mockSpawnSync).toHaveBeenCalledTimes(2)
+  })
+
+  it('spawnSync 가 throw 해도 크래시 없이 false', async () => {
+    setPlatform('win32')
+    mockSpawnSync.mockImplementation(() => {
+      throw new Error('boom')
+    })
+    const { copyToClipboard } = await import('../src/lib/clipboard.js')
+    expect(copyToClipboard('x')).toBe(false)
+  })
+})

--- a/tests/work.test.ts
+++ b/tests/work.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// 클립보드는 mock — 복사 호출 여부와 전달된 프롬프트 내용만 검증.
+const mockCopy = vi.fn(() => true)
+vi.mock('../src/lib/clipboard.js', () => ({
+  copyToClipboard: (...a: unknown[]) => mockCopy(...a),
+}))
+
+// git status 는 safeExecFile mock 으로 고정. work 가 commit/stash/reset 을 부르지 않음도 검증.
+const mockSafeExecFile = vi.fn(() => ({ ok: true, out: ' M src/x.ts' }))
+vi.mock('../src/lib/exec.js', () => ({
+  safeExecFile: (...a: unknown[]) => mockSafeExecFile(...a),
+}))
+
+// context() 는 실제 파일 스캔/생성 → mock. work 흐름엔 호출 여부만 중요.
+const mockContext = vi.fn(async () => {})
+vi.mock('../src/commands/context.js', () => ({
+  context: (...a: unknown[]) => mockContext(...a),
+}))
+
+function tmpProject(label: string): string {
+  const dir = join(
+    tmpdir(),
+    `vhk-work-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  )
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'CLAUDE.md'), '# 기록 규칙 (vhk)\n', 'utf-8')
+  return dir
+}
+
+function makeGoal(dir: string, id: number, status: string): void {
+  mkdirSync(join(dir, 'goals'), { recursive: true })
+  writeFileSync(
+    join(dir, 'goals', `${id}-test.md`),
+    `---\nvhk_format: 1\ntype: goal\nid: ${id}\ntitle: 작업기능\nstatus: ${status}\npriority: P0\n---\nbody\n`,
+    'utf-8'
+  )
+}
+
+describe('work — 프롬프트 빌더', () => {
+  it('buildStartPrompt — 규칙 우선순위·안전 지시·git 상태 포함', async () => {
+    const { buildStartPrompt } = await import('../src/commands/work.js')
+    const p = buildStartPrompt(' M a.ts', 'Goal 1 — x')
+    expect(p).toContain('CLAUDE.md 를 1순위')
+    expect(p).toContain('AGENTS.md 는 Codex')
+    expect(p).toContain('3단계 이하')
+    expect(p).toContain('승인하기 전에는')
+    expect(p).toContain(' M a.ts')
+    expect(p).toContain('Goal 1 — x')
+  })
+
+  it('buildStartPrompt — git 비면 "(변경 없음)"', async () => {
+    const { buildStartPrompt } = await import('../src/commands/work.js')
+    expect(buildStartPrompt('', '정의된 goal 없음')).toContain('(변경 없음)')
+  })
+
+  it('buildHandoffPrompt — 인수인계 요구 항목 전부 포함', async () => {
+    const { buildHandoffPrompt } = await import('../src/commands/work.js')
+    const p = buildHandoffPrompt(' M a.ts')
+    expect(p).toContain('완료된 일 / 미완료된 일')
+    expect(p).toContain('미실행')
+    expect(p).toContain('docs/state/next-task.md')
+    expect(p).toContain('커밋 가능한 상태')
+    expect(p).toContain('vhk goal done 실행 금지')
+    expect(p).toContain('git commit')
+  })
+})
+
+describe('work / workHandoff — 동작·안전장치', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.clearAllMocks()
+    mockCopy.mockReturnValue(true)
+    mockSafeExecFile.mockReturnValue({ ok: true, out: ' M src/x.ts' })
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+  })
+
+  it('work — 시작 프롬프트를 클립보드에 복사', async () => {
+    const dir = tmpProject('start')
+    makeGoal(dir, 1, 'IN_PROGRESS')
+    process.chdir(dir)
+    try {
+      const { work } = await import('../src/commands/work.js')
+      await work()
+      expect(mockCopy).toHaveBeenCalledTimes(1)
+      expect(String(mockCopy.mock.calls[0][0])).toContain('CLAUDE.md 를 1순위')
+      expect(String(mockCopy.mock.calls[0][0])).toContain('Goal 1 — 작업기능')
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('work — HARD_STOP 활성 시 중단(클립보드 미호출)', async () => {
+    const dir = tmpProject('hardstop')
+    mkdirSync(join(dir, '.vhk'), { recursive: true })
+    writeFileSync(join(dir, '.vhk', 'HARD_STOP'), '2026-06-05\nauto: test\n', 'utf-8')
+    process.chdir(dir)
+    try {
+      const { work } = await import('../src/commands/work.js')
+      await work()
+      expect(mockCopy).not.toHaveBeenCalled()
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('workHandoff — 인수인계 프롬프트 복사 + commit/stash/reset 미호출', async () => {
+    const dir = tmpProject('handoff')
+    process.chdir(dir)
+    try {
+      const { workHandoff } = await import('../src/commands/work.js')
+      await workHandoff()
+      expect(mockCopy).toHaveBeenCalledTimes(1)
+      expect(String(mockCopy.mock.calls[0][0])).toContain('완료된 일 / 미완료된 일')
+      // 안전: safeExecFile 은 git status 만 — 변경 파괴 명령 인자로 호출 안 됨
+      for (const call of mockSafeExecFile.mock.calls) {
+        const args = (call[1] ?? []) as string[]
+        expect(args).not.toContain('commit')
+        expect(args).not.toContain('stash')
+        expect(args).not.toContain('reset')
+      }
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('work — 클립보드 실패해도 .vhk/work-prompt.md 사본 저장(폴백)', async () => {
+    const dir = tmpProject('fallback')
+    makeGoal(dir, 0, 'NOT_STARTED')
+    mockCopy.mockReturnValue(false)
+    process.chdir(dir)
+    try {
+      const { existsSync } = await import('node:fs')
+      const { work } = await import('../src/commands/work.js')
+      await work()
+      expect(existsSync(join(dir, '.vhk', 'work-prompt.md'))).toBe(true)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
﻿## 무엇

Claude CLI/Claude Code 가 컴퓨터 재시작으로 세션 대화 기억이 휘발돼도, repo 파일(CLAUDE.md·next-task.md)과 VHK 상태로 빠르게 이어가도록 하는 진입점 2개 추가. CLI 는 상태 수집 + Claude 에게 줄 프롬프트 준비만, 판단·개발·커밋은 Claude.

- `vhk work` — 작업 시작/이어하기. git status + active goal + `.vhk/context.md` 갱신 → 시작 프롬프트 생성·클립보드 복사.
- `vhk work handoff` — 중단 정리. 완료/미완료 분리·테스트 기록·next-task 갱신·커밋 판단 요청 인수인계 프롬프트 생성·복사.

별칭 `작업`/`인수인계`, 자연어 `이어서 작업`·`이어하기`·`인수인계`. 1차 CLI 전용(MCP 2차).

## 왜

비개발자 사용자가 Claude Code 를 메인 엔진으로 쓰는데, 세션 기억 휘발 시 "어디까지 했지"를 매번 설명하는 비효율. 흩어진 상태를 한 번에 모아 Claude 에게 줄 프롬프트로 만드는 진입점을 채움. (`vhk resume --confirm` 은 HARD_STOP 해제 전용이라 충돌 회피 → `vhk work`.)

## 신규 파일

- `src/commands/work.ts` — work()/workHandoff() + 프롬프트 빌더. 재사용 헬퍼 조합(state-files·goal·context·exec·next-step).
- `src/lib/clipboard.ts` — 외부 의존성 0. Windows `Set-Clipboard` 에 base64(UTF-8) stdin 경유(한글 보존 + 명령줄 32K 우회), mac/linux 폴백. 실패 시 `.vhk/work-prompt.md` 사본 + 화면 출력.
- `tests/work.test.ts` + `tests/clipboard.test.ts`.
- `docs/log/2026-06-05-vhk-work-session-handoff.md` — 작업 로그.

## 명령 등록 정합 (drift 가드 통과)

`src/index.ts` · `src/lib/nlp-router.ts`(+`nlp-run.ts`) · `src/lib/command-registry.ts` · `src/lib/cli-args.ts` · `src/i18n/ko.ts`.

## 안전 원칙

- `.vhk/HARD_STOP` 활성 시 즉시 중단.
- git `status --short` 읽기만 — commit/stash/reset/add/checkout/clean 0.
- 자동 커밋·자동 `vhk goal done` 0. 완료 판정은 Claude.

## 검증

- 타입체크 0 · 빌드 OK · 테스트 868 pass (852 + 신규 16).
- E2E: work/handoff 클립보드 복사 + Get-Clipboard 한글 보존 확인. 자연어 3종 라우팅.
- 적대 리뷰: 심각 버그 0. LOW 2건(clipboard 32K → stdin 우회, NLP dead keyword → matchesKeywords 추가) 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
