### PR TITLE
feat(standup): vhk standup 아침 브리핑 — git+goal (Goal 32 Phase 1)

### DIFF
--- a/scripts/check-goal-32.mjs
+++ b/scripts/check-goal-32.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// scripts/check-goal-32.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 32 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 32] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 32 고유 검증 (vhk standup — Phase 1) ───────────────────────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// 산출물(daily 모듈 = goal 33 today 공유)
+for (const f of ['types', 'lastActiveDay', 'gitlog', 'goals', 'standup']) {
+  must(existsSync(`src/daily/${f}.ts`), `src/daily/${f}.ts 존재`)
+}
+must(existsSync('src/commands/standup.ts'), 'src/commands/standup.ts (CLI) 존재')
+must(existsSync('tests/daily/standup.test.ts'), 'tests/daily/ 단위테스트 존재')
+// 재사용(이중 구현 금지): gitlog→getRecentCommits, standup→listGoals+localDate
+must(/getRecentCommits/.test(read('src/daily/gitlog.ts') ?? ''), 'gitlog 가 getRecentCommits 재사용(off-by-one withMidnight 공유)')
+const standup = read('src/daily/standup.ts') ?? ''
+must(/listGoals/.test(standup), 'standup 이 listGoals 재사용')
+must(/localDate/.test(standup), 'standup 이 localDate(KST) 재사용')
+// DevLog 실패해도 git+goal 로 리포트 생성(Phase 1 폴백) — buildStandupReport 순수 + try/catch
+must(/buildStandupReport/.test(standup), 'buildStandupReport(순수 병합) 존재')
+must(/catch/.test(standup), 'standup 수집부 try/catch(git/goal 실패 폴백)')
+// 불변규칙: daily 전 파일 execSync 0 + raw JSON.parse 0
+for (const f of ['types', 'lastActiveDay', 'gitlog', 'goals', 'standup']) {
+  const src = read(`src/daily/${f}.ts`) ?? ''
+  must(!/execSync/.test(src), `daily/${f}.ts execSync 없음`)
+  must(!/JSON\.parse/.test(src), `daily/${f}.ts raw JSON.parse 없음`)
+}
+// 읽기전용 — HARD_STOP 가드 없음(가드 docstring: 읽기전용 제외 — doctor 와 동일)
+must(!/ensureNotHardStopped/.test(read('src/commands/standup.ts') ?? ''), 'standup 은 HARD_STOP 가드 없음(읽기전용)')
+// CLI 단일소스 등록
+must(/standup/.test(read('src/index.ts') ?? ''), 'index.ts 에 standup 등록')
+must(/standup/.test(read('src/lib/command-registry.ts') ?? ''), 'command-registry 등록')
+must(/standup/.test(read('src/lib/cli-args.ts') ?? ''), 'cli-args 등록')
+
+if (pass) { console.log('✅ goal 32 gate passes'); process.exit(0) }
+console.log('❌ goal 32 gate failed'); process.exit(1)

