### PR TITLE
feat(hardstop): MCP surface HARD_STOP 가드 — save/undo/env (Goal 41)

### DIFF
--- a/goals/41-hardstop-mcp-surface.md
+++ b/goals/41-hardstop-mcp-surface.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 41
 title: HARD_STOP 가드 — MCP 서버 surface (직접쓰기 우회 차단) — P2
-status: NOT_STARTED
+status: DONE
 priority: P2
 created: 2026-06-07
+completed: 2026-06-07
 ---
 
 # Goal 41: HARD_STOP 가드 — MCP 서버 surface
@@ -26,13 +27,22 @@ MCP 는 CLI 와 별개 surface. 현재 확인된 우회:
 - **B안**: 재구현된 핸들러(env 등)를 명령 함수 위임으로 교체 → 함수레벨 가드 자동 상속(중복 로직 제거 보너스).
 - 읽기전용 툴(status/diff/doctor/check/recap/log 등)은 제외.
 
+## 감사 결과 (전수)
+MCP 툴 = 3 부류:
+- **인라인 상태변경(가드 우회 → 가드함)**: `save`(git add/commit/push) · `undo`(git reset) · `env`(.env.example/.gitignore 쓰기). hardStopBlocked 가드 적용(채택 = A안: MCP 전용 content 반환 헬퍼).
+- **runVhkCli 위임(CLI 서브프로세스 → guardCli 상속 → 별도 가드 불필요)**: sync/secure/harness/context/brief/ref-list/memory-list/learn/context-show/mcp-init/pattern-detect/pattern-list/evolve-suggest/evolve-list. (learn=트립생성자라 CLI 측도 의도적 미가드.)
+- **MCP 모드 읽기전용(가드 불필요)**: status/diff/doctor/check/recap/env-check/audit/deploy/publish/migrate/update — deploy/publish/migrate/update/audit 는 "실제 미수행, 안내만".
+
+채택: A안. `ensureNotHardStopped`(console.error+exitCode)는 MCP stdio(JSON-RPC) 오염 → `hardStopBlocked(action)` 신설(content 반환, console 미사용).
+undo 가드는 top(save/env 일관) — preview 도 차단(되돌리기 목적 자체가 변경).
+
 ## Completion Check
-- [ ] MCP write 툴 전수 목록 + 각 가드 여부 표
-- [ ] env(및 기타 직접쓰기) 툴이 HARD_STOP 활성 시 파일 미변경
-- [ ] HARD_STOP 없으면 기존 동일(회귀 0)
-- [ ] 회귀 가드 테스트(MCP env 차단/정상)
-- [ ] vhk goal sync → check-goal-41.mjs → check --id 41 통과
-- [ ] 공통 게이트 통과
+- [x] MCP write 툴 전수 목록 + 각 가드 여부 표(위 감사 결과)
+- [x] save/undo/env 가 HARD_STOP 활성 시 파일/git 미변경 + 안내 반환
+- [x] HARD_STOP 없으면 기존 동일(env-ok 회귀 0)
+- [x] 회귀 가드 테스트(tests/mcp-hardstop.test.ts: env 차단/정상 + save/undo 차단)
+- [x] check-goal-41.mjs (import + 헬퍼 + 호출>=3 + 테스트존재) 통과
+- [x] 공통 게이트 통과
 
 ## Mandatory Reading
 - src/mcp/server.ts (registerTool 핸들러 — 특히 env ~387)

--- a/scripts/check-goal-41.mjs
+++ b/scripts/check-goal-41.mjs
@@ -53,8 +53,14 @@ if (!skipDeep) {
 }
 
 // ─── goal 41 고유 검증 (직접 추가) ───────────────────────────────
-// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
-// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+// MCP 전용 상태변경 핸들러(save/undo/env)가 hardStopBlocked 가드를 가지는지 정적 확인.
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+const mcpSrc = read('src/mcp/server.ts') ?? ''
+must(/import \{ isHardStopActive, readHardStopReason \} from '\.\.\/lib\/state-files\.js'/.test(mcpSrc), 'server.ts isHardStopActive import')
+must(/function hardStopBlocked\(/.test(mcpSrc), 'server.ts hardStopBlocked 헬퍼 정의')
+const guardCalls = (mcpSrc.match(/hardStopBlocked\('/g) ?? []).length
+must(guardCalls >= 3, `server.ts hardStopBlocked 호출 ${guardCalls}회(>=3: save/undo/env)`)
+must(existsSync('tests/mcp-hardstop.test.ts'), 'tests/mcp-hardstop.test.ts 존재')
 
 if (pass) { console.log('✅ goal 41 gate passes'); process.exit(0) }
 console.log('❌ goal 41 gate failed'); process.exit(1)

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,6 +8,7 @@ import { detectPlatform } from '../commands/deploy.js'
 import { bumpVersion } from '../commands/publish.js'
 import { detectCurrentPM, parseAuditOutput, runAuditJson } from '../commands/audit.js'
 import { readJsonFile } from '../lib/read-json.js'
+import { isHardStopActive, readHardStopReason } from '../lib/state-files.js'
 import { filterSevereFindings, scanProjectForSecrets } from '../lib/scan-secrets.js'
 import { getVhkVersion } from '../lib/version.js'
 import { resolveVhkCliInvocation, composeInvocation, type VhkCliInvocation } from './cli-path.js'
@@ -18,6 +19,21 @@ const SERVER_VERSION = getVhkVersion()
 
 function isGitRepo(): boolean {
   return safeExecFile('git', ['rev-parse', '--is-inside-work-tree']).ok
+}
+
+// Goal 41: MCP surface HARD_STOP 가드. CLI 의 ensureNotHardStopped 는 console.error +
+// process.exitCode 를 쓰는데, MCP stdio 서버는 stdout/stderr 가 JSON-RPC 채널이라 부적합
+// (로그 출력이 프로토콜 오염) → 대신 content 응답을 반환한다. 상태변경 툴을 *재구현*해
+// CLI 의 guardCli chokepoint 를 우회하는 MCP 전용 핸들러(save/undo/env)에만 적용.
+// runVhkCli 위임 툴은 CLI 서브프로세스가 guardCli 를 그대로 거치므로 별도 가드 불필요.
+function hardStopBlocked(action: string): { content: [{ type: 'text'; text: string }] } | null {
+  if (!isHardStopActive()) return null
+  const reason = readHardStopReason()
+  const text =
+    `🛑 HARD STOP 활성 — '${action}' 을(를) 실행하지 않았습니다.` +
+    (reason ? `\n사유: ${reason.replace(/\s*\n\s*/g, ' ')}` : '') +
+    `\n해제: vhk resume --confirm (사람이 직접 실행)`
+  return { content: [{ type: 'text', text }] }
 }
 
 // ANSI escape sequence (color / cursor / formatting). MCP 클라이언트 일부가
@@ -67,6 +83,8 @@ export function createVhkMcpServer(): McpServer {
       },
     },
     async ({ message }) => {
+      const blocked = hardStopBlocked('save') // Goal 41: HARD_STOP 활성 시 commit/push 차단
+      if (blocked) return blocked
       if (!isGitRepo()) {
         return { content: [{ type: 'text', text: '❌ git 저장소가 아닙니다.' }] }
       }
@@ -147,6 +165,8 @@ export function createVhkMcpServer(): McpServer {
       },
     },
     async ({ confirm }) => {
+      const blocked = hardStopBlocked('undo') // Goal 41: HARD_STOP 활성 시 되돌리기(상태변경) 차단
+      if (blocked) return blocked
       if (!isGitRepo()) {
         return { content: [{ type: 'text', text: '❌ git 저장소가 아닙니다.' }] }
       }
@@ -390,6 +410,8 @@ export function createVhkMcpServer(): McpServer {
       description: '.env → .env.example 동기화 + .gitignore에 .env 자동 추가',
     },
     async () => {
+      const blocked = hardStopBlocked('env') // Goal 41: HARD_STOP 활성 시 .env.example/.gitignore 쓰기 차단
+      if (blocked) return blocked
       if (!existsSync('.env')) {
         return { content: [{ type: 'text', text: '⚠️  .env 파일이 없습니다. 먼저 .env를 만들어주세요.' }] }
       }

--- a/tests/helpers/mcp-introspect.ts
+++ b/tests/helpers/mcp-introspect.ts
@@ -32,3 +32,25 @@ export async function getServerName(): Promise<string> {
   const server = (await loadServer()) as ServerInfoShape
   return server.server._serverInfo.name
 }
+
+interface McpToolResult {
+  content: Array<{ type: string; text: string }>
+}
+interface RegisteredTool {
+  handler: (...a: unknown[]) => unknown
+  inputSchema?: unknown
+}
+
+// 등록된 tool 핸들러를 직접 호출 (SDK executeToolHandler 시그니처 재현:
+// inputSchema 있으면 handler(args, extra), 없으면 handler(extra)).
+export async function callTool(
+  name: string,
+  args: Record<string, unknown> = {}
+): Promise<McpToolResult> {
+  const server = (await loadServer()) as { _registeredTools: Record<string, RegisteredTool> }
+  const tool = server._registeredTools[name]
+  if (!tool) throw new Error(`등록되지 않은 tool: ${name}`)
+  const extra = {}
+  const result = tool.inputSchema ? await tool.handler(args, extra) : await tool.handler(extra)
+  return result as McpToolResult
+}

--- a/tests/mcp-hardstop.test.ts
+++ b/tests/mcp-hardstop.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { callTool } from './helpers/mcp-introspect.js'
+
+// Goal 41: MCP surface HARD_STOP 가드. CLI guardCli 를 우회해 상태를 *재구현*하는
+// MCP 전용 핸들러(save/undo/env)가 HARD_STOP 활성 시 차단되는지 회귀 검증.
+// 실제 fs 사용(node:fs mock 안 함) — isHardStopActive 가 cwd 의 .vhk/HARD_STOP 를 읽음.
+
+function tmpProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'vhk-mcphs-'))
+  mkdirSync(join(dir, '.vhk'), { recursive: true })
+  return dir
+}
+function writeHardStop(dir: string): void {
+  writeFileSync(join(dir, '.vhk', 'HARD_STOP'), '2026-06-07T00:00:00Z\nauto: test\n', 'utf-8')
+}
+const text = (r: { content: Array<{ text: string }> }) => r.content.map((c) => c.text).join('\n')
+
+describe('MCP surface HARD_STOP 가드 (Goal 41)', () => {
+  let origCwd: string
+  let dir: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    dir = tmpProject()
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('env — HARD_STOP 활성 시 .env.example 미생성 + 안내 반환', async () => {
+    // 실제 .env 가 있어야 가드 없을 때 쓰기 경로 도달 → 차별적.
+    writeFileSync(join(dir, '.env'), 'FOO=bar\n', 'utf-8')
+    writeHardStop(dir)
+    process.chdir(dir)
+    const r = await callTool('env')
+    expect(text(r)).toContain('HARD STOP')
+    expect(existsSync(join(dir, '.env.example'))).toBe(false)
+  })
+
+  it('env — HARD_STOP 없으면 .env.example 생성 (회귀 0)', async () => {
+    writeFileSync(join(dir, '.env'), 'FOO=bar\n', 'utf-8')
+    process.chdir(dir)
+    const r = await callTool('env')
+    expect(text(r)).not.toContain('HARD STOP')
+    expect(existsSync(join(dir, '.env.example'))).toBe(true)
+  })
+
+  it('save — HARD_STOP 활성 시 commit 전 차단(안내 반환)', async () => {
+    writeHardStop(dir)
+    process.chdir(dir)
+    // 가드가 함수 첫 줄(isGitRepo·commit 전) → git repo 없이도 안내만 반환.
+    const r = await callTool('save', { message: 'x' })
+    expect(text(r)).toContain('HARD STOP')
+  })
+
+  it('undo — HARD_STOP 활성 시 reset 전 차단(confirm:true 여도)', async () => {
+    writeHardStop(dir)
+    process.chdir(dir)
+    const r = await callTool('undo', { confirm: true })
+    expect(text(r)).toContain('HARD STOP')
+  })
+})


### PR DESCRIPTION
## 요약
MCP 서버 surface 의 HARD_STOP 가드 결함 해결. CLI `guardCli` chokepoint 를 우회해 상태를 인라인 재구현하던 MCP 전용 핸들러(`save`/`undo`/`env`)에 가드 추가. (Goal 39 적대검증서 env 직접쓰기로 발견 → Goal 41 등록.)

## 전수 감사 결과
MCP 툴 3 부류:
- **인라인 상태변경(가드 우회 → 가드 추가)**: `save`(git add/commit/push) · `undo`(git reset) · `env`(.env.example/.gitignore 쓰기)
- **runVhkCli 위임(CLI 서브프로세스 → guardCli 상속, 별도 가드 불필요)**: sync/secure/harness/context/brief/ref-list/memory-list/learn/context-show/mcp-init/pattern-detect/pattern-list/evolve-suggest/evolve-list
- **MCP 모드 읽기전용(불필요)**: status/diff/doctor/check/recap/env-check/audit/deploy/publish/migrate/update ("실제 미수행, 안내만")

## 설계 (A안 채택)
CLI 의 `ensureNotHardStopped` 는 `console.error` + `process.exitCode` 기반 → MCP stdio(JSON-RPC) 채널 오염. 대신 `hardStopBlocked(action)` 신설: `isHardStopActive()` 시 안내 **content 반환**(console 미사용). save/undo/env 핸들러 첫 줄에 적용.
- `undo` 는 top 가드(save/env 와 일관) — preview 도 차단(되돌리기 목적 자체가 상태변경).

## 검토했으나 가드 안 함 (의도적)
- `pattern detect`/`evolve suggest`: 상태(patterns[]/evolve 큐)를 쓰지만 **분석/제안 단계**(reversible). Goal 36 이 적용 단계(`evolve apply`·`pattern dismiss`)만 가드한 doctrine 과 일치 → 갭 아님.
- `learn`: 트립 생성자 계열 → CLI 측도 의도적 미가드(blocker 와 동일).

## 테스트
- `tests/mcp-hardstop.test.ts` (신규): `callTool` 헬퍼로 핸들러 직접 호출(실제 fs). env 차단(.env.example 미생성)/정상(생성) 차별 + save/undo 차단 검증.
- `tests/helpers/mcp-introspect.ts`: `callTool` 추가 (SDK executeToolHandler 시그니처 재현).
- `check-goal-41.mjs`: import + 헬퍼 정의 + 호출 ≥3 + 테스트 존재 정적 검증.

## 게이트
- `tsc --noEmit` 0
- `pnpm build` 성공
- 메인 스위트 **998 테스트 통과** (99 files, vhk-* 제외)
- 적대 코드리뷰(읽기전용) 발견 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
