### PR TITLE
feat(goal): HARD_STOP 가드 — goal 명령군 (Goal 34) + 35~37 등록

### DIFF
--- a/goals/34-hardstop-goal-cmds.md
+++ b/goals/34-hardstop-goal-cmds.md
@@ -1,0 +1,38 @@
+---
+vhk_format: 1
+type: goal
+id: 34
+title: HARD_STOP 가드 — goal 명령군 (next/done/init) — P1
+status: DONE
+priority: P1
+created: 2026-06-07
+completed: 2026-06-07
+leads_to: goal-35-hardstop-memory
+---
+
+# Goal 34: HARD_STOP 가드 — goal 명령군
+
+> 출처: 적대 스윕(2026-06-07, state-append 각도). recap 은 `ensureNotHardStopped` 가드가 있는데(VHK-020)
+> goal 명령군엔 누락 — HARD_STOP(모든 자동화 중단) 활성 시에도 상태파일을 변경하는 일관성 결함.
+
+## 배경
+HARD_STOP = 블로커 3건 누적/토큰초과 시 "모든 자동화 즉시 중단" 신호(.vhk/HARD_STOP). 그런데
+`goalNext`(next-task.md 갱신)·`goalDone`(goal status 전이)·`goalInit`(scaffold)은 가드 없이 실행돼
+HARD_STOP 을 무력화한다. vhk work 가 진입 게이트지만, 개별 명령 직접 실행 경로는 무방비.
+
+## 동작 (최소 변경 — 가드만, 출력/로직 불변)
+- `goalNext`/`goalDone`/`goalInit` 각 함수 첫 줄에 `if (!ensureNotHardStopped('goal next'|'goal done'|'goal init')) return`.
+- `import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'` (기존 헬퍼 재사용 — recap 선례).
+- `goalList`/`goalCheck`(읽기·검증)는 가드 제외 — 상태 변경 아님.
+
+## Completion Check
+- [ ] goalNext/goalDone/goalInit 셋 다 HARD_STOP 활성 시 즉시 중단(상태파일 미변경)
+- [ ] HARD_STOP 없으면 기존과 동일 동작(회귀 0)
+- [ ] 회귀 가드 테스트: `.vhk/HARD_STOP` 존재 시 goalNext 가 next-task.md 안 씀 검증
+- [ ] vhk goal sync → check-goal-34.mjs → vhk goal check --id 34 통과
+- [ ] 공통 게이트(typecheck+test+build) 통과, 기존 회귀 0
+
+## Mandatory Reading
+- src/lib/hard-stop-guard.ts (ensureNotHardStopped 계약)
+- src/commands/recap.ts:19 (가드 선례 — VHK-020)
+- src/commands/goal.ts (goalNext/goalDone/goalInit)

--- a/goals/35-hardstop-memory.md
+++ b/goals/35-hardstop-memory.md
@@ -1,0 +1,36 @@
+---
+vhk_format: 1
+type: goal
+id: 35
+title: HARD_STOP 가드 — memory 명령군 (add/remove/archive/resolve/unarchive) — P1
+status: NOT_STARTED
+priority: P1
+created: 2026-06-07
+leads_to: goal-36-hardstop-evolve-pattern-mission
+---
+
+# Goal 35: HARD_STOP 가드 — memory 명령군
+
+> 출처: 적대 스윕(2026-06-07). Goal 34 와 동일 결함의 memory.ts 판 — 기억(.vhk/memory.json)을
+> 바꾸는 명령들이 HARD_STOP 활성 시에도 실행됨.
+
+## 배경
+`memoryAdd`/`memoryRemove`/`memoryArchive`/`memoryResolve`/`memoryUnarchive` 가 가드 없이
+memory.json 을 변경. HARD_STOP 중에도 기억이 쓰이거나 삭제됨.
+
+## 동작 (최소 변경 — 가드만)
+- 위 5개 함수 첫 줄에 `if (!ensureNotHardStopped('memory add'|...)) return`.
+- `memoryList`/`memoryMigrate` 는 제외(list=읽기 / migrate=복구성 — 별도 판단).
+- import ensureNotHardStopped (기존 헬퍼).
+
+## Completion Check
+- [ ] 5개 mutate 명령 모두 HARD_STOP 활성 시 즉시 중단(memory.json 미변경)
+- [ ] HARD_STOP 없으면 기존 동일(회귀 0)
+- [ ] 회귀 가드 테스트: HARD_STOP 존재 시 memoryAdd 가 memory.json 안 씀
+- [ ] vhk goal sync → check-goal-35.mjs → check --id 35 통과
+- [ ] 공통 게이트 통과
+
+## Mandatory Reading
+- src/lib/hard-stop-guard.ts
+- src/commands/memory.ts (mutate 함수들 + loadForMutation 위치)
+- goals/34-hardstop-goal-cmds.md (동일 패턴 선행 goal)

