### PR TITLE
cleanup(sweep): dead path 제거 + publish UTC 날짜 + camelCase 검사 + gitignore

### DIFF
--- a/.vhk/.gitignore
+++ b/.vhk/.gitignore
@@ -1,5 +1,7 @@
 reports/
 work-prompt.md
 handoff-prompt.md
+context.md
+brief.md
 backups/
 .synced

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -6,6 +6,7 @@ import { safeExecFile, safeExecFileStream } from '../lib/exec.js'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { readJsonFile } from '../lib/read-json.js'
+import { localDate } from '../lib/date.js'
 
 export type BumpType = 'patch' | 'minor' | 'major'
 
@@ -286,7 +287,8 @@ export async function publish(): Promise<void> {
   // CHANGELOG 스텁 (자동화 D) — 버전 누락 방지. 이미 항목 있으면 no-op. 본문은 사람이 보강.
   if (existsSync('CHANGELOG.md')) {
     const cl = readFileSync('CHANGELOG.md', 'utf-8')
-    const date = new Date().toISOString().slice(0, 10)
+    // VHK-019: toISOString().slice 는 UTC 기준 → KST 새벽 발행 시 하루 밀림. 로컬 날짜 사용.
+    const date = localDate()
     const updated = insertChangelogStub(cl, newVersion, date)
     if (updated !== cl) {
       writeFileSync('CHANGELOG.md', updated, 'utf-8')

--- a/src/lib/rules-parser.ts
+++ b/src/lib/rules-parser.ts
@@ -66,7 +66,7 @@ export function parseRules(rulesPath: string): Rule[] {
     // VHK-012: '금지' 인접 백틱 토큰만 — `X` 금지 / 금지: `X`. URL·경로는 제외(금지 뒤 먼 URL 오탐 방지).
     const banToken = extractBanToken(ruleText)
     if (banToken) {
-      rules.push(createContentRule(`ban-L${lineNo}`, currentSection, ruleText, banToken, 'banned'))
+      rules.push(createContentRule(`ban-L${lineNo}`, currentSection, ruleText, banToken))
     }
   }
 
@@ -126,15 +126,23 @@ function createNamingRule(
 
       walkFiles(srcDir, filePath => {
         const name = path.basename(filePath, path.extname(filePath))
+        const exempt = ['index', 'vite.config', 'tsconfig']
+        if (exempt.includes(name)) return
         if (convention === 'kebab-case' && !/^[a-z0-9]+(-[a-z0-9]+)*$/.test(name)) {
-          if (!['index', 'vite.config', 'tsconfig'].includes(name)) {
-            violations.push({
-              ruleId: id,
-              severity: 'warning',
-              message: `파일명이 kebab-case가 아님: ${name}`,
-              file: path.relative(cwd, filePath),
-            })
-          }
+          violations.push({
+            ruleId: id,
+            severity: 'warning',
+            message: `파일명이 kebab-case가 아님: ${name}`,
+            file: path.relative(cwd, filePath),
+          })
+        } else if (convention === 'camelCase' && !/^[a-z][a-zA-Z0-9]*$/.test(name)) {
+          // 과거 camelCase 분기는 미구현(검사 없이 통과)이라 위반이 silent 무시됐다 → 실제 검사 추가.
+          violations.push({
+            ruleId: id,
+            severity: 'warning',
+            message: `파일명이 camelCase가 아님: ${name}`,
+            file: path.relative(cwd, filePath),
+          })
         }
       })
 
@@ -179,12 +187,13 @@ export function codePortionForScan(line: string): string {
   return ci >= 0 ? noStr.slice(0, ci) : noStr
 }
 
+// 금지(banned) 패턴 규칙만 생성한다. 과거 'required'(필수 패턴) 타입이 있었으나 호출처가 0인
+// dead path 였고 분기 로직도 역전(패턴 발견 시 '누락' 보고)이라 제거 — 필요해지면 별도 설계로 추가.
 function createContentRule(
   id: string,
   section: string,
   desc: string,
-  pattern: string,
-  type: 'banned' | 'required'
+  pattern: string
 ): Rule {
   return {
     id,
@@ -205,10 +214,8 @@ function createContentRule(
           if (regex.test(codePortionForScan(line))) {
             violations.push({
               ruleId: id,
-              severity: type === 'banned' ? 'error' : 'warning',
-              message: type === 'banned'
-                ? `금지 패턴 발견: \`${pattern}\``
-                : `필수 패턴 누락: \`${pattern}\``,
+              severity: 'error',
+              message: `금지 패턴 발견: \`${pattern}\``,
               file: path.relative(cwd, filePath),
               line: idx + 1,
             })

--- a/tests/rules-parser.test.ts
+++ b/tests/rules-parser.test.ts
@@ -47,6 +47,21 @@ describe('parseRules (VHK-011/012)', () => {
     fs.rmSync(path.dirname(p), { recursive: true })
   })
 
+  it('camelCase 룰이 위반 파일을 실제로 잡는다 (과거 silent 무시 회귀 가드)', () => {
+    const proj = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-naming-'))
+    fs.mkdirSync(path.join(proj, 'src'))
+    fs.writeFileSync(path.join(proj, 'src', 'bad-name.ts'), '', 'utf-8') // 하이픈 → camelCase 위반
+    fs.writeFileSync(path.join(proj, 'src', 'goodName.ts'), '', 'utf-8') // camelCase 통과
+    const p = writeRules(['## 코딩 규칙', '- 파일명은 camelCase 로'].join('\n'))
+    const naming = parseRules(p).find((r) => r.type === 'naming')
+    expect(naming).toBeDefined()
+    const violations = naming!.check(proj)
+    expect(violations.some((v) => v.file?.includes('bad-name') && v.message.includes('camelCase'))).toBe(true)
+    expect(violations.some((v) => v.file?.includes('goodName'))).toBe(false)
+    fs.rmSync(proj, { recursive: true })
+    fs.rmSync(path.dirname(p), { recursive: true })
+  })
+
   it('codePortionForScan — 주석/문자열 내 토큰 제외, 실제 코드 사용은 유지 (자기 코드 오탐 방지)', () => {
     // 위반 오탐원: 주석/문자열 속 금지 토큰. 코드 부분만 남겨야 한다.
     expect(codePortionForScan('  // A: `execSync` 신규 사용 금지')).toBe('') // 주석 줄


### PR DESCRIPTION
## 무엇

적대 스윕(Workflow 5각도: dead path / 날짜·TZ / exec·IO / 메뉴배선 / 상태파일)에서 나온 작은 결함 4건 정리.

### 수정
- **rules-parser `required` dead type 제거** — `createContentRule` 가 `'banned'|'required'` 받지만 호출은 `banned` 만(0건). `required` 분기는 도달 불가 + 로직 역전("패턴 발견 시 누락 보고")이라 제거.
- **rules-parser camelCase 검사 미구현 → 추가** — `camelCase` 네이밍 룰이 생성은 되는데 `check` 가 kebab-case 만 봐서 위반이 **silent 무시**되던 결함. 실제 검사 추가 + 회귀 가드 테스트.
- **publish UTC 날짜 → localDate** — CHANGELOG 스텁 날짜를 `toISOString().slice`(UTC)로 만들어 KST 새벽 발행 시 하루 밀림. `localDate()`(로컬)로 교체. recap 과 동류 함정(date.ts 가 경고한 패턴).
- **.vhk/.gitignore** — `context.md`·`brief.md` 추가(`vhk context`/`brief` 생성물이 매번 untracked 로 뜨던 잡음 제거).

### 검증
- 타입체크 0 · 빌드 OK · 테스트 **893 pass**(+camelCase 회귀 1).
- `vhk check` 통과(kebab/camel 룰 없는 현 RULES.md 에선 기존대로).

## 별도로 분리한 것 (이 PR 범위 밖)

- **HARD_STOP 가드 누락 14개** (goal/memory/pattern/evolve/mission/context) — 어느 명령에 가드를 넣을지 정책 결정 + 14개 변경이라 별도 작업.
- **비원자 쓰기 3개** (ref/sync/review writeFileSync) — 트리거 희박(쓰기 중 프로세스 kill), 광범위 → 별도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)