### PR TITLE
feat(atomic): 원자적 쓰기 확대 — mission/state-files (Goal 38)

### DIFF
--- a/goals/38-atomic-writes-state-mission.md
+++ b/goals/38-atomic-writes-state-mission.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 38
 title: 원자적 쓰기 확대 — mission.json + state-files (HARD_STOP/blockers) — P2
-status: NOT_STARTED
+status: DONE
 priority: P2
 created: 2026-06-07
+completed: 2026-06-07
 ---
 
 # Goal 38: 원자적 쓰기 확대 — 나머지 영속 상태 파일

--- a/src/commands/mission.ts
+++ b/src/commands/mission.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdirSync, rmSync } from 'node:fs'
+import { atomicWriteFile } from '../lib/atomic-write.js'
 import { join } from 'node:path'
 import chalk from 'chalk'
 import inquirer from 'inquirer'
@@ -105,7 +106,7 @@ export function readMission(cwd: string = process.cwd()): Mission | null {
 
 function writeMission(cwd: string, mission: Mission): void {
   mkdirSync(join(cwd, '.vhk'), { recursive: true })
-  writeFileSync(join(cwd, MISSION_PATH_REL), JSON.stringify(mission, null, 2) + '\n', 'utf-8')
+  atomicWriteFile(join(cwd, MISSION_PATH_REL), JSON.stringify(mission, null, 2) + '\n')
 }
 
 /** working tree + staged 변경 파일 경로 (simple-git status — 추가/수정/삭제/이름변경/미추적 포함). */

--- a/src/lib/state-files.ts
+++ b/src/lib/state-files.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, appendFileSync, rmSync } from 'node:fs'
+import { atomicWriteFile } from './atomic-write.js'
 import { join } from 'node:path'
 import { localDate } from './date.js'
 
@@ -47,10 +48,9 @@ export function appendBlocker(description: string, goalId?: number): {
   const tag = goalId !== undefined ? `goal-${goalId}` : 'no-goal'
   const line = `- [${isoDate()} ${tag}] ${description.trim()}`
   if (!existsSync(BLOCKERS_PATH)) {
-    writeFileSync(
+    atomicWriteFile(
       BLOCKERS_PATH,
-      `# Blockers\n\n_Append-only. 해결 항목은 ~~취소선~~으로 표기._\n\n${line}\n`,
-      'utf-8'
+      `# Blockers\n\n_Append-only. 해결 항목은 ~~취소선~~으로 표기._\n\n${line}\n`
     )
   } else {
     appendFileSync(BLOCKERS_PATH, `${line}\n`, 'utf-8')
@@ -89,7 +89,7 @@ export function getActiveBlockers(limit = 3): string[] {
 export function writeHardStop(reason: string): void {
   ensureVhkDir()
   const ts = new Date().toISOString()
-  writeFileSync(HARD_STOP_PATH, `${ts}\n${reason}\n`, 'utf-8')
+  atomicWriteFile(HARD_STOP_PATH, `${ts}\n${reason}\n`)
 }
 
 export function isHardStopActive(): boolean {

--- a/tests/state-files-atomic.test.ts
+++ b/tests/state-files-atomic.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { writeHardStop, appendBlocker } from '../src/lib/state-files.js'
+
+// Goal 38: state-files 영속 쓰기를 atomicWriteFile 로 — 결과 동일 + temp 잔여 0 회귀 가드.
+describe('state-files atomic 쓰기 (Goal 38)', () => {
+  let origCwd: string
+  let dir: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    dir = mkdtempSync(join(tmpdir(), 'vhk-sf-'))
+    process.chdir(dir)
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('writeHardStop — HARD_STOP 내용 정확 + temp 파일 잔여 0', () => {
+    writeHardStop('auto: 3 active blockers')
+    expect(readFileSync(join(dir, '.vhk', 'HARD_STOP'), 'utf-8')).toContain('auto: 3 active blockers')
+    expect(readdirSync(join(dir, '.vhk')).filter((f) => f.includes('.tmp-'))).toHaveLength(0)
+  })
+
+  it('appendBlocker 첫 생성 — blockers.md 헤더+항목 정확 + temp 잔여 0', () => {
+    appendBlocker('첫 블로커 증상')
+    const c = readFileSync(join(dir, 'docs', 'state', 'blockers.md'), 'utf-8')
+    expect(c).toContain('# Blockers')
+    expect(c).toContain('첫 블로커 증상')
+    expect(readdirSync(join(dir, 'docs', 'state')).filter((f) => f.includes('.tmp-'))).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Goal 38: 원자적 쓰기 확대 — mission/state-files

Goal 37 머지 전 적대검증에서 도출된 **누락분 마무리**(스킵 아닌 계획의 실행).

- `mission.ts`: `.vhk/mission.json`(missionSet) → atomicWriteFile.
- `state-files.ts`: `writeHardStop`(.vhk/HARD_STOP) + blockers.md **첫 생성** → atomicWriteFile.
- append(이어쓰기)는 끝에 추가라 손상 위험 낮음 + atomic 부적합 → 그대로 유지(의도 명시).
- 미사용 writeFileSync import 제거. 회귀 가드 테스트(HARD_STOP·blockers 내용 정확 + temp 잔여 0).

### 검증
- 타입체크 0 · 빌드 OK · 테스트 **949 pass**.
- OS-의존 시뮬(chmod) 사전 스캔 → 대상 테스트엔 없음(review.test 만 해당, #143서 수정 완료).

이 PR로 적대 스윕(HARD_STOP 가드 Goal 34~36 + 원자적 쓰기 37~38) **전체 종료**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)