### PR TITLE
chore: add seo epic goals 21-26 (vhk seo 풀 대시보드)

### DIFF
--- a/goals/21-seo-init.md
+++ b/goals/21-seo-init.md
@@ -1,0 +1,48 @@
+---
+vhk_format: 1
+type: goal
+id: 21
+title: vhk seo init (스캐폴드 + 사이트등록 + 키보관) — P2
+status: NOT_STARTED
+priority: P2
+version: v2.4.0
+---
+
+# Goal 21: vhk seo init
+
+> 출처: vhk seo 풀 대시보드 설계문서 Phase 0+1. 전제: vhk secure 동작.
+> SEO 에픽의 진입점 — 스캐폴드하고 대상 사이트·서비스 자격증명을 안전하게 받아 보관한다.
+
+## 배경
+브라우저 즐겨찾기로 구글 서치콘솔·GA4·애드센스·빙·네이버를 일일이 돌아다니는 대신,
+`vhk seo` 서브커맨드 하나로 API 자동화 + 딥링크 반자동화로 통합 관리한다.
+이 goal은 그 진입점: commands/seo/ 골격을 세우고 5개 서비스 자격증명을 안전하게 받아 vhk secure에 보관한다.
+
+## 철학
+① 자격증명은 vhk secure로만 — 평문 커밋/로그 절대 금지 ② 골격 먼저, 기능은 후속 goal에서 ③ 비대화형 1급 (MCP/CI/스케줄러 안전) ④ src 구조 유지: commands/seo/ 신설.
+
+## 동작 (파일·계약)
+- src/commands/seo/ 디렉터리 + seo 커맨드 라우터 골격, i18n/ko.ts 키 추가.
+- `vhk seo init`: 대상 사이트(도메인) 등록 → .vhk/seo/config.json.
+- 5개 서비스(GSC, GA4, AdSense v2, Bing, IndexNow) 자격증명/API키를 vhk secure로 보관. 평문 커밋/로그 금지.
+- 비대화형 플래그 지원(--yes 등), TTY 가드.
+- 크로스플랫폼: 경로 path.join, 디렉터리 없으면 생성.
+
+## Completion Check
+- [ ] commands/seo/ 골격 + seo 라우터 + i18n/ko.ts 키
+- [ ] `vhk seo init` → 사이트 등록 .vhk/seo/config.json 생성
+- [ ] 5개 서비스 자격증명 vhk secure 보관, 평문 커밋/로그 0
+- [ ] 비대화형/MCP/CI에서 프롬프트 없이 동작 (TTY 가드)
+- [ ] secret 누출 0 (vhk secure scan)
+- [ ] vhk goal sync → check-goal-21.mjs → vhk goal check --id 21 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
+
+## 제외 범위
+- 실제 데이터 수집(Goal 23+) / HTML 리포트(Goal 25)
+- OAuth 동의화면 자동화 → 필요시 후속
+
+## Mandatory Reading
+- src/commands/ (커맨드 라우팅 구조 파악 후 착수)
+- vhk secure 구현 (키 보관 계약)
+- src/i18n/ko.ts
+- docs 또는 노션: vhk seo 풀 대시보드 설계문서

