### PR TITLE
feat(worktree): vhk worktree 가드 — 생성 시 env 자동 복사·누락 점검 (Goal 30)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -72,6 +72,16 @@ Cursor에게 한국어로 말해도 됩니다.
 
 > `preflight` 는 publish/PR 직전 **2FA·shim·worktree env·lint·타입·테스트·git·브랜치 8개**를 한 번에 점검합니다. 치명(🔴: env/lint/타입/테스트) 실패가 1개라도 있으면 `--force` 없이 차단(exit 1). 기본 테스트는 `vitest --changed`(통과분 캐시 스킵), `--full` 로 전체 실행. (읽기 전용 — 자동 수정은 후속)
 
+## worktree 가드 (worktree)
+
+| 하고 싶은 것 | 터미널 명령 | Cursor에게 말하기 |
+|-------------|-----------|------------------|
+| 새 worktree 생성 + env 복사 | `vhk worktree add feat/login` | "worktree 만들어줘" |
+| 생성 + pnpm install까지 | `vhk worktree add feat/login --install` | "worktree 만들고 설치까지" |
+| 현재 worktree env 점검 | `vhk worktree check` | "worktree env 점검해" |
+
+> `worktree add` 는 `git worktree add` 로 새 worktree를 만들고 필수 env/설정(`.env*` + `.vhk/config.json`의 `worktreeCopy`)을 **파일 복사**(심볼릭 링크 X — Windows 안정)로 채웁니다. 비밀값은 **절대 출력 안 함**(env는 키 개수만). 대상 경로가 이미 있으면 덮어쓰지 않고 중단. git 훅은 건드리지 않습니다. `worktree check` 는 현재 worktree의 필수 env 누락을 개수로 점검(Goal 29 `worktree-env` 모듈 재사용).
+
 ## 환경 점검
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ vhk 기획 끝났고 바로 시작
 | `vhk ship` | `출하` | 배포 체크리스트 + 회고 + 빌드 로그 |
 | `vhk doctor` | `환경`, `진단` | Node / npm / pnpm / Git 환경 점검 |
 | `vhk preflight` | `출고점검` | 출고 전 안전점검 — 2FA·shim·worktree env·lint·타입·테스트·git·브랜치 8개 일괄, 치명(env/lint/타입/테스트) 실패 시 차단(exit 1). 기본 `vitest --changed`, `--publish`/`--pr`/`--full` |
+| `vhk worktree` | `워크트리` | worktree 가드 (`add <branch>` / `check`) — 생성 시 필수 env/설정 자동 복사(파일 복사·심볼릭 X, 비밀값 미노출), 누락 점검. `--install` 로 pnpm install. Goal 29 `worktree-env` 모듈 재사용 |
 | `vhk cloud push` | `클라우드`, `올리기` | `.vhk/` 를 GitHub secret gist 로 백업 (gh CLI 인증 사용) |
 | `vhk cloud pull` | `내리기` | gist 에서 `.vhk/` 복원 (`vhk cloud pull <gistId>` 또는 cloud.json) |
 | `vhk save` | `저장`, `커밋` | git add · commit · push 한 번에 |

--- a/scripts/check-goal-30.mjs
+++ b/scripts/check-goal-30.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// scripts/check-goal-30.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 30 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 30] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 30 고유 검증 (vhk worktree 가드) ───────────────────────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// 산출물 모듈
+for (const f of ['types', 'configList', 'check', 'copy', 'add']) {
+  must(existsSync(`src/worktree/${f}.ts`), `src/worktree/${f}.ts 존재`)
+}
+must(existsSync('src/commands/worktree.ts'), 'src/commands/worktree.ts (CLI) 존재')
+must(existsSync('tests/worktree/copy.test.ts'), 'tests/worktree/ 단위테스트 존재')
+// 재사용: check.ts 는 Goal 29 worktree-env 모듈을 import(이중 구현 금지)
+must(/worktree-env/.test(read('src/worktree/check.ts') ?? ''), 'check.ts 가 worktree-env 모듈 재사용')
+// 불변규칙: 심볼릭 링크 금지 — copy 는 copyFile 만, symlink 호출 없음
+const copy = read('src/worktree/copy.ts') ?? ''
+must(/copyFile/.test(copy), 'copy.ts 가 파일 복사(copyFile) 사용')
+must(!/symlink/i.test(copy), 'copy.ts 에 symlink 사용 없음(파일 복사만)')
+// 불변규칙: 외부 명령은 safeExecFile — add 코어에 execSync 직접 사용 없음
+must(!/execSync/.test(read('src/worktree/add.ts') ?? ''), 'add.ts 에 execSync 없음')
+// 불변규칙: git 훅 자동 설치 금지 — .git/hooks 미접근
+for (const f of ['add', 'copy', 'configList']) {
+  must(!/\.git[\\/]hooks|hooksPath/.test(read(`src/worktree/${f}.ts`) ?? ''), `${f}.ts 가 .git/hooks 미접근`)
+}
+// raw JSON.parse 금지 → readJsonFile
+must(!/JSON\.parse/.test(read('src/worktree/configList.ts') ?? ''), 'configList.ts 가 raw JSON.parse 미사용')
+// CLI 단일소스 등록
+must(/worktree/.test(read('src/index.ts') ?? ''), 'index.ts 에 worktree 등록')
+must(/worktree:/.test(read('src/lib/command-registry.ts') ?? ''), 'command-registry 등록')
+must(/worktree/.test(read('src/lib/cli-args.ts') ?? ''), 'cli-args KNOWN_COMMAND_TOKENS 등록')
+
+if (pass) { console.log('✅ goal 30 gate passes'); process.exit(0) }
+console.log('❌ goal 30 gate failed'); process.exit(1)

