### PR TITLE
feat(atomic): 원자적 쓰기 헬퍼 + 영속 상태 적용 (Goal 37) + 38 등록

### DIFF
--- a/goals/37-atomic-writes.md
+++ b/goals/37-atomic-writes.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 37
 title: 원자적 쓰기 헬퍼 — 상태/리포트 파일 (ref/sync/review) — P2
-status: NOT_STARTED
+status: DONE
 priority: P2
 created: 2026-06-07
+completed: 2026-06-07
 ---
 
 # Goal 37: 원자적 쓰기 헬퍼
@@ -20,8 +21,10 @@ created: 2026-06-07
 ## 동작 (공유 헬퍼 + 적용)
 - `src/lib/atomic-write.ts` 신규: `atomicWriteFile(path, data)` = 같은 디렉터리 temp 파일에 쓰고 `fs.renameSync`
   로 교체(rename 은 원자적). 실패 시 temp 정리.
-- ref.ts·sync.ts·review.ts 의 해당 writeFileSync → atomicWriteFile 로 교체. 동작/출력 불변.
-- (선택) memory.json·next-task.md 등 다른 상태 쓰기도 점진 적용 — 단 이번 범위는 3곳만.
+- 영속 상태 쓰기를 atomicWriteFile 로 교체(동작/출력 불변): ref.ts(refs.json) · review.ts·verify.ts(latest.json — 같은 파일이라 둘 다 일관 적용 + verify HTML) · sync.ts(.synced 마커).
+- sync 미러 파일(.cursorrules 등)은 재생성 가능이라 제외 — 코드에 근거 주석 명시.
+- mission.json·HARD_STOP·blockers 등 나머지 영속 상태 쓰기는 Goal 38 로 분리(스킵 아님, 작은 단위 계획).
+- atomicWriteFile temp 명에 process.pid + 단조 카운터 — 동일 파일 동시 호출 temp 충돌 방지(적대검증 반영).
 
 ## Completion Check
 - [ ] atomicWriteFile 단위 테스트(정상 교체 + temp 정리 + 동일 내용)

--- a/goals/38-atomic-writes-state-mission.md
+++ b/goals/38-atomic-writes-state-mission.md
@@ -1,0 +1,36 @@
+---
+vhk_format: 1
+type: goal
+id: 38
+title: 원자적 쓰기 확대 — mission.json + state-files (HARD_STOP/blockers) — P2
+status: NOT_STARTED
+priority: P2
+created: 2026-06-07
+---
+
+# Goal 38: 원자적 쓰기 확대 — 나머지 영속 상태 파일
+
+> 출처: Goal 37 머지 전 적대 검증(2026-06-07). Goal 37 이 ref/review/verify/sync(.synced)만 atomic 화 →
+> 동일 손상 위험인 나머지 영속 상태 쓰기(mission/HARD_STOP/blockers)를 작은 단위로 분리해 마저 처리.
+> (스킵이 아니라 명시적 후속 계획 — 적대검증 지적 반영.)
+
+## 배경
+쓰기 도중 프로세스 kill 시 부분 기록(손상) → 다음 read/parse 실패. Goal 37 의 `atomicWriteFile` 헬퍼를
+나머지 영속 상태 파일 쓰기에도 적용한다.
+
+## 대상 (전체 덮어쓰기만 — append 는 제외)
+- `src/commands/mission.ts` — `.vhk/mission.json` 쓰기(missionSet). 손상 시 mission check 실패.
+- `src/lib/state-files.ts` — `writeHardStop`(.vhk/HARD_STOP 전체 쓰기) + blockers.md **첫 생성** writeFileSync.
+  - 주의: blockers 의 `appendFileSync`(이어쓰기)는 끝에 추가라 손상 위험 낮음 + atomic 부적합 → 제외.
+- (검토) memory.json/next-task.md 는 별도 — 이미 백업(.bak)·재생성 메커니즘 있어 후속 판단.
+
+## Completion Check
+- [ ] mission.json·HARD_STOP·blockers 첫 생성이 atomicWriteFile 사용(append 는 그대로)
+- [ ] 동작 회귀 0(기존 테스트 통과). state-files/mission 테스트 mock 정합(atomic-write mock)
+- [ ] vhk goal sync → check-goal-38.mjs → check --id 38 통과
+- [ ] 공통 게이트 통과
+
+## Mandatory Reading
+- src/lib/atomic-write.ts (Goal 37 헬퍼)
+- src/lib/state-files.ts · src/commands/mission.ts (대상)
+- goals/37-atomic-writes.md (선행 — 적용 패턴 + 제외 근거)

--- a/scripts/check-goal-38.mjs
+++ b/scripts/check-goal-38.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// scripts/check-goal-38.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 38 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 38] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 38 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 38 gate passes'); process.exit(0) }
+console.log('❌ goal 38 gate failed'); process.exit(1)