--- a/goals/22-seo-submit.md
+++ b/goals/22-seo-submit.md
@@ -1,0 +1,48 @@
+---
+vhk_format: 1
+type: goal
+id: 22
+title: vhk seo submit (사이트맵 + IndexNow) — P2
+status: NOT_STARTED
+priority: P2
+version: v2.4.1
+---
+
+# Goal 22: vhk seo submit
+
+> 출처: vhk seo 풀 대시보드 설계문서 Phase 2. 전제: Goal 21(init/config) 완료.
+> 색인 촉진 — 사이트맵 제출과 IndexNow 핑을 한 방에.
+
+## 배경
+새 페이지를 올려도 구글·빙·네이버가 크롤하기까지 수일~수주 걸린다.
+`vhk seo submit`은 사이트맵을 GSC·Bing에 제출하고 IndexNow 한 방 핑으로
+빙·네이버·얀덱스에 동시에 색인 알림을 보내 이 대기시간을 최소화한다.
+구글 Indexing API는 채용공고·라이브영상 전용이라 일반 페이지에 쓰면 페널티 — 사용 금지.
+
+## 철학
+① IndexNow 하나로 빙·네이버·얀덱스 동시 커버 — 코드 최소화 ② 구글 Indexing API 사용 금지(가드/주석 명시) ③ 실패시 exit≠0 + 친절 에러 ④ 비대화형 1급.
+
+## 동작 (파일·계약)
+- `vhk seo submit`: .vhk/seo/config.json의 사이트맵 URL을 GSC + Bing API에 제출.
+- IndexNow 키파일 생성/검증 후 한 방 핑 → 빙·네이버·얀덱스 동시.
+- 결과를 .vhk/seo/ 로그(제출 시각·응답코드).
+- 구글 Indexing API 사용 금지(일반페이지 페널티) — 가드/주석 명시.
+- 비대화형/MCP/CI 프롬프트 없이 동작.
+
+## Completion Check
+- [ ] `vhk seo submit` → 사이트맵 GSC+Bing 제출 성공
+- [ ] IndexNow 키파일 생성/검증 + 핑 전송 (빙·네이버·얀덱스)
+- [ ] 구글 Indexing API 미사용 (일반페이지 즉시색인 시도 0 — 가드)
+- [ ] 실패시 exit≠0 + 친절한 에러, 키/응답 로그에 secret 0
+- [ ] 비대화형/MCP/CI 프롬프트 없이 동작
+- [ ] vhk goal sync → check-goal-22.mjs → vhk goal check --id 22 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
+
+## 제외 범위
+- 색인 결과 조회(Goal 23) / 다음·카카오 제출(확장 슬롯)
+
+## Mandatory Reading
+- Goal 21 config/secure 계약
+- IndexNow 프로토콜(키파일 방식) 공식 문서
+- GSC Sitemaps API + Bing Webmaster API 사이트맵 제출
+- 설계문서 "서비스별 할 수 있는 것" 표 (Indexing API 함정 주의)

--- a/goals/23-seo-check-index.md
+++ b/goals/23-seo-check-index.md
@@ -1,0 +1,49 @@
+---
+vhk_format: 1
+type: goal
+id: 23
+title: vhk seo check 색인+트래픽 (GSC + GA4) — P2
+status: NOT_STARTED
+priority: P2
+version: v2.4.2
+---
+
+# Goal 23: vhk seo check (색인 + 트래픽)
+
+> 출처: vhk seo 풀 대시보드 설계문서 Phase 3. 전제: Goal 21 완료.
+> 수집 계층 1 — 구글 색인·검색성과와 GA4 트래픽을 latest.json으로 모은다.
+
+## 배경
+`vhk seo check`의 첫 번째 반: 구글 서치콘솔 API로 사이트맵 상태·검색성과(노출/클릭/순위)·URL 색인상태를 수집하고,
+GA4 Data API runReport로 방문자·세션·페이지뷰·유입을 수집해 .vhk/seo/latest.json(SoT)에 기록한다.
+URL Inspection은 2,000/일·600/분 한도가 있어 한도 가드가 필수.
+
+## 철학
+① latest.json 단일 진실원천 — verify 패턴 재사용 ② raw JSON.parse 금지 → readJsonFile ③ URL Inspection 한도 가드 필수 ④ 죽은 API 사용 금지(UA, Custom Search).
+
+## 동작 (파일·계약)
+- GSC API: 사이트맵 상태, 검색성과(노출·클릭·순위), URL 색인상태(URL Inspection). 한도 가드 2,000/일·600/분.
+- GA4 Data API: runReport로 방문자·세션·페이지뷰·유입 (무샘플링).
+- 수집 결과를 .vhk/seo/latest.json(SoT)에 기록. readJsonFile 사용.
+- 크로스플랫폼: 고정 경로 path.join, 네트워크 실패 친절 에러.
+- 비대화형/MCP/CI 동작.
+
+## Completion Check
+- [ ] GSC 사이트맵·검색성과·URL색인상태 수집 → latest.json
+- [ ] URL Inspection 한도 가드(초과 전 중단/배치) 동작
+- [ ] GA4 runReport 방문자·유입 수집, 무샘플링 확인
+- [ ] latest.json 스키마 일관, raw JSON.parse 미사용(readJsonFile)
+- [ ] 수집 결과·로그에 secret 0
+- [ ] vhk goal sync → check-goal-23.mjs → vhk goal check --id 23 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
+
+## 제외 범위
+- 수익·빙 수집(Goal 24) / HTML 렌더(Goal 25)
+- Universal Analytics API, Custom Search JSON API — 사용 금지(사망)
+
+## Mandatory Reading
+- vhk verify의 latest.json 스키마 패턴 (src/commands/verify.ts — SoT 재사용)
+- readJsonFile 유틸
+- GSC Search Console API (searchanalytics.query, sitemaps, urlInspection)
+- GA4 Data API runReport 규격
+- 설계문서 API 생존상태 표 (2026-06 검증)

