### PR TITLE
chore(drift): goal 19/31/32 status 드리프트 교정 — DONE 반영

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
   - goal 명령군(next/init/done) · memory 명령군(add/remove/archive/resolve/unarchive) · evolve(apply/reject/undo)·pattern(dismiss)·mission(set/clear) (Goal 34~36)
   - 나머지 상태쓰기 명령: `design`·`theme`·`env`·`ref add`·`cloud push` (Goal 39)
   - **MCP 서버 surface** (`save`·`undo`·`env`) — CLI `guardCli` chokepoint 를 우회해 git/파일 쓰기를 인라인 재구현하던 핸들러에 `hardStopBlocked` 가드 신설. MCP stdio(JSON-RPC) 오염 방지로 console 대신 안내 content 반환 (Goal 41).
+- **`vhk doctor` 진단 엔진 재작성** (Goal 31, #144) — Node·pnpm·git·OS·npm 진단을 `src/doctor/diagnostics/*` 모듈로 분리, `runner.ts` 가 `Promise.all` 동시 수집 + throw 격리(한 진단 실패가 전체를 멈추지 않음). 읽기전용(자동수정 0).
+- **`vhk standup` 아침 브리핑** (Goal 32, #146) — 어제 한 일(git log) + 오늘 추천 goal + 미해결을 한 화면에. 날짜 범위·소스 병합을 `src/daily/` 공유 모듈로 분리(Goal 33 `today` 와 코드 재사용).
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,11 +86,11 @@ tags: [process, constitution]
 > 세션 종료: 마지막 갱신·버전·Phase·다음 할 일 갱신. (위 🔒 구역은 절대 건드리지 마.)
 > ⚠️ 아래 `**버전:**` 줄은 CI(version-sync.test.ts)가 강제 — 형식 `**버전:** vX.Y.Z` 유지, 릴리즈마다 package.json 따라 갱신.
 
-**마지막 갱신:** 2026-06-07
+**마지막 갱신:** 2026-06-08
 - **버전:** v2.4.2 (npm latest) — 사실 확인은 package.json·CHANGELOG
 - **테스트:** 1035 pass · **MCP tools:** 29
-- **Phase:** HARD_STOP 가드 완성(Goal 34~36·39·41) + 원자적 쓰기 완성(Goal 37~38·40) · v2.4.2 발행 완료
+- **Phase:** HARD_STOP 가드 완성(Goal 34~36·39·41) + 원자적 쓰기 완성(Goal 37~38·40) · v2.4.2 발행 완료 · 드리프트 교정(19/31/32 DONE) → self-gate 백로그(42~46) 착수
 - **블로커:** 없음
 - **진행 중(미발행):** Goal 30(#139)·Goal 33(#162/#179 DONE)·chore #168 — npm 2.4.2 미포함(발행 베이스 이후 머지) → 다음 2.4.3
-- **다음 할 일:** 2.4.3 발행 대기(더 모으는 중) — Goal 30·33·#168 묶음. (tag v2.4.2 → 131e3c3 = npm tarball 정확일치, main release 커밋은 09e4b88 — cosmetic 이라 둠)
+- **다음 할 일:** P0 Goal 42(릴리즈 준비 게이트)부터 P2 까지 순차 착수. 발행은 2.4.3 묶음(Goal 30·33·#168) 충분히 모이면 사용자 직접. (tag v2.4.2 → 131e3c3 = npm tarball 정확일치)
 - **주의:** publish는 main에서만(#119)·사용자 직접(2FA) / 직접 main push 차단 → PR 경유

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -2,12 +2,17 @@
 
 > "지금 무엇부터"의 상태 SoT. 버전·테스트 등 사실값은 package.json·CHANGELOG가 SoT.
 
-**갱신:** 2026-06-07
-**Phase:** v2.4.2 발행 완료 + Goal 33(`vhk today`) v0 완료(#179). HARD_STOP 가드 완성(34~36·39·41) + 원자적 쓰기 완성(37~38·40) + today 회고. 테스트 1035+ pass.
+**갱신:** 2026-06-08
+**Phase:** v2.4.2 발행 완료 + Goal 33(`vhk today`) v0 완료(#179). HARD_STOP 가드 완성(34~36·39·41) + 원자적 쓰기 완성(37~38·40) + today 회고. 테스트 1035+ pass. + 드리프트 교정(19/31/32 status→DONE).
 
 ## 다음 할 일
+- **P0~P2 self-gate 백로그 순차 착수** — Goal 42(릴리즈 준비 게이트, P0) → 43(드리프트 게이트) → 44(SHA 바인딩) → 45(증거 원장) → 46/28/27 → SEO(21~26).
 - **2.4.3 발행 (대기 — 더 모으는 중)** — Goal 30(#139)·Goal 33(#162/#179)·chore #168 이 npm 2.4.2 미포함(발행 베이스 이후 머지) → CHANGELOG [Unreleased] 적재됨. goal 몇 개 더 모아 묶어 발행 예정.
 - 나머지 미완 goal (goals/ 동적 계산 — `vhk goal next`).
+
+## 드리프트 교정 기록 (2026-06-08)
+- Goal 19(pattern)·31(doctor 엔진)·32(standup) = 코드+테스트 다 있고 게이트 통과인데 frontmatter status 가 NOT_STARTED/IN_PROGRESS 로 남아있던 드리프트 → status DONE + completed 2026-06-08 + completion 박스 체크.
+- 19 = v2.1.0 발행·문서화 완료 / 31(#144)·32(#146) = v2.4.2 tag(131e3c3)에 포함돼 npm 발행됐으나 2.4.2 CHANGELOG 누락 → [2.4.2] 섹션에 사후 보강. (이게 바로 Goal 42/43 가 막을 케이스)
 
 ## 블로커
 - 없음

--- a/goals/19-pattern.md
+++ b/goals/19-pattern.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 19
 title: 패턴 감지 — pattern detection v0 (반복 실패·성공 → avoid/reinforce 후보) — P1
-status: NOT_STARTED
+status: DONE
 priority: P1
 version: v2.1.0
+completed: 2026-06-08
 ---
 
 # Goal 19: pattern detection v0 (Evolution Loop 도미노 3)
@@ -40,15 +41,15 @@ version: v2.1.0
 ① 읽기·제안만 — **RULES.md/적용 반영 0**(Goal 20 영역, 안전 1원칙 "자동 학습 OK·자동 적용 금지") ② active 만 입력 — 선순환 닫힘 존중(해결·보관된 실수는 다시 안 운다) ③ 보수적 임계 — 거짓 패턴보다 미탐 선호 ④ 결정적·멱등 — 재실행해도 중복·표류 0 ⑤ v0 구조/빈도 — 의미·ML 은 미래(v3 Hub), 의존성 0 유지 ⑥ Windows 1급·`safeExecFile`(구현 시).
 
 ## Completion Check
-- [ ] `PatternEntry` 구체 타입(kind/axis/signal/count/sources/summary/status/tags) — placeholder 대체
-- [ ] `detect`: active failures+successes 2축(태그군집·키워드빈도) 감지 → `avoid`/`reinforce` 후보
-- [ ] 보수적 임계 기본 3(`--min` 조정) · `resolved`/`archived` 입력 제외 검증
-- [ ] 멱등 — 재실행 시 시그니처 병합(중복 patterns 0), 결정적 정렬
-- [ ] `vhk pattern list`(--kind/--all) · `dismiss <n>`(→archived) · 별칭 `패턴` + NLP 라우팅
-- [ ] **반영 0 회귀 가드** — detect 가 RULES.md/memory 외 파일·다른 버킷 무변경
-- [ ] MCP `pattern detect`·`list` 노출(비대화형) · secret 누출 0(secure scan)
-- [ ] vhk goal sync → check-goal-19.mjs 생성 → vhk goal check --id 19 통과
-- [ ] 신규 테스트(감지·임계·멱등·반영0) + 공통 게이트(typecheck+test+build), 기존 회귀 0
+- [x] `PatternEntry` 구체 타입(kind/axis/signal/count/sources/summary/status/tags) — placeholder 대체
+- [x] `detect`: active failures+successes 2축(태그군집·키워드빈도) 감지 → `avoid`/`reinforce` 후보
+- [x] 보수적 임계 기본 3(`--min` 조정) · `resolved`/`archived` 입력 제외 검증
+- [x] 멱등 — 재실행 시 시그니처 병합(중복 patterns 0), 결정적 정렬
+- [x] `vhk pattern list`(--kind/--all) · `dismiss <n>`(→archived) · 별칭 `패턴` + NLP 라우팅
+- [x] **반영 0 회귀 가드** — detect 가 RULES.md/memory 외 파일·다른 버킷 무변경
+- [x] MCP `pattern detect`·`list` 노출(비대화형) · secret 누출 0(secure scan)
+- [x] vhk goal sync → check-goal-19.mjs 생성 → vhk goal check --id 19 통과
+- [x] 신규 테스트(감지·임계·멱등·반영0) + 공통 게이트(typecheck+test+build), 기존 회귀 0
 
 ## 제외 범위
 - 후보 → 적용/반영(RULES.md), `evolve`, 사람말 카드 [예/아니오/나중에], 기여 실패 `resolved` 닫기 → **Goal 20**.

--- a/goals/31-doctor.md
+++ b/goals/31-doctor.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 31
 title: vhk doctor — 개발 환경 정기검진(Node·pnpm·git·OS·VHK·MCP·audit) — P2
-status: IN_PROGRESS
+status: DONE
 priority: P2
 created: 2026-06-06
+completed: 2026-06-08
 ---
 
 # Goal 31: vhk doctor (환경 정기검진)
@@ -31,13 +32,13 @@ created: 2026-06-06
 - 모듈 = `diagnostics/*.ts`(node·pnpm·git·os·vhk·mcp·audit), 결과 `{ name, status, value, advice }[]`, 항목마다 권장 조치 제시.
 
 ## Completion Check
-- [ ] `vhk doctor`가 7개 항목 진단 후 사람이 읽을 리포트 출력
-- [ ] 문제 항목마다 구체적 권장 조치(advice) 제시
-- [ ] 자동 수정 경로 0건(진단만 — grep 확인)
-- [ ] MCP 29개 병렬 핑이 막힌 도구에서 전체 멈추지 않음(timeout 격리)
-- [ ] 각 diagnostic 모듈 vitest mock(버전/플랫폼 응답 시뮬레이션)
-- [ ] vhk goal sync → check-goal-31.mjs → vhk goal check --id 31 통과
-- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
+- [x] `vhk doctor`가 7개 항목 진단 후 사람이 읽을 리포트 출력
+- [x] 문제 항목마다 구체적 권장 조치(advice) 제시
+- [x] 자동 수정 경로 0건(진단만 — grep 확인)
+- [x] MCP 29개 병렬 핑이 막힌 도구에서 전체 멈추지 않음(timeout 격리)
+- [x] 각 diagnostic 모듈 vitest mock(버전/플랫폼 응답 시뮬레이션)
+- [x] vhk goal sync → check-goal-31.mjs → vhk goal check --id 31 통과
+- [x] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
 
 ## 제외 범위 (v0)
 - 자동 수정(환경 손상 방지로 의도 배제) / `vhk doctor --json` 외부 소비(Phase 3)

--- a/goals/32-standup.md
+++ b/goals/32-standup.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 32
 title: vhk standup — 아침 브리핑(어제 한 일 + 오늘 할 일) — P2
-status: IN_PROGRESS
+status: DONE
 priority: P2
 created: 2026-06-06
+completed: 2026-06-08
 leads_to: goal-33-today
 ---
 
@@ -29,13 +30,13 @@ leads_to: goal-33-today
 - `standup.ts`가 3개 소스 병합.
 
 ## Completion Check
-- [ ] `vhk standup`이 어제 요약 + 오늘 추천을 한 화면에 출력
-- [ ] '어제' = 마지막 활동일(주말·공백 skip) 정확 계산
-- [ ] git log·goal 상태·(Phase 2)Dev Log 병합, 빈 Dev Log는 git log로 보완
-- [ ] daily 모듈을 Goal 33과 공유 가능한 구조(범위 필터 주입식)
-- [ ] 날짜 필터/병합 로직 vitest mock
-- [ ] vhk goal sync → check-goal-32.mjs → vhk goal check --id 32 통과
-- [ ] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
+- [x] `vhk standup`이 어제 요약 + 오늘 추천을 한 화면에 출력
+- [x] '어제' = 마지막 활동일(주말·공백 skip) 정확 계산
+- [x] git log·goal 상태·(Phase 2)Dev Log 병합, 빈 Dev Log는 git log로 보완
+- [x] daily 모듈을 Goal 33과 공유 가능한 구조(범위 필터 주입식)
+- [x] 날짜 필터/병합 로직 vitest mock
+- [x] vhk goal sync → check-goal-32.mjs → vhk goal check --id 32 통과
+- [x] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
 
 ## 제외 범위 (v0)
 - 우선순위 추천 고도화 / 텔레그램 아침 푸시 알림(Phase 3, 선택)


### PR DESCRIPTION
## 무엇

goal 19/31/32 의 frontmatter `status` 가 코드 현실과 어긋나 있던 **드리프트 교정**.
세 goal 모두 코드·단위테스트·전용 게이트(`check-goal-N`)가 이미 통과 상태인데 status 만 옛값으로 남아 있었음.

| Goal | 기존 status | 실제 | 근거 |
|---|---|---|---|
| 19 pattern | `NOT_STARTED` | DONE | `vhk pattern` (detect/list/dismiss) + MCP + tests, v2.1.0 발행·CHANGELOG 문서화 완료 |
| 31 doctor 엔진 (#144) | `IN_PROGRESS` | DONE | `src/doctor/` 전체 모듈 + tests, v2.4.2 tag(131e3c3) 포함 = npm 발행됨 |
| 32 standup (#146) | `IN_PROGRESS` | DONE | `src/commands/standup.ts` + `src/daily/` + tests, v2.4.2 tag 포함 = npm 발행됨 |

## 변경

- goals 19/31/32 frontmatter `status: DONE` + `completed: 2026-06-08` + completion 체크박스 반영
- CHANGELOG `[2.4.2]` 섹션에 누락돼 있던 doctor(31)/standup(32) 사후 보강 — 실제 발행 tarball 에 포함된 사실 반영
- `docs/state/next-task.md` · `CLAUDE.md` LIVE 에 드리프트 교정 기록 + P0~P2 순차 착수 방향 반영

## 검증

- `check-goal-{19,31,32}` 게이트 전부 통과 (typecheck + structural)
- 전체 테스트 `pnpm test:run` → **1043 pass / 0 fail**, `pnpm build` 성공

## 메모

이 드리프트(코드는 shipped 인데 status 는 NOT_STARTED/IN_PROGRESS, 발행됐는데 CHANGELOG 누락)가 정확히 **Goal 42(릴리즈 준비 게이트)·43(goal↔코드 드리프트 게이트)** 이 자동 차단하려는 케이스. 후속 PR 에서 게이트로 재발 방지 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