--- a/goals/36-hardstop-evolve-pattern-mission.md
+++ b/goals/36-hardstop-evolve-pattern-mission.md
@@ -1,0 +1,37 @@
+---
+vhk_format: 1
+type: goal
+id: 36
+title: HARD_STOP 가드 — evolve/pattern/mission mutate 명령 — P1
+status: NOT_STARTED
+priority: P1
+created: 2026-06-07
+leads_to: goal-37-atomic-writes
+---
+
+# Goal 36: HARD_STOP 가드 — evolve/pattern/mission
+
+> 출처: 적대 스윕(2026-06-07). Goal 34/35 와 동일 결함의 나머지 mutate 명령(RULES.md·큐·미션 변경).
+
+## 배경
+- `evolveApply`(RULES.md append + sync)·`evolveReject`·`evolveUndo`(큐 변경) — 가장 위험(RULES.md 수정).
+- `patternDismiss`(memory 패턴 상태 변경).
+- `missionClear`(.vhk/mission.json 삭제).
+모두 HARD_STOP 활성 시에도 실행됨.
+
+## 동작 (최소 변경 — 가드만)
+- 위 함수들 첫 줄에 `if (!ensureNotHardStopped('evolve apply'|...)) return`.
+- `context` 명령은 이번 범위 제외 — 자동생성 + work/메뉴가 내부 호출(가드 시 work 흐름과 충돌). 별도 판단.
+- 조회 명령(evolveList/patternList/missionShow)은 제외.
+
+## Completion Check
+- [ ] evolveApply/evolveReject/evolveUndo/patternDismiss/missionClear 모두 HARD_STOP 시 중단
+- [ ] HARD_STOP 없으면 기존 동일(회귀 0). evolveApply 의 TTY 확인 흐름 무손상
+- [ ] 회귀 가드 테스트(대표 1~2개: evolveApply·missionClear)
+- [ ] vhk goal sync → check-goal-36.mjs → check --id 36 통과
+- [ ] 공통 게이트 통과
+
+## Mandatory Reading
+- src/lib/hard-stop-guard.ts
+- src/commands/evolve.ts · src/commands/pattern.ts · src/commands/mission.ts
+- goals/34-hardstop-goal-cmds.md (선행 패턴)

--- a/goals/37-atomic-writes.md
+++ b/goals/37-atomic-writes.md
@@ -1,0 +1,34 @@
+---
+vhk_format: 1
+type: goal
+id: 37
+title: 원자적 쓰기 헬퍼 — 상태/리포트 파일 (ref/sync/review) — P2
+status: NOT_STARTED
+priority: P2
+created: 2026-06-07
+---
+
+# Goal 37: 원자적 쓰기 헬퍼
+
+> 출처: 적대 스윕(2026-06-07, exec-fs 각도). 상태/리포트 파일을 writeFileSync 로 바로 덮어써,
+> 쓰기 도중 프로세스 kill 시 파일이 부분 기록(손상)될 수 있다. 트리거는 희박하나 데이터 손실 방지.
+
+## 배경
+- `src/commands/ref.ts` (refs.json) · `src/commands/sync.ts` (.synced 마커) · `src/commands/review.ts`
+  (latest.json merge-write) 가 비원자 writeFileSync. 중간 kill → 다음 readCache/parse 가 손상 파일에 실패.
+
+## 동작 (공유 헬퍼 + 적용)
+- `src/lib/atomic-write.ts` 신규: `atomicWriteFile(path, data)` = 같은 디렉터리 temp 파일에 쓰고 `fs.renameSync`
+  로 교체(rename 은 원자적). 실패 시 temp 정리.
+- ref.ts·sync.ts·review.ts 의 해당 writeFileSync → atomicWriteFile 로 교체. 동작/출력 불변.
+- (선택) memory.json·next-task.md 등 다른 상태 쓰기도 점진 적용 — 단 이번 범위는 3곳만.
+
+## Completion Check
+- [ ] atomicWriteFile 단위 테스트(정상 교체 + temp 정리 + 동일 내용)
+- [ ] ref/sync/review 3곳 적용, 동작 회귀 0
+- [ ] vhk goal sync → check-goal-37.mjs → check --id 37 통과
+- [ ] 공통 게이트 통과
+
+## Mandatory Reading
+- src/commands/ref.ts · src/commands/sync.ts · src/commands/review.ts (대상 writeFileSync)
+- src/lib/state-files.ts (기존 상태파일 쓰기 패턴 참고)

