### PR TITLE
docs(goals): 생산성 5종 등록 29~33 (preflight·worktree·doctor·standup·today)

### DIFF
--- a/goals/29-preflight.md
+++ b/goals/29-preflight.md
@@ -1,0 +1,55 @@
+---
+vhk_format: 1
+type: goal
+id: 29
+title: vhk preflight — 출고 전 안전점검 (publish/PR 직전 일괄 점검) — P1
+status: NOT_STARTED
+priority: P1
+created: 2026-06-06
+leads_to: goal-30-worktree
+---
+
+# Goal 29: vhk preflight
+
+> 출처: Notion "D1 · vhk preflight 상세 설계 (출고 전 안전점검)". 전제: vhk secure / safeExecFile / publish 가드(#119).
+> publish·PR 직전 사고 날 만한 곳을 한 번에 점검하는 안전점검 명령어 — 비행기 이륙 전 체크리스트.
+
+## 배경 (왜 — 상상이 아니라 Dev Log에 기록된 실제 고통)
+- npm publish 2FA 막힘 (실제 발생)
+- Windows `.cmd` shim 취약점 (Node 20.12+ CVE)
+- git worktree env 누락 사고
+- React19 lint 깨짐
+→ `vhk preflight` 한 번으로 2FA·shim·worktree env·lint·테스트를 자동 점검하고 🟢/🔴로 알린다.
+
+## 철학
+① 치명 실패(🔴)는 무조건 차단 — `--force` 같은 우회 없음(사고 원천 봉쇄) ② 외부 명령은 `safeExecFile`만(execSync 금지 — 불변규칙) ③ 5초 내 완료 목표(테스트는 캐시/스킵) ④ 심각도 분리로 거짓양성 완화 ⑤ MCP 노출.
+
+## 동작 (명령·항목)
+- `vhk preflight` 전체 점검(읽기 전용) / `--publish` 2FA·버전 포함 / `--pr` lint·테스트·한 PR 한 goal / `--fix` 자동수정(Phase 2).
+- 8개 점검 항목 + 심각도:
+  - 🟠 npm 로그인 + 2FA 리마인드(`npm whoami`) / 🟠 shim 안전성(Node ≥ 20.12)
+  - 🔴 worktree env(필수 키 = `.env.example` 기준) / 🔴 lint(eslint) / 🔴 typecheck(`tsc --noEmit`) / 🔴 테스트
+  - 🟡 git 청결(uncommitted 없음) / 🟡 브랜치 규칙(main 직접 아님 · 한 PR 한 goal)
+- 테스트 범위: 기본 `vitest --changed`(통과분 캐시 스킵, 변경 시 자동 재실행) / `--full` 전체.
+- 치명(🔴) 실패 시 HARD_STOP(exit 1)로 publish/PR 차단.
+- 각 검사 = `checks/*.ts` 모듈(2fa·shim·worktree·lint…), 결과 객체 `{ name, status, detail, severity }[]`.
+
+## Completion Check
+- [ ] `vhk preflight --publish`가 8개 항목 점검 후 정확한 exit code 반환
+- [ ] 치명(🔴) 1개라도 있으면 publish 차단(`--force` 우회 없음)
+- [ ] 외부 명령 전부 `safeExecFile`(execSync 0건)
+- [ ] 각 check 모듈 vitest 단위 테스트(성공/실패/경고 mock)
+- [ ] vhk goal sync → check-goal-29.mjs → vhk goal check --id 29 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
+
+## 제외 범위 (v0)
+- `--fix` 자동수정(Phase 2) / git hook·publish 파이프라인 내장(Phase 3)
+
+## 공유 모듈 메모
+- worktree env 점검 로직 = `worktree-env` 모듈로 분리 → **Goal 30(worktree 가드)이 동일 모듈 재사용**. 이중 구현 금지.
+
+## Mandatory Reading
+- src/lib/exec.ts (safeExecFile 계약 — execSync 금지)
+- src/commands/publish.ts (publish 가드 #119 연계 지점)
+- src/commands/verify.ts (테스트/리포트 선례 — Goal 13)
+- goals/_meta.md (공통 게이트 = typecheck/test/build)

--- a/goals/30-worktree.md
+++ b/goals/30-worktree.md
@@ -1,0 +1,46 @@
+---
+vhk_format: 1
+type: goal
+id: 30
+title: vhk worktree 가드 — worktree 생성 시 env 누락 방지(자동복사/차단) — P2
+status: NOT_STARTED
+priority: P2
+created: 2026-06-06
+depends_on: goal-29-preflight
+---
+
+# Goal 30: vhk worktree 가드
+
+> 출처: Notion "D3 · worktree 가드 상세 설계 (env 누락 방지 훅)". 전제: Goal 29의 worktree-env 모듈.
+> git worktree를 만들 때 env·설정 누락을 능동적으로 차단/자동복구하는 가드(훅 + 래퍼 명령).
+
+## 배경 (왜)
+preflight(Goal 29)가 '출고 직전 점검'이라면 이건 'worktree 생성 순간 방어'다. 시점이 다르다:
+- preflight = publish/PR 직전(사후 점검, 수동) / worktree 가드 = worktree 생성 순간(사전 방어, 능동 차단·자동복구).
+→ **핵심 점검 로직(worktree-env 모듈)은 Goal 29와 공유**하고, 이 goal은 "생성 시점 훅"으로 그 로직을 재사용. 독립 명령이되 코드 공유.
+
+## 철학
+① 핵심 = `worktree-env.ts` 모듈(Goal 29 공유) — 이중 구현 금지 ② 복사 방식 = 파일 복사(심볼릭 링크 X — Windows 항상 작동·worktree 독립) ③ 비밀값은 항상 마스킹, 내용 로그 출력 절대 금지 ④ git 훅 자동 설치 안 함(사람 모르게 git 설정 안 건드림 — `vhk worktree add` 쓸 때만 작동) ⑤ safeExecFile로 git 명령 래핑.
+
+## 동작 (명령·훅)
+- `vhk worktree add <branch>` — worktree 생성 + 필수 env/설정 자동 복사.
+- `vhk worktree check` — 현재 worktree env 누락 점검.
+- git post-checkout 훅 — worktree 진입 시 자동 점검(Phase 3, 자동 설치 안 함).
+- 복사 대상 = `.env*` 전부 + VHK 설정에 등록한 추가 로컬 파일(예: `.vscode`). 비밀값 마스킹.
+- 가드 항목: 필수 `.env`/`.env.local` 키 존재 / 로컬 설정 파일 복사 / node_modules·pnpm 설치 필요 안내 / 브랜치-goal 연결(한 PR 한 goal).
+
+## Completion Check
+- [ ] `vhk worktree add <branch>` → worktree 생성 + env 자동 복사, 누락 0건
+- [ ] `vhk worktree check` → 현재 worktree env 누락 정확 탐지 + 복구 안내
+- [ ] env 복사 로그에 비밀값 평문 0건(마스킹 검증)
+- [ ] worktree-env 모듈을 Goal 29와 공유(중복 구현 0)
+- [ ] env 누락/정상/부분누락 케이스 vitest(git worktree mock)
+- [ ] vhk goal sync → check-goal-30.mjs → vhk goal check --id 30 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
+
+## 제외 범위 (v0)
+- git 훅 자동 설치(Phase 3) / node_modules 자동 설치(안내만, 실행은 사람)
+
+## Mandatory Reading
+- goals/29-preflight.md (worktree-env 모듈 계약 — 먼저 구현 후 재사용)
+- src/lib/exec.ts (safeExecFile — git worktree 래핑)

--- a/goals/31-doctor.md
+++ b/goals/31-doctor.md
@@ -1,0 +1,48 @@
+---
+vhk_format: 1
+type: goal
+id: 31
+title: vhk doctor — 개발 환경 정기검진(Node·pnpm·git·OS·VHK·MCP·audit) — P2
+status: NOT_STARTED
+priority: P2
+created: 2026-06-06
+---
+
+# Goal 31: vhk doctor (환경 정기검진)
+
+> 출처: Notion "D2 · vhk doctor 상세 설계 (환경 정기검진)".
+> 개발 환경(머신) 자체가 건강한지 정기검진. preflight(Goal 29)가 '출고물 점검'이라면 doctor는 '몸 건강검진'.
+>
+> ⚠️ **기존 코드 주의**: `src/commands/doctor.ts`가 이미 존재한다. 이 goal = 기존 doctor를 7개 항목 진단으로 확장하는 작업. 착수 시점에 main의 doctor.ts 상태(미커밋 변경 가능)를 먼저 동기화·확인할 것.
+
+## 배경 (왜)
+- preflight = 이번에 내보낼 변경물 / doctor = 머신/환경 자체.
+- 새 PC·새 worktree 셋업 후 "환경 제대로 됐나?", 갑자기 뭔가 안 될 때 원인 좁히기, 주 1회 정기 점검.
+
+## 철학
+① 진단만 — 자동 수정 X(환경 손상 방지) ② CVE = 하이브리드: 평소 내장 '권장 최소 버전' 기준 오프라인·즉시 판정, `--online`(또는 인터넷 있을 때)만 실제 취약점 DB 조회 후 `~/.vhk`에 24h 캐시 ③ audit = 기본 제외(가볍게 유지), 정확히 필요한 3시점만 — publish 직전 / `pnpm install` 직후 / 월 1회 ④ MCP 핑은 짧은 timeout으로 격리(전체 안 멈춤) ⑤ safeExecFile.
+
+## 동작 (7개 진단 항목)
+- Node: 버전 + 내장 기준 판정(`--online` 시 실제 CVE 보정·24h 캐시)
+- 패키지 매니저: pnpm/npm 버전·권장 충족 / git: 버전·user.name·user.email·기본 브랜치
+- OS·셸: Windows 11 / PowerShell 확인 / VHK 설치: 전역 무결성·버전·`~/.vhk` 글로벌 상태
+- MCP: 29개를 2초 timeout 병렬 핑, 막힌 건 "⚠️ 응답없음"만 표시(전체 안 멈춤)
+- 의존성 보안: 기본 생략, `--audit`(또는 publish 전·의존성 변경 후)에만 `pnpm audit`
+- 모듈 = `diagnostics/*.ts`(node·pnpm·git·os·vhk·mcp·audit), 결과 `{ name, status, value, advice }[]`, 항목마다 권장 조치 제시.
+
+## Completion Check
+- [ ] `vhk doctor`가 7개 항목 진단 후 사람이 읽을 리포트 출력
+- [ ] 문제 항목마다 구체적 권장 조치(advice) 제시
+- [ ] 자동 수정 경로 0건(진단만 — grep 확인)
+- [ ] MCP 29개 병렬 핑이 막힌 도구에서 전체 멈추지 않음(timeout 격리)
+- [ ] 각 diagnostic 모듈 vitest mock(버전/플랫폼 응답 시뮬레이션)
+- [ ] vhk goal sync → check-goal-31.mjs → vhk goal check --id 31 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
+
+## 제외 범위 (v0)
+- 자동 수정(환경 손상 방지로 의도 배제) / `vhk doctor --json` 외부 소비(Phase 3)
+
+## Mandatory Reading
+- src/commands/doctor.ts (기존 구현 — 확장 시작점, 미커밋 변경 확인)
+- src/lib/exec.ts (safeExecFile)
+- src/mcp/ (MCP 핑 대상 — 29개 도구)

--- a/goals/32-standup.md
+++ b/goals/32-standup.md
@@ -1,0 +1,49 @@
+---
+vhk_format: 1
+type: goal
+id: 32
+title: vhk standup — 아침 브리핑(어제 한 일 + 오늘 할 일) — P2
+status: NOT_STARTED
+priority: P2
+created: 2026-06-06
+leads_to: goal-33-today
+---
+
+# Goal 32: vhk standup (아침 브리핑)
+
+> 출처: Notion "B3 · vhk standup 상세 설계 (아침 브리핑)".
+> 아침에 `vhk standup` 한 번이면 어제 한 일 + 오늘 할 일을 자동 브리핑. 혼자 일하는 1인기업의 데일리 스탠드업.
+
+## 배경 (왜)
+- 어제 커밋·Dev Log·완료 goal을 요약하고, 오늘 추천 goal과 미해결 항목을 보여준다.
+- 생활 패턴 분석(Dev Log 실제 작업 시각): 이른 아침 루틴이 거의 없고 오후~심야 집중 → '시계'가 아니라 '첫 터미널 여는 순간'에 반응해야 적중.
+
+## 철학
+① '어제' 기준 = 마지막 활동일(주말·공백 건너뜀 — 불규칙 일정에 맞춤) ② 실행 핵심 앵커 = 터미널 자동실행, 텔레그램 고정시각 푸시는 라이프스타일 확인 후 선택 실험(Phase 3) ③ 오늘 추천 v0 = 단순 나열 + 막힌 것 표시(우선순위 고도화는 나중) ④ **daily 모듈을 Goal 33(today)과 공유**(회고 vs 전망) ⑤ git log는 safeExecFile.
+
+## 동작 (데이터 소스 3개 병합)
+- Dev Log 데이터소스: 어제 실행 기록·결과·교훈 (날짜 필터 쿼리, 어제 00:00~24:00)
+- git log: 어제 커밋 요약 (safeExecFile)
+- VHK goals: 다음 NOT_STARTED goal, 진행 중(IN_PROGRESS)
+- 출력 = 📌 어제 한 일 / 🎯 오늘 추천(NOT_STARTED 나열 + 막힌 것) / ⚠️ 미해결. 사람이 읽기 좋은 섹션 포맷.
+- `standup.ts`가 3개 소스 병합.
+
+## Completion Check
+- [ ] `vhk standup`이 어제 요약 + 오늘 추천을 한 화면에 출력
+- [ ] '어제' = 마지막 활동일(주말·공백 skip) 정확 계산
+- [ ] git log·goal 상태·(Phase 2)Dev Log 병합, 빈 Dev Log는 git log로 보완
+- [ ] daily 모듈을 Goal 33과 공유 가능한 구조(범위 필터 주입식)
+- [ ] 날짜 필터/병합 로직 vitest mock
+- [ ] vhk goal sync → check-goal-32.mjs → vhk goal check --id 32 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
+
+## 제외 범위 (v0)
+- 우선순위 추천 고도화 / 텔레그램 아침 푸시 알림(Phase 3, 선택)
+
+## 공유 모듈 메모
+- 날짜 범위 필터·소스 병합 = `daily` 모듈로 분리 → **Goal 33(today)이 today 범위로 재사용**. 명령만 분리, 코드 공유.
+
+## Mandatory Reading
+- src/lib/date.ts (날짜/KST 처리 — '어제' = 마지막 활동일)
+- src/lib/git-porcelain.ts / git.ts (git log 선례, safeExecFile)
+- src/lib/goal-frontmatter.ts (goal 상태 읽기 — NOT_STARTED/IN_PROGRESS)

--- a/goals/33-today.md
+++ b/goals/33-today.md
@@ -1,0 +1,42 @@
+---
+vhk_format: 1
+type: goal
+id: 33
+title: vhk today — 저녁 자축·회고(오늘 해낸 것 담백 요약) — P2
+status: NOT_STARTED
+priority: P2
+created: 2026-06-06
+depends_on: goal-32-standup
+---
+
+# Goal 33: vhk today (저녁 자축·회고)
+
+> 출처: Notion "C1 · vhk today 상세 설계 (저녁 자축·회고)". 전제: Goal 32의 daily 모듈.
+> 하루를 마칠 때 `vhk today` 한 번이면 오늘 해낸 것을 담백하게 요약 + 격려. 혼자라서 사라지기 쉬운 성취감을 시스템이 챙긴다.
+
+## 배경 (왜)
+- standup(Goal 32)과 한 몸 — 시점·방향만 다르다: standup = 아침·미래(할 일), today = 저녁·과거(한 일·회고).
+- 오늘 git 커밋·완료 goal·Dev Log를 모아 "오늘 이만큼 했다"를 보여준다.
+
+## 철학
+① 성취 집계 = 단순 카운트(커밋 N·완료 goal N·Dev Log N) — 명확·즉시·오프라인·결정적 ② 게임 요소(streak 등) 안 넣음 — 담백하게 사실만(유치함·부담 방지) ③ AI 의미요약은 v0 제외(LLM 호출 = 비용·지연·비결정적) → 나중 `vhk today --smart` 플래그로 분리 ④ 실행 = 수동 `vhk today`(마감 시점 불규칙) ⑤ **daily 모듈을 Goal 32와 공유**(today 범위 필터).
+
+## 동작 (오늘 집계)
+- 데이터 소스: 오늘 git 커밋 / 오늘 완료된 goal / 오늘 Dev Log 기록(결과·교훈).
+- `daily` 모듈에 `dayRange(now)`(오늘 00:00~now, KST) 주입 → `TodayReport { commitCount, doneGoalCount, devlogCount, doneGoals, lessons, message }`.
+- 출력 = 🎉 해낸 것(카운트 + 항목) + 💬 격려 문구(간단 템플릿 풀에서 랜덤, 톤 절제).
+
+## Completion Check
+- [ ] `vhk today`가 오늘 성과 요약(커밋·완료 goal·Dev Log 카운트) + 격려 출력
+- [ ] daily 모듈을 Goal 32와 공유(today 범위 필터만 차이, 중복 구현 0)
+- [ ] 단순 카운트 — LLM 호출 0(오프라인 동작)
+- [ ] today 범위 필터(KST 00:00~now) vitest mock
+- [ ] vhk goal sync → check-goal-33.mjs → vhk goal check --id 33 통과
+- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
+
+## 제외 범위 (v0)
+- streak/게임 요소(담백함 우선) / AI 의미요약(`--smart` 후속) / 마감 시각 자동 알림(Phase 3)
+
+## Mandatory Reading
+- goals/32-standup.md (daily 모듈 계약 — 먼저 구현 후 today 범위로 재사용)
+- src/lib/date.ts (KST dayRange)


### PR DESCRIPTION
## 개요
개인 생산성 도구 묶음(데스크톱) 5종을 Goal 시스템에 등록. **문서만 추가(코드 변경 없음).**
출처: Notion "[2026-06-06] 개인 생산성 도구 묶음 — 데스크톱·모바일 설계 정리" 하위 상세설계 5건(D1·D3·D2·B3·C1).

## 추가 파일 (5개)
| 파일 | Goal | 명령 | 한 줄 | 우선 |
|---|---|---|---|---|
| goals/29-preflight.md | 29 | `vhk preflight` | 출고 전 안전점검(2FA·shim·env·lint·test 일괄, 🔴 차단) | P1 |
| goals/30-worktree.md | 30 | `vhk worktree` | worktree 생성 시 env 누락 자동복사/차단 | P2 |
| goals/31-doctor.md | 31 | `vhk doctor` | 개발 환경 정기검진(Node·pnpm·git·OS·VHK·MCP·audit) | P2 |
| goals/32-standup.md | 32 | `vhk standup` | 아침 브리핑(어제 한 일 + 오늘 할 일) | P2 |
| goals/33-today.md | 33 | `vhk today` | 저녁 자축·회고(오늘 해낸 것 담백 요약) | P2 |

## 번호 배치 / 충돌
- 21~26 = PR #126(SEO 풀 대시보드)이 점유. 27~28 = PR #127(품질 게이트, 재번호 완료)이 점유. → 생산성 5종은 **29~33**.
- 셋 다 문서만 추가라 파일명 충돌 없음. 머지 후 `vhk goal list`로 0~33 연속 확인 예정.

## 공유 모듈 (구현 시 재사용 — 이중 구현 금지)
- **worktree-env**: Goal 29(preflight)가 분리 → Goal 30(worktree)이 재사용.
- **daily**: Goal 32(standup)가 분리(범위 필터 주입식) → Goal 33(today)이 today 범위로 재사용.

## 구현 순서 (등록 후, 한 PR = 한 goal)
29(preflight) → 30(worktree, 29의 worktree-env 재사용) · 31(doctor)은 독립 병렬 가능 · 32(standup) → 33(today, 32의 daily 재사용).

## 주의
- `src/commands/doctor.ts`는 이미 존재 → Goal 31은 기존 doctor 확장(착수 시 main 상태 동기화 확인).
- 각 goal은 구현 PR에서 `vhk goal sync`로 `check-goal-<id>.mjs` 백필 후 게이트 통과.

## 체크리스트
- [x] goals/ 파일 5개 (29~33), `vhk goal list`에서 skip/중복 경고 0 확인
- [ ] merge 후 `vhk goal sync` (게이트 스크립트 백필은 구현 PR에서)