--- a/src/commands/worktree.ts
+++ b/src/commands/worktree.ts
@@ -1,0 +1,102 @@
+import chalk from 'chalk'
+import { existsSync } from 'node:fs'
+import { basename, dirname, join } from 'node:path'
+import { ko } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
+import { safeExecFile } from '../lib/exec.js'
+import type { Runner } from '../lib/preflight.js'
+import { runWorktreeCheck } from '../worktree/check.js'
+import { collectCopyItems } from '../worktree/configList.js'
+import { copyAll, realCopyDeps } from '../worktree/copy.js'
+import { addWorktree, sanitizeBranchToDir } from '../worktree/add.js'
+import type { CopyResult, WorktreeOptions } from '../worktree/types.js'
+
+// safeExecFile → Runner 어댑터(외부 명령 단일 경로 — execSync 금지).
+function realRunner(): Runner {
+  return (cmd, args) => {
+    const r = safeExecFile(cmd, args)
+    return r.ok ? { ok: true, out: r.out } : { ok: false, out: r.out, err: r.err }
+  }
+}
+
+// CopyResult 한 줄 출력 — 비밀값 절대 미노출(env 는 키 개수만).
+function printCopy(r: CopyResult): void {
+  const name = basename(r.item.target)
+  if (r.status === 'copied') {
+    const detail = r.item.kind === 'env' ? `(${r.keyCount} keys)` : ''
+    console.log(chalk.green(`  🟢 copied ${name}`) + chalk.dim(` ${detail}`))
+  } else if (r.status === 'missing-source') {
+    console.log(chalk.dim(`  ⚪ skip ${name} — 원본 없음`))
+  } else if (r.status === 'error') {
+    console.log(chalk.yellow(`  🟡 ${name} — ${r.detail}`))
+  }
+}
+
+// vhk worktree check — 현재 worktree 의 필수 env 누락 점검(개수만).
+export async function worktreeCheck(): Promise<void> {
+  console.log(chalk.bold(`\n${ko.worktree.checkTitle}\n`))
+  const r = runWorktreeCheck(process.cwd())
+  const icon = r.status === 'pass' ? '🟢' : r.status === 'skip' ? '⚪' : '🔴'
+  console.log(`  ${icon} ${r.detail}`)
+  if (r.status === 'fail') {
+    process.exitCode = 1
+    printNextStep({
+      message: '누락된 env 키를 채운 뒤 다시 점검하세요.',
+      command: 'vhk worktree check',
+      cursorHint: 'worktree env 다시 점검해줘',
+    })
+  }
+}
+
+// vhk worktree add <branch> — worktree 생성 + 필수 env/설정 자동 복사(+ --install).
+export async function worktreeAdd(branch: string | undefined, opts: WorktreeOptions = {}): Promise<void> {
+  if (!ensureNotHardStopped('worktree add')) return // VHK-020
+  if (!branch) {
+    console.log(chalk.yellow(`  ${ko.worktree.needBranch}`))
+    process.exitCode = 1
+    return
+  }
+  console.log(chalk.bold(`\n${ko.worktree.addTitle(branch)}\n`))
+
+  const cwd = process.cwd()
+  const copyDeps = realCopyDeps()
+  const result = addWorktree(
+    branch,
+    { install: opts.install },
+    {
+      sourceDir: cwd,
+      run: realRunner(),
+      exists: (p) => existsSync(p),
+      // 형제 디렉터리: ../<repoName>-<branch>
+      resolveTargetPath: (b) => join(dirname(cwd), sanitizeBranchToDir(basename(cwd), b)),
+      collectItems: (s, t) => collectCopyItems(s, t),
+      copyAll: (items) => copyAll(items, copyDeps),
+    }
+  )
+
+  if (result.status === 'aborted-exists') {
+    console.log(chalk.yellow(`  ${ko.worktree.abortedExists(result.targetPath)}`))
+    process.exitCode = 1
+    return
+  }
+  if (result.status === 'git-failed') {
+    console.log(chalk.red(`  ${ko.worktree.gitFailed(result.detail)}`))
+    process.exitCode = 1
+    return
+  }
+
+  console.log(chalk.green(`  🟢 worktree created at ${result.targetPath}`))
+  for (const c of result.copies) printCopy(c)
+  if (opts.install) {
+    console.log(result.installed ? chalk.green('  🟢 pnpm install') : chalk.yellow('  🟡 pnpm install 실패 — 수동 실행 필요'))
+  } else {
+    console.log(chalk.dim(`  ⚪ ${ko.worktree.installSkipped}`))
+  }
+  console.log(chalk.green.bold(`\n  ${ko.worktree.ready}`))
+  printNextStep({
+    message: `worktree 준비 완료 — 작업하려면 이동:`,
+    command: `cd ${result.targetPath}`,
+    cursorHint: '새 worktree에서 작업 시작',
+  })
+}

