### PR TITLE
chore(goals): register goals 42-46 (self-gate automation backlog)

### DIFF
--- a/goals/42-release-readiness-gate.md
+++ b/goals/42-release-readiness-gate.md
@@ -1,0 +1,44 @@
+---
+vhk_format: 1
+type: goal
+id: 42
+title: 릴리즈 준비 게이트 자동화 — CHANGELOG 본문/Unreleased 모순 차단 — P0
+status: NOT_STARTED
+priority: P0
+created: 2026-06-07
+leads_to: 빈 본문 릴리즈 차단 (자기게이트 자동화)
+---
+
+# Goal 42: 릴리즈 준비 게이트 자동화
+
+> 출처: VHK 핸드오프(2026-06-07, 실측) Task A. VHK가 자기 철학("게이트 통과 전 done 금지")을
+> 자기 자신한테 강제하게 만드는 작업의 P0. v2.4.0이 CHANGELOG 본문 빈칸인 채 버전만 올라간 드리프트가 동기.
+
+## 근거 (실측)
+- `release.yml`은 태그 push **후** 게시 전용이라 거기서 막으면 늦다(태그가 이미 생성됨).
+- `check-goal-*.mjs`는 CI 미연결(주석 "릴리즈 전·수동"). → 본문 빈 채 버전 올려도 막는 게 없음(v2.4.0 빈칸 사고).
+
+## 동작 (설계 후보)
+- (권장) `vhk publish` 흐름에서 **태그 push 직전** release-readiness 게이트 호출, 또는
+- `ci.yml`에 버전 상승 감지 스텝 추가(main 푸시 시 검사).
+- fail(비0 종료) 조건:
+  1. `## [<현재 package.json version>]` 섹션이 비었거나 플레이스홀더("작성 필요" 등).
+  2. `[Unreleased]`가 안 빈데 새 버전 본문이 빈 모순 상태.
+  3. (선택) footer에 `[<version>]` 비교 링크 없음.
+
+## 수용 기준
+- 본문 빈 채 버전 올리면 CI/publish가 빨간불로 막는다. 통과 시 자동 GitHub Release 노트 정상 생성.
+- 본문 빈 버전 케이스가 게이트에서 fail하는 회귀 테스트 포함.
+
+## Completion Check
+- [ ] release-readiness 게이트 구현(publish 흐름 또는 ci.yml 스텝)
+- [ ] CHANGELOG 본문 빈/플레이스홀더 fail
+- [ ] Unreleased↔새 버전 본문 모순 fail
+- [ ] 본문 빈 버전 케이스 회귀 테스트
+- [ ] check-goal-42.mjs 통과
+- [ ] 공통 게이트(typecheck+test+build) 통과, 회귀 0
+
+## Mandatory Reading
+- src/commands/publish.ts
+- .github/workflows/ci.yml · .github/workflows/release.yml
+- CHANGELOG.md

--- a/goals/43-goal-code-drift-gate.md
+++ b/goals/43-goal-code-drift-gate.md
@@ -1,0 +1,40 @@
+---
+vhk_format: 1
+type: goal
+id: 43
+title: goal 상태↔코드 현실 드리프트 게이트 — shipped인데 NOT_STARTED 차단 — P1
+status: NOT_STARTED
+priority: P1
+created: 2026-06-07
+leads_to: goal 상태 신뢰성 (Goal 19 정정 포함)
+---
+
+# Goal 43: goal 상태↔코드 현실 드리프트 게이트
+
+> 출처: VHK 핸드오프(2026-06-07, 실측) Task D. v2.4.0 CHANGELOG 빈칸과 같은 병
+> (사람이 수동 갱신하다 깜빡, 아무도 안 막음).
+
+## 근거 (실측)
+- Goal 19(pattern) frontmatter `status: NOT_STARTED`인데 `src/commands/pattern.ts`는 이미 풀구현 + v2.1.0 출시.
+- 드리프트가 산 증거로 살아있음.
+
+## 동작
+- goal frontmatter `status`가 코드 현실과 어긋나는지 점검하는 게이트(`vhk goal check`/preflight 확장).
+- 최소: 구현이 shipped됐는데 status가 NOT_STARTED인 goal을 fail/경고.
+- **먼저 Goal 19 status부터 실제(DONE + version)로 정정.**
+
+## 수용 기준
+- 코드 shipped인데 goal 상태 NOT_STARTED로 남으면 CI/preflight가 잡는다.
+
+## Completion Check
+- [ ] Goal 19 status를 DONE(+version)으로 정정
+- [ ] goal status↔코드 드리프트 점검 게이트 구현
+- [ ] shipped인데 NOT_STARTED면 fail/경고
+- [ ] 회귀 테스트
+- [ ] check-goal-43.mjs 통과
+- [ ] 공통 게이트(typecheck+test+build) 통과, 회귀 0
+
+## Mandatory Reading
+- src/commands/goal.ts
+- src/lib/goal-frontmatter.ts
+- goals/19-pattern.md

