### PR TITLE
fix(recap+check): recap 오늘 커밋 누락 + check 자기 코드 주석 오탐

### DIFF
--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -80,12 +80,19 @@ export function buildSessionDiffFromSummary(diffSummary: {
 /** 빈 트리 SHA — since 가 전체 히스토리를 포함할 때(boundary 없음) diff 기준점. */
 const EMPTY_TREE_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
 
+// git approxidate 함정: `--since`/`--before` 에 시각 없는 날짜("2026-06-06")만 주면 git 이
+// 자정이 아니라 **현재 시각**을 붙여 해석한다 → `--since=오늘` 은 "지금 이후"라 그날 커밋이 전부
+// 누락(특히 밤에 recap 시 그날 작업 0건 오판). 시각이 없으면 자정(00:00:00)을 명시한다.
+export function withMidnight(d: string): string {
+  return /\d{1,2}:\d{2}/.test(d) ? d : `${d} 00:00:00`
+}
+
 export async function getSessionDiff(since?: string): Promise<SessionDiff> {
   const sinceDate = since || localDate() // VHK-019: 기본 since 는 로컬 '오늘'
   try {
     // VHK-015: `git diff --since` 는 무효(--since 는 log 옵션) → 워킹트리만 diff 해 항상 0.
     // since 직전 커밋(boundary)..HEAD 의 커밋 범위를 diff 해 실제 변경 통계를 낸다.
-    const boundary = (await git.raw(['rev-list', '-1', `--before=${sinceDate}`, 'HEAD'])).trim()
+    const boundary = (await git.raw(['rev-list', '-1', `--before=${withMidnight(sinceDate)}`, 'HEAD'])).trim()
     const base = boundary || EMPTY_TREE_SHA
     const diffSummary = await git.diffSummary([`${base}..HEAD`])
     // simple-git DiffResult.files 는 text/binary/name-status 의 union.
@@ -114,7 +121,7 @@ export async function getRecentCommits(
   since?: string
 ): Promise<RecentCommit[]> {
   const options: Record<string, unknown> = { maxCount: count }
-  if (since) options['--since'] = since
+  if (since) options['--since'] = withMidnight(since) // 시각 없는 날짜는 자정 명시(approxidate 함정)
 
   try {
     const log = await git.log(options)

--- a/src/lib/rules-parser.ts
+++ b/src/lib/rules-parser.ts
@@ -168,6 +168,17 @@ function createStructureRule(
   }
 }
 
+// 한 줄에서 '코드 부분'만 추출 — 주석 줄/줄끝 주석/문자열·백틱 리터럴 내 토큰은 '실제 사용'이
+// 아니다. 이 가드 없이 라인 전체를 매칭하면 금지패턴 추출기 자신의 설명 주석(예: `execSync` 예시)을
+// 위반으로 오탐한다(자기 코드 도그푸딩 함정).
+export function codePortionForScan(line: string): string {
+  const t = line.trimStart()
+  if (t.startsWith('//') || t.startsWith('*') || t.startsWith('/*')) return ''
+  const noStr = line.replace(/(['"`])(?:\\.|(?!\1).)*?\1/g, '')
+  const ci = noStr.indexOf('//')
+  return ci >= 0 ? noStr.slice(0, ci) : noStr
+}
+
 function createContentRule(
   id: string,
   section: string,
@@ -191,7 +202,7 @@ function createContentRule(
         const fileContent = fs.readFileSync(filePath, 'utf-8')
         const fileLines = fileContent.split('\n')
         fileLines.forEach((line, idx) => {
-          if (regex.test(line)) {
+          if (regex.test(codePortionForScan(line))) {
             violations.push({
               ruleId: id,
               severity: type === 'banned' ? 'error' : 'warning',

--- a/tests/git-recap.test.ts
+++ b/tests/git-recap.test.ts
@@ -4,6 +4,7 @@ import {
   filterRecapFiles,
   inferFileStatusFromDiff,
   buildSessionDiffFromSummary,
+  withMidnight,
 } from '../src/lib/git.js'
 
 describe('git recap filters', () => {
@@ -33,6 +34,14 @@ describe('git recap filters', () => {
     expect(diff.filesChanged).toBe(1)
     expect(diff.files[0].file).toBe('src/a.ts')
     expect(diff.insertions).toBe(10)
+  })
+
+  it('withMidnight — 시각 없는 날짜에 자정 보강(git approxidate 함정 방지)', () => {
+    // git 은 `--since=2026-06-06`(시각 없음)을 자정이 아니라 '현재 시각'으로 채워
+    // 그날 커밋을 전부 누락시킨다(특히 밤에 recap). 시각 없으면 00:00:00 명시해야 한다.
+    expect(withMidnight('2026-06-06')).toBe('2026-06-06 00:00:00')
+    expect(withMidnight('2026-06-06 14:30')).toBe('2026-06-06 14:30') // 시각 있으면 그대로
+    expect(withMidnight('2026-06-06 23:05:08')).toBe('2026-06-06 23:05:08')
   })
 
   it('filterRecapFiles가 noise를 제거한다', () => {

--- a/tests/rules-parser.test.ts
+++ b/tests/rules-parser.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { parseRules } from '../src/lib/rules-parser.js'
+import { parseRules, codePortionForScan } from '../src/lib/rules-parser.js'
 
 function writeRules(content: string): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-rules-'))
@@ -45,6 +45,17 @@ describe('parseRules (VHK-011/012)', () => {
     // URL 토큰은 금지 패턴으로 등록 안 됨
     expect(content.map((r) => r.pattern?.source ?? '').join(' ')).not.toContain('github')
     fs.rmSync(path.dirname(p), { recursive: true })
+  })
+
+  it('codePortionForScan — 주석/문자열 내 토큰 제외, 실제 코드 사용은 유지 (자기 코드 오탐 방지)', () => {
+    // 위반 오탐원: 주석/문자열 속 금지 토큰. 코드 부분만 남겨야 한다.
+    expect(codePortionForScan('  // A: `execSync` 신규 사용 금지')).toBe('') // 주석 줄
+    expect(codePortionForScan('   * `execSync` 예시')).toBe('') // JSDoc 줄
+    expect(codePortionForScan("const p = 'execSync'")).not.toContain('execSync') // 문자열 리터럴
+    expect(codePortionForScan('foo() // execSync 주석')).not.toContain('execSync') // 줄끝 주석
+    // 실제 코드 사용은 반드시 유지(진짜 위반 놓치면 안 됨)
+    expect(codePortionForScan('execSync("npm view")')).toContain('execSync')
+    expect(codePortionForScan("import { execSync } from 'node:child_process'")).toContain('execSync')
   })
 
   it('VHK-012: 구조(필수 디렉터리) 규칙은 아키텍처 섹션에서만', () => {


### PR DESCRIPTION
## 무엇

도그푸딩으로 발견한 vhk 자체 버그 2건 수정.

### 1. `vhk recap` 이 오늘 커밋을 전부 누락 (CONFIRMED)

`git log --since=2026-06-06`(시각 없는 날짜)을 git approxidate 가 자정이 아니라 **현재 시각**(예: 23:05)으로 채워 → "오늘 23:05 이후"만 매칭 → 그날 커밋 거의 전부 누락. 특히 밤에 recap 돌리면 "오늘 변경 없음" 오판. (`--since="2026-06-06 00:00:00"` 명시하면 정상)

수정: `src/lib/git.ts` 의 `getSessionDiff`/`getRecentCommits` 가 `--since`/`--before` 에 시각이 없으면 `00:00:00` 보강(`withMidnight`). → 오늘 31파일·커밋 정상 인식 확인.

### 2. `vhk check` 가 자기 코드 주석을 위반으로 오탐 (FALSE POSITIVE → 수정)

금지패턴 스캔(`rules-parser` content rule)이 라인 전체를 매칭해, 금지패턴 추출기 자신의 설명 주석(`// ... (execSync 신규 사용 금지)`)을 `ban-L31` 위반으로 오탐.

수정: `codePortionForScan` 으로 주석 줄/줄끝 주석/문자열·백틱 리터럴을 제외한 **코드 부분만** 매칭. 실제 코드 사용(`execSync(...)`, `import { execSync }`)은 유지 → 진짜 위반은 안 놓침. → `vhk check` 모든 규칙 통과 확인.

## 검증

- 타입체크 0 · 빌드 OK · 테스트 **892 pass**(890 + 회귀 가드 2).
- 회귀 가드: `withMidnight` 3케이스 + `codePortionForScan` 6케이스(주석/문자열 제외 + 실제 사용 유지).
- E2E: `vhk recap` 31파일 인식, `vhk check` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)