--- a/scripts/check-goal-34.mjs
+++ b/scripts/check-goal-34.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// scripts/check-goal-34.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 34 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 34] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 34 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 34 gate passes'); process.exit(0) }
+console.log('❌ goal 34 gate failed'); process.exit(1)

--- a/scripts/check-goal-35.mjs
+++ b/scripts/check-goal-35.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// scripts/check-goal-35.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 35 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 35] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 35 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 35 gate passes'); process.exit(0) }
+console.log('❌ goal 35 gate failed'); process.exit(1)

--- a/scripts/check-goal-36.mjs
+++ b/scripts/check-goal-36.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// scripts/check-goal-36.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 36 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 36] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 36 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 36 gate passes'); process.exit(0) }
+console.log('❌ goal 36 gate failed'); process.exit(1)

--- a/scripts/check-goal-37.mjs
+++ b/scripts/check-goal-37.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// scripts/check-goal-37.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 37 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 37] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 37 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 37 gate passes'); process.exit(0) }
+console.log('❌ goal 37 gate failed'); process.exit(1)

--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -5,6 +5,7 @@ import { ko } from '../i18n/ko.js'
 import { localDate } from '../lib/date.js'
 import { printNextStep } from '../lib/next-step.js'
 import { safeExecFile } from '../lib/exec.js'
