### PR TITLE
chore: 작업트리 정리 — mission.json gitignore + 도그푸드 샌드박스 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ dist/
 .vhk/refs.json
 # secret gist 포인터 (gistId) — 공개 repo 노출 방지 (VHK-022)
 .vhk/cloud.json
+# 로컬 미션 범위 계약(vhk mission set) — 프로젝트별 로컬 상태, 공유 대상 아님
+.vhk/mission.json
 
 # EnterWorktree 가 .claude/worktrees/ 에 isolated 복사본 생성 — 커밋 금지
 .claude/worktrees/

--- a/tests/mission.test.ts
+++ b/tests/mission.test.ts
@@ -201,5 +201,5 @@ describe('mission — CLI 커맨더 경로 보존 회귀 (default [] 제거)', (
     }
     expect(code).toBe(1)
     fs.rmSync(d, { recursive: true, force: true })
-  })
+  }, 30000)
 })


### PR DESCRIPTION
## 정리 내용
- **삭제(미추적)**: 도그푸드 샌드박스 `vhk-29~33-*/`·`vhk-goal19/`·`vhk-practice-lab/` (각 ~8k files, node_modules 포함 = 무스코프 `vitest --run` 테스트 오염원) + orphan `scripts/check-goal-21~28/30/33.mjs` (재생성 가능 스캐폴드).
- **`.gitignore`**: `.vhk/mission.json` 추가 — 다른 .vhk 로컬파일(HARD_STOP/memory/refs/cloud)과 일관, 로컬 미션 범위 상태라 공유 대상 아님.
- **`tests/mission.test.ts`**: CLI 커맨더 경로 회귀 테스트에 30s 타임아웃(느린 환경 flaky 방지). (세션 전부터 있던 미커밋 수정 흡수.)

발행 전 작업트리 정돈. 코드 동작 변경 없음.

## 게이트
- tsc 0 · mission 테스트 18 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)