--- a/goals/24-seo-check-revenue.md
+++ b/goals/24-seo-check-revenue.md
@@ -1,0 +1,47 @@
+---
+vhk_format: 1
+type: goal
+id: 24
+title: vhk seo check 수익+빙 (AdSense v2 + Bing) — P2
+status: NOT_STARTED
+priority: P2
+version: v2.4.3
+---
+
+# Goal 24: vhk seo check (수익 + 빙)
+
+> 출처: vhk seo 풀 대시보드 설계문서 Phase 4. 전제: Goal 23(latest.json) 완료.
+> 수집 계층 2 — 애드센스 수익과 빙 통계(AI 인용 포함)를 latest.json에 병합한다.
+
+## 배경
+`vhk seo check`의 두 번째 반: AdSense Management API v2로 수익·성과·결제를 읽고(읽기전용),
+Bing Webmaster API로 순위·트래픽·크롤 통계와 AI Performance Report(2026 신규 — AI 인용 측정)를
+latest.json에 병합한다. AdSense v1.4는 2021년 종료 — 절대 사용 금지.
+
+## 철학
+① AdSense는 읽기전용 — 광고 조작 불가, 딥링크로 우회 ② Bing AI Performance Report 베스트에포트(API 안 되면 딥링크 플래그) ③ latest.json 병합 SoT 유지 ④ v1.4 사용 금지(가드).
+
+## 동작 (파일·계약)
+- AdSense Management API v2: 수익·성과·결제 조회 (읽기전용). v1.4 사용 금지.
+- Bing Webmaster API: 순위·트래픽·크롤 통계(GetQueryStats) + AI Performance Report(베스트에포트: API로 안 빠지면 딥링크 플래그).
+- latest.json에 revenue·bing 섹션 병합. readJsonFile 사용.
+- 비대화형/MCP/CI 동작.
+
+## Completion Check
+- [ ] AdSense v2 수익·성과·결제 수집 → latest.json (v1.4 미사용)
+- [ ] Bing 순위·트래픽·크롤 통계 수집
+- [ ] AI Performance Report 베스트에포트 (되면 수집, 안 되면 deepLink 플래그)
+- [ ] latest.json 병합 스키마 일관, secret 0
+- [ ] 비대화형/MCP/CI 동작
+- [ ] vhk goal sync → check-goal-24.mjs → vhk goal check --id 24 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
+
+## 제외 범위
+- HTML 시각화(Goal 25) / 애드센스 광고조작(읽기전용 — 딥링크로)
+- AdSense API v1.4 — 사망, 사용 금지
+
+## Mandatory Reading
+- Goal 23 latest.json 스키마 (revenue/bing 섹션 추가 위치)
+- AdSense Management API v2 reference (developers.google.com/adsense/management)
+- Bing Webmaster API + AI Performance Report (learn.microsoft.com/en-us/bingwebmaster)
+- 설계문서 "못하는 것 = 딥링크" 원칙

