### PR TITLE
chore(track-a): goal 카드 상태 정리 + worktree --install PM 자동감지 (리뷰 nit)

### DIFF
--- a/goals/29-preflight.md
+++ b/goals/29-preflight.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 29
 title: vhk preflight — 출고 전 안전점검 (publish/PR 직전 일괄 점검) — P1
-status: NOT_STARTED
+status: DONE
 priority: P1
 created: 2026-06-06
+completed: 2026-06-07
 leads_to: goal-30-worktree
 ---
 

--- a/goals/30-worktree.md
+++ b/goals/30-worktree.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 30
 title: vhk worktree 가드 — worktree 생성 시 env 누락 방지(자동복사/차단) — P2
-status: NOT_STARTED
+status: DONE
 priority: P2
 created: 2026-06-06
+completed: 2026-06-07
 depends_on: goal-29-preflight
 ---
 

--- a/goals/31-doctor.md
+++ b/goals/31-doctor.md
@@ -3,7 +3,7 @@ vhk_format: 1
 type: goal
 id: 31
 title: vhk doctor — 개발 환경 정기검진(Node·pnpm·git·OS·VHK·MCP·audit) — P2
-status: NOT_STARTED
+status: IN_PROGRESS
 priority: P2
 created: 2026-06-06
 ---

--- a/goals/32-standup.md
+++ b/goals/32-standup.md
@@ -3,7 +3,7 @@ vhk_format: 1
 type: goal
 id: 32
 title: vhk standup — 아침 브리핑(어제 한 일 + 오늘 할 일) — P2
-status: NOT_STARTED
+status: IN_PROGRESS
 priority: P2
 created: 2026-06-06
 leads_to: goal-33-today

--- a/goals/33-today.md
+++ b/goals/33-today.md
@@ -3,7 +3,7 @@ vhk_format: 1
 type: goal
 id: 33
 title: vhk today — 저녁 자축·회고(오늘 해낸 것 담백 요약) — P2
-status: NOT_STARTED
+status: IN_PROGRESS
 priority: P2
 created: 2026-06-06
 depends_on: goal-32-standup

