### PR TITLE
chore: 세션 인수인계 — LIVE/next-task/dev log 갱신 (v2.4.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ dist/
 
 # Cursor MCP 설정 — 절대 로컬 경로 포함, 머신별 — 커밋 금지 (VHK-022 hygiene)
 .cursor/
+
+# Serena MCP 로컬 캐시/프로젝트 메모 — 머신별 툴 산출물, 커밋 금지
+.serena/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,11 +86,11 @@ tags: [process, constitution]
 > 세션 종료: 마지막 갱신·버전·Phase·다음 할 일 갱신. (위 🔒 구역은 절대 건드리지 마.)
 > ⚠️ 아래 `**버전:**` 줄은 CI(version-sync.test.ts)가 강제 — 형식 `**버전:** vX.Y.Z` 유지, 릴리즈마다 package.json 따라 갱신.
 
-**마지막 갱신:** 2026-06-06
+**마지막 갱신:** 2026-06-07
 - **버전:** v2.4.2 (npm latest) — 사실 확인은 package.json·CHANGELOG
-- **테스트:** 890 pass · **MCP tools:** 29
-- **Phase:** 등록 goal 0~20 전부 DONE · v2.4.0 발행 완료 + version-check SoT 추출 + 오프라인 hang 핫픽스(#135)
+- **테스트:** 1035 pass · **MCP tools:** 29
+- **Phase:** HARD_STOP 가드 완성(Goal 34~36·39·41) + 원자적 쓰기 완성(Goal 37~38·40) · v2.4.2 발행 완료
 - **블로커:** 없음
-- **진행 중(미발행):** version-check 오프라인 hang 픽스(#135 main 머지 완료) — 발행 시 2.4.1
-- **다음 할 일:** 뒷단 Goal 21~24 (launch·content·sell·ops). (참고: tag v2.4.0 는 핫픽스 전 커밋 76db882 가리킴 — npm 정상, cosmetic 이라 둠)
-- **주의:** publish는 main에서만(#119)
+- **진행 중(미발행):** Goal 30(#139 DONE)·Goal 33(#162 IN_PROGRESS)·chore #168 — npm 2.4.2 미포함(발행 베이스 이후 머지) → 다음 2.4.3
+- **다음 할 일:** Goal 33(`vhk today`) 마무리 → 2.4.3 발행. (tag v2.4.2 → 131e3c3 = npm tarball 정확일치, main release 커밋은 09e4b88 — cosmetic 이라 둠)
+- **주의:** publish는 main에서만(#119)·사용자 직접(2FA) / 직접 main push 차단 → PR 경유

--- a/docs/log/2026-06-07-hardstop-atomic-completion-2.4.2.md
+++ b/docs/log/2026-06-07-hardstop-atomic-completion-2.4.2.md
@@ -1,0 +1,24 @@
+# 2026-06-07 — HARD_STOP 가드 완성 + 원자적 쓰기 완성 → v2.4.2 발행
+
+> dev log = append-only. 추가만, 수정·삭제 금지.
+
+## 한 일
+- **Goal 39** (#163) — 나머지 상태쓰기 명령 HARD_STOP 가드: `design`·`theme`·`env`·`refAdd`·`cloudPush`.
+  - 후속 핫픽스 **#164** — 가드 라벨이 머지 과정서 camelCase(`cloudPush`/`refAdd`)로 오염 + 주석 누락 → 공백 컨벤션(`cloud push`/`ref add`)으로 복구(check-goal-39 게이트 실패 유발했던 것).
+- **Goal 40** (#165) — `goal.ts` 영속 쓰기(goalNext/goalInit/goalDone) `writeFileSync` → `atomicWriteFile`. 원자적 쓰기 시리즈 완성.
+- **Goal 41** (#166) — MCP 서버 surface HARD_STOP 가드: `save`·`undo`·`env`(CLI guardCli 우회 인라인 핸들러). MCP용 `hardStopBlocked` 헬퍼 신설(console 미사용 — stdio JSON-RPC 오염 방지, content 반환).
+- **정리** (#167) — 도그푸드 샌드박스 `vhk-*/`(~48k files) + orphan check-goal 스크립트 삭제, `.vhk/mission.json` gitignore, mission 테스트 타임아웃.
+- **v2.4.2 발행** — 사용자 직접 npm publish. git 동기화(CHANGELOG 본문 + version bump)는 **#169** PR 로.
+
+## 교훈
+- **워크플로 적대검증 에이전트가 실제 소스를 손상**: worktree 격리 없는 검증 에이전트가 가드를 임시 제거→복원하며 부정확 복원(라벨/주석 변경). 내 무결성 체크가 `grep -c`(개수)라 내용 변경을 못 잡음 → 커밋·머지까지 흘러감. **교훈: 검증 에이전트는 `isolation:'worktree'` 또는 직접 수행, 커밋 전 `git diff` 내용 육안 확인.** (read-only `cavecrew-reviewer` 로 전환 후 재발 0.)
+- **MCP stdio 가드는 console 금지**: CLI `ensureNotHardStopped`(console.error+exitCode)를 MCP 에 쓰면 JSON-RPC 채널 오염 → content 반환형 헬퍼 별도 신설.
+- **동시 머지 중 발행 동기화**: 발행 중 origin/main 이 병렬로 계속 이동(#139·#162·#168) + 직접 main push 차단(분류기) → release 커밋을 최신 main 위로 rebase + PR 경유. npm tarball 은 발행 베이스 스냅샷이라 이후 머지분 미포함(다음 릴리즈로).
+- **tag 정확도 vs main 일관성**: tag `v2.4.2`→`131e3c3`(npm tarball 정확 일치) 유지, main release 커밋(`09e4b88`)과 분리. 발행된 tag 이동 금지(v2.4.0 동류 cosmetic).
+
+## 검증
+- 발행본 tarball grep: `ensureNotHardStopped` 26 + `hardStopBlocked` 4(chunk) + `atomicWriteFile`/`renameSync` 13 → 작업 전부 포함 확인.
+- 메인 스위트 1035 pass (vhk-* 제외). 각 머지 전 read-only 적대리뷰 발견 0.
+
+## 다음
+- Goal 33(`vhk today`) 마무리(IN_PROGRESS) → 2.4.3 발행(Goal 30/33/#168 포함).

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -2,19 +2,19 @@
 
 > "지금 무엇부터"의 상태 SoT. 버전·테스트 등 사실값은 package.json·CHANGELOG가 SoT.
 
-**갱신:** 2026-06-06
-**Phase:** v2.4.0 발행 완료 + version-check SoT 추출 — 앞단 발행 라인 종료.
+**갱신:** 2026-06-07
+**Phase:** v2.4.2 발행 완료 — HARD_STOP 가드 완성(Goal 34~36·39·41) + 원자적 쓰기 완성(Goal 37~38·40). main `09e4b88`, 테스트 1035 pass.
 
 ## 다음 할 일
-- 앞단(코어 CLI) 추가 액션 없음.
-- v2.4.0 발행됨 (npm latest): `vhk work`/`work handoff` + RULES.md 단일소스 + version-check SoT 포함.
-- 미발행: version-check 오프라인 hang 핫픽스(#135 머지 완료) → 다음 발행 시 2.4.1.
-- 뒷단 로드맵 = Goal 21~24 (launch·content·sell·ops) → docs/state/roadmap.md 참조
-- (cosmetic·선택) tag v2.4.0 가 핫픽스 전 커밋 76db882 가리킴 — npm 정상이라 둠. green 커밋 원하면 `git tag -f v2.4.0 dced724; git push -f`.
+- **Goal 33 (`vhk today`) 마무리** — 현재 IN_PROGRESS(Phase 1만 머지 #162). Phase 2+ 완료 후 DONE 전이.
+- **2.4.3 발행** — Goal 30(#139, DONE)·Goal 33·chore #168 이 npm 2.4.2 미포함(발행 베이스 이후 머지) → CHANGELOG [Unreleased] 적재됨. Goal 33 끝내고(또는 goal 2~3개 더 모아) 묶어 발행.
+- 나머지 미완 goal 14개 (goals/ 동적 계산 — `vhk goal next`).
 
 ## 블로커
 - 없음
 
 ## 주의
-- publish는 항상 main에서만 (가드 #119)
+- publish는 항상 main에서만 (가드 #119) · 사용자가 직접(2FA)
+- 직접 main push 차단됨(분류기) → 변경은 PR 경유 + `gh pr merge --squash`
 - active goal 은 goals/ 기준 동적 계산 (vhk work / vhk goal next)
+- (cosmetic) tag `v2.4.2` → `131e3c3` (npm tarball 정확 일치, goals 30/33 미포함). main release 커밋은 `09e4b88` — 발행 tag 이동 금지라 둠(v2.4.0 동류).


### PR DESCRIPTION
## 세션 마무리 (인수인계)
HARD_STOP 가드 완성(Goal 39·41) + 원자적 쓰기 완성(Goal 40) + 정리 + v2.4.2 발행 세션의 상태 기록.

- **CLAUDE.md LIVE**: 마지막갱신/테스트(1035 pass)/Phase/진행중/다음할일 = v2.4.2 상태로 갱신 (버전줄 형식 유지 — version-sync 통과).
- **docs/state/next-task.md**: 다음 = Goal 33(`vhk today`, IN_PROGRESS) 마무리 → 2.4.3 발행(Goal 30/33/#168 미발행분 포함).
- **docs/log/2026-06-07**: append-only 세션 기록 + 교훈(워크플로 에이전트 소스손상→worktree격리·git diff 검증 / MCP 가드 console금지 / 동시머지 발행동기화).
- **.gitignore**: `.serena/` (Serena MCP 로컬 캐시).

문서/정리 전용. 코드 동작 변경 없음.

## 게이트
- version-sync 테스트 통과 · 메인 스위트 1035 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)