--- a/goals/25-seo-report.md
+++ b/goals/25-seo-report.md
@@ -1,0 +1,51 @@
+---
+vhk_format: 1
+type: goal
+id: 25
+title: vhk seo report (무빌드 HTML 대시보드) — P2
+status: NOT_STARTED
+priority: P2
+version: v2.5.0
+---
+
+# Goal 25: vhk seo report
+
+> 출처: vhk seo 풀 대시보드 설계문서 Phase 5. 전제: Goal 23·24(latest.json 완성) 완료.
+> 보기 계층 — latest.json을 무빌드 HTML 대시보드로 렌더한다 (vhk verify --report 패턴 재사용).
+
+## 배경
+수집된 latest.json(색인·트래픽·수익·빙AI)을 사람이 한눈에 볼 수 있는 HTML 1장으로 렌더한다.
+API로 안 되는 항목(광고조작·즉시색인·네이버수집 등)은 ⚠️ 배지 + 딥링크를 달아
+클릭 한 번으로 해당 화면까지 가게 한다. vhk verify --report의 무빌드 패턴을 그대로 재사용.
+
+## 철학
+① latest.json만 읽어 렌더 — 새 증거 안 만듦 ② 무빌드·무의존 — 외부 CDN/번들러 없이 인라인 정적 HTML ③ 오프라인 동작 ④ 못하는 항목마다 ⚠️ 배지 + 딥링크 필수.
+
+## 동작 (파일·계약)
+- `vhk seo report`: latest.json → HTML 1장(인라인 CSS, 오프라인). 4블록:
+  1. 색인 블록: 구글/빙/네이버 색인 수·사이트맵 상태·미색인 URL + URL검사 딥링크
+  2. 트래픽 블록: GSC 검색성과 + GA4 방문자/유입 + 빙 AI 인용 미니섹션
+  3. 수익 블록: 애드센스 수익·성과·결제(읽기전용) + 설정화면 딥링크
+  4. AEO 점검 블록: schema.org·llms.txt·메타 체크리스트(수동 반자동)
+- 못하는 항목마다 ⚠️ 배지 + "여기서 직접 하기" 딥링크 필수.
+- `--open` 옵션: 생성 후 기본 브라우저로 열기 (비대화형/CI/MCP에서 자동 스킵).
+- latest.json 없을 때: 안내(check 선실행) or 명확 종료.
+
+## Completion Check
+- [ ] `vhk seo report` → 오프라인 HTML 4블록 생성 (외부 CDN 의존 0)
+- [ ] 빙 AI 인용 미니섹션 렌더 (데이터 없으면 딥링크 폴백)
+- [ ] 못하는 항목 ⚠️ 배지 + '여기서 직접 하기' 딥링크 전수 표시
+- [ ] latest.json 없을 때 안내(check 선실행) or 명확 종료
+- [ ] --open 비대화형/CI/MCP에서 자동 스킵
+- [ ] 리포트 HTML에 secret 0
+- [ ] vhk goal sync → check-goal-25.mjs → vhk goal check --id 25 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
+
+## 제외 범위
+- Notion 적재/스케줄러(Goal 26) / 인터랙티브 차트 라이브러리(무빌드 원칙 위반)
+- 서버·웹 대시보드 (정적 파일만)
+
+## Mandatory Reading
+- src/commands/verify.ts (--report 무빌드 HTML 렌더링 패턴 — 그대로 재사용)
+- Goal 23·24 latest.json 스키마 (색인/트래픽/revenue/bing 섹션)
+- 설계문서 "대시보드 구성" 섹션 + "못하는 것 = 딥링크" 원칙

