### PR TITLE
fix(hardstop): 가드 라벨 공백 컨벤션 복구 — cloud/env/ref (Goal 39 후속)

### DIFF
--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -43,7 +43,7 @@ export function parseGistId(output: string): string | null {
 
 /** vhk cloud push — .vhk/ 를 secret gist 로 백업 */
 export async function cloudPush(): Promise<void> {
-  if (!ensureNotHardStopped('cloudPush')) return
+  if (!ensureNotHardStopped('cloud push')) return // HARD_STOP 활성 시 .vhk 백업 업로드 차단
   console.log(chalk.bold(`\n${ko.cloud.pushTitle}\n`))
   const cwd = process.cwd()
 

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -54,7 +54,7 @@ function ensureGitignore(): void {
 }
 
 export async function env(): Promise<void> {
-  if (!ensureNotHardStopped('env')) return
+  if (!ensureNotHardStopped('env')) return // HARD_STOP 활성 시 .env.example/.gitignore 쓰기 차단
   console.log(chalk.bold('\n🔐 ' + t('env.title')))
   console.log(chalk.gray('─'.repeat(40)))
 

--- a/src/commands/ref.ts
+++ b/src/commands/ref.ts
@@ -31,7 +31,7 @@ function saveRefs(refs: RefEntry[]): void {
 }
 
 export async function refAdd(url: string, memo = ''): Promise<void> {
-  if (!ensureNotHardStopped('refAdd')) return
+  if (!ensureNotHardStopped('ref add')) return // HARD_STOP 활성 시 refs.json 쓰기 차단
   console.log(chalk.bold('\n🔗 ' + t('ref.addTitle')))
   console.log(chalk.gray('─'.repeat(40)))
 


### PR DESCRIPTION
## 요약
Goal 39(#163) 후속 핫픽스. HARD_STOP 가드 라벨을 공백 컨벤션으로 복구.

## 배경
PR #163 머지 결과(3ace961)에서 `cloud push`·`ref add` 가드 라벨이 camelCase(`cloudPush`/`refAdd`)로 들어가고 주석이 누락됨. (적대검증 워크플로 에이전트가 가드를 임시 제거→복원하는 과정에서 라벨/주석을 부정확하게 복원 — worktree 격리 없이 작업트리 직접 편집.)

영향:
- **goal-39 게이트 실패**: `check-goal-39.mjs` 의 정적 검증 regex(`'cloud push'`·`'ref add'`)가 소스(`'cloudPush'`·`'refAdd'`)와 불일치 → 2개 must() 실패.
- **컨벤션 위반**: 타 가드(`memory add`·`mission set`·`evolve apply` 등)는 전부 공백 라벨. cloud/ref 만 camelCase 이탈 + 사용자 대면 HARD_STOP 메시지 가독성 저하.

## 변경
- `cloud.ts`: `'cloudPush'` → `'cloud push'` + 주석 복원
- `env.ts`: 주석 복원 (라벨 `'env'` 유지)
- `ref.ts`: `'refAdd'` → `'ref add'` + 주석 복원

기능 동일 — 라벨은 `ensureNotHardStopped(action)` 의 표시 메시지용. 테스트는 라벨 미검증.

## 게이트
- `tsc --noEmit` 0
- `pnpm build` 성공
- `check-goal-39.mjs` 게이트 통과(5개 가드 ✓)
- cloud/ref/remaining-hardstop 테스트 통과 (215 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
