### PR TITLE
fix(cli): learn/blocker 다단어 인자 NLP 가로채기 수정 (#147)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -678,16 +678,18 @@ goalCmd
   .action(async () => { await goalSync() })
 
 program
-  .command('blocker <description>')
+  // #147: variadic — 따옴표 없는 다단어 본문도 받는다 (vhk blocker sync 중단 증상). join 으로 원문 복원.
+  .command('blocker <description...>')
   .alias('블로커')
   .description('블로커 기록 → docs/state/blockers.md append (3건 누적 시 HARD_STOP 자동 생성)')
-  .action(async (description: string) => { await blocker(description) })
+  .action(async (description: string[]) => { await blocker(description.join(' ')) })
 
 program
-  .command('learn <lesson>')
+  // #147: variadic — 따옴표 없는 다단어 교훈도 받는다 (vhk learn dogfood lesson without sync keyword).
+  .command('learn <lesson...>')
   .alias('교훈')
   .description('교훈 기록 → memory v2 failures.lesson 단일 SoT (v2.0 통합 — vhk memory list 로 확인)')
-  .action(async (lesson: string) => { await learn(lesson) })
+  .action(async (lesson: string[]) => { await learn(lesson.join(' ')) })
 
 program
   .command('resume')

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -60,6 +60,13 @@ function isOptionToken(token: string): boolean {
 }
 
 /**
+ * 자유형식 본문을 인자로 받는 명령(#147). 본문에 'sync'·'상태' 등 NLP 키워드가 섞이면
+ * 라우터가 문장 전체를 가로채 엉뚱한 명령(sync 등)이 실행되므로, 이 명령들은 NL 가로채기를
+ * 건너뛰고 항상 commander 가 인자 그대로 처리한다. (영문 + 한글 별칭 모두 포함)
+ */
+const FREEFORM_ARG_COMMANDS = new Set(['learn', '교훈', 'blocker', '블로커'])
+
+/**
  * 서브커맨드를 갖는 컨테이너 명령 → 실제 서브커맨드 이름 목록.
  * `goal check` · `ref add` · `memory list` 처럼 rest[1] 이 실제 서브커맨드면
  * commander 가 직접 처리한다(자연어 라우터가 가로채지 못하게 — R1: 명령어 매칭 우선).
@@ -102,6 +109,9 @@ export function detectNaturalLanguageInput(argv: string[]): string | null {
   if (!input) return null
 
   const firstIsKnown = KNOWN_COMMAND_TOKENS.has(first)
+
+  // #147: 자유형식 본문 명령(learn/blocker)은 본문에 NLP 키워드가 있어도 가로채지 않는다.
+  if (firstIsKnown && FREEFORM_ARG_COMMANDS.has(first)) return null
 
   // vhk save / vhk 검증
   if (firstIsKnown && rest.length === 1) return null

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -153,6 +153,29 @@ describe('detectNaturalLanguageInput — pattern/evolve 라우팅 (회귀: Goal 
   })
 })
 
+describe('detectNaturalLanguageInput — freeform 인자 명령 NLP 가로채기 금지 (#147)', () => {
+  // 실결함: learn/blocker 는 자유형식 본문을 받는데, 본문에 'sync' 같은 NLP 키워드가
+  // 들어가면 라우터가 가로채 vhk sync 가 실행되고 learn()/blocker() 가 안 돔.
+  it('vhk learn <다단어, sync 포함> → null (commander learn 처리)', () => {
+    expect(
+      detectNaturalLanguageInput(['node', 'vhk', 'learn', 'dogfood', 'lesson', 'without', 'sync', 'keyword'])
+    ).toBeNull()
+  })
+  it('vhk 교훈 <다단어, sync 포함> → null (한글 별칭)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '교훈', 'sync', '없이', '배운', '교훈'])).toBeNull()
+  })
+  it('vhk blocker <다단어, sync 포함> → null', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'blocker', 'sync', '중단', '반복', '증상'])).toBeNull()
+  })
+  it('vhk 블로커 <다단어, sync 포함> → null', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '블로커', 'sync', '중단', '반복', '증상'])).toBeNull()
+  })
+  // 회귀: freeform 아닌 명령은 기존대로 자연어 라우팅 유지
+  it('회귀: vhk 보안 확인 은 여전히 자연어', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '보안', '확인'])).toBe('보안 확인')
+  })
+})
+
 describe('cli NL e2e', () => {
   const bin = path.join(process.cwd(), 'dist', 'index.js')
 
@@ -165,6 +188,20 @@ describe('cli NL e2e', () => {
     })
     expect(String(r.stderr ?? '')).not.toMatch(/too many arguments/i)
     expect(String(r.stdout ?? '')).toMatch(/보안|secure|스캔/i)
+  })
+
+  it('vhk learn <다단어 unquoted> — too many arguments 없이 교훈 기록, sync 안 탐 (#147)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-learn-'))
+    const r = spawnSync(
+      process.execPath,
+      [bin, 'learn', 'dogfood', 'lesson', 'without', 'sync', 'keyword'],
+      { encoding: 'utf-8', cwd: tmp, env: { ...process.env, CI: '1' } }
+    )
+    const out = String(r.stdout ?? '')
+    expect(String(r.stderr ?? '')).not.toMatch(/too many arguments/i)
+    expect(out).toMatch(/교훈 기록/) // learn 실행됨
+    expect(out).not.toMatch(/규칙 파일 동기화|규칙 동기화 완료/) // sync 로 새지 않음
+    fs.rmSync(tmp, { recursive: true, force: true })
   })
 
   it('vhk --version', () => {


### PR DESCRIPTION
## 무엇 (#147)
`vhk learn` / `vhk blocker` 에 따옴표 없는 다단어 본문을 주면, 본문에 `sync` 같은 NLP 키워드가 섞일 때 라우터가 문장 전체를 가로채 `vhk sync` 가 실행되고 learn/blocker 가 안 돌던 문제.

예: `vhk learn dogfood lesson without sync keyword` → (버그) sync 실행

## 고친 곳 (2계층)
1. **cli-args.ts** — `FREEFORM_ARG_COMMANDS`(learn/교훈/blocker/블로커)는 `detectNaturalLanguageInput` 에서 null 반환 → NLP 가로채기 건너뛰고 commander 가 인자 그대로 처리.
2. **index.ts** — learn/blocker 인자를 variadic(`<lesson...>`/`<description...>`)으로 바꾸고 공백 join 으로 원문 복원 → 따옴표 없는 다단어도 `too many arguments` 없이 기록.

> issue 제안 Fix B(`\bsync\b` word boundary)는 repro 를 못 고침 — `without sync keyword` 에서 sync 가 독립 단어라 boundary 로도 매칭됨. Fix A(가로채기 제외)가 정답.

## 검증
- TDD red→green (신규 6: 단위 5 + e2e 1)
- 적대적 리뷰: 회귀/join 엣지/variadic greedy 점검 → 결함 없음
- 실제 CLI 도그푸딩: blocker 다단어(sync 포함)·learn 단일·따옴표·무인자 가드 전부 확인
- 전체 게이트: `pnpm build` 성공 · **1041 tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)