### PR TITLE
feat(doctor): Phase 2 — VHK/MCP/audit 진단 + --json/--audit (Goal 31 완료)

### DIFF
--- a/goals/31-doctor.md
+++ b/goals/31-doctor.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 31
 title: vhk doctor — 개발 환경 정기검진(Node·pnpm·git·OS·VHK·MCP·audit) — P2
-status: IN_PROGRESS
+status: DONE
 priority: P2
 created: 2026-06-06
+completed: 2026-06-07
 ---
 
 # Goal 31: vhk doctor (환경 정기검진)

--- a/scripts/check-goal-31.mjs
+++ b/scripts/check-goal-31.mjs
@@ -83,5 +83,15 @@ must(/runDiagnostics/.test(doc), 'doctor.ts 가 새 진단 엔진 흡수')
 // 읽기전용 진단 — HARD_STOP 가드 없어야 함(가드 docstring: 읽기전용 제외 — 리뷰 반영)
 must(!/ensureNotHardStopped/.test(doc), 'doctor.ts 는 HARD_STOP 가드 없음(읽기전용)')
 
+// ─── Phase 2 (vhk/mcp/audit 진단 + --json) ───────────────────────────────
+for (const d of ['vhk', 'mcp', 'audit']) {
+  must(existsSync(`src/doctor/diagnostics/${d}.ts`), `diagnostics/${d}.ts 존재 (Phase 2)`)
+  must(!/writeFileSync|copyFileSync|execSync/.test(read(`src/doctor/diagnostics/${d}.ts`) ?? ''), `diagnostics/${d}.ts 진단만(부작용 없음)`)
+}
+must(/buildVhkDiag/.test(doc) && /buildMcpDiag/.test(doc) && /buildAuditDiag/.test(doc), 'doctor.ts 가 Phase 2 진단(vhk/mcp/audit) 포함')
+must(/formatDiagnosticsJson/.test(doc) && /opts\.json/.test(doc), 'doctor.ts 가 --json 기계가독 출력 분기')
+must(/mcpToolCount/.test(read('src/doctor/diagnostics/mcp.ts') ?? ''), 'mcp 진단이 자체 MCP 서버 도구 수 점검')
+must(existsSync('tests/doctor/phase2.test.ts'), 'Phase 2 단위테스트 존재')
+
 if (pass) { console.log('✅ goal 31 gate passes'); process.exit(0) }
 console.log('❌ goal 31 gate failed'); process.exit(1)

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -10,13 +10,16 @@ import { checkRuleDrift, checkContextDrift } from '../lib/drift.js'
 import os from 'node:os'
 import type { Runner } from '../lib/preflight.js'
 import { runDiagnostics } from '../doctor/runner.js'
-import { formatDiagnostics } from '../doctor/report.js'
+import { formatDiagnostics, formatDiagnosticsJson } from '../doctor/report.js'
 import { diagNode } from '../doctor/diagnostics/node.js'
 import { diagNpm } from '../doctor/diagnostics/npm.js'
 import { diagPnpm } from '../doctor/diagnostics/pnpm.js'
 import { diagGit } from '../doctor/diagnostics/git.js'
 import { diagOs } from '../doctor/diagnostics/os.js'
-import type { DiagDeps, DoctorOptions } from '../doctor/types.js'
+import { buildVhkDiag } from '../doctor/diagnostics/vhk.js'
+import { buildMcpDiag, mcpToolCount } from '../doctor/diagnostics/mcp.js'
+import { buildAuditDiag } from '../doctor/diagnostics/audit.js'
+import type { DiagDeps, DoctorOptions, DiagFn } from '../doctor/types.js'
 // 업데이트 체크 함수는 version-check.ts 단일 소스로 이동(메뉴와 공용). 여기선 import + re-export
 // (doctor.test.ts 의 `from doctor.js` import 경로 보존) + 내부 사용.
 import { fetchLatestNpmVersion, compareSemver, recordLatest } from '../lib/version-check.js'
