### PR TITLE
docs(changelog): 2.4.3 발행 준비 — [Unreleased]에 doctor P2·daily DevLog P2·worktree PM 자동감지 적재

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 > main 에 머지됐으나 2.4.2 발행 시점 이후라 다음 릴리즈(2.4.3) 포함 예정.
 
 - **`vhk worktree` 가드** (Goal 30, #139) — worktree 생성 시 `.env` 자동 복사 + 누락 점검.
+- **`vhk worktree add --install` PM 자동감지** (#168) — lockfile 로 pnpm/yarn/npm 감지(기존 pnpm 하드코딩 → yarn/npm 프로젝트 설치 실패 위험 제거).
+- **`vhk doctor` Phase 2** (Goal 31, #177) — VHK·MCP·audit 진단 3종 + `--json`(CI·MCP용)·`--audit`(PM 자동감지 취약점 점검) 추가. 진단 전용(자동수정 0).
+- **`vhk standup`·`vhk today` DevLog 연동** (Goal 32·33, #178) — 로컬 dev log(`docs/log/`)를 파싱해 "어제 한 일"·"오늘 교훈"에 반영(공유 `daily/devlog.ts`, Notion 아님·인증 불요).
 - **`vhk today`** (Goal 33, #162) — 저녁 자축·회고 브리핑(git + goal 기반).
 
 ## [2.4.2] - 2026-06-07


### PR DESCRIPTION
## 목적
2.4.2 발행 이후 main 에 머지됐으나 CHANGELOG 미기재였던 항목을 `[Unreleased]` 에 적재 — 2.4.3 발행 준비.

## 추가된 항목
- **#177** `vhk doctor` Phase 2 — VHK·MCP·audit 진단 + `--json`/`--audit` (Goal 31)
- **#178** `vhk standup`·`vhk today` 로컬 dev log 연동 (Goal 32·33)
- **#168** `vhk worktree add --install` PM 자동감지(pnpm/yarn/npm)

## 게이트
- `pnpm build` green · `pnpm test:run` **1055 pass** (107 files), origin/main(9cfd184) 베이스.

## 발행 절차 (사람이 수행)
- ⚠️ 버전 범프·`[2.4.3]` 승격·npm publish 는 **사람이 main 에서 `vhk publish` 직접 실행**(가드 #119: feature 브랜치/미커밋 차단, 2FA OTP).
- 이 PR 은 **버전 미범프** — `vhk publish` 가 2.4.2→2.4.3 자동 범프 + CHANGELOG 스텁 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)