--- a/goals/44-evidence-sha-binding.md
+++ b/goals/44-evidence-sha-binding.md
@@ -1,0 +1,38 @@
+---
+vhk_format: 1
+type: goal
+id: 44
+title: 증거↔커밋 SHA 바인딩 — verify 리포트에 HEAD SHA·dirty 기록 — P1
+status: NOT_STARTED
+priority: P1
+created: 2026-06-07
+leads_to: 증거 신선도 검증 (낡은 PASS 차단)
+---
+
+# Goal 44: 증거↔커밋 SHA 바인딩
+
+> 출처: VHK 핸드오프(2026-06-07, 실측) Task E. Task B(증거를 남김)와 묶음 — 이건 그 증거를 지금 코드에 묶는 작업.
+
+## 근거 (실측)
+- `latest.json`은 종료코드는 기록해도 **git 커밋 SHA가 없어** "이 증거가 지금 이 코드 것"임을 증명 못 함.
+- 낡은 PASS가 코드 변경 후에도 유효한 척 남는다.
+
+## 동작
+- `verifyEvidence`가 리포트 쓸 때 현재 `HEAD` SHA(+ working tree dirty 여부)를 `VerifyReport`에 기록.
+- 릴리즈/완료 게이트에서 원장 SHA ≠ HEAD 또는 dirty면 경고/fail(증거 신선도 불일치).
+- SHA 수집은 기존 git-access 통로 사용(새 execSync 금지 — Goal 46과 맞물림).
+
+## 수용 기준
+- 코드 바뀐 뒤 낡은 증거로 done 처리하면 게이트가 "증거 불일치"로 잡는다.
+
+## Completion Check
+- [ ] VerifyReport에 HEAD SHA + dirty 기록
+- [ ] 게이트에서 SHA≠HEAD/dirty 시 경고·fail
+- [ ] SHA 수집은 기존 git-access 통로(새 execSync 없음)
+- [ ] 회귀 테스트
+- [ ] check-goal-44.mjs 통과
+- [ ] 공통 게이트(typecheck+test+build) 통과, 회귀 0
+
+## Mandatory Reading
+- src/commands/verify.ts · src/commands/verify-report.ts
+- src/lib/git.ts · src/lib/git-repo.ts · src/lib/exec.ts

--- a/goals/45-evidence-ledger.md
+++ b/goals/45-evidence-ledger.md
@@ -1,0 +1,36 @@
+---
+vhk_format: 1
+type: goal
+id: 45
+title: 증거 원장 커밋 — reports 요약(ledger.jsonl) git 추적 — P1
+status: NOT_STARTED
+priority: P1
+created: 2026-06-07
+leads_to: 릴리즈 증거 영속화 (레포만 보고 확인)
+---
+
+# Goal 45: 증거 원장 커밋
+
+> 출처: VHK 핸드오프(2026-06-07, 실측) Task B. Goal 44 SHA와 묶음.
+
+## 근거 (실측)
+- `reports/`가 `.vhk/.gitignore`로 제외(휘발) → 레포만 보고 "그 릴리즈가 증거 통과였나" 확인 불가.
+
+## 동작
+- `reports/` 전체 커밋은 부담 → 요약 한 줄(`reports/ledger.jsonl`에 `{version, date, gates: PASS/FAIL, sha}` append)만 git 추적,
+- 또는 release 아티팩트로 `latest.json` 첨부.
+- Goal 44 SHA와 묶음.
+
+## 수용 기준
+- 릴리즈 증거 통과 상태가 레포에 영속으로 남는다.
+
+## Completion Check
+- [ ] reports/ledger.jsonl(요약 한 줄) git 추적 또는 release 아티팩트 첨부
+- [ ] 각 항목에 version·date·gates·sha 기록
+- [ ] 회귀 테스트
+- [ ] check-goal-45.mjs 통과
+- [ ] 공통 게이트(typecheck+test+build) 통과, 회귀 0
+
+## Mandatory Reading
+- .vhk/.gitignore
+- src/commands/verify.ts

