### PR TITLE
feat(preflight): vhk preflight — 출고 전 안전점검 8개 항목 (Goal 29)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -61,6 +61,17 @@ Cursor에게 한국어로 말해도 됩니다.
 
 > **v2.0 BREAKING**: 평면 memory.json → 4버킷(결정/실패/성공/패턴). **조회 명령(`vhk memory list`·`context`·`brief`) 첫 실행 시에도 v1→v2 자동 마이그레이션 + `.v1.bak` 원본 백업**(어느 명령으로 먼저 실행해도 동일). **교훈은 `vhk learn`·`memory failure --lesson` 단일 SoT** (구 `docs/state/learnings.md` 분리 폐지·흡수). 보관(archive)된 항목은 패턴·진화에서 제외(선순환).
 
+## 출고 전 안전점검 (preflight)
+
+| 하고 싶은 것 | 터미널 명령 | Cursor에게 말하기 |
+|-------------|-----------|------------------|
+| 출고 전 일괄 점검 | `vhk preflight` | "출고 전 점검해" |
+| publish 직전 점검 | `vhk preflight --publish` | "출시 전 점검해" |
+| PR 직전 점검 | `vhk preflight --pr` | "PR 전 점검해" |
+| 테스트 전체 실행 | `vhk preflight --full` | "전체 테스트로 점검해" |
+
+> `preflight` 는 publish/PR 직전 **2FA·shim·worktree env·lint·타입·테스트·git·브랜치 8개**를 한 번에 점검합니다. 치명(🔴: env/lint/타입/테스트) 실패가 1개라도 있으면 `--force` 없이 차단(exit 1). 기본 테스트는 `vitest --changed`(통과분 캐시 스킵), `--full` 로 전체 실행. (읽기 전용 — 자동 수정은 후속)
+
 ## 환경 점검
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ vhk 기획 끝났고 바로 시작
 | `vhk secure` | `보안` | 시크릿·키 유출 스캔 (`scan` / `스캔` 동일). **CRITICAL/HIGH 발견 시 exit code 1** (CI용) |
 | `vhk ship` | `출하` | 배포 체크리스트 + 회고 + 빌드 로그 |
 | `vhk doctor` | `환경`, `진단` | Node / npm / pnpm / Git 환경 점검 |
+| `vhk preflight` | `출고점검` | 출고 전 안전점검 — 2FA·shim·worktree env·lint·타입·테스트·git·브랜치 8개 일괄, 치명(env/lint/타입/테스트) 실패 시 차단(exit 1). 기본 `vitest --changed`, `--publish`/`--pr`/`--full` |
 | `vhk cloud push` | `클라우드`, `올리기` | `.vhk/` 를 GitHub secret gist 로 백업 (gh CLI 인증 사용) |
 | `vhk cloud pull` | `내리기` | gist 에서 `.vhk/` 복원 (`vhk cloud pull <gistId>` 또는 cloud.json) |
 | `vhk save` | `저장`, `커밋` | git add · commit · push 한 번에 |

--- a/scripts/check-goal-29.mjs
+++ b/scripts/check-goal-29.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// scripts/check-goal-29.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 29 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 29] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 29 고유 검증 (vhk preflight) ───────────────────────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// 산출물: 코어 + CLI + 재사용 모듈(worktree-env, goal 30 공유) + 테스트
+must(existsSync('src/lib/preflight.ts'), 'src/lib/preflight.ts 존재 (코어)')
+must(existsSync('src/lib/worktree-env.ts'), 'src/lib/worktree-env.ts 존재 (goal 30 재사용 모듈)')
+must(existsSync('src/commands/preflight.ts'), 'src/commands/preflight.ts 존재 (CLI)')
+must(existsSync('tests/preflight.test.ts'), 'tests/preflight.test.ts 존재')
+must(existsSync('tests/worktree-env.test.ts'), 'tests/worktree-env.test.ts 존재')
+const core = read('src/lib/preflight.ts') ?? ''
+must(/export function runPreflight/.test(core), 'runPreflight 오케스트레이터 export')
+must(/export function summarizePreflight/.test(core), 'summarizePreflight(차단 판정) export')
+// 불변규칙: 외부 명령은 safeExecFile 한 곳으로 — preflight 코어에 execSync 직접 사용 금지
+must(!/execSync/.test(core), 'preflight 코어에 execSync 직접 사용 없음 (safeExecFile 경유)')
+// CLI 가 commander/registry/자연어 라우터 단일소스에 등록됐는지
+must(/preflight/.test(read('src/index.ts') ?? ''), 'index.ts 에 preflight 명령 등록')
+must(/preflight/.test(read('src/lib/command-registry.ts') ?? ''), 'command-registry TOP_LEVEL 등록')
+must(/preflight/.test(read('src/lib/cli-args.ts') ?? ''), 'cli-args KNOWN_COMMAND_TOKENS 등록')
+
+if (pass) { console.log('✅ goal 29 gate passes'); process.exit(0) }
+console.log('❌ goal 29 gate failed'); process.exit(1)

