### PR TITLE
chore(goal-33): vhk today v0 완료 닫기 (status DONE)

### DIFF
--- a/goals/33-today.md
+++ b/goals/33-today.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 33
 title: vhk today — 저녁 자축·회고(오늘 해낸 것 담백 요약) — P2
-status: IN_PROGRESS
+status: DONE
 priority: P2
 created: 2026-06-06
+completed: 2026-06-07
 depends_on: goal-32-standup
 ---
 
@@ -27,12 +28,12 @@ depends_on: goal-32-standup
 - 출력 = 🎉 해낸 것(카운트 + 항목) + 💬 격려 문구(간단 템플릿 풀에서 랜덤, 톤 절제).
 
 ## Completion Check
-- [ ] `vhk today`가 오늘 성과 요약(커밋·완료 goal·Dev Log 카운트) + 격려 출력
-- [ ] daily 모듈을 Goal 32와 공유(today 범위 필터만 차이, 중복 구현 0)
-- [ ] 단순 카운트 — LLM 호출 0(오프라인 동작)
-- [ ] today 범위 필터(KST 00:00~now) vitest mock
-- [ ] vhk goal sync → check-goal-33.mjs → vhk goal check --id 33 통과
-- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
+- [x] `vhk today`가 오늘 성과 요약(커밋·완료 goal·Dev Log 카운트) + 격려 출력 (runToday + buildTodayReport + pickMessage)
+- [x] daily 모듈을 Goal 32와 공유(today 범위 필터만 차이, 중복 구현 0) — gitlog/goals 재사용
+- [x] 단순 카운트 — LLM 호출 0(오프라인 동작) — buildTodayReport 순수함수, execSync/fetch 0
+- [x] today 범위 필터(KST 00:00~now) vitest mock — dayRange + buildTodayReport "어제 제외" 테스트
+- [x] vhk goal sync → check-goal-33.mjs → vhk goal check --id 33 통과
+- [x] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
 
 ## 제외 범위 (v0)
 - streak/게임 요소(담백함 우선) / AI 의미요약(`--smart` 후속) / 마감 시각 자동 알림(Phase 3)


### PR DESCRIPTION
## 요약
Goal 33(`vhk today`)을 **DONE 으로 닫음**. 코드는 Phase 1(#162)이 v0 전부 구현 — 이 PR 은 전 완료조건 실재 검증 후 status 전이(구현 변경 0).

## 검증 (거짓완료 자기검증)
- `check-goal-33.mjs` **풀게이트 통과** (typecheck + test + build + 정적검사 18종).
- Completion Check 전 항목 실재 확인:
  - `vhk today` 오늘 성과(커밋·완료goal·devlog) + 격려 — `runToday`/`buildTodayReport`/`pickMessage`
  - daily 모듈 Goal 32 공유(gitlog/goals 재사용, 중복 0)
  - LLM 0·오프라인 — `buildTodayReport` 순수함수(execSync/fetch 0)
  - KST 범위 필터 — `dayRange` + `buildTodayReport` '어제 제외' 테스트
- Phase 2/3(`--smart`·마감 알림)은 v0 **제외 범위** — 이 goal 완료와 무관.

## 변경
- `goals/33-today.md`: status IN_PROGRESS → DONE + completed 2026-06-07 + Completion Check 체크.

🤖 Generated with [Claude Code](https://claude.com/claude-code)