@@ -60,10 +63,9 @@ function getVhkVersion(): string | undefined {
 export async function doctor(opts: DoctorOptions = {}) {
   // 읽기전용 진단 — HARD_STOP 으로 막지 않는다(가드 docstring: '제외: 읽기전용(status 등)').
   // 오히려 HARD_STOP 켜진 순간이 환경 진단이 가장 필요한 때.
-  console.log(chalk.bold(`\n${ko.doctor.title}\n`))
+  const cwd = process.cwd()
 
-  // 환경 진단(Phase 1: Node/pnpm/git/OS) — doctor 엔진(병렬 + throw 격리, 진단만).
-  // Node 판정은 Goal 29 nodeMeetsShimSafe 재사용.
+  // 환경 진단 — doctor 엔진(throw 격리, 진단만). Node 판정은 Goal 29 nodeMeetsShimSafe 재사용.
   const run: Runner = (cmd, args) => {
     const r = safeExecFile(cmd, args)
     return r.ok ? { ok: true, out: r.out } : { ok: false, out: r.out, err: r.err }
@@ -74,33 +76,38 @@ export async function doctor(opts: DoctorOptions = {}) {
     platform: process.platform,
     osRelease: os.release(),
   }
-  const diags = await runDiagnostics([diagNode, diagNpm, diagPnpm, diagGit, diagOs], opts, deps)
+  // Phase 2: VHK 설치/업데이트 · MCP 서버 무결성 · 의존성 audit(--audit 시) 추가.
+  const auditPm = fs.existsSync(path.join(cwd, 'pnpm-lock.yaml'))
+    ? 'pnpm'
+    : fs.existsSync(path.join(cwd, 'yarn.lock'))
+      ? 'yarn'
+      : 'npm'
+  const diagnostics: DiagFn[] = [
+    diagNode, diagNpm, diagPnpm, diagGit, diagOs,
+    () => {
+      const version = getVhkVersion()
+      const latest = version ? (fetchLatestNpmVersion('@byh3071/vhk') ?? null) : null
+      if (latest) recordLatest(latest) // 메뉴(getUpdateInfo) 캐시 적재
+      return buildVhkDiag({ version, latest })
+    },
+    async () => buildMcpDiag(await mcpToolCount()),
+    (o) => buildAuditDiag(o, () => run(auditPm, ['audit'])),
+  ]
+  const diags = await runDiagnostics(diagnostics, opts, deps)
+
+  // --json: 기계가독 출력만(제목·프로젝트파일·드리프트 생략) — Phase 2.
+  if (opts.json) {
+    console.log(formatDiagnosticsJson(diags))
+    return
+  }
+
+  console.log(chalk.bold(`\n${ko.doctor.title}\n`))
   for (const line of formatDiagnostics(diags)) console.log(line)
   const anyFail = diags.some((d) => d.status === 'fail')
   const warnCount = diags.filter((d) => d.status === 'warn').length
 
   console.log('')
-  const vhkVersion = getVhkVersion()
-  if (vhkVersion) {
-    console.log(chalk.green('  ✅ VHK') + chalk.dim(` — v${vhkVersion}`))
-  } else {
-    console.log(chalk.green('  ✅ VHK') + chalk.dim(' — 설치됨'))
-  }
-
-  if (vhkVersion) {
-    const latest = fetchLatestNpmVersion('@byh3071/vhk')
-    if (latest) recordLatest(latest) // 메뉴(getUpdateInfo)가 다음에 활용할 캐시 적재
-    if (latest && compareSemver(latest, vhkVersion) > 0) {
-      console.log(chalk.yellow(`  ${ko.doctor.updateAvailable(latest)}`))
-    } else if (latest) {
-      console.log(chalk.dim(`     ${ko.doctor.updateCurrent}`))
-    }
-  }
-
-  console.log('')
   console.log(chalk.bold(`  ${ko.doctor.projectFiles}`))
-
-  const cwd = process.cwd()
 
   const projectFiles = [
     { name: 'RULES.md', hint: 'vhk init으로 생성 가능' },

--- a/src/doctor/diagnostics/audit.ts
+++ b/src/doctor/diagnostics/audit.ts
@@ -1,0 +1,16 @@
+import type { Diagnostic, DoctorOptions } from '../types.js'
+
+type AuditRun = () => { ok: boolean; out: string; err?: string }
+
+// 의존성 보안 진단(Phase 2). 기본 생략(가볍게) — --audit 일 때만 PM audit 실행.
+// 취약점 있으면 audit 가 exit≠0 → run.ok=false. 출력 파싱 대신 exit code 로 판정(견고).
+export function buildAuditDiag(opts: DoctorOptions, run: AuditRun): Diagnostic {
+  if (!opts.audit) {
+    return { name: 'audit', status: 'skip', value: '생략 — --audit 로 실행' }
+  }
+  const r = run()
+  if (r.ok) {
+    return { name: 'audit', status: 'ok', value: '알려진 취약점 없음' }
+  }
+  return { name: 'audit', status: 'warn', value: '취약점 발견', advice: 'pnpm audit (또는 vhk audit --fix) 로 확인' }
+}

--- a/src/doctor/diagnostics/mcp.ts
+++ b/src/doctor/diagnostics/mcp.ts
@@ -1,0 +1,24 @@
+import type { Diagnostic } from '../types.js'
+
+// VHK 자체 MCP 서버의 등록 도구 수로 무결성 판정(Phase 2). 외부 서버 핑은 환경의존이라 별도.
+export function buildMcpDiag(toolCount: number, expected = 20): Diagnostic {
+  if (toolCount <= 0) {
+    return { name: 'MCP', status: 'fail', value: '도구 0개', advice: 'MCP 서버 등록 깨짐 — vhk 재설치' }
+  }
+  if (toolCount < expected) {
+    return { name: 'MCP', status: 'warn', value: `${toolCount} tools (기대 ${expected}+)`, advice: 'MCP 도구 일부 누락 가능 — vhk 버전 확인' }
+  }
+  return { name: 'MCP', status: 'ok', value: `${toolCount} tools 등록` }
+}
+
+// 런타임: createVhkMcpServer 를 in-process 구성(stdio 시작 X)해 등록 도구 수를 센다.
+// SDK private(_registeredTools) 접근 — SDK 메이저 업글 시 여기 패치(mcp-introspect 테스트가 회귀 가드).
+export async function mcpToolCount(): Promise<number> {
+  try {
+    const { createVhkMcpServer } = await import('../../mcp/server.js')
+    const server = (await createVhkMcpServer()) as unknown as { _registeredTools?: Record<string, unknown> }
+    return Object.keys(server._registeredTools ?? {}).length
+  } catch {
+    return 0
+  }
+}

--- a/src/doctor/diagnostics/vhk.ts
+++ b/src/doctor/diagnostics/vhk.ts
@@ -1,0 +1,13 @@
+import { compareSemver } from '../../lib/version-check.js'
+import type { Diagnostic } from '../types.js'
+
+// VHK 설치/버전 진단 (Phase 2). 기존 doctor 명령의 인라인 VHK 블록을 진단으로 흡수.
+export function buildVhkDiag(input: { version: string | undefined; latest: string | null }): Diagnostic {
+  if (!input.version) {
+    return { name: 'VHK', status: 'warn', value: '버전 확인 불가', advice: '전역 설치 확인: npm i -g @byh3071/vhk' }
+  }
+  if (input.latest && compareSemver(input.latest, input.version) > 0) {
+    return { name: 'VHK', status: 'warn', value: `v${input.version}`, advice: `업데이트 가능: v${input.latest} — vhk update` }
+  }
+  return { name: 'VHK', status: 'ok', value: `v${input.version}${input.latest ? ' (최신)' : ''}` }
+}

--- a/src/doctor/report.ts
+++ b/src/doctor/report.ts
@@ -18,3 +18,8 @@ export function formatDiagnostics(diags: Diagnostic[]): string[] {
   }
   return lines
 }
+
+// 기계가독(CI·MCP) 출력 — --json (Phase 2).
+export function formatDiagnosticsJson(diags: Diagnostic[]): string {
+  return JSON.stringify(diags, null, 2)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -298,8 +298,10 @@ program
   .alias('환경')
   .alias('진단')
   .option('--strict', '규칙 드리프트 발견 시 실패 처리 (exit 1, CI 게이트용)')
-  .description('개발 환경 점검 — Node/Git/npm 상태 확인')
-  .action(async (opts: { strict?: boolean }) => { await doctor(opts) })
+  .option('--audit', '의존성 보안 audit 포함 (기본 생략 — pnpm/yarn/npm audit)')
+  .option('--json', '진단 결과를 JSON 으로 출력 (CI/MCP용 — 제목·드리프트 생략)')
+  .description('개발 환경 점검 — Node/npm/pnpm/git/OS + VHK/MCP/audit 진단')
+  .action(async (opts: { strict?: boolean; audit?: boolean; json?: boolean }) => { await doctor(opts) })
 
 program
   .command('save')

--- a/tests/doctor/phase2.test.ts
+++ b/tests/doctor/phase2.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { buildVhkDiag } from '../../src/doctor/diagnostics/vhk.js'
+import { buildMcpDiag } from '../../src/doctor/diagnostics/mcp.js'
+import { buildAuditDiag } from '../../src/doctor/diagnostics/audit.js'
+import { formatDiagnosticsJson } from '../../src/doctor/report.js'
+import type { Diagnostic } from '../../src/doctor/types.js'
+
+describe('buildVhkDiag', () => {
+  it('버전 있고 최신 → ok', () => {
+    const r = buildVhkDiag({ version: '2.4.2', latest: '2.4.2' })
+    expect(r.status).toBe('ok')
+    expect(r.value).toContain('2.4.2')
+  })
+  it('업데이트 있으면 warn + 안내', () => {
+    const r = buildVhkDiag({ version: '2.4.0', latest: '2.4.2' })
+    expect(r.status).toBe('warn')
+    expect(r.advice).toContain('2.4.2')
+  })
+  it('버전 확인 불가 → warn', () => {
+    expect(buildVhkDiag({ version: undefined, latest: null }).status).toBe('warn')
+  })
+  it('최신 조회 실패(latest null)여도 버전 있으면 ok', () => {
+    expect(buildVhkDiag({ version: '2.4.2', latest: null }).status).toBe('ok')
+  })
+})
+
+describe('buildMcpDiag', () => {
+  it('도구 수 충분(>= 기대) → ok', () => {
+    const r = buildMcpDiag(29, 20)
+    expect(r.status).toBe('ok')
+    expect(r.value).toContain('29')
+  })
+  it('도구 수 부족 → warn', () => {
+    expect(buildMcpDiag(10, 20).status).toBe('warn')
+  })
+  it('0개 → fail (서버 깨짐)', () => {
+    expect(buildMcpDiag(0, 20).status).toBe('fail')
+  })
+})
+
+describe('buildAuditDiag', () => {
+  it('--audit 없으면 skip (기본 생략)', () => {
+    let called = false
+    const r = buildAuditDiag({ audit: false }, () => { called = true; return { ok: true, out: '' } })
+    expect(r.status).toBe('skip')
+    expect(called).toBe(false)
+  })
+  it('--audit + 취약점 0(run ok) → ok', () => {
+    const r = buildAuditDiag({ audit: true }, () => ({ ok: true, out: 'No known vulnerabilities found' }))
+    expect(r.status).toBe('ok')
+  })
+  it('--audit + 취약점 발견(run fail) → warn + 안내', () => {
+    const r = buildAuditDiag({ audit: true }, () => ({ ok: false, out: '3 vulnerabilities', err: '' }))
+    expect(r.status).toBe('warn')
+    expect(r.advice).toBeTruthy()
+  })
+})
+
+describe('formatDiagnosticsJson', () => {
+  it('Diagnostic[] 를 파싱 가능한 JSON 으로', () => {
+    const diags: Diagnostic[] = [{ name: 'Node', status: 'ok', value: 'v20' }]
+    const json = formatDiagnosticsJson(diags)
+    expect(JSON.parse(json)).toEqual(diags)
+  })
+})


### PR DESCRIPTION
## Goal 31 doctor — Phase 2 (goal 완료)

Phase 1(Node/npm/pnpm/git/OS)에 **VHK·MCP·audit 진단 3종 + --json/--audit** 추가.

## 동작 (도그푸딩)
```
🩺 개발 환경 점검
  🟢 Node/npm/pnpm/git/OS  (Phase 1)
  🟢 VHK      v2.4.2 (최신)
  🟢 MCP      29 tools 등록
  ⚪ audit    생략 — --audit 로 실행
```
`vhk doctor --json` → 진단 배열을 JSON으로(CI/MCP용, P1의 죽은 `json` 필드 배선).
`vhk doctor --audit` → PM(pnpm/yarn/npm 자동감지) audit 실행.

## 진단 3종
- **VHK**: 설치/버전 + 업데이트 가능 여부(기존 인라인 블록을 진단으로 흡수).
- **MCP**: `createVhkMcpServer` in-process 구성해 **자체 서버 등록 도구 수**(=무결성, 29). stdio 시작 X.
- **audit**: `--audit` 시만 PM audit. 취약점 = exit code 판정(출력 파싱 X, 견고).

## 불변규칙
진단만(자동수정 0)·execSync 0 유지. 순수 빌더(buildVhk/Mcp/AuditDiag) TDD.

## 게이트
check-goal-31 ✅ (Phase 2 검증 추가) · tsc 0 · 전체 **1046 green**(+11) · 도그푸딩 통과.

## 보류 (후속/Phase 3 — 정직 표기)
- CVE **온라인 DB 보정**: 공개 CVE 데이터소스 부재 → 오프라인 판정(nodeMeetsShimSafe) 유지.
- 외부 MCP 서버 핑(28/29 timeout): 환경의존(프로젝트별 .cursor/mcp.json 스폰 필요).

> goal 31 카드 → DONE. npm publish 사람만. 머지 리뷰 후 사람.