### PR TITLE
feat(memory): HARD_STOP 가드 — memory 명령군 (Goal 35)

### DIFF
--- a/goals/35-hardstop-memory.md
+++ b/goals/35-hardstop-memory.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 35
 title: HARD_STOP 가드 — memory 명령군 (add/remove/archive/resolve/unarchive) — P1
-status: NOT_STARTED
+status: DONE
 priority: P1
 created: 2026-06-07
+completed: 2026-06-07
 leads_to: goal-36-hardstop-evolve-pattern-mission
 ---
 

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { readJsonFile, stripBom } from '../lib/read-json.js'
+import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
 
 /**
  * Goal 18: memory schema v2 — 평면 배열 → 4버킷(decisions/failures/successes/patterns).
@@ -314,6 +315,7 @@ export async function memoryAdd(
   content: string,
   opts: { tags?: string[]; type?: string; why?: string; lesson?: string } = {}
 ): Promise<void> {
+  if (!ensureNotHardStopped('memory add')) return // HARD_STOP 활성 시 memory.json 변경 차단
   console.log(chalk.bold('\n🧠 ' + t('memory.addTitle')))
   console.log(chalk.gray('─'.repeat(40)))
   if (!content || !content.trim()) {
@@ -394,6 +396,7 @@ function resolveIndex(indexStr: string, len: number): number | null {
 }
 
 export async function memoryRemove(indexStr: string): Promise<void> {
+  if (!ensureNotHardStopped('memory remove')) return
   const cwd = process.cwd()
   const loaded = loadForMutation(cwd)
   if (!loaded.ok) {
@@ -446,6 +449,7 @@ function entryLabel(entry: MemEntry): string {
 }
 
 export async function memoryArchive(indexStr: string): Promise<void> {
+  if (!ensureNotHardStopped('memory archive')) return
   const r = resolveEntryForMutation(indexStr)
   if (!r) return
   r.entry.status = 'archived'
@@ -458,6 +462,7 @@ export async function memoryArchive(indexStr: string): Promise<void> {
 
 /** 항목 해결 표시 (active→resolved). 실패가 교훈으로 정리됨을 기록 — 패턴/진화에서 제외. */
 export async function memoryResolve(indexStr: string): Promise<void> {
+  if (!ensureNotHardStopped('memory resolve')) return
   const r = resolveEntryForMutation(indexStr)
   if (!r) return
   r.entry.status = 'resolved'
@@ -470,6 +475,7 @@ export async function memoryResolve(indexStr: string): Promise<void> {
 
 /** 보관/해결 항목을 다시 active 로 — 오조작 복구(archive/resolve 역전). */
 export async function memoryUnarchive(indexStr: string): Promise<void> {
+  if (!ensureNotHardStopped('memory unarchive')) return
   const r = resolveEntryForMutation(indexStr)
   if (!r) return
   if (isActive(r.entry)) {

--- a/tests/memory-hardstop.test.ts
+++ b/tests/memory-hardstop.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// Goal 35: memory 명령군(add/remove/archive/resolve/unarchive) HARD_STOP 가드 회귀 테스트.
+
+function tmpProject(label: string): string {
+  const dir = join(tmpdir(), `vhk-memhs-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  mkdirSync(join(dir, '.vhk'), { recursive: true })
+  return dir
+}
+
+function writeHardStop(dir: string): void {
+  writeFileSync(join(dir, '.vhk', 'HARD_STOP'), '2026-06-07T00:00:00Z\nauto: test\n', 'utf-8')
+}
+
+function readMemoryRaw(dir: string): string {
+  return readFileSync(join(dir, '.vhk', 'memory.json'), 'utf-8')
+}
+
+describe('memory 명령군 HARD_STOP 가드 (Goal 35)', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    process.exitCode = 0
+    vi.restoreAllMocks()
+  })
+
+  it('HARD_STOP 활성 → memoryAdd 가 memory.json 을 만들지 않는다', async () => {
+    const dir = tmpProject('add-blocked')
+    writeHardStop(dir)
+    process.chdir(dir)
+    try {
+      const { memoryAdd } = await import('../src/commands/memory.js')
+      await memoryAdd('차단되어야 할 기억', { type: 'decision' })
+      // HARD_STOP 가드로 즉시 return → memory.json 생성 안 됨
+      expect(() => readMemoryRaw(dir)).toThrow()
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('HARD_STOP 없으면 memoryAdd 정상(memory.json 생성) — 회귀 0', async () => {
+    const dir = tmpProject('add-ok')
+    process.chdir(dir)
+    try {
+      const { memoryAdd } = await import('../src/commands/memory.js')
+      await memoryAdd('정상 저장 기억', { type: 'decision' })
+      expect(readMemoryRaw(dir)).toContain('정상 저장 기억')
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Goal 35: HARD_STOP 가드 — memory 명령군

Goal 34(goal 명령군)와 동일 패턴. `memoryAdd`/`memoryRemove`/`memoryArchive`/`memoryResolve`/`memoryUnarchive` 첫 줄에 `ensureNotHardStopped` 가드 → HARD_STOP 활성 시 `.vhk/memory.json` 변경 차단.

- 읽기/복구성 명령(`memoryList`/`memoryMigrate`)은 제외.
- 회귀 가드 테스트 2종(add 차단 / add 정상-회귀0).
- 타입체크 0 · 빌드 OK · 테스트 **941 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)