### PR TITLE
feat(atomic): 원자적 쓰기 완성 — goal.ts (Goal 40)

### DIFF
--- a/goals/40-atomic-completion.md
+++ b/goals/40-atomic-completion.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 40
 title: 원자적 쓰기 완성 — goal.ts (next-task/scaffold/frontmatter) — P2
-status: NOT_STARTED
+status: DONE
 priority: P2
 created: 2026-06-07
+completed: 2026-06-07
 ---
 
 # Goal 40: 원자적 쓰기 완성 — goal.ts 영속 쓰기
@@ -24,11 +25,11 @@ created: 2026-06-07
 - **제외**: goalSync 의 check-goal-*.mjs 생성 = 재생성 가능(idempotent backfill)이라 손상돼도 vhk goal sync 재실행 복구 → 저위험, 보류.
 
 ## Completion Check
-- [ ] goalNext/goalInit/goalDone 의 영속 쓰기가 atomicWriteFile 사용
-- [ ] 동작 회귀 0(기존 goal 테스트 + goal-hardstop 통과). 결과 파일 내용 동일
-- [ ] 회귀 가드 테스트(next-task atomic 결과 + temp 잔여 0)
-- [ ] vhk goal sync → check-goal-40.mjs → check --id 40 통과
-- [ ] 공통 게이트 통과
+- [x] goalNext/goalInit/goalDone 의 영속 쓰기가 atomicWriteFile 사용
+- [x] 동작 회귀 0(기존 goal 테스트 + goal-hardstop 통과). 결과 파일 내용 동일
+- [x] 회귀 가드 테스트(goal-atomic.test.ts: next/init/done 내용 + temp 잔여 0)
+- [x] check-goal-40.mjs (import + 호출>=3 + 테스트존재) 통과
+- [x] 공통 게이트 통과
 
 ## Mandatory Reading
 - src/lib/atomic-write.ts (Goal 37 헬퍼)

--- a/scripts/check-goal-40.mjs
+++ b/scripts/check-goal-40.mjs
@@ -53,8 +53,13 @@ if (!skipDeep) {
 }
 
 // ─── goal 40 고유 검증 (직접 추가) ───────────────────────────────
-// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
-// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+// goal.ts 의 영속 쓰기 3곳(goalNext/goalInit/goalDone)이 atomicWriteFile 사용.
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+const goalSrc = read('src/commands/goal.ts') ?? ''
+must(/import \{ atomicWriteFile \} from '\.\.\/lib\/atomic-write\.js'/.test(goalSrc), 'goal.ts atomicWriteFile import')
+const atomicCalls = (goalSrc.match(/atomicWriteFile\(/g) ?? []).length
+must(atomicCalls >= 3, `goal.ts atomicWriteFile 호출 ${atomicCalls}회(>=3: next-task/scaffold/frontmatter)`)
+must(existsSync('tests/goal-atomic.test.ts'), 'tests/goal-atomic.test.ts 존재')
 
 if (pass) { console.log('✅ goal 40 gate passes'); process.exit(0) }
 console.log('❌ goal 40 gate failed'); process.exit(1)

--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -6,6 +6,7 @@ import { localDate } from '../lib/date.js'
 import { printNextStep } from '../lib/next-step.js'
 import { safeExecFile } from '../lib/exec.js'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
+import { atomicWriteFile } from '../lib/atomic-write.js'
 import {
   listGoals,
   findDuplicateIds,
@@ -122,7 +123,7 @@ export async function goalNext(): Promise<void> {
     '',
   ].join('\n')
   mkdirSync(STATE_DIR, { recursive: true })
-  writeFileSync(join(STATE_DIR, 'next-task.md'), text, 'utf-8')
+  atomicWriteFile(join(STATE_DIR, 'next-task.md'), text) // Goal 40: 쓰기 중 kill 시 next-task.md 손상 방지
   console.log(
     chalk.green(
       `  ✅ next-task.md 갱신 — Goal ${activeId}: ${active.frontmatter.title ?? ''}`
@@ -205,7 +206,7 @@ export async function goalInit(): Promise<void> {
       console.log(chalk.gray(`  ⊘ skip (이미 존재): ${t.path}`))
       skipped++
     } else {
-      writeFileSync(t.path, t.content, 'utf-8')
+      atomicWriteFile(t.path, t.content) // Goal 40: scaffold 첫 생성 원자적 쓰기
       console.log(chalk.green(`  ✓ created: ${t.path}`))
       created++
     }
@@ -338,7 +339,7 @@ export async function goalDone(opts: { id?: string }): Promise<void> {
   const content = readFileSync(target.filePath, 'utf-8')
   const today = localDate() // VHK-019
   const updated = updateFrontmatterStatus(content, 'DONE', { completed: today })
-  writeFileSync(target.filePath, updated, 'utf-8')
+  atomicWriteFile(target.filePath, updated) // Goal 40: frontmatter 갱신 중 kill 시 goal 파일 손상 방지
   console.log(chalk.green(`\n  ✅ Goal ${id} → DONE (completed: ${today})`))
   printNextStep({
     message: `Goal ${id} 완료! 다음 goal 로:`,

--- a/tests/goal-atomic.test.ts
+++ b/tests/goal-atomic.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, writeFileSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// Goal 40: goal.ts 영속 쓰기(goalNext/goalInit/goalDone)를 atomicWriteFile 로.
+// 결과 내용 동일 + 성공 경로에 temp(.tmp-) 잔여 0 회귀 가드.
+// (실패-경로 cleanup 은 OS-의존 시뮬이 atomic rename 을 우회해 깨지므로 검증 안 함 — 성공 경로만.)
+
+function tmpProject(label: string): string {
+  const dir = join(tmpdir(), `vhk-goalatomic-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+function makeGoalFile(dir: string, id: number, status: string): void {
+  mkdirSync(join(dir, 'goals'), { recursive: true })
+  writeFileSync(
+    join(dir, 'goals', `${id}-test.md`),
+    `---\nvhk_format: 1\ntype: goal\nid: ${id}\ntitle: Goal ${id}\nstatus: ${status}\npriority: P0\nversion: v0.${id}\n---\nbody\n`,
+    'utf-8'
+  )
+}
+const noTmp = (d: string) => readdirSync(d).filter((f) => f.includes('.tmp-'))
+
+describe('goal.ts atomic 쓰기 (Goal 40)', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    process.exitCode = 0
+    vi.restoreAllMocks()
+  })
+
+  it('goalNext — next-task.md 내용 정확 + temp 잔여 0', async () => {
+    const dir = tmpProject('next')
+    makeGoalFile(dir, 1, 'NOT_STARTED')
+    process.chdir(dir)
+    try {
+      const { goalNext } = await import('../src/commands/goal.js')
+      await goalNext()
+      const text = readFileSync(join(dir, 'docs/state/next-task.md'), 'utf-8')
+      expect(text).toContain('Goal 1')
+      expect(noTmp(join(dir, 'docs/state'))).toHaveLength(0)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('goalInit — scaffold 4파일 생성 + temp 잔여 0', async () => {
+    const dir = tmpProject('init')
+    process.chdir(dir)
+    try {
+      const { goalInit } = await import('../src/commands/goal.js')
+      await goalInit()
+      expect(readFileSync(join(dir, 'goals/_meta.md'), 'utf-8').length).toBeGreaterThan(0)
+      expect(readFileSync(join(dir, 'docs/state/blockers.md'), 'utf-8').length).toBeGreaterThan(0)
+      expect(noTmp(join(dir, 'goals'))).toHaveLength(0)
+      expect(noTmp(join(dir, 'docs/state'))).toHaveLength(0)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('goalDone — 게이트 통과 후 frontmatter DONE + temp 잔여 0', async () => {
+    const dir = tmpProject('done')
+    makeGoalFile(dir, 5, 'NOT_STARTED')
+    // 통과하는 trivial 게이트(node exit 0) — runGate 가 `node scripts/check-goal-5.mjs` 실행.
+    mkdirSync(join(dir, 'scripts'), { recursive: true })
+    writeFileSync(join(dir, 'scripts', 'check-goal-5.mjs'), 'process.exit(0)\n', 'utf-8')
+    process.chdir(dir)
+    try {
+      const { goalDone } = await import('../src/commands/goal.js')
+      await goalDone({ id: '5' })
+      const text = readFileSync(join(dir, 'goals', '5-test.md'), 'utf-8')
+      expect(text).toContain('status: DONE')
+      expect(text).toContain('completed:')
+      expect(noTmp(join(dir, 'goals'))).toHaveLength(0)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## 요약
atomic 쓰기 완성 — `goal.ts` 의 영속 쓰기 3곳을 `atomicWriteFile`(Goal 37 헬퍼)로 교체. Goal 37/38(ref/review/verify/sync/mission/state-files)에 이은 마무리.

## 변경
- `goalNext` → `docs/state/next-task.md`
- `goalInit` → `goals/_meta.md` · `docs/state/{next-task,blockers,learnings}.md` (scaffold 첫 생성)
- `goalDone` → goal 파일 frontmatter status 갱신

`writeFileSync(..., 'utf-8')` → `atomicWriteFile(...)`. atomicWriteFile 이 utf-8 하드코딩 → 인코딩 동일. 3곳 모두 호출 전 디렉터리 보장(mkdir 선행 또는 기존 파일).

**제외**: `goalSync` 의 `check-goal-*.mjs` 생성 = 재생성 가능(idempotent backfill)이라 손상돼도 `vhk goal sync` 재실행으로 복구 → 저위험, 보류.

## 테스트
- `tests/goal-atomic.test.ts` (신규): goalNext/goalInit/goalDone 결과 내용 정확 + 성공 경로 temp(`.tmp-`) 잔여 0. goalDone 은 trivial 통과 게이트(node exit 0) fixture 로 통합 검증. OS-의존 시뮬 없음(state-files-atomic 패턴).
- `check-goal-40.mjs`: `atomicWriteFile` import + 호출 ≥3 + 테스트 존재 정적 검증.

## 게이트
- `tsc --noEmit` 0
- `pnpm build` 성공
- 메인 스위트 **994 테스트 통과** (98 files, vhk-* 제외)
- 적대 코드리뷰(읽기전용) 발견 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
