### PR TITLE
fix(secure): .cursor 스캔 + Authorization Bearer 자격증명 탐지 (#170)

### DIFF
--- a/src/lib/scan-files.ts
+++ b/src/lib/scan-files.ts
@@ -18,7 +18,8 @@ const IGNORE_DIRS = new Set([
   '.pnpm',
   '.idea',
   '.claude',
-  '.cursor',
+  // '.cursor' 는 제외하지 않음 (#170): tracked 에이전트 설정(mcp.json 등)에 자격증명이
+  // 들어갈 수 있어 스캔 대상. 캐시·생성물은 .gitignore(isPathIgnored)가 거른다.
 ])
 
 const SKIP_FILE_NAMES = new Set([

--- a/src/lib/secret-patterns.ts
+++ b/src/lib/secret-patterns.ts
@@ -60,6 +60,14 @@ export const SECRET_PATTERNS: SecretPattern[] = [
     pattern: /(?:api[_-]?key|apikey|access[_-]?token)\s*[:=]\s*['"]?[A-Za-z0-9_\-]{16,}['"]?/i,
   },
   {
+    // #170: 리터럴 Authorization: Bearer 자격증명. 토큰 문자 클래스가 '$','{' 를 제외하므로
+    // ${env:AUTH_HEADER} 같은 환경변수 참조는 매칭되지 않는다(오탐 방지).
+    id: 'authorization-bearer',
+    name: 'Authorization Bearer Token',
+    severity: 'high',
+    pattern: /Authorization\s*:\s*Bearer\s+[A-Za-z0-9._\-~+/=]{8,}/i,
+  },
+  {
     id: 'password-inline',
     name: 'Inline Password',
     severity: 'high',

--- a/tests/scan-files.test.ts
+++ b/tests/scan-files.test.ts
@@ -30,4 +30,18 @@ describe('scan-files', () => {
 
     fs.rmSync(tmp, { recursive: true })
   })
+
+  // #170: .cursor 는 tracked 에이전트 설정 디렉터리 → walk 대상 (캐시는 gitignore 가 거름)
+  it('.cursor/mcp.json 은 walk 대상에 포함', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-scan-cursor-'))
+    fs.mkdirSync(path.join(tmp, '.cursor'), { recursive: true })
+    fs.writeFileSync(path.join(tmp, '.cursor', 'mcp.json'), '{}\n')
+
+    const scanned: string[] = []
+    walkProjectFiles(tmp, (_abs, rel) => scanned.push(rel))
+
+    expect(scanned).toContain('.cursor/mcp.json')
+
+    fs.rmSync(tmp, { recursive: true })
+  })
 })

--- a/tests/scan-secrets.test.ts
+++ b/tests/scan-secrets.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { findSecretsInLine } from '../src/lib/scan-secrets.js'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { findSecretsInLine, scanProjectForSecrets } from '../src/lib/scan-secrets.js'
 
 // fake AWS key — 자기 레포 secure 스캔에 걸리지 않게 조각 합성.
 // scanner regex (/AKIA[0-9A-Z]{16}/) 는 contiguous 매칭만 잡고 concat 표현은 매칭 안 함.
@@ -16,5 +19,38 @@ describe('scan-secrets', () => {
   it('example 주석 줄은 스킵', () => {
     const findings = findSecretsInLine(`// example ${FAKE_AWS_KEY}`, 'a.ts', 1)
     expect(findings).toHaveLength(0)
+  })
+
+  // #170: Authorization Bearer 리터럴 자격증명 탐지.
+  // "Bearer" 경계서 concat 분리 → 자기 레포 secure 스캔 자기탐지 방지 (런타임엔 합쳐짐).
+  it('Authorization Bearer 리터럴 자격증명 탐지', () => {
+    const line = 'Authorization: Bearer' + ' tok_AbCdEf123456'
+    const findings = findSecretsInLine(line, '.cursor/mcp.json', 1)
+    expect(findings.filter(f => f.patternId === 'authorization-bearer')).toHaveLength(1)
+  })
+
+  it('Authorization Bearer 환경변수 참조(${env:...})는 오탐 안 함', () => {
+    const line = 'Authorization: Bearer ${env:AUTH_HEADER}'
+    const findings = findSecretsInLine(line, '.cursor/mcp.json', 1)
+    expect(findings.filter(f => f.patternId === 'authorization-bearer')).toHaveLength(0)
+  })
+
+  // #170 회귀 픽스처: tracked .cursor/mcp.json 의 Bearer 자격증명을 프로젝트 스캔이 탐지.
+  it('회귀: .cursor/mcp.json 의 Bearer 자격증명을 scanProjectForSecrets 가 탐지', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-scan-cursor-'))
+    try {
+      fs.mkdirSync(path.join(tmp, '.cursor'), { recursive: true })
+      const headerArg = 'Authorization: Bearer' + ' tok_AbCdEf123456'
+      fs.writeFileSync(
+        path.join(tmp, '.cursor', 'mcp.json'),
+        JSON.stringify({ mcpServers: { x: { args: ['--header', headerArg] } } }, null, 2)
+      )
+      const { findings } = scanProjectForSecrets(tmp)
+      expect(
+        findings.some(f => f.patternId === 'authorization-bearer' && f.file === '.cursor/mcp.json')
+      ).toBe(true)
+    } finally {
+      fs.rmSync(tmp, { recursive: true })
+    }
   })
 })


### PR DESCRIPTION
## 무엇 (#170)
`vhk secure scan` 의 두 가지 보안 사각지대 수정.

1. **`.cursor` 스캔 누락** — `.cursor` 가 `IGNORE_DIRS` 에 박혀 있어 tracked 한 `.cursor/mcp.json` 의 자격증명을 스캔조차 안 했음. 제거 → 스캔 대상에 포함. 캐시·생성물은 기존대로 `.gitignore`(`isPathIgnored`)가 거른다(gitignore 된 `.cursor` 는 여전히 스킵).
2. **Authorization Bearer 미탐지** — 리터럴 `Authorization: Bearer <token>` 패턴 추가(severity `high` → 스캔 실패 처리).

## 오탐 방지
토큰 문자 클래스가 `$`, `{` 를 제외 → `${env:AUTH_HEADER}` 같은 환경변수 참조는 매칭 안 됨.

## 검증
- TDD red→green (신규 테스트 4개)
- 엣지케이스 10종 직접 검증(대소문자/콜론공백/짧은토큰/placeholder/env참조/prose)
- 적대적 리뷰 통과(ReDoS 없음·gitignore 이중필터·exitCode 게이트 확인)
- 전체 게이트: `pnpm build` 성공 · **1039 tests passed**

## 회귀 픽스처
tracked `.cursor/mcp.json` 의 Bearer 자격증명을 프로젝트 스캔이 탐지하는지 + env 참조 오탐 안 함 + `.cursor` walk 포함 테스트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)