### PR TITLE
feat(work): vhk work / work handoff 세션 의례 + CLAUDE.md 2구역 재설계

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,93 +1,92 @@
 ---
 id: claude-md-vhk
-date: 2026-05-28
-tags: [process, documentation]
+tags: [process, constitution]
 ---
 
-# 기록 규칙 (vhk)
+# CLAUDE.md — vhk 헌법 + 현재 상태
 
-> 이 파일은 기록/운영 전용. 코딩/디자인 → .cursorrules 참조.
-> See also: AGENTS.md
+> 📖 **읽는 법 (필수):** 이 파일은 두 구역이다.
+> 1) 위 = 🔒 영구 헌법 (절대 수정 금지)
+> 2) 맨 아래 = ✏️ LIVE 현재 상태 (매 세션 갱신, 여기만 수정)
+> **반드시 맨 아래 ✏️ LIVE 구역까지 읽고 "다음 할 일"에서 이어간다. 스킵 금지.**
+> 사실 SoT: 버전·테스트 = package.json·CHANGELOG / 상세 상태 = docs/state/.
 
-## 프로젝트 정보
+════════════ 🔒 영구 헌법 (수정 금지) ════════════
 
-- **레포:** <https://github.com/byh3071-cpu/vhk> (public)
-- **npm:** @byh3071/vhk (public, scoped)
-- **버전:** v2.3.2 (npm latest. package.json + MCP SERVER_VERSION 정합, getVhkVersion 동적)
-- **MCP tool:** 29 (Goal 0 24 + `learn` v2.0 쓰기 도구 + `pattern-detect` + `pattern-list` v2.1 + `evolve-suggest` + `evolve-list` v2.2)
-- **테스트:** 868 pass (vitest)
-- **패키지 매니저:** pnpm
+## 언어·소통 규칙
+- 응답은 무조건 한국어. 영어는 기술 용어(commit·MCP·build 등)에만.
+- 사용자는 비개발자 → 두괄식(결론 먼저) + 전문용어는 쉬운 말로 풀이.
+- 결론 → 이유 → 다음 행동 순, 짧게.
 
-## 현재 상태
+## 프로젝트 좌표 (포인터)
+- 레포: github.com/byh3071-cpu/vhk (public) · npm: @byh3071/vhk
+- 패키지 매니저: pnpm (npm 아님)
+- 코딩·디자인 규칙 → .cursorrules / 에이전트 루프 → AGENTS.md / 명령 사용법 → COMMANDS.md
+- 단계 미션 → goals/<n>-<name>.md · 공통 게이트 → goals/_meta.md
+- 상태 SoT → docs/state/next-task.md · blockers.md
 