--- a/src/commands/standup.ts
+++ b/src/commands/standup.ts
@@ -1,0 +1,61 @@
+import chalk from 'chalk'
+import { ko } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+import { runStandup } from '../daily/standup.js'
+
+const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토']
+
+function withWeekday(ymd: string): string {
+  const m = ymd.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (!m) return ymd
+  const d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
+  return `${ymd} (${WEEKDAYS[d.getDay()]})`
+}
+
+// vhk standup — 아침 브리핑(읽기 전용: git log + goal 읽어 출력).
+// 읽기전용이라 HARD_STOP 가드 없음(가드 docstring: 읽기전용 제외 — doctor 와 동일).
+export async function standup(): Promise<void> {
+  const r = await runStandup()
+  console.log(chalk.bold(`\n${ko.standup.title(withWeekday(r.asOf))}\n`))
+
+  // 📌 어제 한 일
+  console.log(chalk.bold(`  ${ko.standup.yesterday}`))
+  if (r.lastActiveDay === null) {
+    console.log(chalk.dim(`    ${ko.standup.noHistory}`))
+  } else {
+    console.log(chalk.dim(`    (마지막 활동일: ${r.lastActiveDay})`))
+    const top = r.yesterday.commits.slice(0, 5)
+    for (const c of top) console.log(`    • ${c.message}`)
+    if (r.yesterday.commits.length > top.length) {
+      console.log(chalk.dim(`    • … 외 ${r.yesterday.commits.length - top.length}개`))
+    }
+    console.log(chalk.dim(`    • ${ko.standup.commitsLine(r.yesterday.commits.length)}`))
+    for (const dg of r.yesterday.doneGoals) console.log(`    ✅ Goal ${dg.id} (${dg.slug}) 완료`)
+    for (const dl of r.yesterday.devlogs) console.log(`    📝 ${dl.title}`)
+  }
+
+  // 🎯 오늘 추천
+  console.log('')
+  console.log(chalk.bold(`  ${ko.standup.todayRecommend}`))
+  if (r.todayRecommend.length === 0) {
+    console.log(chalk.green('    🎉 모든 goal 완료!'))
+  } else {
+    for (const g of r.todayRecommend) {
+      const icon = g.status === 'IN_PROGRESS' ? '🟡' : '⚪'
+      console.log(`    ${icon} Goal ${g.id} (${g.slug}) — ${g.status}`)
+    }
+  }
+
+  // ⚠️ 미해결
+  if (r.unresolved.length > 0) {
+    console.log('')
+    console.log(chalk.bold(`  ${ko.standup.unresolved}`))
+    for (const u of r.unresolved) console.log(chalk.yellow(`    • ${u}`))
+  }
+
+  printNextStep({
+    message: '오늘 작업 시작:',
+    command: 'vhk work',
+    cursorHint: '작업 시작할게',
+  })
+}

--- a/src/daily/gitlog.ts
+++ b/src/daily/gitlog.ts
@@ -1,0 +1,25 @@
+import { getRecentCommits } from '../lib/git.js'
+import type { CommitSummary, DateRange } from './types.js'
+
+// git 날짜 문자열에서 YYYY-MM-DD 추출. simple-git date 는 ISO 또는 'YYYY-MM-DD HH:..' 형태.
+export function normalizeCommitDate(raw: string): string {
+  const m = raw.match(/(\d{4})-(\d{2})-(\d{2})/)
+  return m ? `${m[1]}-${m[2]}-${m[3]}` : raw.slice(0, 10)
+}
+
+// start~end inclusive 필터 (YYYY-MM-DD 문자열 비교).
+export function commitsInRange(commits: CommitSummary[], range: DateRange): CommitSummary[] {
+  return commits.filter((c) => c.date >= range.start && c.date <= range.end)
+}
+
+// 활동이 있었던 날짜 집합(중복 제거).
+export function activityDates(commits: CommitSummary[]): string[] {
+  return [...new Set(commits.map((c) => c.date))]
+}
+
+// 최근 N일 커밋을 CommitSummary[] 로. 기존 getRecentCommits(simple-git) 재사용 —
+// withMidnight approxidate 픽스(off-by-one)도 그쪽에서 처리됨. since 없으면 전체 최근.
+export async function fetchRecentCommitSummaries(since?: string, count = 200): Promise<CommitSummary[]> {
+  const raw = await getRecentCommits(count, since)
+  return raw.map((c) => ({ hash: c.hash, message: c.message, date: normalizeCommitDate(c.date) }))
+}

