### PR TITLE
fix(version-check): 오프라인 신규 사용자 매 실행 1.5s hang 방지

### DIFF
--- a/src/lib/version-check.ts
+++ b/src/lib/version-check.ts
@@ -45,8 +45,8 @@ export function compareSemver(a: string, b: string): number {
 }
 
 export interface VersionCache {
-  latest: string
-  checkedAt: number // 성공 갱신 시각(Date.now())
+  latest?: string // 조회 성공 시에만. 실패-쿨다운 기록(캐시 없던 상태)엔 없을 수 있음.
+  checkedAt: number // 성공 갱신 시각(Date.now()). 미성공 쿨다운 기록은 0.
   lastTriedAt?: number // 실패 포함 마지막 시도 시각(쿨다운용)
 }
 
@@ -69,7 +69,11 @@ export function readCache(): VersionCache | null {
     const p = getCachePath()
     if (!fs.existsSync(p)) return null
     const data = readJsonFile<Partial<VersionCache>>(p)
-    if (!data || typeof data.latest !== 'string' || typeof data.checkedAt !== 'number') {
+    if (
+      !data ||
+      typeof data.checkedAt !== 'number' ||
+      (data.latest !== undefined && typeof data.latest !== 'string')
+    ) {
       return null
     }
     return { latest: data.latest, checkedAt: data.checkedAt, lastTriedAt: data.lastTriedAt }
@@ -119,8 +123,9 @@ export function getUpdateInfo(now: number = Date.now()): UpdateInfo {
         writeCache({ latest: fetched, checkedAt: now, lastTriedAt: now })
         latest = fetched
       } else {
-        // 조회 실패 — 쿨다운 기록 + 이전 값(있으면) 유지.
-        if (cache) writeCache({ ...cache, lastTriedAt: now })
+        // 조회 실패 — 쿨다운 기록(캐시가 없던 경우에도 lastTriedAt 를 남겨야 매 실행 1.5s 재조회를
+        // 무한 반복하지 않는다 — 오프라인 신규 사용자 hang 방지). 이전 latest·checkedAt 은 보존.
+        writeCache({ latest: cache?.latest, checkedAt: cache?.checkedAt ?? 0, lastTriedAt: now })
         latest = cache?.latest
       }
     } else {

--- a/tests/version-check.test.ts
+++ b/tests/version-check.test.ts
@@ -99,13 +99,37 @@ describe('getUpdateInfo — 가끔 자동 확인', () => {
     expect(info.latest).toBe('2.5.0')
   })
 
-  it('⑥ 캐시 없음 + 조회 실패 → latest undefined, 크래시 0', async () => {
+  it('⑥ 캐시 없음 + 조회 실패 → 쿨다운 기록(BUG#1 가드), latest undefined', async () => {
     mockExistsSync.mockReturnValue(false)
     mockSafeExecFile.mockReturnValue({ ok: false, err: 'offline', out: '' })
     const { getUpdateInfo } = await import('../src/lib/version-check.js')
     const info = getUpdateInfo(NOW)
     expect(info).toEqual({ current: '2.4.0', latest: undefined, updateAvailable: false })
-    expect(mockWriteFileSync).not.toHaveBeenCalled() // 캐시 없으면 write 안 함
+    // BUG#1: 캐시 없어도 lastTriedAt 기록해야 다음 호출이 1.5s 재조회를 반복하지 않음.
+    expect(mockWriteFileSync).toHaveBeenCalled()
+    const payload = JSON.parse(String(mockWriteFileSync.mock.calls[0][1]))
+    expect(payload.lastTriedAt).toBe(NOW)
+    expect(payload.latest).toBeUndefined()
+  })
+
+  it('⑥-b 캐시 없음 + 조회 성공 → 첫날 알림 + 캐시 생성', async () => {
+    mockExistsSync.mockReturnValue(false)
+    mockSafeExecFile.mockReturnValue({ ok: true, out: '2.9.0' })
+    const { getUpdateInfo } = await import('../src/lib/version-check.js')
+    const info = getUpdateInfo(NOW)
+    expect(info.latest).toBe('2.9.0')
+    expect(info.updateAvailable).toBe(true)
+    expect(mockWriteFileSync).toHaveBeenCalled()
+  })
+
+  it('⑥-c 조회 실패 후 쿨다운 내 재호출 → 재조회 0 (1.5s hang 방지 회귀 가드)', async () => {
+    // 첫 실패가 남긴 캐시(latest 없음, checkedAt 0, lastTriedAt=NOW)를 읽는 상황
+    mockExistsSync.mockReturnValue(true)
+    mockReadJsonFile.mockReturnValue({ checkedAt: 0, lastTriedAt: NOW })
+    mockSafeExecFile.mockReturnValue({ ok: false, err: 'offline', out: '' })
+    const { getUpdateInfo } = await import('../src/lib/version-check.js')
+    getUpdateInfo(NOW + 10 * 60 * 1000) // 10분 후(쿨다운 1h 내)
+    expect(mockSafeExecFile).not.toHaveBeenCalled() // 쿨다운 → 네트워크 0
   })
 
   it('⑦ 캐시 JSON 손상 → readCache null, throw 0 (알림만 생략)', async () => {


### PR DESCRIPTION
﻿## 무엇

`vhk` 메뉴의 업데이트 체크(`getUpdateInfo`) 적대 검증에서 발견한 CRITICAL 버그 수정.

## 버그 (BUG#1)

캐시 파일(`~/.vhk/version-check.json`)이 **한 번도 없던 상태 + 오프라인**이면, `getUpdateInfo`가 매 `vhk` 실행마다 1.5초 `npm view`를 무한 재시도 → 메뉴가 매번 멈춤(hang).

원인: 쿨다운(`lastTriedAt`)을 캐시 쓰기에만 의존했는데, 조회 실패 시 `if (cache) writeCache(...)`라 **캐시가 없으면 쿨다운이 영영 안 걸림** → `lastTried=0` → `cooledDown` 항상 true → 재조회 반복.

## 수정

- `VersionCache.latest`를 optional로 — 조회 실패 시 캐시가 없던 경우에도 `{ checkedAt:0, lastTriedAt:now }`를 기록해 1h 쿨다운 발동(매 실행 재조회 차단).
- `readCache` 검증 완화(`latest` 없거나 string이면 유효).
- 테스트: ⑥를 쿨다운 기록 기대로 수정(버그를 정상으로 문서화하던 것 교정) + ⑥-b(첫날 알림 커버리지) + ⑥-c(쿨다운 내 재조회 0 — BUG#1 회귀 가드).

## 검증

- 타입체크 0 · 빌드 OK · 테스트 **890 pass**.
- 적대 검증 4각도(캐시 상태머신/통합/엣지/테스트) — BUG#1 외 나머지는 REFUTED(자동 await 정상, 방어코드로 crash 차단).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