--- a/src/commands/preflight.ts
+++ b/src/commands/preflight.ts
@@ -1,0 +1,93 @@
+import chalk from 'chalk'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { ko } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
+import { safeExecFile } from '../lib/exec.js'
+import { readJsonFile } from '../lib/read-json.js'
+import { checkWorktreeEnvDir } from '../lib/worktree-env.js'
+import {
+  runPreflight,
+  summarizePreflight,
+  statusIcon,
+  detectHasLinter,
+  type Runner,
+  type PreflightOptions,
+} from '../lib/preflight.js'
+
+// 린트 설정 파일 후보(eslint). 하나라도 있으면 lint 점검 활성.
+const ESLINT_CONFIGS = [
+  '.eslintrc.js',
+  '.eslintrc.cjs',
+  '.eslintrc.json',
+  '.eslintrc.yml',
+  'eslint.config.js',
+  'eslint.config.mjs',
+]
+
+export interface PreflightCliOptions {
+  publish?: boolean
+  pr?: boolean
+  full?: boolean
+}
+
+// vhk preflight — 출고 전 안전점검(Phase 1, 읽기 전용).
+// 치명(critical) 실패 1개라도 있으면 exit 1 로 차단(--force 우회 없음).
+export async function preflight(opts: PreflightCliOptions = {}): Promise<void> {
+  if (!ensureNotHardStopped('preflight')) return // VHK-020
+  console.log(chalk.bold(`\n${ko.preflight.title}\n`))
+
+  const cwd = process.cwd()
+
+  // 외부 명령은 safeExecFile 한 곳으로(execSync 금지). 코어는 주입된 run 만 호출.
+  const run: Runner = (cmd, args) => {
+    const r = safeExecFile(cmd, args)
+    return r.ok ? { ok: true, out: r.out } : { ok: false, out: r.out, err: r.err }
+  }
+
+  // lint 활성 여부 = lint 스크립트 또는 eslint 설정 존재.
+  let hasLintScript = false
+  try {
+    const pkg = readJsonFile<{ scripts?: Record<string, string> }>(join(cwd, 'package.json'))
+    hasLintScript = !!pkg.scripts?.lint
+  } catch {
+    // package.json 없거나 파싱 실패 → lint 스킵(아래 detectHasLinter 가 false 처리)
+  }
+  const hasEslintConfig = ESLINT_CONFIGS.some((f) => existsSync(join(cwd, f)))
+  const hasLinter = detectHasLinter({ hasLintScript, hasEslintConfig })
+
+  const mode: PreflightOptions['mode'] = opts.publish ? 'publish' : opts.pr ? 'pr' : 'default'
+  const checks = runPreflight(
+    { full: opts.full, mode },
+    {
+      run,
+      nodeVersion: process.version,
+      hasLinter,
+      worktreeEnv: () => checkWorktreeEnvDir(cwd),
+    }
+  )
+
+  for (const c of checks) {
+    console.log(`  ${statusIcon(c)} ${c.name.padEnd(14)} ${chalk.dim(c.detail)}`)
+  }
+
+  const s = summarizePreflight(checks)
+  console.log('')
+  if (s.blocked) {
+    console.log(chalk.red.bold(`  ${ko.preflight.resultBlocked(s.failed)}`))
+    printNextStep({
+      message: ko.preflight.nextBlocked,
+      command: 'vhk preflight',
+      cursorHint: 'preflight 다시 돌려줘',
+    })
+    process.exitCode = 1
+  } else {
+    console.log(chalk.green.bold(`  ${ko.preflight.resultPass(s.warned)}`))
+    printNextStep({
+      message: ko.preflight.nextPass,
+      command: opts.publish ? 'vhk publish' : 'vhk save',
+      cursorHint: '다음 단계로',
+    })
+  }
+}

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -217,6 +217,13 @@ export const ko = {
       `⚠️ RULES.md와 어긋난 규칙 파일: ${files} — vhk sync 를 다시 실행하세요`,
     driftContextWarn: '⚠️ .vhk/context.md 가 현재 코드보다 낡았어요 — vhk context 로 갱신하세요',
   },