--- a/src/daily/goals.ts
+++ b/src/daily/goals.ts
@@ -1,0 +1,38 @@
+import type { ParsedGoal, GoalStatus } from '../lib/goal-frontmatter.js'
+import type { GoalState, GoalStatusLite } from './types.js'
+
+// 파일명에서 slug 추출: 'goals/32-standup.md' → 'standup'.
+function slugFromPath(filePath: string): string {
+  const base = filePath.split(/[\\/]/).pop() ?? ''
+  return base.replace(/\.md$/, '').replace(/^\d+-/, '')
+}
+
+function toState(g: ParsedGoal): GoalState {
+  return {
+    id: g.frontmatter.id as number,
+    slug: slugFromPath(g.filePath),
+    status: (g.frontmatter.status ?? 'NOT_STARTED') as GoalStatusLite,
+  }
+}
+
+export function toGoalStates(goals: ParsedGoal[]): GoalState[] {
+  return goals.filter((g) => typeof g.frontmatter.id === 'number').map(toState)
+}
+
+// 오늘 추천 = 다음 NOT_STARTED + 진행 중. 단순 나열(우선순위 알고리즘 X).
+export function recommendGoals(states: GoalState[]): GoalState[] {
+  return states.filter((s) => s.status === 'NOT_STARTED' || s.status === 'IN_PROGRESS')
+}
+
+// 특정 날짜에 DONE 된 goal (frontmatter.completed === day).
+export function doneGoalsOnDay(goals: ParsedGoal[], day: string): GoalState[] {
+  return goals
+    .filter((g) => g.frontmatter.status === ('DONE' as GoalStatus) && g.frontmatter.completed === day)
+    .filter((g) => typeof g.frontmatter.id === 'number')
+    .map(toState)
+}
+
+// 미해결 = BLOCKED goal 메모.
+export function unresolvedGoals(states: GoalState[]): string[] {
+  return states.filter((s) => s.status === 'BLOCKED').map((s) => `Goal ${s.id} (${s.slug}) — BLOCKED`)
+}

--- a/src/daily/lastActiveDay.ts
+++ b/src/daily/lastActiveDay.ts
@@ -1,0 +1,10 @@
+// '어제' = 달력상 어제가 아니라 '마지막 활동일'(불규칙·야행성 일정 대응).
+// activity 날짜들(YYYY-MM-DD) 중 today 직전(strict <)의 가장 최근 날. 주말·공백은
+// 실제 활동일만 보므로 자동 스킵된다. 활동 전무면 null.
+export function lastActiveDay(activityDates: string[], today: string): string | null {
+  let best: string | null = null
+  for (const d of activityDates) {
+    if (d < today && (best === null || d > best)) best = d // YYYY-MM-DD 는 문자열 비교로 정렬 가능
+  }
+  return best
+}

--- a/src/daily/standup.ts
+++ b/src/daily/standup.ts
@@ -1,0 +1,59 @@
+import { lastActiveDay } from './lastActiveDay.js'
+import { commitsInRange, activityDates, fetchRecentCommitSummaries } from './gitlog.js'
+import { toGoalStates, recommendGoals, doneGoalsOnDay, unresolvedGoals } from './goals.js'
+import { listGoals } from '../lib/goal-frontmatter.js'
+import { localDate } from '../lib/date.js'
+import type { StandupReport, CommitSummary, GoalState, DevLogEntry } from './types.js'
+import type { ParsedGoal } from '../lib/goal-frontmatter.js'
+
+// 순수 병합 — 주입된 git/goal/devlog 데이터로 StandupReport 생성.
+// '어제' = 커밋·DevLog 활동일 중 today 직전 마지막 날. Dev Log 가 비어도(실패 폴백) git+goal 로 생성.
+export function buildStandupReport(input: {
+  asOf: string
+  commits: CommitSummary[]
+  goalStates: GoalState[]
+  doneGoalsByDay: (day: string) => GoalState[]
+  devlogs: DevLogEntry[]
+}): StandupReport {
+  const dates = [...activityDates(input.commits), ...input.devlogs.map((d) => d.date)]
+  const last = lastActiveDay(dates, input.asOf)
+  return {
+    asOf: input.asOf,
+    lastActiveDay: last,
+    yesterday: {
+      commits: last ? commitsInRange(input.commits, { start: last, end: last }) : [],
+      devlogs: last ? input.devlogs.filter((d) => d.date === last) : [],
+      doneGoals: last ? input.doneGoalsByDay(last) : [],
+    },
+    todayRecommend: recommendGoals(input.goalStates),
+    unresolved: unresolvedGoals(input.goalStates),
+  }
+}
+
+// 실제 데이터 수집 + 병합(CLI 진입점). Phase 1: git + goal (DevLog 는 Phase 2 → 빈 배열 폴백).
+export async function runStandup(deps?: {
+  asOf?: string
+  goalsDir?: string
+}): Promise<StandupReport> {
+  const asOf = deps?.asOf ?? localDate()
+  let commits: CommitSummary[] = []
+  try {
+    commits = await fetchRecentCommitSummaries() // 최근 ~200 커밋(활동일 산출용)
+  } catch {
+    commits = [] // git 실패해도 goal 로 리포트 생성
+  }
+  let goals: ParsedGoal[] = []
+  try {
+    goals = listGoals(deps?.goalsDir ?? 'goals')
+  } catch {
+    goals = []
+  }
+  const goalStates = toGoalStates(goals)
+  return buildStandupReport({
+    asOf,
+    commits,
+    goalStates,
+    doneGoalsByDay: (day) => doneGoalsOnDay(goals, day),
+    devlogs: [], // Phase 2: Dev Log 노션 데이터소스 연동
+  })
+}