--- a/src/commands/ref.ts
+++ b/src/commands/ref.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync } from 'node:fs'
+import { atomicWriteFile } from '../lib/atomic-write.js'
 import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
@@ -25,7 +26,7 @@ function loadRefs(): RefEntry[] {
 
 function saveRefs(refs: RefEntry[]): void {
   mkdirSync('.vhk', { recursive: true })
-  writeFileSync(REFS_PATH, JSON.stringify(refs, null, 2) + '\n', 'utf-8')
+  atomicWriteFile(REFS_PATH, JSON.stringify(refs, null, 2) + '\n')
 }
 
 export async function refAdd(url: string, memo = ''): Promise<void> {

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -1,4 +1,5 @@
-import { existsSync, writeFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
+import { atomicWriteFile } from '../lib/atomic-write.js'
 import { join } from 'node:path'
 import chalk from 'chalk'
 import { listGoals, type ParsedGoal } from '../lib/goal-frontmatter.js'
@@ -328,7 +329,7 @@ export async function review(opts: { id?: string } = {}): Promise<void> {
   let mergeOk = false
   try {
     const merged = { ...report, review: result }
-    writeFileSync(jsonPath, JSON.stringify(merged, null, 2) + '\n', 'utf-8')
+    atomicWriteFile(jsonPath, JSON.stringify(merged, null, 2) + '\n')
     mergeOk = true
     console.log(chalk.dim(`  📄 판정 병합: ${REPORT_PATH_REL} (review 섹션)`))
   } catch (e) {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -7,6 +7,7 @@ import { ko } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { normalizeForCompare } from '../lib/drift.js'
 import { saveBackup, pruneBackups, ensureVhkIgnored } from '../lib/backup.js'
+import { atomicWriteFile } from '../lib/atomic-write.js'
 import { PREAMBLE_TITLE } from '../lib/rules-import.js'
 import { isInteractive, promptOrDefault } from '../lib/interactive.js'
 
@@ -518,6 +519,8 @@ export async function syncCore(
     }
     const fullPath = path.join(rootDir, item.path)
     fs.mkdirSync(path.dirname(fullPath), { recursive: true }) // 중첩 경로(.github/·.agents/rules/) 보장
+    // 미러 파일(.cursorrules 등)은 RULES.md 에서 언제든 재생성 가능(vhk sync 재실행) → 원자성 불필요.
+    // 영속 상태(refs.json·latest.json·.synced)만 atomicWriteFile(Goal 37) — 손상 시 복구 불가라.
     fs.writeFileSync(fullPath, item.newContent, 'utf-8')
     written.push(item.path)
     // 절삭 마커는 antigravity 만 생성 — 전체 마커 문구로 한정(오탐 방지)
@@ -528,7 +531,7 @@ export async function syncCore(
 
   // 동기화 마커(로컬 전용) — 다음 실행 firstSync 판정용
   fs.mkdirSync(path.join(rootDir, '.vhk'), { recursive: true })
-  fs.writeFileSync(path.join(rootDir, SYNCED_MARKER_REL), new Date().toISOString() + '\n', 'utf-8')
+  atomicWriteFile(path.join(rootDir, SYNCED_MARKER_REL), new Date().toISOString() + '\n')
   ensureVhkIgnored(rootDir, '.synced')
 
   return { dryRun: false, firstSync, backupId, backedUp, written, skipped, truncated, plan, unmapped, claudeMigration }

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import chalk from 'chalk'
 import { readConfig } from '../lib/config.js'
@@ -9,6 +9,7 @@ import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
 import { ensureVhkIgnored } from '../lib/backup.js'
 import { readJsonFile } from '../lib/read-json.js'
 import { localDate } from '../lib/date.js'
+import { atomicWriteFile } from '../lib/atomic-write.js'
 import { scanProjectForSecrets, filterSevereFindings } from '../lib/scan-secrets.js'
 import { renderReportHtml } from './verify-report.js'
 import { isInteractive } from '../lib/interactive.js'
@@ -265,7 +266,7 @@ export function verifyEvidence(cwd: string = process.cwd()): { report: VerifyRep
   const dir = join(cwd, REPORT_DIR_REL)
   mkdirSync(dir, { recursive: true })
   const path = join(cwd, REPORT_PATH_REL)
-  writeFileSync(path, JSON.stringify(report, null, 2) + '\n', 'utf-8')
+  atomicWriteFile(path, JSON.stringify(report, null, 2) + '\n')
   // reports/ 는 개인 환경 산물 → 로컬 전용(추적·클라우드 제외).
   try {
     ensureVhkIgnored(cwd, 'reports/')
@@ -307,7 +308,7 @@ async function renderVerifyReport(cwd: string, opts: { open?: boolean }): Promis
   const htmlPath = join(cwd, REPORT_HTML_PATH_REL)
   try {
     mkdirSync(join(cwd, REPORT_DIR_REL), { recursive: true })
-    writeFileSync(htmlPath, html, 'utf-8')
+    atomicWriteFile(htmlPath, html)
   } catch (e) {
     // 쓰기 권한 없음 등 → 크래시 대신 친절 안내 + 비-0 종료.
     console.error(

--- a/src/lib/atomic-write.ts
+++ b/src/lib/atomic-write.ts
@@ -1,0 +1,30 @@
+import { writeFileSync, renameSync, rmSync } from 'node:fs'
+import { join, dirname, basename } from 'node:path'
+
+// 같은 프로세스 내 temp 파일명 충돌 방지용 단조 증가 카운터.
+// (process.pid 만으로는 동일 파일을 동시에 두 번 쓸 때 temp 경로가 겹쳐 마지막 쓰기로 오염될 수 있다.)
+let writeCounter = 0
+
+/**
+ * 원자적 파일 쓰기 — 같은 디렉터리의 temp 파일에 먼저 쓰고 `renameSync`(원자적 교체)로 옮긴다.
+ *
+ * 왜: 상태/캐시/리포트 파일을 `writeFileSync` 로 바로 덮어쓰면, 쓰기 도중 프로세스가 kill 되었을 때
+ * 대상 파일이 부분 기록(손상)된다 → 다음 read/JSON.parse 가 실패. rename 은 (같은 볼륨에서) 원자적이라
+ * 대상 파일은 "이전 내용" 또는 "완전한 새 내용" 둘 중 하나만 갖는다(손상 중간상태 없음).
+ *
+ * temp 파일명에 process.pid 를 붙여 동시 실행 충돌을 피한다. 실패 시 temp 를 정리하고 에러를 다시 던진다.
+ */
+export function atomicWriteFile(filePath: string, data: string): void {
+  const tmp = join(dirname(filePath), `.${basename(filePath)}.tmp-${process.pid}-${writeCounter++}`)
+  try {
+    writeFileSync(tmp, data, 'utf-8')
+    renameSync(tmp, filePath)
+  } catch (err) {
+    try {
+      rmSync(tmp, { force: true })
+    } catch {
+      /* temp 정리 실패는 무시 — 원래 에러를 던진다 */
+    }
+    throw err
+  }
+}

--- a/tests/atomic-write.test.ts
+++ b/tests/atomic-write.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, readdirSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { atomicWriteFile } from '../src/lib/atomic-write.js'
+
+describe('atomicWriteFile (Goal 37)', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'vhk-atomic-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('새 파일을 정확한 내용으로 쓴다', () => {
+    const p = join(dir, 'out.json')
+    atomicWriteFile(p, '{"a":1}\n')
+    expect(readFileSync(p, 'utf-8')).toBe('{"a":1}\n')
+  })
+
+  it('기존 파일을 덮어쓴다(원자적 교체)', () => {
+    const p = join(dir, 'out.txt')
+    writeFileSync(p, 'old', 'utf-8')
+    atomicWriteFile(p, 'new')
+    expect(readFileSync(p, 'utf-8')).toBe('new')
+  })
+
+  it('같은 파일 연속 호출 — temp 충돌 없이 마지막 내용만 남는다 (카운터 유니크)', () => {
+    const p = join(dir, 'c.json')
+    atomicWriteFile(p, 'first')
+    atomicWriteFile(p, 'second')
+    expect(readFileSync(p, 'utf-8')).toBe('second')
+    expect(readdirSync(dir).filter((f) => f.includes('.tmp-'))).toHaveLength(0)
+  })
+
+  it('쓰기 후 temp 파일을 남기지 않는다', () => {
+    const p = join(dir, 'refs.json')
+    atomicWriteFile(p, 'data')
+    // 디렉터리에 대상 파일만 — .refs.json.tmp-* 잔여 없음
+    const leftover = readdirSync(dir).filter((f) => f.includes('.tmp-'))
+    expect(leftover).toHaveLength(0)
+    expect(existsSync(p)).toBe(true)
+  })
+})

--- a/tests/ref.test.ts
+++ b/tests/ref.test.ts
@@ -5,12 +5,18 @@ const mockMkdirSync = vi.fn()
 const mockReadFileSync = vi.fn()
 const mockWriteFileSync = vi.fn()
 const mockSafeExecFile = vi.fn()
+const mockAtomicWrite = vi.fn()
 
 vi.mock('node:fs', () => ({
   existsSync: (...a: unknown[]) => mockExistsSync(...a),
   mkdirSync: (...a: unknown[]) => mockMkdirSync(...a),
   readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
   writeFileSync: (...a: unknown[]) => mockWriteFileSync(...a),
+}))
+
+// ref.ts 는 저장 시 atomicWriteFile 사용(Goal 37) → 쓰기 검증은 이 mock 으로.
+vi.mock('../src/lib/atomic-write.js', () => ({
+  atomicWriteFile: (...a: unknown[]) => mockAtomicWrite(...a),
 }))
 
 vi.mock('../src/lib/exec.js', () => ({
@@ -33,7 +39,7 @@ describe('ref', () => {
   it('refAdd — 빈 URL이면 안내만 출력하고 파일은 쓰지 않는다', async () => {
     const { refAdd } = await import('../src/commands/ref.js')
     await refAdd('')
-    expect(mockWriteFileSync).not.toHaveBeenCalled()
+    expect(mockAtomicWrite).not.toHaveBeenCalled()
   })
 
   it('refAdd — 새 URL이면 .vhk/refs.json에 항목을 추가한다', async () => {
@@ -42,7 +48,7 @@ describe('ref', () => {
     await refAdd('https://example.com', '참고 사이트')
 
     expect(mockMkdirSync).toHaveBeenCalledWith('.vhk', { recursive: true })
-    const call = mockWriteFileSync.mock.calls[0]
+    const call = mockAtomicWrite.mock.calls[0]
     expect(String(call[0])).toContain('refs.json')
     const data = JSON.parse(String(call[1]))
     expect(data).toHaveLength(1)
@@ -58,7 +64,7 @@ describe('ref', () => {
     )
     const { refAdd } = await import('../src/commands/ref.js')
     await refAdd('https://example.com')
-    expect(mockWriteFileSync).not.toHaveBeenCalled()
+    expect(mockAtomicWrite).not.toHaveBeenCalled()
   })
 
   it('refList — 저장된 항목이 없으면 안내만 출력', async () => {

--- a/tests/review.test.ts
+++ b/tests/review.test.ts
@@ -14,6 +14,15 @@ import {
 import type { GateResult, ReportStatus, VerifyReport } from '../src/commands/verify.js'
 import { routeNaturalLanguage } from '../src/lib/nlp-router.js'
 import { dispatchNlpRoute } from '../src/lib/nlp-run.js'
+
+// review.ts 는 latest.json 을 atomicWriteFile(temp→rename)로 쓴다. 단, 이 테스트는 chmod 0o444
+// (대상 파일 읽기전용)로 write 실패를 시뮬하는데 rename 은 파일 권한이 아니라 디렉터리 권한만 보므로
+// ubuntu 에서 읽기전용 파일도 덮어써져 시뮬이 무력화된다(OS 의존). 여기선 atomicWriteFile 을
+// "직접 writeFileSync" 로 mock 해 권한 시뮬이 OS 무관하게 작동하도록 한다(원자성 자체는 atomic-write.test 가 검증).
+vi.mock('../src/lib/atomic-write.js', async () => {
+  const { writeFileSync } = await import('node:fs')
+  return { atomicWriteFile: (p: string, data: string) => writeFileSync(p, data, 'utf-8') }
+})
 import { KNOWN_COMMAND_TOKENS } from '../src/lib/cli-args.js'
 
 const GEN_AT = '2026-06-02T00:00:00.000Z'


### PR DESCRIPTION
## Goal 37: 원자적 쓰기 헬퍼 + 영속 상태 적용

적대 스윕(exec-fs) + **머지 전 적대 검증** 반영. 상태/리포트 파일을 쓰기 도중 kill 시 부분 기록(손상)되는 걸 방지.

### 구현
- `src/lib/atomic-write.ts` — `atomicWriteFile` = 같은 디렉터리 temp 에 쓰고 `renameSync`(원자 교체). temp 명에 **pid + 단조 카운터**(동일 파일 동시 호출 temp 충돌 방지 — 적대검증 지적).
- 적용: `ref.ts`(refs.json) · `review.ts`+`verify.ts`(latest.json — **같은 파일**이라 둘 다 일관 적용 + verify HTML) · `sync.ts`(.synced 마커).
- `sync` 미러 파일(.cursorrules 등)은 RULES.md 에서 재생성 가능 → 제외(코드 근거 주석).

### 적대 검증 발견 반영
- 🔴 temp 충돌 → 카운터 추가
- 🟡 verify latest.json 비원자(review와 같은 파일 모순) → verify 도 atomic
- 🟡 mission.json·HARD_STOP·blockers 누락 → **Goal 38 로 분리 등록**(스킵 아닌 계획)
- 동시성 미커버 → 연속 호출 테스트 추가

### 검증
- 타입체크 0 · 빌드 OK · 테스트 **947 pass**(회귀 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)