### PR TITLE
chore: release v2.4.2 — git 동기화 (version bump + CHANGELOG 본문)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,32 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ## [Unreleased]
 
-_다음 릴리즈 예정 항목 없음._
+> main 에 머지됐으나 2.4.2 발행 시점 이후라 다음 릴리즈(2.4.3) 포함 예정.
+
+- **`vhk worktree` 가드** (Goal 30, #139) — worktree 생성 시 `.env` 자동 복사 + 누락 점검.
+- **`vhk today`** (Goal 33, #162) — 저녁 자축·회고 브리핑(git + goal 기반).
+
+## [2.4.2] - 2026-06-07
+
+> **Safety 강화 — HARD_STOP 가드 완성 + 원자적 쓰기 완성.** 자동화 트립와이어(`.vhk/HARD_STOP`)가 모든 상태변경 경로를 막고, 영속 쓰기가 쓰기 도중 kill 에도 손상되지 않도록 마무리(Goal 34~41).
+
+### Added
+
+- **HARD_STOP 가드 전면 확대** — 활성 시 상태변경 작업을 즉시 차단(파일/git 미변경 + 안내 출력, `vhk resume --confirm` 으로만 사람이 해제).
+  - goal 명령군(next/init/done) · memory 명령군(add/remove/archive/resolve/unarchive) · evolve(apply/reject/undo)·pattern(dismiss)·mission(set/clear) (Goal 34~36)
+  - 나머지 상태쓰기 명령: `design`·`theme`·`env`·`ref add`·`cloud push` (Goal 39)
+  - **MCP 서버 surface** (`save`·`undo`·`env`) — CLI `guardCli` chokepoint 를 우회해 git/파일 쓰기를 인라인 재구현하던 핸들러에 `hardStopBlocked` 가드 신설. MCP stdio(JSON-RPC) 오염 방지로 console 대신 안내 content 반환 (Goal 41).
+
+### Changed
+
+- **원자적 쓰기(`atomicWriteFile`) 완성** — temp 파일에 먼저 쓰고 `rename`(원자 교체)으로 옮겨, 쓰기 도중 kill 되어도 대상 파일이 부분기록(손상)되지 않도록.
+  - 헬퍼 신설 + 영속 상태 적용 · `ref`/`review`/`verify`/`sync`/`mission`/`state-files` 확대 (Goal 37~38)
+  - `goal.ts`: `next-task.md`·scaffold 첫 생성·goal frontmatter 갱신 (Goal 40)
+- **`.gitignore`** — `.vhk/mission.json`(로컬 미션 범위 상태) 추가, 다른 `.vhk` 로컬 파일과 일관.
+
+### 내부
+
+- 도그푸드 샌드박스 디렉터리·orphan goal 게이트 스크립트 정리 + 회귀 가드 테스트 다수 추가(998 pass).
 
 ## [2.4.1] - 2026-06-06
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ tags: [process, constitution]
 > ⚠️ 아래 `**버전:**` 줄은 CI(version-sync.test.ts)가 강제 — 형식 `**버전:** vX.Y.Z` 유지, 릴리즈마다 package.json 따라 갱신.
 
 **마지막 갱신:** 2026-06-06
-- **버전:** v2.4.1 (npm latest) — 사실 확인은 package.json·CHANGELOG
+- **버전:** v2.4.2 (npm latest) — 사실 확인은 package.json·CHANGELOG
 - **테스트:** 890 pass · **MCP tools:** 29
 - **Phase:** 등록 goal 0~20 전부 DONE · v2.4.0 발행 완료 + version-check SoT 추출 + 오프라인 hang 핫픽스(#135)
 - **블로커:** 없음

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "packageManager": "pnpm@11.2.2",
   "description": "Vibe Harness Kit — AI 코딩 도구·기기를 바꿔도 규칙·맥락이 따라가는 포터빌리티 CLI (sync: Cursor·Claude·Windsurf·Copilot·Antigravity / cloud 백업)",
   "bin": {


### PR DESCRIPTION
## 요약
v2.4.2 npm 발행 후 **git 동기화** — `package.json` 2.4.1 → 2.4.2 범프 + `CHANGELOG.md` [2.4.2] 본문 작성 + `CLAUDE.md` LIVE 버전 줄 갱신.

npm `@byh3071/vhk@2.4.2` 는 이미 발행됨. 이 PR 은 repo 측 버전/체인지로그를 발행본에 맞춤.

## 변경
- `package.json`: 2.4.1 → **2.4.2**
- `CHANGELOG.md`:
  - [2.4.2] 본문 — HARD_STOP 가드 완성(Goal 34~36, 39, 41) + 원자적 쓰기 완성(Goal 37~38, 40) + 정리.
  - [Unreleased] — Goal 30(#139)·Goal 33(#162)는 2.4.2 발행 베이스 이후 머지라 다음 릴리즈(2.4.3) 예정으로 기록.
- `CLAUDE.md`: LIVE `**버전:**` v2.4.2 (version-sync.test 강제 형식).

## 참고 (동시 머지 부산물)
npm 2.4.2 는 발행 시점 베이스(Goal 41 + 정리까지)에서 빌드됨. 이후 Goal 30/33/#168 이 병렬 머지돼 main 에 누적 → main 트리는 npm 2.4.2 tarball 보다 앞섬(다음 발행 2.4.3 에 반영). v2.4.0 때와 동류의 cosmetic 차이.

## 게이트
- tsc 0 · version-sync 테스트 통과 · build 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)