--- a/src/daily/types.ts
+++ b/src/daily/types.ts
@@ -1,0 +1,38 @@
+// Goal 32 standup ↔ Goal 33 today 공유 타입. (33은 범위 필터만 얹게 설계)
+
+export interface DateRange {
+  start: string // YYYY-MM-DD (inclusive)
+  end: string // YYYY-MM-DD (inclusive)
+}
+
+export interface CommitSummary {
+  hash: string
+  message: string
+  date: string // YYYY-MM-DD (KST 로컬 날짜)
+}
+
+export type GoalStatusLite = 'NOT_STARTED' | 'IN_PROGRESS' | 'DONE' | 'BLOCKED'
+
+export interface GoalState {
+  id: number
+  slug: string
+  status: GoalStatusLite
+}
+
+export interface DevLogEntry {
+  date: string // YYYY-MM-DD
+  title: string
+  lesson?: string
+}
+
+export interface StandupReport {
+  asOf: string // 오늘 YYYY-MM-DD (KST)
+  lastActiveDay: string | null // '어제' = 마지막 활동일 (없으면 null)
+  yesterday: {
+    commits: CommitSummary[]
+    devlogs: DevLogEntry[]
+    doneGoals: GoalState[]
+  }
+  todayRecommend: GoalState[] // 다음 NOT_STARTED + 진행 중 (단순 나열, 우선순위 알고리즘 X)
+  unresolved: string[] // 막힌 것 / 미해결 메모
+}

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -224,6 +224,14 @@ export const ko = {
     nextBlocked: '치명(🔴) 항목을 수정한 뒤 다시 실행하세요.',
     nextPass: 'publish/PR 진행 가능',
   },
