### PR TITLE
chore(rules): RULES.md 단일소스 부활 + CLAUDE.md sync 마커 삽입 (A안)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ tags: [process, constitution]
 ## 프로젝트 좌표 (포인터)
 - 레포: github.com/byh3071-cpu/vhk (public) · npm: @byh3071/vhk
 - 패키지 매니저: pnpm (npm 아님)
-- 코딩·디자인 규칙 → .cursorrules / 에이전트 루프 → AGENTS.md / 명령 사용법 → COMMANDS.md
+- 규칙 단일소스 → RULES.md → (vhk sync) → .cursorrules·AGENTS.md 등 / 명령 사용법 → COMMANDS.md
 - 단계 미션 → goals/<n>-<name>.md · 공통 게이트 → goals/_meta.md
 - 상태 SoT → docs/state/next-task.md · blockers.md
 
@@ -43,13 +43,17 @@ tags: [process, constitution]
 - dev log `docs/log/YYYY-MM-DD-<작업명>.md` = append-only. 추가만, 수정·삭제 금지.
 - 미완으로 꺼도 next-task.md에 "다음 할 일" 반드시 남김
 
-## 기록물 위치
-- 의사결정 → docs/adr/ · 에러 → docs/troubleshooting/ · 배움 → docs/til.md · 설계 → docs/rfc/
-- 코드 변경이 동작/사용법을 바꾸면 README만 같이 갱신 (이 파일은 갱신 대상 아님)
+<!-- vhk:rules:start -->
+> ⚡ 아래 규칙 섹션은 RULES.md에서 자동 생성됨 (vhk sync). 직접 수정 금지.
 
-## 기억 SoT
-- 교훈·결정·실패·성공 = `vhk memory`(4버킷) / `vhk learn`.
-- learnings.md는 v2로 흡수·동결 → 신규 기록 금지.
+## 기록 규칙
+- 의사결정 → docs/adr/ · 에러 → docs/troubleshooting/ · 배움 → docs/til.md · 설계 → docs/rfc/
+- dev log `docs/log/YYYY-MM-DD-<작업명>.md` = append-only (추가만, 수정·삭제 금지)
+- 코드 변경이 동작/사용법을 바꾸면 README 만 같이 갱신 (CLAUDE.md 는 갱신 대상 아님)
+- 교훈·결정·실패·성공 = `vhk memory`(4버킷) / `vhk learn`. learnings.md 는 v2 흡수·동결 → 신규 기록 금지.
+- 상태 SoT = docs/state/next-task.md · blockers.md (append-only)
+
+<!-- vhk:rules:end -->
 
 ## Safety — HARD_STOP
 - 작업 시작 시 `.vhk/HARD_STOP` 확인 → 있으면 즉시 중단 (vhk work가 자동 체크)
@@ -73,7 +77,7 @@ tags: [process, constitution]
 - 🔒 영구 구역 수정 / 상태값을 영구 구역에 박제 금지 (버전 줄은 LIVE 예외 ↓)
 - dev log·blockers 과거 항목 수정·삭제 금지 (append-only)
 - 게이트 실패에 done / `vhk resume` 자동 호출 금지
-- 코딩·디자인 규칙 여기 적기 금지 → .cursorrules
+- 코딩·디자인 규칙 여기 적기 금지 → RULES.md
 - AGENTS.md·.cursorrules 직접 편집 금지 → RULES.md 단일소스 + `vhk sync` 로만
 
 ════════════ ✏️ LIVE — 현재 상태 (매 세션 갱신 · 여기만 수정) ════════════
@@ -85,8 +89,8 @@ tags: [process, constitution]
 **마지막 갱신:** 2026-06-05
 - **버전:** v2.3.2 (npm latest) — 사실 확인은 package.json·CHANGELOG
 - **테스트:** 868 pass · **MCP tools:** 29
-- **Phase:** 등록 goal 0~20 전부 DONE · v2.3.2 발행 완료 (발행 라인 종료)
+- **Phase:** 등록 goal 0~20 전부 DONE · v2.3.2 발행 완료
 - **블로커:** 없음
