### PR TITLE
chore(state): Goal 33 DONE 반영 — next-task/LIVE 갱신

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,6 @@ tags: [process, constitution]
 - **테스트:** 1035 pass · **MCP tools:** 29
 - **Phase:** HARD_STOP 가드 완성(Goal 34~36·39·41) + 원자적 쓰기 완성(Goal 37~38·40) · v2.4.2 발행 완료
 - **블로커:** 없음
-- **진행 중(미발행):** Goal 30(#139 DONE)·Goal 33(#162 IN_PROGRESS)·chore #168 — npm 2.4.2 미포함(발행 베이스 이후 머지) → 다음 2.4.3
-- **다음 할 일:** Goal 33(`vhk today`) 마무리 → 2.4.3 발행. (tag v2.4.2 → 131e3c3 = npm tarball 정확일치, main release 커밋은 09e4b88 — cosmetic 이라 둠)
+- **진행 중(미발행):** Goal 30(#139)·Goal 33(#162/#179 DONE)·chore #168 — npm 2.4.2 미포함(발행 베이스 이후 머지) → 다음 2.4.3
+- **다음 할 일:** 2.4.3 발행 대기(더 모으는 중) — Goal 30·33·#168 묶음. (tag v2.4.2 → 131e3c3 = npm tarball 정확일치, main release 커밋은 09e4b88 — cosmetic 이라 둠)
 - **주의:** publish는 main에서만(#119)·사용자 직접(2FA) / 직접 main push 차단 → PR 경유

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -3,12 +3,11 @@
 > "지금 무엇부터"의 상태 SoT. 버전·테스트 등 사실값은 package.json·CHANGELOG가 SoT.
 
 **갱신:** 2026-06-07
-**Phase:** v2.4.2 발행 완료 — HARD_STOP 가드 완성(Goal 34~36·39·41) + 원자적 쓰기 완성(Goal 37~38·40). main `09e4b88`, 테스트 1035 pass.
+**Phase:** v2.4.2 발행 완료 + Goal 33(`vhk today`) v0 완료(#179). HARD_STOP 가드 완성(34~36·39·41) + 원자적 쓰기 완성(37~38·40) + today 회고. 테스트 1035+ pass.
 
 ## 다음 할 일
-- **Goal 33 (`vhk today`) 마무리** — 현재 IN_PROGRESS(Phase 1만 머지 #162). Phase 2+ 완료 후 DONE 전이.
-- **2.4.3 발행** — Goal 30(#139, DONE)·Goal 33·chore #168 이 npm 2.4.2 미포함(발행 베이스 이후 머지) → CHANGELOG [Unreleased] 적재됨. Goal 33 끝내고(또는 goal 2~3개 더 모아) 묶어 발행.
-- 나머지 미완 goal 14개 (goals/ 동적 계산 — `vhk goal next`).
+- **2.4.3 발행 (대기 — 더 모으는 중)** — Goal 30(#139)·Goal 33(#162/#179)·chore #168 이 npm 2.4.2 미포함(발행 베이스 이후 머지) → CHANGELOG [Unreleased] 적재됨. goal 몇 개 더 모아 묶어 발행 예정.
+- 나머지 미완 goal (goals/ 동적 계산 — `vhk goal next`).
 
 ## 블로커
 - 없음


### PR DESCRIPTION
Goal 33(`vhk today`)이 #179 로 DONE → 상태 문서를 발행본에 맞춤.

- `docs/state/next-task.md`: '다음 할 일' 에서 'Goal 33 마무리' 제거 → **2.4.3 발행 대기(더 모으는 중)** 로. Phase 에 today v0 완료 반영.
- `CLAUDE.md` LIVE: 진행중(Goal 33 DONE)·다음할일 갱신. 버전줄 불변(v2.4.2, version-sync 통과).

문서 전용. 코드 변경 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)