+import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
 import {
   listGoals,
   findDuplicateIds,
@@ -90,6 +91,7 @@ function printSkippedGoalWarnings(skipped: ReturnType<typeof findSkippedGoalFile
 }
 
 export async function goalNext(): Promise<void> {
+  if (!ensureNotHardStopped('goal next')) return // HARD_STOP 활성 시 next-task.md 변경 차단
   console.log(chalk.bold(`\n${ko.goal.nextTitle}\n`))
   const goals = listGoals(GOALS_DIR)
   // VHK-017: goal 0개와 '전부 완료'를 구분(같은 상태를 정반대로 묘사하던 오보 제거).
@@ -186,6 +188,7 @@ const STATE_LEARNINGS_TEMPLATE =
   '# Learnings\n\n_Append-only. 한 줄 = 한 교훈._\n'
 
 export async function goalInit(): Promise<void> {
+  if (!ensureNotHardStopped('goal init')) return // HARD_STOP 활성 시 scaffold 생성 차단
   console.log(chalk.bold(`\n${ko.goal.initTitle}\n`))
   const targets: Array<{ path: string; content: string }> = [
     { path: join(GOALS_DIR, '_meta.md'), content: META_TEMPLATE },
@@ -290,6 +293,7 @@ export async function goalCheck(opts: { id?: string }): Promise<void> {
 }
 
 export async function goalDone(opts: { id?: string }): Promise<void> {
+  if (!ensureNotHardStopped('goal done')) return // HARD_STOP 활성 시 status 전이 차단
   console.log(chalk.bold(`\n${ko.goal.doneTitle}\n`))
   const goals = listGoals(GOALS_DIR)
   const id = resolveGoalId(opts.id, goals)

--- a/tests/goal-hardstop.test.ts
+++ b/tests/goal-hardstop.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// Goal 34: goal 명령군(next/done/init) HARD_STOP 가드 회귀 테스트.
+// HARD_STOP 활성 시 상태파일을 변경하면 안 된다(모든 자동화 중단 신호).
+
+function tmpProject(label: string): string {
+  const dir = join(tmpdir(), `vhk-goalhs-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+function makeGoalFile(dir: string, id: number, status: string): void {
+  mkdirSync(join(dir, 'goals'), { recursive: true })
+  writeFileSync(
+    join(dir, 'goals', `${id}-test.md`),
+    `---\nvhk_format: 1\ntype: goal\nid: ${id}\ntitle: Goal ${id}\nstatus: ${status}\npriority: P0\n---\nbody\n`,
+    'utf-8'
+  )
+}
+
+function writeHardStop(dir: string): void {
+  mkdirSync(join(dir, '.vhk'), { recursive: true })
+  writeFileSync(join(dir, '.vhk', 'HARD_STOP'), '2026-06-07T00:00:00Z\nauto: test\n', 'utf-8')
+}
+
+describe('goal 명령군 HARD_STOP 가드 (Goal 34)', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    process.exitCode = 0 // ensureNotHardStopped 가 설정한 exitCode 리셋(다른 테스트 오염 방지)
+    vi.restoreAllMocks()
+  })
+
+  it('HARD_STOP 활성 → goalNext 가 next-task.md 를 쓰지 않는다', async () => {
+    const dir = tmpProject('next-blocked')
+    makeGoalFile(dir, 0, 'NOT_STARTED')
+    writeHardStop(dir)
+    process.chdir(dir)
+    try {
+      const { goalNext } = await import('../src/commands/goal.js')
+      await goalNext()
+      expect(existsSync(join(dir, 'docs', 'state', 'next-task.md'))).toBe(false)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('HARD_STOP 없으면 goalNext 정상 동작(next-task.md 생성) — 회귀 0', async () => {
+    const dir = tmpProject('next-ok')
+    makeGoalFile(dir, 0, 'NOT_STARTED')
+    process.chdir(dir)
+    try {
+      const { goalNext } = await import('../src/commands/goal.js')
+      await goalNext()
+      expect(existsSync(join(dir, 'docs', 'state', 'next-task.md'))).toBe(true)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('HARD_STOP 활성 → goalInit 가 scaffold(goals/_meta.md)를 만들지 않는다', async () => {
+    const dir = tmpProject('init-blocked')
+    writeHardStop(dir)
+    process.chdir(dir)
+    try {
+      const { goalInit } = await import('../src/commands/goal.js')
+      await goalInit()
+      expect(existsSync(join(dir, 'goals', '_meta.md'))).toBe(false)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## 무엇

적대 스윕(2026-06-07)에서 나온 **HARD_STOP 가드 누락**을 작은 goal 로 쪼개 등록하고, 첫 goal(34)을 구현.

`recap` 만 `ensureNotHardStopped` 가드가 있었고(VHK-020), 다른 상태변경 명령들은 HARD_STOP(모든 자동화 중단) 활성 시에도 그냥 실행되던 일관성 결함.

## Goal 34 (이 PR에서 구현)

- `goalNext`/`goalDone`/`goalInit` 첫 줄에 `ensureNotHardStopped` 가드 추가 → HARD_STOP 활성 시 `next-task.md`·goal status 전이·scaffold 변경 차단.
- 읽기 명령(`goalList`/`goalCheck`)은 제외(상태 변경 아님).
- 회귀 가드 테스트 3종: next 차단 / next 정상(회귀 0) / init 차단.

## 등록만 (다음 작업, 미구현)

- **Goal 35**: memory 명령군 가드 (add/remove/archive/resolve/unarchive)
- **Goal 36**: evolve/pattern/mission mutate 가드
- **Goal 37**: 원자적 쓰기 헬퍼 (ref/sync/review)

각 goal 은 파일 단위로 작게 쪼갰고 `check-goal-N.mjs` 게이트 스크립트도 함께 등록.

## 검증

- 타입체크 0 · 빌드 OK · 테스트 **939 pass** (회귀 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)