-- **진행 중(미발행):** `vhk work` / `vhk work handoff` (feat/vhk-work-session-handoff 브랜치, [Unreleased] · 버전 범프·발행 대기)
-- **다음 할 일:** 뒷단 Goal 21~24 (launch·content·sell·ops) → docs/state/roadmap.md
+- **진행 중(미발행):** `vhk work` / `vhk work handoff` (main 병합 완료 #122 · 버전 범프·발행 대기 = `vhk publish`)
+- **다음 할 일:** RULES.md 단일소스 부활 후 `vhk sync` 1회 실행 → 그다음 뒷단 Goal 21~24 (launch·content·sell·ops)
 - **주의:** publish는 main에서만(#119)

--- a/RULES.md
+++ b/RULES.md
@@ -1,0 +1,61 @@
+# vhk — 프로젝트 규칙 단일 소스 (Single Source of Truth)
+
+> ⚡ 이 파일이 모든 규칙의 원본이다. 규칙 변경은 **여기서만** 하고 `vhk sync` 로 전파한다.
+> 전파 대상: .cursorrules · .windsurfrules · .github/copilot-instructions.md · .agents/rules/vhk-rules.md · AGENTS.md · GEMINI.md · .clinerules/vhk-rules.md · CLAUDE.md(기록 규칙 영역)
+> 기록/운영 의례·현재 상태는 CLAUDE.md 가, 명령 사용법은 COMMANDS.md 가 담당.
+
+## 서문
+
+- 한 줄 설명: 바이브코딩 풀사이클 CLI
+- 레포: https://github.com/byh3071-cpu/vhk (public)
+- npm: @byh3071/vhk
+- 패키지 매니저: pnpm (npm 아님)
+
+## 기술 스택
+
+> 변경 시 ADR(docs/adr/) 필수.
+
+- Node.js + TypeScript (strict)
+- commander (CLI) + inquirer (인터랙티브) + chalk (출력)
+- tsup (빌드) + vitest (테스트)
+- @modelcontextprotocol/sdk + zod (MCP)
+- pnpm (패키지 매니저)
+- src/i18n/ko.ts (한국어 i18n)
+- src/nlp-router.ts (자연어 라우팅)
+
+## 코딩 규칙
+
+- TypeScript strict (any 금지)
+- try-catch 필수, 빈 catch 금지
+- console.log 프로덕션 제거
+- `execSync` 신규 사용 금지 → `safeExecFile` 사용
+- 모든 커맨드 파일에 `printNextStep()` 패턴 사용
+- 한국어 별칭 `.alias()` + `ko.ts` 메시지 필수
+- 신규 커맨드 시 `nlp-router.ts` 키워드 추가 필수
+
+### MCP 규칙
+
+- handler 내부 `process.exit()` 금지
+- MCP 모드에서 inquirer 프롬프트 호출 금지 (TTY 없음)
+- 신규 handler 는 `runVhkCli(args, headline)` 헬퍼 패턴 사용
+- 대화형 커맨드 (gate/init/design palette/theme) 는 MCP 제외
+- 기존 tool API 시그니처 변경 금지 (GA 안정성)
+
+## 디자인 Anti-patterns
+
+- 보라-파랑 기본 그라디언트 금지
+- 과도한 둥근 모서리 (>16px) 금지
+- 그림자 중첩 · 장식 SVG 남발 금지
+
+## 커밋 컨벤션
+
+- 형식: `feat:` / `fix:` / `refactor:` / `docs:` / `chore:`
+- 1 iteration = 작은 commit 하나 + 게이트 통과(or 정직한 블로커)
+
+## 기록 규칙
+
+- 의사결정 → docs/adr/ · 에러 → docs/troubleshooting/ · 배움 → docs/til.md · 설계 → docs/rfc/
+- dev log `docs/log/YYYY-MM-DD-<작업명>.md` = append-only (추가만, 수정·삭제 금지)
+- 코드 변경이 동작/사용법을 바꾸면 README 만 같이 갱신 (CLAUDE.md 는 갱신 대상 아님)
+- 교훈·결정·실패·성공 = `vhk memory`(4버킷) / `vhk learn`. learnings.md 는 v2 흡수·동결 → 신규 기록 금지.
+- 상태 SoT = docs/state/next-task.md · blockers.md (append-only)


### PR DESCRIPTION
## 왜 (A안)
2구역 CLAUDE.md(🔒 영구 헌법 + ✏️ LIVE)를 **손으로 유지**하면서, 규칙 원본은 `RULES.md` 단일소스로 되살려 `vhk sync` 가 .cursorrules·AGENTS.md 등 7개 미러를 자동 정렬하게 한다.

## 무엇을
- **신규 `RULES.md`** — 규칙 단일 소스(SoT). 섹션: 서문 / 기술 스택(변경 시 ADR) / 코딩 규칙(+MCP 규칙) / 디자인 Anti-patterns / 커밋 컨벤션 / 기록 규칙. 모든 섹션 제목이 sync 키와 매칭 → unmapped 경고 없음.
- **`CLAUDE.md` 편집** — `## 기록물 위치` + `## 기억 SoT` 자리에 `<!-- vhk:rules:start/end -->` 마커 블록(기록 규칙)을 삽입. 포인터/Forbidden 줄에 규칙 원본=RULES.md 명시. **2구역 구조·`**버전:** v2.3.2` 그대로 유지.**

## 왜 마커를 미리 넣었나
CLAUDE.md 는 `buildSyncPlan` 에 하드코딩(하이브리드)이라 sync에서 제외 불가. 마커가 없으면 첫 `vhk sync` 가 migration 경로로 빠져 `기록` 포함 섹션을 삭제함(= `## 기록물 위치` 날아감). 마커를 미리 넣으면 split 경로를 타서 마커 밖은 그대로 보존, 마커 안만 RULES.md 기록 규칙으로 재생성. → 2구역 100% 보존.

## 머지 후 할 일
로컬에서 `vhk sync` 1회 실행 → 7개 미러(.cursorrules·.windsurfrules·copilot-instructions·.agents·AGENTS.md·GEMINI.md·.clinerules) 재생성(드리프트 백업 후 덮어쓰기).

## CI
- doctor 드리프트는 경고-only(비차단), dogfood 잡은 read-only — sync/드리프트 강제 없음.
- version-sync: CLAUDE.md `**버전:**` == package.json (둘 다 2.3.2) 유지.