+  preflight: {
+    title: '🛫 Preflight — 출고 전 안전점검',
+    resultBlocked: (n: number) => `결과: 차단 — 치명 실패 ${n}개. 고친 뒤 다시 실행하세요.`,
+    resultPass: (warn: number) => (warn > 0 ? `결과: 통과 (경고 ${warn})` : '결과: 통과'),
+    nextBlocked: '치명(🔴) 항목을 수정한 뒤 다시 실행하세요.',
+    nextPass: 'publish/PR 진행 가능',
+  },
   nlp: {
     matched: '이게 맞나요?',
     notMatched: '무슨 뜻인지 모르겠어요. vhk를 입력하면 메뉴에서 선택할 수 있습니다.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import { QUICK_ACTIONS } from './commands/help.js'
 import { start } from './commands/start.js'
 import { mode } from './commands/mode.js'
 import { verify } from './commands/verify.js'
+import { preflight } from './commands/preflight.js'
 import { review } from './commands/review.js'
 import { missionSet, missionShow, missionCheck, missionClear } from './commands/mission.js'
 import { runGuarded } from './lib/safety-guard.js'
@@ -143,6 +144,7 @@ const KO_ALIASES: Record<string, string> = {
   memory: '기억',
   brief: '브리핑',
   goal: '목표',
+  preflight: '출고점검',
   review: '검토',
   mission: '미션',
   blocker: '블로커',
@@ -462,6 +464,15 @@ program
   .option('--open', '리포트 생성 후 기본 브라우저로 열기 (비대화형/CI/MCP 자동 스킵)')
   .description('검증 게이트(tsc/test/build/secure) 실제 실행 + 증거 기록 (.vhk/reports/latest.json)')
   .action(async (opts: { json?: boolean; report?: boolean; open?: boolean }) => { await verify(opts) })
+
+program
+  .command('preflight')
+  .alias('출고점검')
+  .option('--publish', 'publish 직전 점검 (2FA·버전 강조)')
+  .option('--pr', 'PR 직전 점검 (lint·테스트·브랜치 강조)')
+  .option('--full', '테스트 전체 실행 (--changed 캐시 미사용)')
+  .description('출고 전 안전점검 — 2FA·shim·env·lint·타입·테스트·git 8개 항목, 치명 실패 시 차단')
+  .action(async (opts: { publish?: boolean; pr?: boolean; full?: boolean }) => { await preflight(opts) })
 
 program
   .command('review')

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -43,6 +43,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'resume', '재개',
   'mode', '모드',
   'verify', '사전점검',
+  'preflight', '출고점검',
   'review', '검토',
   'mission', '미션',
   'pattern', '패턴',

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -79,6 +79,7 @@ export const TOP_LEVEL_COMMANDS: ReadonlyArray<{ name: string; desc: string }> =
   { name: 'context', desc: '프로젝트 맥락 파일 생성 (.vhk/context.md)' },
   { name: 'mode', desc: 'Safety Mode 조회/변경 (lite|standard|strict)' },
   { name: 'verify', desc: '검증 게이트 실행 + 증거 기록' },
+  { name: 'preflight', desc: '출고 전 안전점검 (2FA·shim·env·lint·타입·테스트·git, 치명 시 차단)' },
   { name: 'review', desc: '적대적 자기검증 (거짓완료 의심 탐지)' },
   { name: 'mission', desc: '미션 계약 — 작업 목표·허용/금지 범위 선언·검증' },
   { name: 'context-show', desc: '컨텍스트 파일 내용 출력' },

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -1,0 +1,151 @@
+// Goal 29 — vhk preflight 코어(출고 전 안전점검).
+// 외부 명령은 주입된 Runner 로만 호출 → 단위 테스트에서 safeExecFile mock 격리.
+// 치명(critical) 실패 1개라도 있으면 blocked(차단). high/normal 은 경고만.
+
+import type { CheckStatus, Severity, EnvCheckResult } from './worktree-env.js'
+
+export type { CheckStatus, Severity }
+
+// PreflightCheck 는 EnvCheckResult 와 동형 — worktree-env 모듈 결과를 그대로 합칠 수 있다.
+export type PreflightCheck = EnvCheckResult
+
+// 주입형 외부 명령 실행기. safeExecFile 을 얇게 감싼 형태.
+export type Runner = (cmd: string, args: string[]) => { ok: boolean; out: string; err?: string }
+
+export interface PreflightOptions {
+  full?: boolean // 테스트를 전체 실행(--changed 캐시 미사용)
+  mode?: 'default' | 'publish' | 'pr'
+}
+
+export interface PreflightDeps {
+  run: Runner
+  nodeVersion: string // 예: process.version ('v20.18.0')
+  hasLinter: boolean // eslint 설정/스크립트 존재 여부
+  worktreeEnv: () => PreflightCheck // checkWorktreeEnvDir 래핑(주입)
+}
+
+const check = (
+  name: string,
+  status: CheckStatus,
+  detail: string,
+  severity: Severity
+): PreflightCheck => ({ name, status, detail, severity })
+
+// ── 순수: Node .cmd shim CVE-2024-27980 안전 버전 판정 (20.12+ / 21.7+) ──
+export function nodeMeetsShimSafe(version: string): boolean {
+  const m = version.replace(/^v/, '').split('.')
+  const major = Number(m[0])
+  const minor = Number(m[1] ?? 0)
+  if (!Number.isFinite(major)) return false
+  if (major > 21) return true
+  if (major === 21) return minor >= 7
+  if (major === 20) return minor >= 12
+  return false
+}
+
+// ── 개별 점검(주입 Runner) ──
+export function checkNpmAuth(run: Runner): PreflightCheck {
+  const r = run('npm', ['whoami'])
+  if (r.ok && r.out.trim()) {
+    return check('2FA / npm', 'pass', `logged in as ${r.out.trim()}`, 'high')
+  }
+  return check('2FA / npm', 'warn', 'npm 로그인 필요 (npm login). publish 시 2FA OTP는 사람이 직접 입력', 'high')
+}
+
+export function checkShim(nodeVersion: string): PreflightCheck {
+  if (nodeMeetsShimSafe(nodeVersion)) {
+    return check('shim', 'pass', `Node ${nodeVersion} (safe)`, 'high')
+  }
+  return check('shim', 'warn', `Node ${nodeVersion} — .cmd shim CVE 취약(20.12+/21.7+ 권장)`, 'high')
+}
+
+export function checkLint(run: Runner, hasLinter: boolean): PreflightCheck {
+  if (!hasLinter) {
+    return check('lint', 'skip', 'eslint 미설정 — 린트 스킵', 'critical')
+  }
+  const r = run('npx', ['eslint', '.'])
+  return r.ok
+    ? check('lint', 'pass', '0 errors', 'critical')
+    : check('lint', 'fail', 'eslint 오류 — 출력 확인', 'critical')
+}
+
+export function checkTypecheck(run: Runner): PreflightCheck {
+  const r = run('npx', ['tsc', '--noEmit'])
+  return r.ok
+    ? check('typecheck', 'pass', 'tsc --noEmit pass', 'critical')
+    : check('typecheck', 'fail', 'tsc 타입 오류 — 출력 확인', 'critical')
+}
+
+export function checkTests(run: Runner, opts: { full?: boolean }): PreflightCheck {
+  const args = opts.full ? ['vitest', '--run'] : ['vitest', '--changed', '--run']
+  const r = run('npx', args)
+  return r.ok
+    ? check('tests', 'pass', opts.full ? '전체 통과' : '변경분 통과(캐시 스킵)', 'critical')
+    : check('tests', 'fail', '테스트 실패 — 출력 확인', 'critical')
+}
+
+export function checkGitClean(run: Runner): PreflightCheck {
+  const r = run('git', ['status', '--porcelain'])
+  if (!r.ok) return check('git', 'warn', 'git 상태 확인 실패', 'normal')
+  const lines = r.out.split('\n').filter((l) => l.trim())
+  return lines.length === 0
+    ? check('git', 'pass', 'clean', 'normal')
+    : check('git', 'warn', `uncommitted ${lines.length} files`, 'normal')
+}
+
+export function checkBranch(run: Runner): PreflightCheck {
+  const r = run('git', ['rev-parse', '--abbrev-ref', 'HEAD'])
+  const branch = r.out.trim()
+  if (branch === 'main' || branch === 'master') {
+    return check('branch', 'warn', `${branch} 직접 — feature 브랜치 권장(한 PR 한 goal)`, 'normal')
+  }
+  return check('branch', 'pass', branch || '(unknown)', 'normal')
+}
+
+// ── 집계 ──
+export interface PreflightSummary {
+  blocked: boolean // critical fail 1개라도 있으면 true
+  passed: number
+  warned: number
+  failed: number
+  skipped: number
+}
+
+export function summarizePreflight(checks: PreflightCheck[]): PreflightSummary {
+  const s: PreflightSummary = { blocked: false, passed: 0, warned: 0, failed: 0, skipped: 0 }
+  for (const c of checks) {
+    if (c.status === 'pass') s.passed++
+    else if (c.status === 'warn') s.warned++
+    else if (c.status === 'fail') s.failed++
+    else if (c.status === 'skip') s.skipped++
+    if (c.status === 'fail' && c.severity === 'critical') s.blocked = true
+  }
+  return s
+}
+
+// lint 점검 활성 여부 — lint 스크립트 또는 eslint 설정 파일 존재 시. (값은 CLI가 fs/pkg에서 계산)
+export function detectHasLinter(input: { hasLintScript: boolean; hasEslintConfig: boolean }): boolean {
+  return input.hasLintScript || input.hasEslintConfig
+}
+
+// 출력 아이콘: 상태 우선, warn 은 severity 로 🟠(high)/🟡(normal) 구분.
+export function statusIcon(c: PreflightCheck): string {
+  if (c.status === 'pass') return '🟢'
+  if (c.status === 'fail') return '🔴'
+  if (c.status === 'skip') return '⚪'
+  return c.severity === 'high' ? '🟠' : '🟡'
+}
+
+// ── 오케스트레이션: 8개 항목 점검(읽기 전용, Phase 1) ──
+export function runPreflight(opts: PreflightOptions, deps: PreflightDeps): PreflightCheck[] {
+  return [
+    checkNpmAuth(deps.run),
+    checkShim(deps.nodeVersion),
+    deps.worktreeEnv(),
+    checkLint(deps.run, deps.hasLinter),
+    checkTypecheck(deps.run),
+    checkTests(deps.run, { full: opts.full }),
+    checkGitClean(deps.run),
+    checkBranch(deps.run),
+  ]
+}

--- a/src/lib/worktree-env.ts
+++ b/src/lib/worktree-env.ts
@@ -1,0 +1,78 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Goal 29 preflight ↔ Goal 30 worktree 공유 모듈.
+// worktree 의 필수 env 키가 채워졌는지 점검한다. SoT = .env.example 의 키 목록.
+// 순수 함수(parse/missing) + 얇은 IO 래퍼(checkWorktreeEnv) 로 분리 — 테스트·재사용 용이.
+
+export type Severity = 'critical' | 'high' | 'normal'
+export type CheckStatus = 'pass' | 'warn' | 'fail' | 'skip'
+
+export interface EnvCheckResult {
+  name: string
+  status: CheckStatus
+  detail: string
+  severity: Severity
+}
+
+// `KEY=value` 줄에서 KEY 만 추출. 주석(#)·빈 줄·'=' 없는 줄은 무시.
+// `export KEY=` 접두사 허용(.env.example 관례). nested/multiline 미지원(flat 만).
+export function parseEnvKeys(content: string): string[] {
+  const keys: string[] = []
+  for (const raw of content.split(/\r?\n/)) {
+    let line = raw.trim()
+    if (!line || line.startsWith('#')) continue
+    if (line.startsWith('export ')) line = line.slice('export '.length).trim()
+    const idx = line.indexOf('=')
+    if (idx <= 0) continue
+    const key = line.slice(0, idx).trim()
+    if (key) keys.push(key)
+  }
+  return keys
+}
+
+// required 중 present 에 없는 키만 반환(순서 보존).
+export function missingEnvKeys(required: string[], present: string[]): string[] {
+  const have = new Set(present)
+  return required.filter((k) => !have.has(k))
+}
+
+// .env.example(필수 SoT) ↔ 실제 env 파일 비교. 비밀값은 절대 읽지/로그하지 않고 키 존재만 본다.
+// exampleContent === null → 필수 명세 없음 → skip(강제 안 함).
+export function checkWorktreeEnv(input: {
+  exampleContent: string | null
+  envContent: string | null
+}): EnvCheckResult {
+  const name = 'worktree env'
+  const severity: Severity = 'critical'
+  if (input.exampleContent === null) {
+    return { name, status: 'skip', detail: '.env.example 없음 — 필수 키 명세 없음', severity }
+  }
+  const required = parseEnvKeys(input.exampleContent)
+  if (required.length === 0) {
+    return { name, status: 'skip', detail: '.env.example 에 필수 키 없음', severity }
+  }
+  const present = input.envContent === null ? [] : parseEnvKeys(input.envContent)
+  const missing = missingEnvKeys(required, present)
+  if (missing.length === 0) {
+    return { name, status: 'pass', detail: `${required.length}/${required.length} keys present`, severity }
+  }
+  return {
+    name,
+    status: 'fail',
+    detail: `누락 ${missing.length}개: ${missing.join(', ')}`,
+    severity,
+  }
+}
+
+// 실제 디렉터리에서 .env.example + env 파일을 읽어 점검(IO 래퍼).
+// env 후보: .env.local 우선(Vite 관례), 없으면 .env. 비밀값은 읽되 키 추출 외 사용/로그 금지.
+export function checkWorktreeEnvDir(cwd: string): EnvCheckResult {
+  const read = (p: string): string | null => {
+    const fp = join(cwd, p)
+    return existsSync(fp) ? readFileSync(fp, 'utf-8') : null
+  }
+  const exampleContent = read('.env.example')
+  const envContent = read('.env.local') ?? read('.env')
+  return checkWorktreeEnv({ exampleContent, envContent })
+}

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest'
+import {
+  nodeMeetsShimSafe,
+  checkNpmAuth,
+  checkShim,
+  checkLint,
+  checkTypecheck,
+  checkTests,
+  checkGitClean,
+  checkBranch,
+  summarizePreflight,
+  runPreflight,
+  detectHasLinter,
+  statusIcon,
+  type Runner,
+  type PreflightCheck,
+} from '../src/lib/preflight.js'
+
+// 호출 기록 + 지정 응답을 주는 mock runner.
+function mockRunner(responses: Record<string, { ok: boolean; out: string; err?: string }>): {
+  run: Runner
+  calls: string[]
+} {
+  const calls: string[] = []
+  const run: Runner = (cmd, args) => {
+    const key = `${cmd} ${args.join(' ')}`.trim()
+    calls.push(key)
+    return responses[key] ?? { ok: true, out: '' }
+  }
+  return { run, calls }
+}
+
+describe('nodeMeetsShimSafe', () => {
+  it('20.12+ 는 안전', () => {
+    expect(nodeMeetsShimSafe('v20.18.0')).toBe(true)
+    expect(nodeMeetsShimSafe('v20.12.0')).toBe(true)
+  })
+  it('20.11 이하는 취약', () => {
+    expect(nodeMeetsShimSafe('v20.11.0')).toBe(false)
+  })
+  it('21.7+ 안전, 21.6 이하 취약', () => {
+    expect(nodeMeetsShimSafe('v21.7.0')).toBe(true)
+    expect(nodeMeetsShimSafe('v21.6.0')).toBe(false)
+  })
+  it('22+ 는 안전', () => {
+    expect(nodeMeetsShimSafe('v22.0.0')).toBe(true)
+  })
+})
+
+describe('checkShim', () => {
+  it('안전 버전 → pass (high)', () => {
+    const r = checkShim('v20.18.0')
+    expect(r.status).toBe('pass')
+    expect(r.severity).toBe('high')
+  })
+  it('취약 버전 → warn', () => {
+    expect(checkShim('v20.10.0').status).toBe('warn')
+  })
+})
+
+describe('checkNpmAuth', () => {
+  it('whoami 성공 → pass', () => {
+    const { run } = mockRunner({ 'npm whoami': { ok: true, out: 'byh3071' } })
+    const r = checkNpmAuth(run)
+    expect(r.status).toBe('pass')
+    expect(r.detail).toContain('byh3071')
+  })
+  it('whoami 실패 → warn (high, 차단 아님)', () => {
+    const { run } = mockRunner({ 'npm whoami': { ok: false, out: '', err: 'ENEEDAUTH' } })
+    const r = checkNpmAuth(run)
+    expect(r.status).toBe('warn')
+    expect(r.severity).toBe('high')
+  })
+})
+
+describe('checkLint', () => {
+  it('린터 미설정 → skip (차단 안 함)', () => {
+    const { run, calls } = mockRunner({})
+    const r = checkLint(run, false)
+    expect(r.status).toBe('skip')
+    expect(calls).toEqual([]) // 린터 없으면 실행조차 안 함
+  })
+  it('린터 있고 통과 → pass', () => {
+    const { run } = mockRunner({ 'npx eslint .': { ok: true, out: '' } })
+    expect(checkLint(run, true).status).toBe('pass')
+  })
+  it('린터 있고 실패 → critical fail', () => {
+    const { run } = mockRunner({ 'npx eslint .': { ok: false, out: '', err: 'errors' } })
+    const r = checkLint(run, true)
+    expect(r.status).toBe('fail')
+    expect(r.severity).toBe('critical')
+  })
+})
+
+describe('checkTypecheck', () => {
+  it('tsc 통과 → pass (critical)', () => {
+    const { run } = mockRunner({ 'npx tsc --noEmit': { ok: true, out: '' } })
+    const r = checkTypecheck(run)
+    expect(r.status).toBe('pass')
+    expect(r.severity).toBe('critical')
+  })
+  it('tsc 실패 → fail', () => {
+    const { run } = mockRunner({ 'npx tsc --noEmit': { ok: false, out: 'TS2322', err: '' } })
+    expect(checkTypecheck(run).status).toBe('fail')
+  })
+})
+
+describe('checkTests', () => {
+  it('기본은 --changed (캐시 스킵)', () => {
+    const { run, calls } = mockRunner({})
+    checkTests(run, {})
+    expect(calls[0]).toContain('--changed')
+  })
+  it('--full 은 전체 실행 (--changed 없음)', () => {
+    const { run, calls } = mockRunner({})
+    checkTests(run, { full: true })
+    expect(calls[0]).not.toContain('--changed')
+  })
+  it('테스트 실패 → critical fail', () => {
+    const { run } = mockRunner({ 'npx vitest --changed --run': { ok: false, out: '1 failed', err: '' } })
+    const r = checkTests(run, {})
+    expect(r.status).toBe('fail')
+    expect(r.severity).toBe('critical')
+  })
+})
+
+describe('checkGitClean', () => {
+  it('변경 없음 → pass', () => {
+    const { run } = mockRunner({ 'git status --porcelain': { ok: true, out: '' } })
+    expect(checkGitClean(run).status).toBe('pass')
+  })
+  it('uncommitted 있음 → warn (normal)', () => {
+    const { run } = mockRunner({ 'git status --porcelain': { ok: true, out: ' M a.ts\n?? b.ts' } })
+    const r = checkGitClean(run)
+    expect(r.status).toBe('warn')
+    expect(r.severity).toBe('normal')
+  })
+})
+
+describe('checkBranch', () => {
+  it('feature 브랜치 → pass', () => {
+    const { run } = mockRunner({ 'git rev-parse --abbrev-ref HEAD': { ok: true, out: 'feat/x' } })
+    expect(checkBranch(run).status).toBe('pass')
+  })
+  it('main 직접 → warn', () => {
+    const { run } = mockRunner({ 'git rev-parse --abbrev-ref HEAD': { ok: true, out: 'main' } })
+    expect(checkBranch(run).status).toBe('warn')
+  })
+})
+
+describe('summarizePreflight', () => {
+  const mk = (status: PreflightCheck['status'], severity: PreflightCheck['severity']): PreflightCheck => ({
+    name: 'x', status, detail: '', severity,
+  })
+  it('critical fail 있으면 blocked', () => {
+    const s = summarizePreflight([mk('pass', 'critical'), mk('fail', 'critical')])
+    expect(s.blocked).toBe(true)
+    expect(s.failed).toBe(1)
+  })
+  it('high/normal fail 은 차단 안 함', () => {
+    const s = summarizePreflight([mk('warn', 'high'), mk('warn', 'normal')])
+    expect(s.blocked).toBe(false)
+    expect(s.warned).toBe(2)
+  })
+  it('전부 pass → blocked 아님', () => {
+    expect(summarizePreflight([mk('pass', 'critical'), mk('skip', 'critical')]).blocked).toBe(false)
+  })
+})
+
+describe('detectHasLinter', () => {
+  it('lint 스크립트 있으면 true', () => {
+    expect(detectHasLinter({ hasLintScript: true, hasEslintConfig: false })).toBe(true)
+  })
+  it('eslint config 있으면 true', () => {
+    expect(detectHasLinter({ hasLintScript: false, hasEslintConfig: true })).toBe(true)
+  })
+  it('둘 다 없으면 false', () => {
+    expect(detectHasLinter({ hasLintScript: false, hasEslintConfig: false })).toBe(false)
+  })
+})
+
+describe('statusIcon', () => {
+  const mk = (status: PreflightCheck['status'], severity: PreflightCheck['severity']): PreflightCheck => ({
+    name: 'x', status, detail: '', severity,
+  })
+  it('pass → 🟢, fail → 🔴, skip → ⚪', () => {
+    expect(statusIcon(mk('pass', 'normal'))).toBe('🟢')
+    expect(statusIcon(mk('fail', 'critical'))).toBe('🔴')
+    expect(statusIcon(mk('skip', 'critical'))).toBe('⚪')
+  })
+  it('warn 은 severity로 구분: high → 🟠, normal → 🟡', () => {
+    expect(statusIcon(mk('warn', 'high'))).toBe('🟠')
+    expect(statusIcon(mk('warn', 'normal'))).toBe('🟡')
+  })
+})
+
+describe('runPreflight', () => {
+  const okRunner = mockRunner({
+    'npm whoami': { ok: true, out: 'me' },
+    'npx tsc --noEmit': { ok: true, out: '' },
+    'npx vitest --changed --run': { ok: true, out: '' },
+    'git status --porcelain': { ok: true, out: '' },
+    'git rev-parse --abbrev-ref HEAD': { ok: true, out: 'feat/29-preflight' },
+  })
+  const deps = {
+    run: okRunner.run,
+    nodeVersion: 'v20.18.0',
+    hasLinter: false,
+    worktreeEnv: (): PreflightCheck => ({ name: 'worktree env', status: 'pass', detail: 'ok', severity: 'critical' }),
+  }
+
+  it('8개 항목을 점검한다', () => {
+    const checks = runPreflight({}, deps)
+    expect(checks).toHaveLength(8)
+  })
+  it('정상 환경 → blocked 아님', () => {
+    const checks = runPreflight({}, deps)
+    expect(summarizePreflight(checks).blocked).toBe(false)
+  })
+  it('worktree env 누락(critical fail) → blocked', () => {
+    const checks = runPreflight({}, {
+      ...deps,
+      worktreeEnv: (): PreflightCheck => ({ name: 'worktree env', status: 'fail', detail: '누락', severity: 'critical' }),
+    })
+    expect(summarizePreflight(checks).blocked).toBe(true)
+  })
+})

--- a/tests/worktree-env.test.ts
+++ b/tests/worktree-env.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { parseEnvKeys, missingEnvKeys, checkWorktreeEnv } from '../src/lib/worktree-env.js'
+
+describe('parseEnvKeys', () => {
+  it('KEY=value 줄에서 키만 뽑는다', () => {
+    expect(parseEnvKeys('API_KEY=abc\nDB_URL=postgres://x')).toEqual(['API_KEY', 'DB_URL'])
+  })
+
+  it('주석(#)·빈 줄은 무시한다', () => {
+    expect(parseEnvKeys('# comment\n\nA=1\n  \nB=2')).toEqual(['A', 'B'])
+  })
+
+  it('값이 비어도 키는 인식한다', () => {
+    expect(parseEnvKeys('EMPTY=')).toEqual(['EMPTY'])
+  })
+
+  it("'='가 없는 줄은 무시한다", () => {
+    expect(parseEnvKeys('JUST_TEXT\nA=1')).toEqual(['A'])
+  })
+
+  it('export 접두사를 허용한다', () => {
+    expect(parseEnvKeys('export TOKEN=xyz')).toEqual(['TOKEN'])
+  })
+})
+
+describe('missingEnvKeys', () => {
+  it('필수 중 빠진 키만 반환한다', () => {
+    expect(missingEnvKeys(['A', 'B', 'C'], ['A', 'C'])).toEqual(['B'])
+  })
+
+  it('전부 있으면 빈 배열', () => {
+    expect(missingEnvKeys(['A', 'B'], ['A', 'B', 'X'])).toEqual([])
+  })
+
+  it('필수가 없으면 빈 배열', () => {
+    expect(missingEnvKeys([], ['A'])).toEqual([])
+  })
+})
+
+describe('checkWorktreeEnv', () => {
+  it('필수 env 파일(.env.example) 없으면 skip — 강제하지 않음', () => {
+    const r = checkWorktreeEnv({ exampleContent: null, envContent: null })
+    expect(r.status).toBe('skip')
+    expect(r.severity).toBe('critical')
+  })
+
+  it('필수 키가 모두 있으면 pass', () => {
+    const r = checkWorktreeEnv({ exampleContent: 'A=\nB=', envContent: 'A=1\nB=2' })
+    expect(r.status).toBe('pass')
+    expect(r.detail).toContain('2/2')
+  })
+
+  it('필수 키가 빠지면 critical fail + 누락 키 표시', () => {
+    const r = checkWorktreeEnv({ exampleContent: 'A=\nB=\nC=', envContent: 'A=1' })
+    expect(r.status).toBe('fail')
+    expect(r.severity).toBe('critical')
+    expect(r.detail).toContain('B')
+    expect(r.detail).toContain('C')
+  })
+
+  it('env 파일 자체가 없는데 필수 키가 있으면 fail', () => {
+    const r = checkWorktreeEnv({ exampleContent: 'A=', envContent: null })
+    expect(r.status).toBe('fail')
+  })
+})


### PR DESCRIPTION
## Goal 29 — `vhk preflight` (출고 전 안전점검)

Notion "D1 · vhk preflight 상세 설계" Phase 1(읽기 전용) 구현. publish/PR 직전 사고날 곳을 한 번에 점검.

## 동작
`vhk preflight` (별칭 `출고점검`) — 8개 항목 일괄 점검, 치명 실패 시 차단.

```
🛫 Preflight — 출고 전 안전점검
  🟢 2FA / npm      logged in as byh3071
  🟢 shim           Node v24.13.0 (safe)
  ⚪ worktree env   .env.example 없음 — 필수 키 명세 없음
  ⚪ lint           eslint 미설정 — 린트 스킵
  🟢 typecheck      tsc --noEmit pass
  🟢 tests          변경분 통과(캐시 스킵)
  🟡 git            uncommitted N files
  🟢 branch         feat/29-preflight
  결과: 통과 (경고 1)
```

| 심각도 | 항목 | 실패 시 |
|---|---|---|
| 🔴 critical | worktree env · lint · typecheck · tests | **차단(exit 1)** |
| 🟠 high | 2FA/npm · shim | 경고 |
| 🟡 normal | git 청결 · 브랜치 | 경고 |

- 플래그: `--publish` / `--pr` / `--full`(테스트 전체, 기본은 `vitest --changed` 캐시 스킵).
- 치명 1개라도 있으면 `--force` 없이 차단(사고 원천 봉쇄).
- lint·typecheck 미설정 환경은 graceful skip(이 레포는 eslint 미설정 → ⚪).

## 설계 (불변규칙 준수)
- 외부 명령은 **주입 Runner(safeExecFile)** 로만 → `execSync` 0, 단위테스트 mock 격리.
- `src/lib/worktree-env.ts` 분리 → **Goal 30(worktree 가드)이 재사용**(이중 구현 금지).
- `HARD_STOP` 가드 + commander/registry/cli-args 단일소스 등록(드리프트 가드 통과).

## 파일
- 신규: `src/lib/preflight.ts`(코어), `src/lib/worktree-env.ts`(공유), `src/commands/preflight.ts`(CLI), `tests/preflight.test.ts`, `tests/worktree-env.test.ts`, `scripts/check-goal-29.mjs`
- 수정: `src/index.ts`, `src/lib/cli-args.ts`, `src/lib/command-registry.ts`, `src/i18n/ko.ts`, `README.md`, `COMMANDS.md`

## 게이트 (통과 확인)
- `vhk goal check --id 29` ✅ — typecheck ✓ · test ✓ · build ✓ · 고유검증 11/11 ✓
- 전체 테스트 **933 pass**(84 files) — 신규 43(worktree-env 12 + preflight 31), 회귀 0.

## 범위 밖 (후속)
- `--fix` 자동수정(Phase 2) · git post-checkout hook(Phase 3) · MCP 도구 노출.

> 한 PR = 한 goal. npm publish는 사람만. 머지는 리뷰 후 사람.