--- a/goals/26-seo-automate.md
+++ b/goals/26-seo-automate.md
@@ -1,0 +1,49 @@
+---
+vhk_format: 1
+type: goal
+id: 26
+title: vhk seo 자동화 (Notion 적재 + 스케줄러 + 확장슬롯) — P2
+status: NOT_STARTED
+priority: P2
+version: v2.5.1
+---
+
+# Goal 26: vhk seo 자동화
+
+> 출처: vhk seo 풀 대시보드 설계문서 Phase 6. 전제: Goal 25(report) 완료.
+> 자동화 계층 — report 결과를 Notion에 적재하고 스케줄러로 주기 실행, 확장 슬롯 자리를 둔다.
+
+## 배경
+`vhk seo report`가 HTML을 만들어도 주기적으로 실행되지 않으면 수동 도구와 다를 게 없다.
+report 요약을 Notion Dev Log에 적재해 히스토리를 남기고,
+Windows 작업 스케줄러로 submit+check+report 체인을 자동화한다.
+확장 슬롯(다음/카카오·GBP)은 어댑터 인터페이스 자리만 비워둔다. 얀덱스는 IndexNow에 이미 포함.
+
+## 철학
+① SoT Key 멱등 동기화 — 재실행해도 중복 없음 ② 스케줄러는 비대화형으로(프롬프트 없이) ③ 확장 슬롯은 자리만, 구현은 후속 ④ secret은 vhk secure로만.
+
+## 동작 (파일·계약)
+- `vhk seo report`(또는 별도 subcommand) 결과 요약을 Notion Dev Log에 적재 (SoT Key 멱등 동기화).
+- Windows 작업 스케줄러 등록 도우미/문서 (submit+check+report 체인).
+- 확장 슬롯 어댑터 인터페이스 정의:
+  - 얀덱스: IndexNow에 이미 포함(자동), 별도 코드 X
+  - 다음/카카오·GBP: 인터페이스 자리만 (구현은 후속)
+- 비대화형/CI 동작.
+
+## Completion Check
+- [ ] report 결과 Notion Dev Log 적재, SoT Key로 재실행 시 중복 0(멱등)
+- [ ] 스케줄러 도우미/문서로 submit+check+report 체인 자동화
+- [ ] 확장 슬롯 인터페이스 정의(얀덱스 자동 커버 확인, 나머지 자리만)
+- [ ] Notion 적재 내용·로그에 secret 0
+- [ ] 비대화형/CI 동작(스케줄러는 프롬프트 없이)
+- [ ] vhk goal sync → check-goal-26.mjs → vhk goal check --id 26 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
+
+## 제외 범위
+- 다음/카카오·GBP 실제 구현(v2 슬롯) / 양방향 동기화
+- Notion 실시간 watch 모드
+
+## Mandatory Reading
+- src/notion/ 적재 어댑터 + SoT Key 멱등 패턴 (기존 Notion 연동 코드)
+- vhk cloud 또는 스케줄러 관련 선례
+- 설계문서 "확장 슬롯" 섹션


### PR DESCRIPTION
## 개요
vhk seo 풀 대시보드 에픽을 Goal 시스템에 등록.

## 추가 파일 (6개)
| 파일 | Goal | 내용 |
|---|---|---|
| goals/21-seo-init.md | 21 | vhk seo init — 스캐폴드+사이트등록+키보관 (Phase 0+1) |
| goals/22-seo-submit.md | 22 | vhk seo submit — 사이트맵+IndexNow (Phase 2) |
| goals/23-seo-check-index.md | 23 | vhk seo check 색인+트래픽 GSC+GA4 (Phase 3) |
| goals/24-seo-check-revenue.md | 24 | vhk seo check 수익+빙 AdSense v2+Bing (Phase 4) |
| goals/25-seo-report.md | 25 | vhk seo report 무빌드 HTML 4블록 (Phase 5) |
| goals/26-seo-automate.md | 26 | vhk seo 자동화 Notion적재+스케줄러+확장슬롯 (Phase 6) |

## 참고
- id 18-20은 기존 goal(memory-schema-v2, pattern, evolve)이 점유 중이어서 21-26으로 배치.
- 설계문서: Notion Dev Log "(2026-06-06) VHK - vhk seo 풀 대시보드 설계"
- merge 후 `vhk goal sync` → `vhk goal next`로 21부터 선택됨 (15·16·17 NOT_STARTED가 우선).

## 체크리스트
- [x] goals/ 파일 6개 추가
- [ ] merge 후 `vhk goal sync` 실행
- [ ] `vhk goal check --id 21` (구현 착수 전 spec 확인용)