### PR TITLE
fix(sync): CLAUDE.md 코딩/커밋/아키텍처 + VHK 운영 섹션 전파 (#133, #149)

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -17,7 +17,15 @@ interface RulesSection {
 }
 
 const CURSORRULES_KEYS = ['코딩 규칙', '기술 스택', '아키텍처', '디자인', 'Anti-patterns', '커밋']
-const CLAUDE_MD_KEYS = ['기록', '로그', 'ADR', '트러블슈팅', 'TIL', '/done', '체크리스트']
+// #149: 'VHK 운영'(이슈 정책 등 운영 규약)을 매핑 — CLAUDE.md/AGENTS.md record 그룹으로 전파.
+// (코딩 타깃에는 안 들어감 — 운영 규약은 코딩 규칙이 아니므로 의도된 분리.)
+// 키를 'VHK 운영'으로 한정 — '운영'만 쓰면 '## 자동 운영 스크립트' 등 무관 섹션까지 substring 오탐.
+const CLAUDE_MD_KEYS = ['기록', '로그', 'ADR', '트러블슈팅', 'TIL', '/done', '체크리스트', 'VHK 운영']
+
+// #133: CLAUDE.md 자동생성 블록이 다른 타깃(AGENTS.md 등)과 동일하게 코딩+기록 섹션을 모두
+// 담도록 통합 키셋. toClaudeMd 출력과 마이그레이션(stripLegacyAutogen)의 옛 자동생성 판정이
+// 같은 집합을 써야 재생성 섹션이 사용자 섹션으로 오인돼 중복되지 않는다.
+const VHK_MANAGED_KEYS = [...CURSORRULES_KEYS, ...CLAUDE_MD_KEYS]
 
 /**
  * RULES.md 섹션 중 어느 sync 타깃 키(CURSORRULES_KEYS ∪ CLAUDE_MD_KEYS)에도
@@ -183,10 +191,10 @@ const CLAUDE_AUTOGEN_BANNER = '> ⚡ 아래 규칙 섹션은 RULES.md에서 자�
 const VHK_BLOCK_START = '<!-- vhk:rules:start -->'
 const VHK_BLOCK_END = '<!-- vhk:rules:end -->'
 
-/** vhk 관리 블록(배너 + record 섹션)을 마커로 감싸 생성. toClaudeMd 가 매 sync 이 형태로 재생성한다. */
-function buildVhkBlock(recordSections: RulesSection[]): string {
+/** vhk 관리 블록(배너 + 관리 섹션=코딩+기록/운영)을 마커로 감싸 생성. toClaudeMd 가 매 sync 이 형태로 재생성. */
+function buildVhkBlock(managedSections: RulesSection[]): string {
   const lines = [VHK_BLOCK_START, CLAUDE_AUTOGEN_BANNER, '']
-  for (const section of recordSections) {
+  for (const section of managedSections) {
     lines.push(`## ${section.title}`)
     lines.push(section.content)
     lines.push('')
@@ -246,8 +254,8 @@ function stripLegacyAutogen(existing: string): { cleaned: string; removed: strin
   const preserved: string[] = []
   const keptBodies: string[] = []
   for (const b of blocks) {
-    if (CLAUDE_MD_KEYS.some(k => b.title.includes(k))) {
-      removed.push(b.title) // 옛 자동생성 → record 로 재생성
+    if (VHK_MANAGED_KEYS.some(k => b.title.includes(k))) {
+      removed.push(b.title) // 옛 자동생성(코딩+기록) → vhk 블록으로 재생성 (#133 중복 방지)
     } else {
       preserved.push(b.title) // 사용자 섹션 → 보존
       keptBodies.push(b.body.join('\n').trimEnd())
@@ -282,10 +290,18 @@ export function claudeMdMigration(existing: string): ClaudeMdMigration {
  * 멱등: 마이그레이션 출력에 마커가 박히므로 재호출 시 마커 경로로 동일 결과를 낸다.
  */
 export function toClaudeMd(sections: RulesSection[], existing: string): string {
-  const recordSections = sections.filter(s =>
-    CLAUDE_MD_KEYS.some(k => s.title.includes(k))
-  )
-  const vhkBlock = buildVhkBlock(recordSections)
+  // #133: CLAUDE.md 도 .cursorrules·AGENTS.md 수준으로 코딩 규칙/커밋/아키텍처까지 전파.
+  // 코딩 섹션 먼저, 그 다음 기록/운영 섹션 (AGENTS.md 순서와 동일). 한 섹션이 양쪽 키에
+  // 걸쳐도 1회만 — 중복 emit 방지(dedup).
+  const codingSections = sections.filter(s => CURSORRULES_KEYS.some(k => s.title.includes(k)))
+  const recordSections = sections.filter(s => CLAUDE_MD_KEYS.some(k => s.title.includes(k)))
+  const seen = new Set<string>()
+  const managedSections = [...codingSections, ...recordSections].filter(s => {
+    if (seen.has(s.title)) return false
+    seen.add(s.title)
+    return true
+  })
+  const vhkBlock = buildVhkBlock(managedSections)
 
   const split = splitVhkBlock(existing)
   if (split) {

--- a/tests/sync-guard.test.ts
+++ b/tests/sync-guard.test.ts
@@ -8,6 +8,8 @@ import {
   parseRulesMd,
   deriveProjectName,
   toClaudeMd,
+  toAgentsMd,
+  findUnmappedSections,
   claudeMdMigration,
 } from '../src/commands/sync.js'
 import { listBackups } from '../src/lib/backup.js'
@@ -359,6 +361,54 @@ tags: [process, documentation]
     expect(r.claudeMigration?.preserved).toEqual(
       expect.arrayContaining(['프로젝트 정보', '코딩 컨벤션', 'MCP 모드 규칙', 'Safety — HARD_STOP', 'Stability Gates'])
     )
+  })
+})
+
+describe('#133 — CLAUDE.md 도 코딩 규칙/커밋/아키텍처 섹션 전파 (다른 타깃과 통일)', () => {
+  const sections = parseRulesMd(RULES) // [코딩 규칙(execSync 금지), 기록 규칙(세션 로그)]
+  const name = deriveProjectName(RULES)
+
+  it('자동생성 블록에 코딩 규칙 본문도 포함 (기록 규칙은 유지)', () => {
+    const out = toClaudeMd(sections, `# 기록 규칙 (${name})\n\n## 현재 상태\n- P5\n`)
+    expect(out).toContain('execSync 금지') // 코딩 규칙 본문 (#133 누락분)
+    expect(out).toContain('## 기록 규칙') // 기록 섹션 회귀 방지
+    expect(out).toContain('## 현재 상태') // 사용자 영역 보존
+  })
+
+  it('코딩 규칙이 마커 안(자동생성 영역)에 들어가 멱등 (재호출 바이트 동일)', () => {
+    const a = toClaudeMd(sections, `# 기록 규칙 (${name})\n\n## 현재 상태\n- P5\n`)
+    expect(toClaudeMd(sections, a)).toBe(a)
+    expect((a.match(/⚡ 아래 규칙 섹션은/g) || []).length).toBe(1)
+  })
+
+  it('마이그레이션 시 코딩 규칙 중복 안 됨 (옛 ## 코딩 규칙 → 재생성 1개만)', () => {
+    const existing = `# 기록 규칙 (${name})\n\n## 코딩 규칙\n- 옛 자동생성 코딩\n\n## 현재 상태\n- P5\n`
+    const out = toClaudeMd(sections, existing)
+    expect((out.match(/## 코딩 규칙/g) || []).length).toBe(1) // 중복 0
+    expect(out).toContain('execSync 금지') // RULES 유래 재생성본
+    expect(out).not.toContain('옛 자동생성 코딩') // 옛것 제거
+  })
+})
+
+describe('#149 — VHK 운영 섹션을 CLAUDE.md/AGENTS.md 로 매핑 (silent drop 제거)', () => {
+  const opsRules = '# P — Rules\n\n## VHK 운영\n- github 이슈 정책 xyz123\n\n## 코딩 규칙\n- a\n'
+
+  it('VHK 운영은 더 이상 unmapped 가 아님 (경고 사라짐)', () => {
+    expect(findUnmappedSections(parseRulesMd(opsRules))).not.toContain('VHK 운영')
+  })
+
+  it('VHK 운영 본문이 CLAUDE.md 에 전파', () => {
+    const out = toClaudeMd(parseRulesMd(opsRules), '# 기록 규칙 (P)\n\n## 현재 상태\n- P5\n')
+    expect(out).toContain('github 이슈 정책 xyz123')
+  })
+
+  it('VHK 운영 본문이 AGENTS.md 에 전파', () => {
+    expect(toAgentsMd(parseRulesMd(opsRules), 'P')).toContain('github 이슈 정책 xyz123')
+  })
+
+  it('프로젝트 정체성은 여전히 unmapped (기존 계약 유지 — 회귀 방지)', () => {
+    const s = parseRulesMd('# P\n\n## 프로젝트 정체성\n- x\n\n## 코딩 규칙\n- a\n')
+    expect(findUnmappedSections(s)).toContain('프로젝트 정체성')
   })
 })
 


### PR DESCRIPTION
## 무엇
`vhk sync` 의 섹션 매핑 사각지대 두 개 수정.

### #133 (severity:high, dogfooding)
CLAUDE.md 자동생성 블록이 **기록 섹션만** 담고 `코딩 규칙`(작업 3원칙)·`커밋`·`아키텍처`를 누락 → 정작 Claude Code 주 규칙 파일에 가드가 빠짐. (다른 7개 타깃은 정상 전파)
- `toClaudeMd` 가 코딩+기록 섹션을 **모두** 마커 블록에 담도록 통일 (AGENTS.md 와 동일 수준).
- 통합 키셋 `VHK_MANAGED_KEYS` 를 마이그레이션(`stripLegacyAutogen`) 판정에도 적용 → 재생성 섹션이 사용자 섹션으로 오인돼 **중복되는 것 차단**.

### #149
`## VHK 운영`(이슈 정책 등)이 어느 타깃에도 매핑 안 돼 **조용히 빠짐**.
- `CLAUDE_MD_KEYS` 에 `'VHK 운영'` 추가 → CLAUDE.md / AGENTS.md 로 전파.
- 키를 `'VHK 운영'`으로 한정 → `## 자동 운영 스크립트` 등 무관 섹션 substring 오탐 방지(적대적 리뷰 반영).
- `## 프로젝트 정체성`은 기존 계약대로 unmapped 경고 유지(회귀 방지).

## 데이터 안전
마이그레이션이 옛 손글 코딩 섹션을 재생성으로 교체하지만, `syncCore` 가 덮어쓰기 전 **항상 백업** + 제거 섹션을 경고 → 영구 손실 없음(복구 가능).

## 검증
- TDD red→green (신규 테스트 7개)
- 적대적 리뷰: 중복/데이터손실/substring 오탐 점검 → '운영'→'VHK 운영' 한정으로 오탐 수정
- **실제 CLI 도그푸딩**: 코딩+운영 전파 / 코딩규칙 헤딩 중복 0 / 백업 복구 확인
- 전체 게이트: `pnpm build` 성공 · **1042 tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)