### PR TITLE
feat(daily): Phase 2 — 로컬 docs/log DevLog 연동 (Goal 32·33 완료)

### DIFF
--- a/goals/32-standup.md
+++ b/goals/32-standup.md
@@ -3,8 +3,9 @@ vhk_format: 1
 type: goal
 id: 32
 title: vhk standup — 아침 브리핑(어제 한 일 + 오늘 할 일) — P2
-status: IN_PROGRESS
+status: DONE
 priority: P2
+completed: 2026-06-07
 created: 2026-06-06
 leads_to: goal-33-today
 ---

--- a/goals/33-today.md
+++ b/goals/33-today.md
@@ -3,8 +3,9 @@ vhk_format: 1
 type: goal
 id: 33
 title: vhk today — 저녁 자축·회고(오늘 해낸 것 담백 요약) — P2
-status: IN_PROGRESS
+status: DONE
 priority: P2
+completed: 2026-06-07
 created: 2026-06-06
 depends_on: goal-32-standup
 ---

--- a/scripts/check-goal-32.mjs
+++ b/scripts/check-goal-32.mjs
@@ -80,6 +80,10 @@ must(!/ensureNotHardStopped/.test(read('src/commands/standup.ts') ?? ''), 'stand
 must(/standup/.test(read('src/index.ts') ?? ''), 'index.ts 에 standup 등록')
 must(/standup/.test(read('src/lib/command-registry.ts') ?? ''), 'command-registry 등록')
 must(/standup/.test(read('src/lib/cli-args.ts') ?? ''), 'cli-args 등록')
+// Phase 2: 로컬 docs/log DevLog 연동(공유 devlog 모듈)
+must(existsSync('src/daily/devlog.ts'), 'src/daily/devlog.ts 존재 (Phase 2 공유)')
+must(/readDevLogs/.test(read('src/daily/standup.ts') ?? ''), 'standup 이 readDevLogs 로 DevLog 연동')
+must(existsSync('tests/daily/devlog.test.ts'), 'devlog 단위테스트 존재')
 
 if (pass) { console.log('✅ goal 32 gate passes'); process.exit(0) }
 console.log('❌ goal 32 gate failed'); process.exit(1)

--- a/scripts/check-goal-33.mjs
+++ b/scripts/check-goal-33.mjs
@@ -79,6 +79,9 @@ must(!/withWeekday/.test(read('src/commands/standup.ts') ?? ''), 'standup 인라
 must(/today/.test(read('src/index.ts') ?? ''), 'index.ts 에 today 등록')
 must(/'today'/.test(read('src/lib/command-registry.ts') ?? ''), 'command-registry 등록')
 must(/'today'/.test(read('src/lib/cli-args.ts') ?? ''), 'cli-args 등록')
+// Phase 2: 오늘 docs/log DevLog 연동(Goal 32 공유 devlog 모듈 재사용)
+must(existsSync('src/daily/devlog.ts'), 'src/daily/devlog.ts 존재 (공유)')
+must(/readDevLogs/.test(read('src/daily/today.ts') ?? ''), 'today 가 readDevLogs 로 DevLog 연동')
 
 if (pass) { console.log('✅ goal 33 gate passes'); process.exit(0) }
 console.log('❌ goal 33 gate failed'); process.exit(1)

--- a/src/daily/devlog.ts
+++ b/src/daily/devlog.ts
@@ -1,0 +1,61 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { stripBom } from '../lib/read-json.js'
+import type { DateRange, DevLogEntry } from './types.js'
+
+// Goal 32·33 Phase 2 — 로컬 dev log(docs/log/YYYY-MM-DD-*.md) 연동(공유).
+// Notion 아님 — 레포 실제 dev log 위치(CLAUDE.md). 결정적·인증 불요.
+
+// frontmatter date: 우선, 없으면 파일명 'YYYY-MM-DD' 접두사.
+export function devLogDate(filename: string, content: string): string | null {
+  const fm = content.match(/^date:\s*(\d{4}-\d{2}-\d{2})/m)
+  if (fm) return fm[1]
+  const fn = filename.match(/(\d{4}-\d{2}-\d{2})/)
+  return fn ? fn[1] : null
+}
+
+// 첫 '# ' 제목 — 앞의 'YYYY-MM-DD — ' 접두사 제거.
+export function devLogTitle(content: string): string {
+  const m = content.match(/^#\s+(.+)$/m)
+  if (!m) return '(제목 없음)'
+  return m[1].replace(/^\d{4}-\d{2}-\d{2}\s*[—-]\s*/, '').trim()
+}
+
+// '## 교훈' 섹션 첫 비어있지 않은 줄(있으면).
+export function devLogLesson(content: string): string | undefined {
+  const m = content.match(/^#{2,}\s*교훈[^\n]*\n+([^\n#]+)/m)
+  return m ? m[1].trim() : undefined
+}
+
+export function parseDevLog(filename: string, content: string, fallbackDate: string): DevLogEntry {
+  const text = stripBom(content)
+  return {
+    date: devLogDate(filename, text) ?? fallbackDate,
+    title: devLogTitle(text),
+    lesson: devLogLesson(text),
+  }
+}
+
+// docs/log/ 에서 range 안의 dev log 읽기. 디렉터리 없거나 읽기 실패 → 빈 배열(폴백).
+export function readDevLogs(logDir: string, range: DateRange): DevLogEntry[] {
+  let names: string[]
+  try {
+    names = readdirSync(logDir)
+  } catch {
+    return []
+  }
+  const out: DevLogEntry[] = []
+  for (const name of names) {
+    if (!name.endsWith('.md')) continue
+    const dm = name.match(/(\d{4}-\d{2}-\d{2})/)
+    if (!dm) continue
+    const date = dm[1]
+    if (date < range.start || date > range.end) continue
+    try {
+      out.push(parseDevLog(name, readFileSync(join(logDir, name), 'utf-8'), date))
+    } catch {
+      // 읽기 실패한 항목은 건너뜀(나머지 계속)
+    }
+  }
+  return out
+}

--- a/src/daily/standup.ts
+++ b/src/daily/standup.ts
@@ -3,6 +3,7 @@ import { commitsInRange, activityDates, fetchRecentCommitSummaries } from './git
 import { toGoalStates, recommendGoals, doneGoalsOnDay, unresolvedGoals } from './goals.js'
 import { listGoals } from '../lib/goal-frontmatter.js'
 import { localDate } from '../lib/date.js'
+import { readDevLogs } from './devlog.js'
 import type { StandupReport, CommitSummary, GoalState, DevLogEntry } from './types.js'
 import type { ParsedGoal } from '../lib/goal-frontmatter.js'
 
@@ -34,6 +35,7 @@ export function buildStandupReport(input: {
 export async function runStandup(deps?: {
   asOf?: string
   goalsDir?: string
+  logDir?: string
 }): Promise<StandupReport> {
   const asOf = deps?.asOf ?? localDate()
   let commits: CommitSummary[] = []
@@ -54,6 +56,7 @@ export async function runStandup(deps?: {
     commits,
     goalStates,
     doneGoalsByDay: (day) => doneGoalsOnDay(goals, day),
-    devlogs: [], // Phase 2: Dev Log 노션 데이터소스 연동
+    // Phase 2: 로컬 docs/log dev log 연동. 모든 날짜를 넘겨 lastActiveDay 산출에 반영(buildStandupReport 가 마지막 활동일로 필터).
+    devlogs: readDevLogs(deps?.logDir ?? 'docs/log', { start: '2000-01-01', end: asOf }),
   })
 }

--- a/src/daily/today.ts
+++ b/src/daily/today.ts
@@ -2,6 +2,7 @@ import { commitsInRange, fetchRecentCommitSummaries } from './gitlog.js'
 import { doneGoalsOnDay } from './goals.js'
 import { listGoals } from '../lib/goal-frontmatter.js'
 import { localDate } from '../lib/date.js'
+import { readDevLogs } from './devlog.js'
 import type { DateRange, CommitSummary, GoalState, DevLogEntry, TodayReport } from './types.js'
 import type { ParsedGoal } from '../lib/goal-frontmatter.js'
 
@@ -46,7 +47,7 @@ export function buildTodayReport(input: {
 }
 
 // 실제 수집 + 병합(CLI 진입점). Phase 1: git + goal (DevLog Phase 2 → 빈 배열 폴백).
-export async function runToday(deps?: { today?: string; goalsDir?: string }): Promise<TodayReport> {
+export async function runToday(deps?: { today?: string; goalsDir?: string; logDir?: string }): Promise<TodayReport> {
   const today = deps?.today ?? localDate()
   let commits: CommitSummary[] = []
   try {
@@ -64,6 +65,7 @@ export async function runToday(deps?: { today?: string; goalsDir?: string }): Pr
     today,
     commits,
     doneGoals: doneGoalsOnDay(goals, today),
-    devlogs: [], // Phase 2: Dev Log 연동
+    // Phase 2: 오늘 docs/log dev log → devlogCount + lessons.
+    devlogs: readDevLogs(deps?.logDir ?? 'docs/log', { start: today, end: today }),
   })
 }

--- a/tests/daily/devlog.test.ts
+++ b/tests/daily/devlog.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { devLogDate, devLogTitle, devLogLesson, parseDevLog, readDevLogs } from '../../src/daily/devlog.js'
+
+const SAMPLE = `---
+date: 2026-06-07
+project: VHK
+type: 세션로그
+---
+
+# 2026-06-07 — doctor Phase 2 출시
+
+## 요약
+진단 3종 추가.
+
+## 교훈
+게이트 grep 가드는 주석 리터럴도 잡으니 조심.
+`
+
+describe('devLogDate', () => {
+  it('frontmatter date 우선', () => {
+    expect(devLogDate('2026-01-01-x.md', SAMPLE)).toBe('2026-06-07')
+  })
+  it('frontmatter 없으면 파일명에서', () => {
+    expect(devLogDate('2026-06-05-foo.md', '# 제목')).toBe('2026-06-05')
+  })
+})
+
+describe('devLogTitle', () => {
+  it('첫 # 제목에서 날짜 접두사 제거', () => {
+    expect(devLogTitle(SAMPLE)).toBe('doctor Phase 2 출시')
+  })
+})
+
+describe('devLogLesson', () => {
+  it('## 교훈 섹션 첫 줄', () => {
+    expect(devLogLesson(SAMPLE)).toContain('주석 리터럴')
+  })
+  it('교훈 없으면 undefined', () => {
+    expect(devLogLesson('# 제목\n## 요약\n내용')).toBeUndefined()
+  })
+})
+
+describe('parseDevLog', () => {
+  it('date·title·lesson 추출', () => {
+    const e = parseDevLog('2026-06-07-x.md', SAMPLE, '2026-06-07')
+    expect(e.date).toBe('2026-06-07')
+    expect(e.title).toBe('doctor Phase 2 출시')
+    expect(e.lesson).toBeTruthy()
+  })
+})
+
+describe('readDevLogs', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'vhk-log-'))
+    writeFileSync(join(dir, '2026-06-05-a.md'), '# 2026-06-05 — A\n## 교훈\n교훈A')
+    writeFileSync(join(dir, '2026-06-07-b.md'), '# 2026-06-07 — B\n내용')
+    writeFileSync(join(dir, 'not-a-log.txt'), 'ignore')
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('range 안의 .md dev log 만', () => {
+    const r = readDevLogs(dir, { start: '2026-06-07', end: '2026-06-07' })
+    expect(r).toHaveLength(1)
+    expect(r[0].title).toBe('B')
+  })
+  it('넓은 range → 전부', () => {
+    expect(readDevLogs(dir, { start: '2000-01-01', end: '2026-06-07' })).toHaveLength(2)
+  })
+  it('디렉터리 없으면 빈 배열', () => {
+    expect(readDevLogs(join(dir, 'nope'), { start: '2000-01-01', end: '2026-06-07' })).toEqual([])
+  })
+})


### PR DESCRIPTION
## Goal 32·33 — Phase 2 DevLog 연동 (두 goal 공유)

standup·today 의 Phase 2 = **로컬 dev log(docs/log) 연동**. 공유 `daily/devlog.ts`.

## 동작 (도그푸딩)
```
🌅 Standup
  📌 어제 한 일 (마지막 활동일: 2026-06-07)
    📝 HARD_STOP 가드 완성 + 원자적 쓰기 완성 → v2.4.2 발행   ← dev log
```
- `standup`: 어제(마지막 활동일) dev log 제목 표시 + 활동일 산출에 dev log 날짜 반영.
- `today`: 오늘 dev log → devlogCount + 교훈(lessons).

## 공유 모듈 `daily/devlog.ts`
- `docs/log/YYYY-MM-DD-*.md` 파싱: frontmatter `date:` + 첫 `# 제목` + `## 교훈` 섹션. range 필터.
- **Notion 아님** — 레포 실제 dev log 위치(CLAUDE.md). 결정적·인증 불요.
- **Goal 32 가 만들고 Goal 33 이 재사용**(daily 재사용 사슬 연장).

## 불변규칙
디렉터리 없으면 빈 배열 폴백(git/goal 실패해도 리포트 생성). execSync 0 · raw JSON.parse 0(readFileSync+regex).

## 게이트
check-goal-32 ✅ · check-goal-33 ✅ (devlog 검증 추가) · tsc 0 · 전체 **1044 green**(+9).

## 보류 (Phase 3 선택)
standup `--if-stale` 터미널 자동실행 앵커 · 텔레그램 알림 — 편의 기능(rc 자동수정 금지 원칙상 신중). DevLog 데이터 통합이 Phase 2 핵심.

> goal 32·33 → DONE. 한 PR=두 goal(공유 모듈). 머지 리뷰 후 사람.