--- a/goals/46-git-access-single-path.md
+++ b/goals/46-git-access-single-path.md
@@ -1,0 +1,38 @@
+---
+vhk_format: 1
+type: goal
+id: 46
+title: git-access 레이어 단일 통로화 — safeExecFile 통일 + 중복 함수 통합 — P2
+status: NOT_STARTED
+priority: P2
+created: 2026-06-07
+leads_to: git 호출 SoT 단일화 (회귀 0)
+---
+
+# Goal 46: git-access 레이어 단일 통로화
+
+> 출처: VHK 핸드오프(2026-06-07, 실측) Task F. Goal 44·45의 선행(SHA 수집 통로 정리).
+
+## 근거 (실측)
+- git 접근이 3엔진 — `safeExecFile`(exec.ts) / `execFileSync('git',…)` 직접(git-repo.ts, 우회) / `simple-git`(git.ts).
+- 중복: "커밋 있나?" = `hasAnyCommits`(simple-git) vs `countLocalCommits`(execFileSync); "레포냐?" = `isGitRepo`(simple-git) vs `getGitRoot`(execFileSync). 에러 컨벤션 4종.
+
+## 동작
+- git-repo.ts 직접 `execFileSync('git',…)`를 `safeExecFile` 경유로 통일(timeout 백스톱·에러 일관성).
+- 커밋 존재/레포 감지 중복을 함수 하나로 통합.
+- `simple-git` 유지(diff/log 파싱 편의) vs 제거(의존성 감소) 판단.
+- git-porcelain.ts 순수 파서는 유지.
+
+## 수용 기준
+- git 호출이 단일 통로로 모이고 같은 질문에 함수 하나만 남는다. 회귀 0.
+
+## Completion Check
+- [ ] git-repo.ts 직접 execFileSync → safeExecFile 통일
+- [ ] 커밋존재/레포감지 중복 함수 통합
+- [ ] simple-git 유지/제거 판단·반영
+- [ ] 회귀 테스트
+- [ ] check-goal-46.mjs 통과
+- [ ] 공통 게이트(typecheck+test+build) 통과, 회귀 0
+
+## Mandatory Reading
+- src/lib/exec.ts · src/lib/git.ts · src/lib/git-repo.ts · src/lib/git-porcelain.ts


### PR DESCRIPTION
## 무엇
자기 게이트 자동화 백로그 **Goal 42~46을 `goals/`에 등록**한다. 전부 `status: NOT_STARTED` — 등록만 하고 **구현은 goal별 개별 PR**로 들어간다 (한 PR=한 goal).

| Goal | 우선순위 | 내용 | 출처 Task |
|---|---|---|---|
| 42 | **P0** | 릴리즈 준비 게이트 자동화 (CHANGELOG 본문/Unreleased 모순 차단) | A |
| 43 | P1 | goal 상태↔코드 드리프트 게이트 (shipped인데 NOT_STARTED 차단, **Goal 19 정정 포함**) | D |
| 44 | P1 | 증거↔커밋 SHA 바인딩 (verify 리포트에 HEAD SHA·dirty) | E |
| 45 | P1 | 증거 원장 커밋 (reports 요약 ledger.jsonl git 추적) | B |
| 46 | P2 | git-access 단일 통로화 (safeExecFile 통일 + 중복 함수 통합) | F |

## 왜
VHK가 자기 철학("게이트 통과 전 done 금지 · 항상 증거")을 자기 자신한테 강제하게 만든다. v2.4.0 CHANGELOG 빈칸 드리프트 + Goal 19 frontmatter NOT_STARTED인데 pattern.ts 풀구현(드리프트 산 증거)이 동기.

## 권장 진행 순서
42(P0) → 43(첫 일 = Goal 19 status 정정) → 46(44·45 선행) → 44 → 45

## 주의
- 이 PR은 **문서 등록만**. raw 등록이라 `check-goal-42~46.mjs` scaffold는 아직 없음 → 각 goal 구현 착수 시 생성.
- 본문/frontmatter는 핸드오프 실측본 기준.