--- a/scripts/check-goal-33.mjs
+++ b/scripts/check-goal-33.mjs
@@ -74,7 +74,7 @@ must(!/ensureNotHardStopped/.test(read('src/commands/today.ts') ?? ''), 'today �
 // 공유 헬퍼: 요일 포맷 date.ts 로 추출(standup 인라인 중복 실제 축소)
 must(/formatYmdWeekday/.test(read('src/lib/date.ts') ?? ''), 'date.ts 에 formatYmdWeekday 공유 헬퍼')
 must(/formatYmdWeekday/.test(read('src/commands/standup.ts') ?? ''), 'standup 이 formatYmdWeekday 재사용(인라인 중복 제거)')
-must(!/function withWeekday/.test(read('src/commands/standup.ts') ?? ''), 'standup 인라인 withWeekday 제거됨')
+must(!/withWeekday/.test(read('src/commands/standup.ts') ?? ''), 'standup 인라인 요일 포맷(withWeekday 어떤 형태든) 제거됨 — 공유 헬퍼만')
 // CLI 단일소스 등록
 must(/today/.test(read('src/index.ts') ?? ''), 'index.ts 에 today 등록')
 must(/'today'/.test(read('src/lib/command-registry.ts') ?? ''), 'command-registry 등록')

--- a/src/commands/worktree.ts
+++ b/src/commands/worktree.ts
@@ -10,6 +10,7 @@ import { runWorktreeCheck } from '../worktree/check.js'
 import { collectCopyItems } from '../worktree/configList.js'
 import { copyAll, realCopyDeps } from '../worktree/copy.js'
 import { addWorktree, sanitizeBranchToDir } from '../worktree/add.js'
+import { detectPM, installCommandFor } from '../worktree/pm.js'
 import type { CopyResult, WorktreeOptions } from '../worktree/types.js'
 
 // safeExecFile → Runner 어댑터(외부 명령 단일 경로 — execSync 금지).
@@ -61,17 +62,23 @@ export async function worktreeAdd(branch: string | undefined, opts: WorktreeOpti
 
   const cwd = process.cwd()
   const copyDeps = realCopyDeps()
+  const run = realRunner()
+  const pm = detectPM(cwd) // 범용: pnpm 고정 X — lockfile 로 yarn/npm 자동 감지
   const result = addWorktree(
     branch,
     { install: opts.install },
     {
       sourceDir: cwd,
-      run: realRunner(),
+      run,
       exists: (p) => existsSync(p),
       // 형제 디렉터리: ../<repoName>-<branch>
       resolveTargetPath: (b) => join(dirname(cwd), sanitizeBranchToDir(basename(cwd), b)),
       collectItems: (s, t) => collectCopyItems(s, t),
       copyAll: (items) => copyAll(items, copyDeps),
+      installRun: (tp) => {
+        const { cmd, args } = installCommandFor(pm, tp)
+        return run(cmd, args)
+      },
     }
   )
 

--- a/src/worktree/add.ts
+++ b/src/worktree/add.ts
@@ -9,6 +9,9 @@ export interface AddDeps {
   resolveTargetPath: (branch: string) => string
   collectItems: (sourceDir: string, targetDir: string) => CopyItem[]
   copyAll: (items: CopyItem[]) => CopyResult[]
+  // --install 시 설치 실행(주입). 호출자가 PM(pnpm/yarn/npm)을 감지해 적절한 명령으로 구성.
+  // 미주입 시 pnpm 폴백(하위호환).
+  installRun?: (targetPath: string) => { ok: boolean; out: string; err?: string }
 }
 
 export type AddStatus = 'created' | 'aborted-exists' | 'git-failed'
@@ -49,8 +52,10 @@ export function addWorktree(branch: string, opts: WorktreeOptions, deps: AddDeps
 
   let installed: boolean | undefined
   if (opts.install) {
-    // cwd 변경 없이 대상 디렉터리에서 설치(pnpm --dir <path> install).
-    const r = deps.run('pnpm', ['--dir', targetPath, 'install'])
+    // cwd 변경 없이 대상 디렉터리에서 설치. PM 감지는 호출자(installRun)가 담당 — 미주입 시 pnpm 폴백.
+    const r = deps.installRun
+      ? deps.installRun(targetPath)
+      : deps.run('pnpm', ['--dir', targetPath, 'install'])
     installed = r.ok
   }
 

--- a/src/worktree/pm.ts
+++ b/src/worktree/pm.ts
@@ -1,0 +1,18 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+export type PackageManager = 'pnpm' | 'yarn' | 'npm'
+
+// lockfile 기반 PM 감지(레포 루트). 기본 npm. (vhk 는 범용 도구라 pnpm 고정 금지)
+export function detectPM(dir: string): PackageManager {
+  if (existsSync(join(dir, 'pnpm-lock.yaml'))) return 'pnpm'
+  if (existsSync(join(dir, 'yarn.lock'))) return 'yarn'
+  return 'npm'
+}
+
+// cwd 변경 없이 특정 worktree 디렉터리에 설치하는 명령(PM별 dir 지정 플래그가 다름).
+export function installCommandFor(pm: PackageManager, targetPath: string): { cmd: string; args: string[] } {
+  if (pm === 'yarn') return { cmd: 'yarn', args: ['--cwd', targetPath, 'install'] }
+  if (pm === 'npm') return { cmd: 'npm', args: ['--prefix', targetPath, 'install'] }
+  return { cmd: 'pnpm', args: ['--dir', targetPath, 'install'] }
+}

--- a/tests/worktree/add.test.ts
+++ b/tests/worktree/add.test.ts
@@ -54,9 +54,19 @@ describe('addWorktree', () => {
     const r = addWorktree('feat/x', {}, deps)
     expect(r.status).toBe('git-failed')
     expect(copied).toBe(false)
+    // detail 은 순수 err — ko.worktree.gitFailed 가 접두사를 1회만 붙이도록(이중 접두사 방지)
+    expect(r.detail).toBe('fatal')
   })
 
-  it('--install 시 pnpm install (대상 디렉터리 지정)', () => {
+  it('--install 시 installRun(PM 주입) 우선 사용 — 대상 경로 전달', () => {
+    let installedTp = ''
+    const { deps } = mkDeps({ installRun: (tp) => { installedTp = tp; return { ok: true, out: '' } } })
+    const r = addWorktree('feat/x', { install: true }, deps)
+    expect(r.installed).toBe(true)
+    expect(installedTp).toBe('/repo-feat-x')
+  })
+
+  it('--install + installRun 미주입 → pnpm 폴백(하위호환)', () => {
     const { deps, calls } = mkDeps()
     const r = addWorktree('feat/x', { install: true }, deps)
     expect(r.installed).toBe(true)

--- a/tests/worktree/pm.test.ts
+++ b/tests/worktree/pm.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { detectPM, installCommandFor } from '../../src/worktree/pm.js'
+
+describe('installCommandFor (PM별 dir 지정 플래그)', () => {
+  it('pnpm → --dir', () => {
+    expect(installCommandFor('pnpm', '/wt')).toEqual({ cmd: 'pnpm', args: ['--dir', '/wt', 'install'] })
+  })
+  it('yarn → --cwd', () => {
+    expect(installCommandFor('yarn', '/wt')).toEqual({ cmd: 'yarn', args: ['--cwd', '/wt', 'install'] })
+  })
+  it('npm → --prefix', () => {
+    expect(installCommandFor('npm', '/wt')).toEqual({ cmd: 'npm', args: ['--prefix', '/wt', 'install'] })
+  })
+})
+
+describe('detectPM (lockfile 기반)', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'vhk-pm-')) })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('pnpm-lock.yaml → pnpm', () => {
+    writeFileSync(join(dir, 'pnpm-lock.yaml'), '')
+    expect(detectPM(dir)).toBe('pnpm')
+  })
+  it('yarn.lock → yarn', () => {
+    writeFileSync(join(dir, 'yarn.lock'), '')
+    expect(detectPM(dir)).toBe('yarn')
+  })
+  it('lockfile 없음 → npm 기본', () => {
+    expect(detectPM(dir)).toBe('npm')
+  })
+})


### PR DESCRIPTION
## Track A 마무리 정리 (goal 카드 + 리뷰 nit)

### 1. goal 카드 상태 (구현 머지 반영)
| Goal | status |
|---|---|
| 29 preflight / 30 worktree | NOT_STARTED → **DONE** (completed 2026-06-07) |
| 31 doctor / 32 standup / 33 today | NOT_STARTED → **IN_PROGRESS** (Phase 1 완료·Phase 2 잔여) |

### 2. #139 리뷰 nit — `--install` PM 자동감지
- vhk 는 범용 도구인데 `worktree add --install` 이 **pnpm 하드코딩** → yarn/npm 프로젝트 실패 위험(적대 리뷰 CONFIRMED).
- `src/worktree/pm.ts`(신규): `detectPM`(lockfile 기반) + `installCommandFor`(PM별 dir 플래그 — pnpm `--dir`/yarn `--cwd`/npm `--prefix`).
- `addWorktree` 가 주입형 `installRun` 사용(미주입 시 pnpm 폴백·하위호환). command 가 cwd lockfile 로 PM 감지해 주입.
- 테스트: `pm.test`(installCommandFor·detectPM temp dir) + installRun 주입 + **git-failed detail 순수err 단언**(리뷰가 짚은 무검증 갭).

### 3. #162 리뷰 nit — 게이트 강화
- `check-goal-33` 의 standup 인라인 제거 검사 `!/function withWeekday/` → `!/withWeekday/`(화살표·다른이름 재도입도 차단).

## 게이트
- check-goal-30 ✅ · check-goal-33 ✅ · tsc 0 · 전체 **1035 green**(105 files).

> 리뷰가 GO 판정한 비차단 nit 정리. Phase 2(doctor MCP/audit/CVE·standup/today DevLog)는 별도.