--- a/src/commands/worktree.ts
+++ b/src/commands/worktree.ts
@@ -88,10 +88,21 @@ export async function worktreeAdd(branch: string | undefined, opts: WorktreeOpti
 
   console.log(chalk.green(`  🟢 worktree created at ${result.targetPath}`))
   for (const c of result.copies) printCopy(c)
+  const installFailed = opts.install === true && result.installed === false
   if (opts.install) {
-    console.log(result.installed ? chalk.green('  🟢 pnpm install') : chalk.yellow('  🟡 pnpm install 실패 — 수동 실행 필요'))
+    console.log(result.installed ? chalk.green('  🟢 install 완료') : chalk.yellow('  🟡 install 실패 — 수동 설치 필요'))
   } else {
     console.log(chalk.dim(`  ⚪ ${ko.worktree.installSkipped}`))
+  }
+  if (installFailed) {
+    // 의존성 설치가 깨진 worktree — '준비 완료'로 묻지 않고 비-0 종료(즉시 작업 불가).
+    process.exitCode = 1
+    printNextStep({
+      message: 'worktree 생성됨 — 의존성 수동 설치 후 작업:',
+      command: `cd ${result.targetPath}`,
+      cursorHint: '설치 후 작업 시작',
+    })
+    return
   }
   console.log(chalk.green.bold(`\n  ${ko.worktree.ready}`))
   printNextStep({

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -224,6 +224,15 @@ export const ko = {
     nextBlocked: '치명(🔴) 항목을 수정한 뒤 다시 실행하세요.',
     nextPass: 'publish/PR 진행 가능',
   },
+  worktree: {
+    checkTitle: '🌳 Worktree env 점검',
+    addTitle: (b: string) => `🌳 Worktree 생성: ${b}`,
+    ready: '✅ ready',
+    needBranch: '브랜치명이 필요합니다 — 예: vhk worktree add feat/login',
+    abortedExists: (p: string) => `🛑 이미 존재 — 중단(덮어쓰기 안 함): ${p}`,
+    gitFailed: (d: string) => `❌ git worktree add 실패: ${d}`,
+    installSkipped: 'node_modules 없음 → pnpm install (또는 --install 로 자동)',
+  },
   nlp: {
     matched: '이게 맞나요?',
     notMatched: '무슨 뜻인지 모르겠어요. vhk를 입력하면 메뉴에서 선택할 수 있습니다.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import { start } from './commands/start.js'
 import { mode } from './commands/mode.js'
 import { verify } from './commands/verify.js'
 import { preflight } from './commands/preflight.js'
+import { worktreeAdd, worktreeCheck } from './commands/worktree.js'
 import { review } from './commands/review.js'
 import { missionSet, missionShow, missionCheck, missionClear } from './commands/mission.js'
 import { runGuarded } from './lib/safety-guard.js'
@@ -145,6 +146,7 @@ const KO_ALIASES: Record<string, string> = {
   brief: '브리핑',
   goal: '목표',
   preflight: '출고점검',
+  worktree: '워크트리',
   review: '검토',
   mission: '미션',
   blocker: '블로커',
@@ -473,6 +475,25 @@ program
   .option('--full', '테스트 전체 실행 (--changed 캐시 미사용)')
   .description('출고 전 안전점검 — 2FA·shim·env·lint·타입·테스트·git 8개 항목, 치명 실패 시 차단')
   .action(async (opts: { publish?: boolean; pr?: boolean; full?: boolean }) => { await preflight(opts) })
+
+const worktreeCmd = program
+  .command('worktree')
+  .alias('워크트리')
+  .description('worktree 가드 — 생성 시 필수 env/설정 자동 복사·누락 점검 (add / check)')
+  .action(async () => { await worktreeCheck() })
+
+worktreeCmd
+  .command('check')
+  .alias('점검')
+  .description('현재 worktree 의 필수 env 키 누락 점검 (개수만, 값 미노출)')
+  .action(async () => { await worktreeCheck() })
+
+worktreeCmd
+  .command('add <branch>')
+  .alias('추가')
+  .option('--install', 'worktree 생성 후 pnpm install 자동 실행')
+  .description('worktree 생성 + 필수 env/설정 자동 복사 (파일 복사·심볼릭 X, 비밀값 미노출)')
+  .action(async (branch: string, opts: { install?: boolean }) => { await worktreeAdd(branch, opts) })
 
 program
   .command('review')

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -44,6 +44,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'mode', '모드',
   'verify', '사전점검',
   'preflight', '출고점검',
+  'worktree', '워크트리',
   'review', '검토',
   'mission', '미션',
   'pattern', '패턴',

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -19,6 +19,7 @@ export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
   pattern: ['detect', 'list', 'dismiss'],
   evolve: ['suggest', 'list', 'apply', 'reject', 'undo'],
   work: ['handoff'],
+  worktree: ['add', 'check'],
 }
 
 /** 한국어 별칭 → 영문 컨테이너 명령. 별칭도 같은 서브커맨드 집합을 공유한다. */
@@ -35,6 +36,7 @@ export const CONTAINER_ALIASES: Record<string, string> = {
   패턴: 'pattern',
   진화: 'evolve',
   작업: 'work',
+  워크트리: 'worktree',
 }
 
 /**
@@ -80,6 +82,7 @@ export const TOP_LEVEL_COMMANDS: ReadonlyArray<{ name: string; desc: string }> =
   { name: 'mode', desc: 'Safety Mode 조회/변경 (lite|standard|strict)' },
   { name: 'verify', desc: '검증 게이트 실행 + 증거 기록' },
   { name: 'preflight', desc: '출고 전 안전점검 (2FA·shim·env·lint·타입·테스트·git, 치명 시 차단)' },
+  { name: 'worktree', desc: 'worktree 가드 — 생성 시 env/설정 자동 복사·누락 점검 (add/check)' },
   { name: 'review', desc: '적대적 자기검증 (거짓완료 의심 탐지)' },
   { name: 'mission', desc: '미션 계약 — 작업 목표·허용/금지 범위 선언·검증' },
   { name: 'context-show', desc: '컨텍스트 파일 내용 출력' },

--- a/src/worktree/add.ts
+++ b/src/worktree/add.ts
@@ -1,0 +1,57 @@
+import type { Runner } from '../lib/preflight.js'
+import type { CopyItem, CopyResult, WorktreeOptions } from './types.js'
+
+// git worktree add 오케스트레이션 의존성(주입).
+export interface AddDeps {
+  sourceDir: string
+  run: Runner // safeExecFile 래퍼
+  exists: (p: string) => boolean
+  resolveTargetPath: (branch: string) => string
+  collectItems: (sourceDir: string, targetDir: string) => CopyItem[]
+  copyAll: (items: CopyItem[]) => CopyResult[]
+}
+
+export type AddStatus = 'created' | 'aborted-exists' | 'git-failed'
+
+export interface AddResult {
+  status: AddStatus
+  targetPath: string
+  copies: CopyResult[]
+  installed?: boolean
+  detail: string
+}
+
+// 브랜치명 → worktree 디렉터리명. 슬래시/특수문자를 '-' 로(양끝 '-' 제거).
+export function sanitizeBranchToDir(repoName: string, branch: string): string {
+  const safe = branch.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '')
+  return `${repoName}-${safe}`
+}
+
+// worktree 생성 + 필수 env/설정 복사(+ 선택 install).
+// 대상 경로가 이미 있으면 절대 덮어쓰지 않고 안전 중단. git 실패 시 복사 안 함.
+export function addWorktree(branch: string, opts: WorktreeOptions, deps: AddDeps): AddResult {
+  const targetPath = deps.resolveTargetPath(branch)
+
+  if (deps.exists(targetPath)) {
+    return { status: 'aborted-exists', targetPath, copies: [], detail: `이미 존재 — 중단(덮어쓰기 안 함): ${targetPath}` }
+  }
+
+  // 새 브랜치로 worktree 생성. git 훅은 자동 설치/수정하지 않음(설계상 hooks 미접근).
+  const git = deps.run('git', ['worktree', 'add', '-b', branch, targetPath])
+  if (!git.ok) {
+    const err = ('err' in git && git.err ? git.err : '').slice(0, 200)
+    return { status: 'git-failed', targetPath, copies: [], detail: `git worktree add 실패: ${err}`.trim() }
+  }
+
+  const items = deps.collectItems(deps.sourceDir, targetPath)
+  const copies = deps.copyAll(items)
+
+  let installed: boolean | undefined
+  if (opts.install) {
+    // cwd 변경 없이 대상 디렉터리에서 설치(pnpm --dir <path> install).
+    const r = deps.run('pnpm', ['--dir', targetPath, 'install'])
+    installed = r.ok
+  }
+
+  return { status: 'created', targetPath, copies, installed, detail: `worktree 생성: ${targetPath}` }
+}

--- a/src/worktree/add.ts
+++ b/src/worktree/add.ts
@@ -40,7 +40,8 @@ export function addWorktree(branch: string, opts: WorktreeOptions, deps: AddDeps
   const git = deps.run('git', ['worktree', 'add', '-b', branch, targetPath])
   if (!git.ok) {
     const err = ('err' in git && git.err ? git.err : '').slice(0, 200)
-    return { status: 'git-failed', targetPath, copies: [], detail: `git worktree add 실패: ${err}`.trim() }
+    // detail 은 순수 에러만 — 'git worktree add 실패:' 접두사는 ko.worktree.gitFailed 가 한 번 붙인다(이중 방지).
+    return { status: 'git-failed', targetPath, copies: [], detail: err.trim() || '원인 미상' }
   }
 
   const items = deps.collectItems(deps.sourceDir, targetPath)

--- a/src/worktree/check.ts
+++ b/src/worktree/check.ts
@@ -1,0 +1,8 @@
+import { checkWorktreeEnvDir } from '../lib/worktree-env.js'
+import type { EnvCheckResult } from '../lib/worktree-env.js'
+
+// 현재 worktree 의 필수 env 키 누락 점검(개수만).
+// Goal 29 의 worktree-env 모듈을 그대로 재사용한다(이중 구현 금지).
+export function runWorktreeCheck(cwd: string): EnvCheckResult {
+  return checkWorktreeEnvDir(cwd)
+}

--- a/src/worktree/configList.ts
+++ b/src/worktree/configList.ts
@@ -1,0 +1,64 @@
+import { existsSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { readJsonFile } from '../lib/read-json.js'
+import type { CopyItem } from './types.js'
+
+// 커밋되는 env 템플릿(.example/.sample/.template)은 이미 git 으로 따라오므로 복사 제외.
+const ENV_TEMPLATE_SUFFIXES = ['.example', '.sample', '.template']
+
+// `.env*` 이면서 템플릿이 아닌 것 = 복사 대상(gitignore 된 시크릿 env).
+export function isCopyableEnvFile(name: string): boolean {
+  if (!name.startsWith('.env')) return false
+  return !ENV_TEMPLATE_SUFFIXES.some((s) => name.endsWith(s))
+}
+
+// 디렉터리 파일명 목록 → 복사 대상 env 파일만.
+export function listEnvFiles(names: string[]): string[] {
+  return names.filter(isCopyableEnvFile)
+}
+
+// 순수: env 파일 + 추가 설정 → CopyItem[]. (호출자가 fs 에서 목록을 채워 넣음)
+export function buildCopyList(input: {
+  sourceDir: string
+  targetDir: string
+  envFiles: string[]
+  extraConfigs: string[]
+}): CopyItem[] {
+  const items: CopyItem[] = []
+  for (const f of input.envFiles) {
+    items.push({ source: join(input.sourceDir, f), target: join(input.targetDir, f), kind: 'env' })
+  }
+  for (const f of input.extraConfigs) {
+    items.push({ source: join(input.sourceDir, f), target: join(input.targetDir, f), kind: 'config' })
+  }
+  return items
+}
+
+// VHK 설정(.vhk/config.json 의 worktreeCopy[])에 등록된 추가 복사 대상. 없으면 [].
+// 손상/형식 오류여도 worktree 생성을 막지 않는다(빈 목록으로 graceful).
+export function readExtraConfigs(sourceDir: string): string[] {
+  const p = join(sourceDir, '.vhk', 'config.json')
+  if (!existsSync(p)) return []
+  try {
+    const cfg = readJsonFile<{ worktreeCopy?: unknown }>(p)
+    if (Array.isArray(cfg.worktreeCopy)) {
+      return cfg.worktreeCopy.filter((x): x is string => typeof x === 'string')
+    }
+  } catch {
+    // 무시 — 빈 목록
+  }
+  return []
+}
+
+// IO 수집: sourceDir 스캔(.env*) + .vhk/config.json 추가 설정 → CopyItem[].
+export function collectCopyItems(sourceDir: string, targetDir: string): CopyItem[] {
+  let names: string[] = []
+  try {
+    names = readdirSync(sourceDir)
+  } catch {
+    names = []
+  }
+  const envFiles = listEnvFiles(names)
+  const extraConfigs = readExtraConfigs(sourceDir)
+  return buildCopyList({ sourceDir, targetDir, envFiles, extraConfigs })
+}

--- a/src/worktree/copy.ts
+++ b/src/worktree/copy.ts
@@ -1,4 +1,5 @@
-import { copyFileSync, existsSync, readFileSync } from 'node:fs'
+import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { dirname } from 'node:path'
 import { parseEnvKeys } from '../lib/worktree-env.js'
 import type { CopyItem, CopyResult } from './types.js'
 
@@ -38,7 +39,11 @@ export function copyAll(items: CopyItem[], deps: CopyDeps): CopyResult[] {
 export function realCopyDeps(): CopyDeps {
   return {
     exists: (p) => existsSync(p),
-    copyFile: (src, dst) => copyFileSync(src, dst),
+    // 대상 부모 디렉터리 보장 — .vscode/settings.json 같은 중첩 경로도 복사되게(없으면 ENOENT).
+    copyFile: (src, dst) => {
+      mkdirSync(dirname(dst), { recursive: true })
+      copyFileSync(src, dst)
+    },
     readKeys: (p) => {
       try {
         return parseEnvKeys(readFileSync(p, 'utf-8')).length

--- a/src/worktree/copy.ts
+++ b/src/worktree/copy.ts
@@ -1,0 +1,50 @@
+import { copyFileSync, existsSync, readFileSync } from 'node:fs'
+import { parseEnvKeys } from '../lib/worktree-env.js'
+import type { CopyItem, CopyResult } from './types.js'
+
+// 파일 복사 의존성(주입) — 테스트에서 fs mock 격리.
+export interface CopyDeps {
+  exists: (p: string) => boolean
+  copyFile: (src: string, dst: string) => void
+  readKeys: (p: string) => number // env 키 개수만(값 미노출)
+}
+
+// 한 건 복사. throw 하지 않고 CopyResult 로 상태 반환 → 호출자가 나머지를 계속 처리.
+// 비밀값은 detail 에 절대 출력하지 않음(env 는 키 개수만).
+export function copyOne(item: CopyItem, deps: CopyDeps): CopyResult {
+  if (!deps.exists(item.source)) {
+    return { item, status: 'missing-source', detail: '원본 없음' }
+  }
+  try {
+    deps.copyFile(item.source, item.target)
+    if (item.kind === 'env') {
+      const keyCount = deps.readKeys(item.source)
+      return { item, status: 'copied', keyCount, detail: `${keyCount} keys` }
+    }
+    return { item, status: 'copied', detail: '복사됨' }
+  } catch (e) {
+    // 에러 메시지는 시스템 메시지(EACCES 등)뿐 — env 값 노출 위험 없음.
+    const msg = e instanceof Error ? e.message : String(e)
+    return { item, status: 'error', detail: `복사 실패: ${msg}` }
+  }
+}
+
+// 여러 건 복사 — 한 건 실패해도 나머지 계속(copyOne 이 throw 안 함).
+export function copyAll(items: CopyItem[], deps: CopyDeps): CopyResult[] {
+  return items.map((it) => copyOne(it, deps))
+}
+
+// 실제 fs 주입(심볼릭 링크 금지 — copyFileSync 만 사용, Windows 안정).
+export function realCopyDeps(): CopyDeps {
+  return {
+    exists: (p) => existsSync(p),
+    copyFile: (src, dst) => copyFileSync(src, dst),
+    readKeys: (p) => {
+      try {
+        return parseEnvKeys(readFileSync(p, 'utf-8')).length
+      } catch {
+        return 0
+      }
+    },
+  }
+}

--- a/src/worktree/types.ts
+++ b/src/worktree/types.ts
@@ -1,0 +1,22 @@
+// Goal 30 — vhk worktree 가드 타입.
+
+export interface WorktreeOptions {
+  install?: boolean // --install: worktree 생성 후 pnpm install 실행
+}
+
+export type CopyKind = 'env' | 'config'
+
+export interface CopyItem {
+  source: string
+  target: string
+  kind: CopyKind
+}
+
+export type CopyStatus = 'copied' | 'skipped' | 'missing-source' | 'error'
+
+export interface CopyResult {
+  item: CopyItem
+  status: CopyStatus
+  keyCount?: number // env 파일일 때 키 개수(값은 절대 노출 안 함)
+  detail: string
+}

--- a/src/worktree/types.ts
+++ b/src/worktree/types.ts
@@ -12,7 +12,7 @@ export interface CopyItem {
   kind: CopyKind
 }
 
-export type CopyStatus = 'copied' | 'skipped' | 'missing-source' | 'error'
+export type CopyStatus = 'copied' | 'missing-source' | 'error'
 
 export interface CopyResult {
   item: CopyItem

--- a/tests/worktree/add.test.ts
+++ b/tests/worktree/add.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { addWorktree, sanitizeBranchToDir, type AddDeps } from '../../src/worktree/add.js'
+import type { CopyItem, CopyResult } from '../../src/worktree/types.js'
+
+function mkDeps(over: Partial<AddDeps> = {}): { deps: AddDeps; calls: string[] } {
+  const calls: string[] = []
+  const items: CopyItem[] = [{ source: '/s/.env', target: '/t/.env', kind: 'env' }]
+  const deps: AddDeps = {
+    sourceDir: '/repo',
+    run: (cmd, args) => {
+      calls.push(`${cmd} ${args.join(' ')}`)
+      return { ok: true, out: '' }
+    },
+    exists: () => false,
+    resolveTargetPath: () => '/repo-feat-x',
+    collectItems: () => items,
+    copyAll: (its): CopyResult[] => its.map((it) => ({ item: it, status: 'copied', keyCount: 1, detail: '1 keys' })),
+    ...over,
+  }
+  return { deps, calls }
+}
+
+describe('sanitizeBranchToDir', () => {
+  it('슬래시·특수문자를 - 로 정규화', () => {
+    expect(sanitizeBranchToDir('vhk', 'feat/login')).toBe('vhk-feat-login')
+    expect(sanitizeBranchToDir('vhk', 'fix/a@b#c')).toBe('vhk-fix-a-b-c')
+  })
+})
+
+describe('addWorktree', () => {
+  it('대상 경로 이미 있으면 안전 중단 — git 호출 안 함', () => {
+    const { deps, calls } = mkDeps({ exists: () => true })
+    const r = addWorktree('feat/x', {}, deps)
+    expect(r.status).toBe('aborted-exists')
+    expect(calls).toEqual([]) // git worktree add 호출 없음
+    expect(r.copies).toEqual([])
+  })
+
+  it('정상 → git worktree add 후 복사', () => {
+    const { deps, calls } = mkDeps()
+    const r = addWorktree('feat/x', {}, deps)
+    expect(r.status).toBe('created')
+    expect(calls[0]).toContain('git worktree add')
+    expect(r.copies).toHaveLength(1)
+    expect(r.copies[0].status).toBe('copied')
+  })
+
+  it('git 실패 → git-failed, 복사 안 함', () => {
+    let copied = false
+    const { deps } = mkDeps({
+      run: () => ({ ok: false, out: '', err: 'fatal' }),
+      copyAll: (its) => { copied = true; return its.map((it) => ({ item: it, status: 'copied' as const, detail: '' })) },
+    })
+    const r = addWorktree('feat/x', {}, deps)
+    expect(r.status).toBe('git-failed')
+    expect(copied).toBe(false)
+  })
+
+  it('--install 시 pnpm install (대상 디렉터리 지정)', () => {
+    const { deps, calls } = mkDeps()
+    const r = addWorktree('feat/x', { install: true }, deps)
+    expect(r.installed).toBe(true)
+    expect(calls.some((c) => c.includes('pnpm') && c.includes('install') && c.includes('/repo-feat-x'))).toBe(true)
+  })
+
+  it('--install 없으면 pnpm 미호출', () => {
+    const { deps, calls } = mkDeps()
+    addWorktree('feat/x', {}, deps)
+    expect(calls.some((c) => c.includes('pnpm'))).toBe(false)
+  })
+})

--- a/tests/worktree/check.test.ts
+++ b/tests/worktree/check.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { runWorktreeCheck } from '../../src/worktree/check.js'
+
+describe('runWorktreeCheck (worktree-env 재사용)', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'vhk-wt-')) })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('.env.example 없음 → skip (강제 안 함)', () => {
+    expect(runWorktreeCheck(dir).status).toBe('skip')
+  })
+
+  it('필수 키 모두 있으면 pass', () => {
+    writeFileSync(join(dir, '.env.example'), 'A=\nB=')
+    writeFileSync(join(dir, '.env'), 'A=1\nB=2')
+    expect(runWorktreeCheck(dir).status).toBe('pass')
+  })
+
+  it('필수 키 누락 → fail, 개수만(값은 절대 미노출)', () => {
+    writeFileSync(join(dir, '.env.example'), 'A=\nB=\nC=')
+    writeFileSync(join(dir, '.env'), 'A=super-secret-value-xyz')
+    const r = runWorktreeCheck(dir)
+    expect(r.status).toBe('fail')
+    expect(r.detail).not.toContain('super-secret-value-xyz')
+    expect(r.detail).toContain('2') // 누락 B, C = 2개
+  })
+})

--- a/tests/worktree/configList.test.ts
+++ b/tests/worktree/configList.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { isCopyableEnvFile, listEnvFiles, buildCopyList } from '../../src/worktree/configList.js'
+
+describe('isCopyableEnvFile', () => {
+  it('.env / .env.local / .env.production 은 복사 대상', () => {
+    expect(isCopyableEnvFile('.env')).toBe(true)
+    expect(isCopyableEnvFile('.env.local')).toBe(true)
+    expect(isCopyableEnvFile('.env.production')).toBe(true)
+  })
+  it('템플릿(.example/.sample/.template)은 제외 — 이미 git에 있음', () => {
+    expect(isCopyableEnvFile('.env.example')).toBe(false)
+    expect(isCopyableEnvFile('.env.sample')).toBe(false)
+    expect(isCopyableEnvFile('.env.template')).toBe(false)
+  })
+  it('.env 로 시작 안 하면 제외', () => {
+    expect(isCopyableEnvFile('package.json')).toBe(false)
+    expect(isCopyableEnvFile('env.txt')).toBe(false)
+  })
+})
+
+describe('listEnvFiles', () => {
+  it('디렉터리 목록에서 복사 대상 env만 추린다', () => {
+    const names = ['.env', '.env.local', '.env.example', 'package.json', 'README.md']
+    expect(listEnvFiles(names)).toEqual(['.env', '.env.local'])
+  })
+})
+
+describe('buildCopyList', () => {
+  it('env + 추가 설정을 source/target 경로 CopyItem 으로 만든다', () => {
+    const items = buildCopyList({
+      sourceDir: '/src',
+      targetDir: '/tgt',
+      envFiles: ['.env', '.env.local'],
+      extraConfigs: ['.vscode/settings.json'],
+    })
+    expect(items).toHaveLength(3)
+    expect(items[0]).toMatchObject({ kind: 'env' })
+    expect(items[0].source).toContain('.env')
+    expect(items[0].target).toContain('.env')
+    const cfg = items.find((i) => i.kind === 'config')
+    expect(cfg?.source).toContain('.vscode')
+  })
+  it('빈 목록이면 빈 배열', () => {
+    expect(buildCopyList({ sourceDir: '/s', targetDir: '/t', envFiles: [], extraConfigs: [] })).toEqual([])
+  })
+})

--- a/tests/worktree/copy.test.ts
+++ b/tests/worktree/copy.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from 'vitest'
-import { copyOne, copyAll, type CopyDeps } from '../../src/worktree/copy.js'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, existsSync, readFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { copyOne, copyAll, realCopyDeps, type CopyDeps } from '../../src/worktree/copy.js'
 import type { CopyItem } from '../../src/worktree/types.js'
 
 const envItem: CopyItem = { source: '/src/.env', target: '/tgt/.env', kind: 'env' }
@@ -49,6 +52,37 @@ describe('copyOne', () => {
     const r = copyOne(envItem, deps({ readKeys: (p) => { readArg = p; return 3 } }))
     expect(r.detail).toBe('3 keys')
     expect(readArg).toBe('/src/.env')
+  })
+})
+
+describe('realCopyDeps (실제 fs — 중첩 경로 mkdir)', () => {
+  let src: string
+  let tgt: string
+  beforeEach(() => {
+    src = mkdtempSync(join(tmpdir(), 'vhk-cp-src-'))
+    tgt = mkdtempSync(join(tmpdir(), 'vhk-cp-tgt-'))
+  })
+  afterEach(() => {
+    rmSync(src, { recursive: true, force: true })
+    rmSync(tgt, { recursive: true, force: true })
+  })
+
+  it('중첩 config(.vscode/settings.json) — 대상 부모 폴더 없어도 mkdir 후 복사 성공', () => {
+    writeFileSync(join(src, 'settings.json'), '{"a":1}')
+    const item: CopyItem = { source: join(src, 'settings.json'), target: join(tgt, '.vscode', 'settings.json'), kind: 'config' }
+    const r = copyOne(item, realCopyDeps()) // 대상 .vscode 폴더는 아직 없음
+    expect(r.status).toBe('copied')
+    expect(existsSync(join(tgt, '.vscode', 'settings.json'))).toBe(true)
+    expect(readFileSync(join(tgt, '.vscode', 'settings.json'), 'utf-8')).toBe('{"a":1}')
+  })
+
+  it('env 키 개수만 셈(값 미노출)', () => {
+    writeFileSync(join(src, '.env'), 'A=secret1\nB=secret2')
+    const item: CopyItem = { source: join(src, '.env'), target: join(tgt, '.env'), kind: 'env' }
+    const r = copyOne(item, realCopyDeps())
+    expect(r.status).toBe('copied')
+    expect(r.keyCount).toBe(2)
+    expect(r.detail).not.toContain('secret1')
   })
 })
 

--- a/tests/worktree/copy.test.ts
+++ b/tests/worktree/copy.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { copyOne, copyAll, type CopyDeps } from '../../src/worktree/copy.js'
+import type { CopyItem } from '../../src/worktree/types.js'
+
+const envItem: CopyItem = { source: '/src/.env', target: '/tgt/.env', kind: 'env' }
+const cfgItem: CopyItem = { source: '/src/.vscode/settings.json', target: '/tgt/.vscode/settings.json', kind: 'config' }
+
+// 기본 성공 deps. 개별 테스트에서 override.
+function deps(over: Partial<CopyDeps> = {}): CopyDeps {
+  return {
+    exists: () => true,
+    copyFile: () => {},
+    readKeys: () => 7,
+    ...over,
+  }
+}
+
+describe('copyOne', () => {
+  it('env 복사 성공 → copied + keyCount, detail 에 값 없음(개수만)', () => {
+    const r = copyOne(envItem, deps())
+    expect(r.status).toBe('copied')
+    expect(r.keyCount).toBe(7)
+    expect(r.detail).toContain('7')
+    expect(r.detail).not.toContain('/src/.env') // 경로/값 노출 최소(개수 위주)
+  })
+
+  it('config 복사 성공 → copied (keyCount 없음)', () => {
+    const r = copyOne(cfgItem, deps())
+    expect(r.status).toBe('copied')
+    expect(r.keyCount).toBeUndefined()
+  })
+
+  it('원본 없음 → missing-source, copyFile 호출 안 함', () => {
+    let copied = false
+    const r = copyOne(envItem, deps({ exists: () => false, copyFile: () => { copied = true } }))
+    expect(r.status).toBe('missing-source')
+    expect(copied).toBe(false)
+  })
+
+  it('복사 중 에러 → error (throw 안 함), detail 에 env 값 미노출', () => {
+    const r = copyOne(envItem, deps({ copyFile: () => { throw new Error('EACCES') } }))
+    expect(r.status).toBe('error')
+    expect(r.detail).toContain('EACCES')
+    expect(r.keyCount).toBeUndefined()
+  })
+
+  it('마스킹: readKeys 가 키 개수만 반환 — 값은 절대 읽지/출력하지 않음', () => {
+    let readArg = ''
+    const r = copyOne(envItem, deps({ readKeys: (p) => { readArg = p; return 3 } }))
+    expect(r.detail).toBe('3 keys')
+    expect(readArg).toBe('/src/.env')
+  })
+})
+
+describe('copyAll', () => {
+  it('한 건 실패해도 나머지 계속 — 모든 결과 반환', () => {
+    const items: CopyItem[] = [
+      { source: '/s/.env', target: '/t/.env', kind: 'env' },
+      { source: '/s/.env.local', target: '/t/.env.local', kind: 'env' },
+    ]
+    const d = deps({
+      copyFile: (src) => { if (src === '/s/.env') throw new Error('boom') },
+    })
+    const results = copyAll(items, d)
+    expect(results).toHaveLength(2)
+    expect(results[0].status).toBe('error')
+    expect(results[1].status).toBe('copied')
+  })
+})


### PR DESCRIPTION
## Goal 30 — `vhk worktree` 가드 (env 누락 방지)

Notion "D3 · worktree 가드 상세 설계" Phase 1~2 구현. worktree 생성 순간 필수 env/설정 누락을 능동 방어. **Goal 29의 `worktree-env` 모듈 재사용**(이중 구현 없음).

## 동작 (도그푸딩 실제 출력)
```
🌳 Worktree 생성: test/dogfood-30
  🟢 worktree created at ...vhk-...-test-dogfood-30
  🟢 copied .env (2 keys)          ← 파일 복사 + 마스킹(값 미노출, 개수만)
  ⚪ node_modules 없음 → pnpm install (또는 --install 로 자동)
  ✅ ready
```
- `vhk worktree add <branch>` — `git worktree add` 래핑 → 필수 env/설정 자동 복사(+ `--install` 시 pnpm install).
- `vhk worktree check` — 현재 worktree 필수 env 누락 점검(개수만).
- 복사 대상 = `.env*`(템플릿 `.example`/`.sample`/`.template` 제외) + `.vhk/config.json`의 `worktreeCopy[]`.

## 불변규칙 준수 (게이트 고유검증으로 강제)
- **파일 복사만**(`copyFile`) — 심볼릭 링크 0 (Windows 안정)
- **비밀값 미노출** — env는 키 개수만, 에러도 값 미포함
- **대상 존재 시 덮어쓰기 없이 안전 중단**
- **git 훅 미접근** — `.git/hooks` 자동 설치/수정 안 함
- `safeExecFile`만(execSync 0) · `readJsonFile`(raw JSON.parse 0)
- 건별 try/catch — 한 건 실패해도 나머지 계속 · HARD_STOP 가드

## 재사용 (핵심)
`src/worktree/check.ts` → Goal 29 `src/lib/worktree-env.ts`(`checkWorktreeEnvDir`) 그대로 import. parse/missing 로직 중복 0.

## 파일
- 신규: `src/worktree/{types,configList,check,copy,add}.ts`, `src/commands/worktree.ts`, `tests/worktree/{configList,copy,add,check}.test.ts`, `scripts/check-goal-30.mjs`
- 수정: `src/index.ts`, `src/lib/{command-registry,cli-args}.ts`, `src/i18n/ko.ts`, `README.md`, `COMMANDS.md`

## 게이트 (증거)
- `vhk goal check --id 30` ✅ — tsc ✓ · test ✓ · build ✓ · 고유검증 19/19 ✓
- 전체 **956 pass**(88 files) — 신규 21(configList 6·copy 6·add 6·check 3) · 회귀 0
- 실제 worktree 도그푸딩 → 생성·복사·마스킹 확인 후 정리

## 범위 밖 (후속)
- git post-checkout 훅 자동 설치(Phase 3) · MCP 도구 노출

> 한 PR = 한 goal. npm publish 사람만. 머지는 리뷰 후 사람.