-- **Phase:** 등록 goal 0~20 전부 DONE. CLAUDE.md sentinel marker(#117)·pattern dismiss/detect 누수(#118) 픽스 + publish 브랜치/clean 가드(#119) main 머지, **v2.3.2 발행 완료**. npm 2.3.1 은 오발행(`feat/goal-20-evolve` 서 발행 → 픽스 누락) → deprecate 처리됨(unpublish 금지·immutable).
-- **블로커:** 없음
-- **다음 액션:** 없음(vhk 발행 라인 종료). 별개 라인 = Goal 19 도그푸딩 → 20(다른 세션). ⚠️ publish 는 항상 `main` 에서만(가드 #119 가 feature 브랜치/미커밋 발행 차단).
-- **진행 중(미발행):** `vhk work` / `vhk work handoff` — AI 세션 이어받기/인수인계 기능(`src/commands/work.ts` + `src/lib/clipboard.ts`). CLI는 수집·프롬프트만, 커밋/done 0. [Unreleased] 상태, 버전 범프·발행 대기.
-- **마지막 업데이트:** 2026-06-05
+## 세션 시작 의례
+1. `vhk work` 실행 → 상태 수집 + 시작 프롬프트를 클립보드에 복사 (HARD_STOP 자동 확인)
+2. `claude` 실행 후 Ctrl+V 붙여넣기
+3. Claude는 이 파일(✏️ LIVE 포함)을 1순위로 읽고 → AGENTS.md는 참고만 →
+   docs/state/next-task.md·.vhk/context.md 기준으로 이어서 작업
 
-> **기억 SoT (v2):** 교훈·결정·실패·성공은 `vhk memory`(memory v2 4버킷, `vhk learn`→`failures.lesson`). `docs/state/learnings.md` 는 v2 마이그레이션으로 흡수·신규기록 중단(분리 폐지).
+## 작업 단위 의례
+- 1 iteration = active goal 하나 + 작은 commit 하나 + 게이트 통과(or 정직한 블로커)
+- 범위 계약: `vhk mission set` → `vhk mission check`
+- 완료 주장 전 `vhk review`(거짓완료 자기검증)
+- 막히면(3 cycle 진전 없음): `vhk blocker "<증상>"` → 다음 태스크
 
-## 코딩 컨벤션
+## 세션 중단/종료 의례 (🔒 dev log = 영구·삭제 금지)
+- `vhk work handoff` 실행 → 인수인계 프롬프트 클립보드 복사 →
+  Claude가 완료/미완 정리 + next-task.md 갱신 + 커밋 가능 여부 판단
+- dev log `docs/log/YYYY-MM-DD-<작업명>.md` = append-only. 추가만, 수정·삭제 금지.
+- 미완으로 꺼도 next-task.md에 "다음 할 일" 반드시 남김
 
-- `execSync` 신규 사용 금지 → `safeExecFile` 사용
-- 모든 커맨드 파일에 `printNextStep()` 패턴 사용
-- 한국어 별칭 `.alias()` + `ko.ts` 메시지 필수
-- 자연어 라우터 키워드 추가 필수
+## 기록물 위치
+- 의사결정 → docs/adr/ · 에러 → docs/troubleshooting/ · 배움 → docs/til.md · 설계 → docs/rfc/
+- 코드 변경이 동작/사용법을 바꾸면 README만 같이 갱신 (이 파일은 갱신 대상 아님)
 
-## MCP 모드 규칙
-
-- handler 내부 `process.exit()` 금지
-- MCP 모드에서 inquirer 프롬프트 호출 금지 (TTY 없음)
-- 신규 handler는 `runVhkCli(args, headline)` 헬퍼 패턴 사용 (`src/mcp/server.ts`)
-- 대화형 커맨드 (gate/init/design palette/theme) 는 MCP 제외
-- 기존 tool API 시그니처 변경 금지 (GA 안정성)
-
-## ADR
-
-기술/라이브러리 선택 시 docs/adr/ADR-{번호}-{제목}.md 생성.
-
-## 작업 로그
-
-세션 종료 시 docs/log/YYYY-MM-DD-{작업명}.md 생성.
-
-## 트러블슈팅
-
-에러 해결 시 docs/troubleshooting/TS-{번호}-{증상}.md
-
-## TIL
-
-새로 배운 개념 → docs/til.md 한 줄 추가
-
-## /done 커맨드
-
-세션 종료 → /done → 요약 자동 생성 → docs/log/ 저장
-
-## 종료 전 체크리스트
-
-1. ADR 2. 작업 로그 3. 트러블슈팅 4. TIL 5. /done
+## 기억 SoT
+- 교훈·결정·실패·성공 = `vhk memory`(4버킷) / `vhk learn`.
+- learnings.md는 v2로 흡수·동결 → 신규 기록 금지.
 
 ## Safety — HARD_STOP
+- 작업 시작 시 `.vhk/HARD_STOP` 확인 → 있으면 즉시 중단 (vhk work가 자동 체크)
+  PowerShell: `if (Test-Path .vhk/HARD_STOP) { Write-Host '🛑 HARD STOP'; exit 1 }`
+- 자동 생성: 블로커 3개 누적 / 토큰 예산 초과
+- 해제: `vhk resume --confirm` (사람만, 자동 호출 금지)
 
-- 매 작업 시작 시: `.vhk/HARD_STOP` 파일 존재 여부 확인. 존재하면 모든 자동화 즉시 중단.
-  - PowerShell: `if (Test-Path .vhk/HARD_STOP) { Write-Host '🛑 HARD STOP'; exit 1 }`
-  - bash: `[ -f .vhk/HARD_STOP ] && echo "🛑 HARD STOP" && exit 1`
-- 자동 생성 조건: 블로커 3개 누적 (`docs/state/blockers.md`) / 토큰 예산 초과 감지
-- 해제: `vhk resume --confirm` 만 가능 (사람이 직접 실행, 자동 호출 금지)
-- 게이트 스크립트 (`scripts/check-*.sh`) 는 시작 시 이 파일을 검사한다
-- `.vhk/HARD_STOP` 자체는 `.gitignore` 에 등록되어 로컬 전용 신호로 동작
+## Stability Gates
+- 작업 전 게이트 통과 필수: `pnpm build; pnpm test`
+  (PowerShell은 `&&` 미지원 → 반드시 `;` 로 연결)
+- 게이트 실패 시 done 금지
+- publish는 항상 main에서만 (가드 #119가 feature 브랜치/미커밋 발행 차단)
+- 새 이벤트 리스너 → 해제 로직 짝으로 / 새 캐시(Map·Set) → TTL 또는 maxSize 필수
 
-## Goals / State 체계 (v1.1+)
+## Goals / State 체계
+- 단계 미션 = goals/<n>-<name>.md (frontmatter + 표준 섹션)
+- 공통 게이트 = goals/_meta.md + scripts/check-meta.sh
+- 상태 SoT = docs/state/next-task.md · blockers.md
 
-- 단계별 미션은 `goals/<n>-<name>.md` (YAML frontmatter + 표준 섹션)
-- 공통 게이트는 `goals/_meta.md` + `scripts/check-meta.sh`
-- 현재 상태 SoT 는 `docs/state/next-task.md` / `blockers.md` (교훈은 v2 부터 `vhk memory` failures.lesson — `learnings.md` 는 흡수·동결)
-- 자세한 규약은 `goals/_meta.md` 와 `goals/0-mcp-full-coverage.md` 참조
+## Forbidden
+- 🔒 영구 구역 수정 / 상태값을 영구 구역에 박제 금지 (버전 줄은 LIVE 예외 ↓)
+- dev log·blockers 과거 항목 수정·삭제 금지 (append-only)
+- 게이트 실패에 done / `vhk resume` 자동 호출 금지
+- 코딩·디자인 규칙 여기 적기 금지 → .cursorrules
+- AGENTS.md·.cursorrules 직접 편집 금지 → RULES.md 단일소스 + `vhk sync` 로만
 
-## Stability Gates (v1.3.1+)
+════════════ ✏️ LIVE — 현재 상태 (매 세션 갱신 · 여기만 수정) ════════════
 
-- 모든 PR/작업 전: `npm run build && npm test` 통과 필수
-- MCP 핸들러 수정 시: 시크릿 가드 체크리스트 확인
-- 새 이벤트 리스너 등록 시: 해제 로직 반드시 짝으로 작성
-- 캐시(Map/Set) 신규 추가 시: TTL 또는 maxSize 필수
-- 문서 관련 코드 변경 시: README/CLAUDE.md 동시 업데이트
+> 세션 시작: 이 구역 읽고 "다음 할 일"부터.
+> 세션 종료: 마지막 갱신·버전·Phase·다음 할 일 갱신. (위 🔒 구역은 절대 건드리지 마.)
+> ⚠️ 아래 `**버전:**` 줄은 CI(version-sync.test.ts)가 강제 — 형식 `**버전:** vX.Y.Z` 유지, 릴리즈마다 package.json 따라 갱신.
+
+**마지막 갱신:** 2026-06-05
+- **버전:** v2.3.2 (npm latest) — 사실 확인은 package.json·CHANGELOG
+- **테스트:** 868 pass · **MCP tools:** 29
+- **Phase:** 등록 goal 0~20 전부 DONE · v2.3.2 발행 완료 (발행 라인 종료)
+- **블로커:** 없음
+- **진행 중(미발행):** `vhk work` / `vhk work handoff` (feat/vhk-work-session-handoff 브랜치, [Unreleased] · 버전 범프·발행 대기)
+- **다음 할 일:** 뒷단 Goal 21~24 (launch·content·sell·ops) → docs/state/roadmap.md
+- **주의:** publish는 main에서만(#119)

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -1,12 +1,20 @@
-# Next Task
+# 다음 작업 (next-task)
 
-_Updated 2026-06-04 — Goal 19(vhk pattern) DONE + npm v2.1.0 발행 완료. Goal 20 설계 spike 등록됨._
+> "지금 무엇부터"의 상태 SoT. 버전·테스트 등 사실값은 package.json·CHANGELOG가 SoT.
 
-```
-✅ ALL REGISTERED GOALS DONE (0~19)
+**갱신:** 2026-06-05
+**Phase:** v2.3.2 발행 완료 — 앞단(검증→배포) 발행 라인 종료.
 
-다음 = Goal 20 — vhk evolve (v2.2.0 예정)
-  status: 구현 진행 중 (feat/goal-20-evolve)
-  의존: Goal 19 patterns[] 안정화 완료 (v2.1.0)
-  이후: publish v2.2.0 (사람 2FA)
-```
+## 다음 할 일
+- 앞단(코어 CLI) 추가 액션 없음.
+- 진행 중(미발행): `vhk work` / `vhk work handoff`
+  - 브랜치: feat/vhk-work-session-handoff ([Unreleased])
+  - 다음: 버전 범프 → main 머지 → 발행
+- 뒷단 로드맵 = Goal 21~24 (launch·content·sell·ops) → docs/state/roadmap.md 참조
+
+## 블로커
+- 없음
+
+## 주의
+- publish는 항상 main에서만 (가드 #119)
+- active goal 은 goals/ 기준 동적 계산 (vhk work / vhk goal next)


### PR DESCRIPTION
## 요약

세션 시작/인수인계를 자동화하는 `vhk work` / `vhk work handoff` 커맨드 추가 + 프롬젝트 운영 문서(CLAUDE.md / next-task.md) 정리.

## 변경

### 기능
- `vhk work` — 상태 수집 + 세션 시작 프롬프트를 클립보드로 복사 (HARD_STOP 자동 확인)
- `vhk work handoff` — 인수인계 프롬프트 복사 (완료/미완 정리 + next-task 갱신 안내)
- CLI는 수집·프롬프트만 생성. git 문제·goal done 자동 수행 없음 (읽기 전용)
- 신규 테스트 16개 추가 → 총 868 pass

### 문서
- **CLAUDE.md** — 🔒영구 헌법 + ✏️LIVE 현재상태 2구역 재설계. 기존 혼재 구조의 모순 5개 정리 (npm→pnpm / PowerShell `&&`→`;` / `/done` 유령 제거 / 문서동시갱신→README만 / frontmatter date 삭제). version-sync CI 용 `**버전:**` 줄 유지.
- **docs/state/next-task.md** — v2.1/Goal20 스테일 → v2.3.2 발행라인 종료 + 뒷단 Goal21~24 포인터로 현행화

## 발행 메모
- 이 PR 머지 후 **main에서 `vhk publish`** 로 버전 범프(신규 기능→minor 2.4.0 제안) → build·test → npm publish → tag push.
- tag push 시 release.yml 이 CHANGELOG 서션으로 GitHub Release 자동 생성.

## 알려진 문서 격차(별도 작업)
- README / COMMANDS.md 에 `vhk work` 미반영 (스테일)
- README 버전·MCP tool 수(25) 스테일 — 실제 29