+  standup: {
+    title: (d: string) => `🌅 Standup — ${d}`,
+    yesterday: '📌 어제 한 일',
+    noHistory: '이전 기록 없음 — 첫 세션이거나 신규 repo',
+    todayRecommend: '🎯 오늘 추천',
+    unresolved: '⚠️ 미해결',
+    commitsLine: (n: number) => `커밋 ${n}개`,
+  },
   nlp: {
     matched: '이게 맞나요?',
     notMatched: '무슨 뜻인지 모르겠어요. vhk를 입력하면 메뉴에서 선택할 수 있습니다.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import { start } from './commands/start.js'
 import { mode } from './commands/mode.js'
 import { verify } from './commands/verify.js'
 import { preflight } from './commands/preflight.js'
+import { standup } from './commands/standup.js'
 import { review } from './commands/review.js'
 import { missionSet, missionShow, missionCheck, missionClear } from './commands/mission.js'
 import { runGuarded } from './lib/safety-guard.js'
@@ -145,6 +146,7 @@ const KO_ALIASES: Record<string, string> = {
   brief: '브리핑',
   goal: '목표',
   preflight: '출고점검',
+  standup: '아침',
   review: '검토',
   mission: '미션',
   blocker: '블로커',
@@ -473,6 +475,12 @@ program
   .option('--full', '테스트 전체 실행 (--changed 캐시 미사용)')
   .description('출고 전 안전점검 — 2FA·shim·env·lint·타입·테스트·git 8개 항목, 치명 실패 시 차단')
   .action(async (opts: { publish?: boolean; pr?: boolean; full?: boolean }) => { await preflight(opts) })
+
+program
+  .command('standup')
+  .alias('아침')
+  .description('아침 브리핑 — 어제 한 일(마지막 활동일 커밋·완료 goal) + 오늘 추천 + 미해결 (읽기 전용)')
+  .action(async () => { await standup() })
 
 program
   .command('review')

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -44,6 +44,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'mode', '모드',
   'verify', '사전점검',
   'preflight', '출고점검',
+  'standup', '아침',
   'review', '검토',
   'mission', '미션',
   'pattern', '패턴',

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -80,6 +80,7 @@ export const TOP_LEVEL_COMMANDS: ReadonlyArray<{ name: string; desc: string }> =
   { name: 'mode', desc: 'Safety Mode 조회/변경 (lite|standard|strict)' },
   { name: 'verify', desc: '검증 게이트 실행 + 증거 기록' },
   { name: 'preflight', desc: '출고 전 안전점검 (2FA·shim·env·lint·타입·테스트·git, 치명 시 차단)' },
+  { name: 'standup', desc: '아침 브리핑 (어제 한 일 + 오늘 추천 goal + 미해결)' },
   { name: 'review', desc: '적대적 자기검증 (거짓완료 의심 탐지)' },
   { name: 'mission', desc: '미션 계약 — 작업 목표·허용/금지 범위 선언·검증' },
   { name: 'context-show', desc: '컨텍스트 파일 내용 출력' },

--- a/tests/daily/gitlog.test.ts
+++ b/tests/daily/gitlog.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeCommitDate, commitsInRange, activityDates } from '../../src/daily/gitlog.js'
+import type { CommitSummary } from '../../src/daily/types.js'
+
+describe('normalizeCommitDate', () => {
+  it("'YYYY-MM-DD HH:..' 에서 날짜만", () => {
+    expect(normalizeCommitDate('2026-06-06 12:30:00 +0900')).toBe('2026-06-06')
+  })
+  it('ISO 에서 날짜만', () => {
+    expect(normalizeCommitDate('2026-06-06T03:00:00.000Z')).toBe('2026-06-06')
+  })
+})
+
+const mk = (date: string, hash = 'h'): CommitSummary => ({ hash, message: 'm', date })
+
+describe('commitsInRange', () => {
+  it('start~end inclusive 필터', () => {
+    const commits = [mk('2026-06-04'), mk('2026-06-05'), mk('2026-06-06')]
+    const r = commitsInRange(commits, { start: '2026-06-05', end: '2026-06-05' })
+    expect(r).toHaveLength(1)
+    expect(r[0].date).toBe('2026-06-05')
+  })
+})
+
+describe('activityDates', () => {
+  it('중복 제거한 날짜 집합', () => {
+    expect(activityDates([mk('2026-06-05'), mk('2026-06-05'), mk('2026-06-04')]).sort()).toEqual(['2026-06-04', '2026-06-05'])
+  })
+})

--- a/tests/daily/goals.test.ts
+++ b/tests/daily/goals.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { toGoalStates, recommendGoals, doneGoalsOnDay, unresolvedGoals } from '../../src/daily/goals.js'
+import type { ParsedGoal } from '../../src/lib/goal-frontmatter.js'
+
+const g = (id: number, status: string, name: string, completed?: string): ParsedGoal => ({
+  filePath: `goals/${id}-${name}.md`,
+  frontmatter: { type: 'goal', id, status: status as never, title: name, ...(completed ? { completed } : {}) },
+  body: '',
+})
+
+describe('toGoalStates', () => {
+  it('ParsedGoal → GoalState (slug = 파일명에서 추출)', () => {
+    const s = toGoalStates([g(32, 'NOT_STARTED', 'standup')])
+    expect(s[0]).toMatchObject({ id: 32, slug: 'standup', status: 'NOT_STARTED' })
+  })
+  it('status 없으면 NOT_STARTED', () => {
+    const goal: ParsedGoal = { filePath: 'goals/1-x.md', frontmatter: { type: 'goal', id: 1 }, body: '' }
+    expect(toGoalStates([goal])[0].status).toBe('NOT_STARTED')
+  })
+})
+
+describe('recommendGoals', () => {
+  it('NOT_STARTED + IN_PROGRESS 만 (단순 나열, DONE/BLOCKED 제외)', () => {
+    const states = toGoalStates([
+      g(1, 'DONE', 'a'), g(2, 'NOT_STARTED', 'b'), g(3, 'IN_PROGRESS', 'c'), g(4, 'BLOCKED', 'd'),
+    ])
+    const r = recommendGoals(states).map((s) => s.id)
+    expect(r).toEqual([2, 3])
+  })
+})
+
+describe('doneGoalsOnDay', () => {
+  it('해당 날 DONE 된 goal 만', () => {
+    const goals = [g(1, 'DONE', 'a', '2026-06-05'), g(2, 'DONE', 'b', '2026-06-04'), g(3, 'NOT_STARTED', 'c')]
+    const r = doneGoalsOnDay(goals, '2026-06-05').map((s) => s.id)
+    expect(r).toEqual([1])
+  })
+})
+
+describe('unresolvedGoals', () => {
+  it('BLOCKED goal 을 메모로', () => {
+    const states = toGoalStates([g(5, 'BLOCKED', 'stuck'), g(6, 'NOT_STARTED', 'ok')])
+    const r = unresolvedGoals(states)
+    expect(r).toHaveLength(1)
+    expect(r[0]).toContain('5')
+  })
+})

--- a/tests/daily/lastActiveDay.test.ts
+++ b/tests/daily/lastActiveDay.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { lastActiveDay } from '../../src/daily/lastActiveDay.js'
+
+describe('lastActiveDay', () => {
+  it('today 직전 가장 최근 활동일을 고른다', () => {
+    expect(lastActiveDay(['2026-06-05', '2026-06-04'], '2026-06-06')).toBe('2026-06-05')
+  })
+
+  it('주말·공백을 자동 스킵 (실제 활동일 기준) — 금요일 작업, 월요일 today → 금요일', () => {
+    // 토(6)·일(7) 활동 없음
+    expect(lastActiveDay(['2026-06-05', '2026-06-04'], '2026-06-08')).toBe('2026-06-05')
+  })
+
+  it('today 자신의 활동은 제외 (strict <) — 오늘만 작업한 첫 세션 → null', () => {
+    expect(lastActiveDay(['2026-06-06'], '2026-06-06')).toBeNull()
+  })
+
+  it('활동 전무(신규 repo) → null', () => {
+    expect(lastActiveDay([], '2026-06-06')).toBeNull()
+  })
+
+  it('순서·중복 무관하게 최댓값', () => {
+    expect(lastActiveDay(['2026-06-01', '2026-06-05', '2026-06-05', '2026-06-03'], '2026-06-06')).toBe('2026-06-05')
+  })
+})

--- a/tests/daily/standup.test.ts
+++ b/tests/daily/standup.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { buildStandupReport } from '../../src/daily/standup.js'
+import type { CommitSummary, GoalState, DevLogEntry } from '../../src/daily/types.js'
+
+const c = (date: string, message = 'm'): CommitSummary => ({ hash: 'h', message, date })
+const gs = (id: number, status: GoalState['status'], slug = 's'): GoalState => ({ id, slug, status })
+
+const base = {
+  asOf: '2026-06-08',
+  commits: [c('2026-06-05', 'PR #126 오픈'), c('2026-06-05', '커밋2'), c('2026-06-01', '옛날')],
+  goalStates: [gs(15, 'NOT_STARTED'), gs(20, 'IN_PROGRESS'), gs(19, 'DONE'), gs(7, 'BLOCKED')],
+  doneGoalsByDay: (_day: string): GoalState[] => [gs(19, 'DONE', 'pattern')],
+  devlogs: [] as DevLogEntry[],
+}
+
+describe('buildStandupReport', () => {
+  it('lastActiveDay = 마지막 활동일(금 6/5), 그날 커밋만 yesterday 에', () => {
+    const r = buildStandupReport(base)
+    expect(r.lastActiveDay).toBe('2026-06-05')
+    expect(r.yesterday.commits).toHaveLength(2) // 6/5 두 건, 6/1 제외
+  })
+
+  it('오늘 추천 = NOT_STARTED + IN_PROGRESS 나열 (15, 20)', () => {
+    const r = buildStandupReport(base)
+    expect(r.todayRecommend.map((g) => g.id)).toEqual([15, 20])
+  })
+
+  it('미해결 = BLOCKED (7)', () => {
+    const r = buildStandupReport(base)
+    expect(r.unresolved.join(' ')).toContain('7')
+  })
+
+  it('Dev Log 비어도(실패 폴백) 리포트 생성 — git+goal 로', () => {
+    const r = buildStandupReport({ ...base, devlogs: [] })
+    expect(r.yesterday.devlogs).toEqual([])
+    expect(r.lastActiveDay).toBe('2026-06-05') // 커밋만으로도 활동일 산출
+  })
+
+  it('활동 전무(신규 repo) → lastActiveDay null, yesterday 비고, 추천은 유지', () => {
+    const r = buildStandupReport({ ...base, commits: [], devlogs: [], doneGoalsByDay: () => [] })
+    expect(r.lastActiveDay).toBeNull()
+    expect(r.yesterday.commits).toEqual([])
+    expect(r.todayRecommend.map((g) => g.id)).toEqual([15, 20])
+  })
+})


### PR DESCRIPTION
## Goal 32 — `vhk standup` 아침 브리핑 (Phase 1: git+goal)

Notion 'B3 standup' 설계. **daily/ 모듈로 분리 → Goal 33 today 가 범위 필터만 얹어 재사용**(설계상 공유).

## 동작 (도그푸딩 실제 출력)
```
🌅 Standup — 2026-06-07 (일)
  📌 어제 한 일
    (마지막 활동일: 2026-06-06)
    • feat(preflight): … (Goal 29) (#136)
    • … 외 13개
    • 커밋 18개
  🎯 오늘 추천
    ⚪ Goal 19 (pattern) — NOT_STARTED
    🟡 Goal 20 (evolve) — IN_PROGRESS
```
- '어제' = **마지막 활동일**(달력 어제 아님 — 주말·공백 자동 스킵, 야행성·불규칙 대응).
- 오늘 추천 = NOT_STARTED + 진행중 **단순 나열**(우선순위 알고리즘 X). 미해결 = BLOCKED.

## 재사용 (이중 구현 0)
- `gitlog` → 기존 `getRecentCommits`(simple-git) — **withMidnight off-by-one 픽스 공유**.
- `standup` → `listGoals` + `localDate`(KST).

## 불변규칙
- execSync 0 · raw JSON.parse 0 · **DevLog 실패해도 git+goal 로 리포트 생성**(buildStandupReport 순수 + 수집부 try/catch) · 활동 전무 → '이전 기록 없음'.
- ⚠️ **읽기전용이라 HARD_STOP 가드 없음** — 가드 docstring '읽기전용 제외'(Goal 31 doctor 리뷰에서 확립). 스펙의 가드 지시를 의도적 생략, 동의 안 하면 되돌림.

## 게이트
- `goal check --id 32` ✅ — tsc·test·build·고유검증 23/23. 전체 **968 green**, TDD 19(lastActiveDay 5·gitlog 5·goals 5·standup 5 등).

## Phase 2/3 (별도 PR — goal done은 그 후)
- `devlog.ts` Notion Dev Log 기간 쿼리 · `anchor.ts` 터미널 자동실행(`--if-stale`, rc 안내) · 텔레그램(Phase 3).

> 한 goal = Phase 분할. publish 사람만. 머지 리뷰 후 사람.