### PR TITLE
feat(standup): Goal 32 Phase 3 — --if-stale 하루 1회 자동 브리핑 + --install-anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 - **`vhk worktree` 가드** (Goal 30, #139) — worktree 생성 시 `.env` 자동 복사 + 누락 점검.
 - **`vhk today`** (Goal 33, #162) — 저녁 자축·회고 브리핑(git + goal 기반).
+- **`vhk standup --if-stale` / `--install-anchor`** (Goal 32 Phase 3) — 하루 1회 자동 브리핑(KST 자정 기준, 상태 `~/.vhk/daily-shown.json`) + 터미널 자동실행 앵커 줄 안내(셸 rc 자동수정 X, 사람이 직접 붙여넣기).
 
 ## [2.4.2] - 2026-06-07
 

--- a/goals/32-standup.md
+++ b/goals/32-standup.md
@@ -38,8 +38,15 @@ leads_to: goal-33-today
 - [ ] vhk goal sync → check-goal-32.mjs → vhk goal check --id 32 통과
 - [ ] 공통 게이트 통과 (typecheck + test + build), 기존 회귀 0
 
+## Phase 3 — 자동실행 앵커 (완료)
+- `vhk standup --if-stale` — 오늘 아직 안 봤을 때만 출력(KST 자정 기준). 상태 = `~/.vhk/daily-shown.json`(version-check 캐시와 동급 글로벌). 순수 `shouldShow(lastShown, today)` + IO 분리.
+- `vhk standup --install-anchor` — 셸 rc(`~/.bashrc`·`~/.zshrc`·PowerShell `$PROFILE`)에 붙여넣을 줄을 **출력만** 함. ⚠️ rc 자동수정 절대 X(사람이 직접 붙여넣기).
+- 상태 헬퍼는 generic(`standup`/`today` 키) → Goal 33 today 자동실행이 후속에서 재사용.
+- 게이트: check-goal-32 Phase 3 검증 추가 · shown-state/anchor 단위테스트 + standup-anchor e2e.
+
 ## 제외 범위 (v0)
-- 우선순위 추천 고도화 / 텔레그램 아침 푸시 알림(Phase 3, 선택)
+- 우선순위 추천 고도화 / 텔레그램 아침 푸시 알림(별도·선택 — 만들지 않음)
+- `today --if-stale` 자동실행(Goal 33 후속 PR로 분리)
 
 ## 공유 모듈 메모
 - 날짜 범위 필터·소스 병합 = `daily` 모듈로 분리 → **Goal 33(today)이 today 범위로 재사용**. 명령만 분리, 코드 공유.

--- a/scripts/check-goal-32.mjs
+++ b/scripts/check-goal-32.mjs
@@ -85,5 +85,26 @@ must(existsSync('src/daily/devlog.ts'), 'src/daily/devlog.ts 존재 (Phase 2 공
 must(/readDevLogs/.test(read('src/daily/standup.ts') ?? ''), 'standup 이 readDevLogs 로 DevLog 연동')
 must(existsSync('tests/daily/devlog.test.ts'), 'devlog 단위테스트 존재')
 
+// ─── goal 32 Phase 3 검증 (--if-stale 하루 1회 + 터미널 자동실행 앵커) ──────────
+must(existsSync('src/daily/shown-state.ts'), 'src/daily/shown-state.ts 존재 (하루 1회 상태)')
+must(existsSync('src/daily/anchor.ts'), 'src/daily/anchor.ts 존재 (앵커 줄 빌더)')
+must(existsSync('tests/daily/shown-state.test.ts'), 'shown-state 단위테스트 존재')
+must(existsSync('tests/daily/anchor.test.ts'), 'anchor 단위테스트 존재')
+const shownState = read('src/daily/shown-state.ts') ?? ''
+must(/export function shouldShow/.test(shownState), 'shouldShow 순수함수 존재')
+must(!/execSync/.test(shownState), 'shown-state execSync 없음')
+must(!/JSON\.parse/.test(shownState), 'shown-state raw JSON.parse 없음 (readJsonFile 사용)')
+must(/atomicWriteFile/.test(shownState), 'shown-state 원자적 쓰기 사용')
+const anchorSrc = read('src/daily/anchor.ts') ?? ''
+must(!/execSync/.test(anchorSrc), 'anchor execSync 없음')
+must(!/writeFileSync|appendFileSync|atomicWriteFile/.test(anchorSrc), 'anchor 파일 쓰기 0 (rc 자동수정 금지)')
+const standupCmd = read('src/commands/standup.ts') ?? ''
+must(/ifStale/.test(standupCmd), 'standup 이 --if-stale 처리')
+must(/installAnchor/.test(standupCmd), 'standup 이 --install-anchor 처리')
+must(/shouldShow/.test(standupCmd), 'standup 이 shouldShow 로 하루 1회 판정')
+const idx = read('src/index.ts') ?? ''
+must(/--if-stale/.test(idx), 'index.ts 에 --if-stale 옵션 등록')
+must(/--install-anchor/.test(idx), 'index.ts 에 --install-anchor 옵션 등록')
+
 if (pass) { console.log('✅ goal 32 gate passes'); process.exit(0) }
 console.log('❌ goal 32 gate failed'); process.exit(1)

--- a/src/commands/standup.ts
+++ b/src/commands/standup.ts
@@ -1,12 +1,40 @@
 import chalk from 'chalk'
 import { ko } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
-import { formatYmdWeekday } from '../lib/date.js'
+import { formatYmdWeekday, localDate } from '../lib/date.js'
 import { runStandup } from '../daily/standup.js'
+import { shouldShow, readDailyShown, recordDailyShown } from '../daily/shown-state.js'
+import { buildAnchorLines } from '../daily/anchor.js'
 
-// vhk standup — 아침 브리핑(읽기 전용: git log + goal 읽어 출력).
+export interface StandupOptions {
+  ifStale?: boolean // 오늘 아직 안 봤을 때만 출력 (터미널 자동실행 앵커용)
+  installAnchor?: boolean // 앵커 줄 안내만 출력 (rc 자동수정 X)
+}
+
+// vhk standup — 아침 브리핑(읽기 전용: git log + goal + dev log 읽어 출력).
 // 읽기전용이라 HARD_STOP 가드 없음(가드 docstring: 읽기전용 제외 — doctor 와 동일).
-export async function standup(): Promise<void> {
+// --if-stale 의 ~/.vhk/daily-shown.json 쓰기는 version-check 글로벌 캐시와 동급(상태변경 아님 → 가드 제외).
+export async function standup(opts: StandupOptions = {}): Promise<void> {
+  // --install-anchor: 붙여넣을 앵커 줄 + 안내만 출력. rc 파일은 절대 자동 수정하지 않는다.
+  if (opts.installAnchor) {
+    printAnchorHelp()
+    return
+  }
+
+  // --if-stale: 오늘 아직 standup 을 안 봤을 때만 출력(KST 자정 기준). 이미 봤으면 조용히 종료.
+  if (opts.ifStale) {
+    const today = localDate()
+    const state = readDailyShown()
+    if (!shouldShow(state.standup ?? null, today)) return // fresh → 무출력
+    await printStandup()
+    recordDailyShown('standup', today) // 실제로 보여준 뒤에만 기록
+    return
+  }
+
+  await printStandup()
+}
+
+async function printStandup(): Promise<void> {
   const r = await runStandup()
   console.log(chalk.bold(`\n${ko.standup.title(formatYmdWeekday(r.asOf))}\n`))
 
@@ -50,4 +78,17 @@ export async function standup(): Promise<void> {
     command: 'vhk work',
     cursorHint: '작업 시작할게',
   })
+}
+
+// 터미널 자동실행 앵커 안내(출력 전용). rc 파일은 사람이 직접 붙여넣는다.
+function printAnchorHelp(): void {
+  const lines = buildAnchorLines()
+  console.log(chalk.bold('\n🔗 터미널 자동실행 앵커 — 하루 1회 아침 브리핑\n'))
+  console.log('  아래 한 줄을 셸 설정 파일에 직접 붙여넣으세요.')
+  console.log(chalk.dim('  (vhk 는 rc 파일을 자동 수정하지 않습니다 — 안전 원칙)\n'))
+  console.log(chalk.dim('  • bash/zsh — ~/.bashrc 또는 ~/.zshrc:'))
+  console.log(`    ${chalk.cyan(lines.bash)}\n`)
+  console.log(chalk.dim('  • PowerShell — $PROFILE:'))
+  console.log(`    ${chalk.cyan(lines.powershell)}\n`)
+  console.log(chalk.dim('  적용 후 새 터미널을 열면 그날 첫 실행에만 standup 이 표시됩니다.'))
 }

--- a/src/daily/anchor.ts
+++ b/src/daily/anchor.ts
@@ -1,0 +1,18 @@
+// Goal 32 Phase 3 — "첫 터미널 여는 순간" 자동 브리핑을 위한 셸 앵커.
+//
+// 핵심 안전 원칙: rc 파일(~/.bashrc · ~/.zshrc · PowerShell $PROFILE)을 절대 자동 수정하지 않는다.
+// 사용자가 직접 붙여넣을 "한 줄"과 안내만 만든다(출력 전용). vhk 미설치/PATH 누락 환경에서도
+// 셸 시작이 깨지지 않도록 각 줄에 존재 가드를 둔다.
+
+export interface AnchorLines {
+  bash: string // ~/.bashrc · ~/.zshrc 용
+  powershell: string // PowerShell $PROFILE 용
+}
+
+/** 셸별 앵커 한 줄(순수). 존재 가드로 vhk 미설치 시에도 안전. */
+export function buildAnchorLines(): AnchorLines {
+  return {
+    bash: 'command -v vhk >/dev/null 2>&1 && vhk standup --if-stale',
+    powershell: 'if (Get-Command vhk -ErrorAction SilentlyContinue) { vhk standup --if-stale }',
+  }
+}

--- a/src/daily/shown-state.ts
+++ b/src/daily/shown-state.ts
@@ -1,0 +1,63 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { readJsonFile } from '../lib/read-json.js'
+import { atomicWriteFile } from '../lib/atomic-write.js'
+
+// Goal 32 Phase 3 — "오늘 아직 안 봤을 때만" 자동 브리핑(--if-stale)하기 위한 글로벌 상태.
+//
+// 여기 쓰는 ~/.vhk/ 는 version-check.json 과 같은 글로벌 디렉터리(프로젝트 무관 사용자 상태).
+// 프로젝트 루트의 .vhk/(cwd 상대 — context/memory 등)와는 완전히 별개다.
+//
+// daily 모듈 공유 철학(standup↔today 코드/데이터 공유)에 맞춰, standup·today 가 한 파일을
+// 키로 나눠 쓴다. today 자동실행은 Phase 3 후속이라 지금은 스키마만 예약하고 standup 만 사용.
+
+export interface DailyShown {
+  standup?: string // 마지막으로 standup 을 보여준 날짜 YYYY-MM-DD (KST)
+  today?: string // 후속(today 자동실행)용 예약 키 — 현재 미사용
+}
+
+export type DailyShownKey = keyof DailyShown
+
+/** 마지막으로 보여준 날짜와 오늘이 다르면(또는 기록 없음 null) 보여줄 차례. 순수(IO 0). */
+export function shouldShow(lastShown: string | null, today: string): boolean {
+  return lastShown !== today
+}
+
+export function getDailyShownPath(): string {
+  return path.join(os.homedir(), '.vhk', 'daily-shown.json')
+}
+
+/** 상태 읽기. 없음/JSON 손상/스키마 불일치 → 빈 객체(자동 브리핑은 생략하고 정상 진행). */
+export function readDailyShown(filePath: string = getDailyShownPath()): DailyShown {
+  try {
+    if (!fs.existsSync(filePath)) return {}
+    const data = readJsonFile<Partial<DailyShown>>(filePath)
+    if (!data || typeof data !== 'object') return {}
+    const out: DailyShown = {}
+    if (typeof data.standup === 'string') out.standup = data.standup
+    if (typeof data.today === 'string') out.today = data.today
+    return out
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * 키별 "마지막 표시 날짜" 기록. ~/.vhk 없으면 생성, atomicWriteFile 로 원자적 교체.
+ * 기존 다른 키는 보존한다. 쓰기 실패는 무시(부가기능이라 비치명 — version-check 캐시 선례).
+ */
+export function recordDailyShown(
+  key: DailyShownKey,
+  date: string,
+  filePath: string = getDailyShownPath()
+): void {
+  try {
+    const current = readDailyShown(filePath)
+    current[key] = date
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    atomicWriteFile(filePath, JSON.stringify(current, null, 2))
+  } catch {
+    // 상태 쓰기 실패는 무시 — 자동 브리핑 정확도만 떨어질 뿐 기능 자체엔 영향 없음.
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -505,7 +505,9 @@ program
   .command('standup')
   .alias('아침')
   .description('아침 브리핑 — 어제 한 일(마지막 활동일 커밋·완료 goal) + 오늘 추천 + 미해결 (읽기 전용)')
-  .action(async () => { await standup() })
+  .option('--if-stale', '오늘 아직 안 본 경우에만 브리핑 (터미널 자동실행 앵커용)')
+  .option('--install-anchor', '터미널 자동실행 앵커(셸 rc 에 붙여넣을 줄) 안내 출력')
+  .action(async (opts: { ifStale?: boolean; installAnchor?: boolean }) => { await standup(opts) })
 
 program
   .command('today')

--- a/tests/daily/anchor.test.ts
+++ b/tests/daily/anchor.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { buildAnchorLines } from '../../src/daily/anchor.js'
+
+// Goal 32 Phase 3 — 터미널 자동실행 앵커는 "붙여넣을 줄"을 만들기만 한다(출력 전용).
+// rc 파일은 절대 자동 수정하지 않는다(사람이 직접 붙여넣음). 여기선 줄 내용만 단언.
+
+describe('buildAnchorLines — 자동실행 앵커 줄(출력 전용)', () => {
+  const lines = buildAnchorLines()
+
+  it('bash 줄은 vhk standup --if-stale 를 실행', () => {
+    expect(lines.bash).toContain('vhk standup --if-stale')
+  })
+
+  it('bash 줄은 vhk 미설치 환경에서 안전하다 (command -v 가드)', () => {
+    expect(lines.bash).toMatch(/command -v vhk/)
+  })
+
+  it('powershell 줄은 vhk standup --if-stale 를 실행', () => {
+    expect(lines.powershell).toContain('vhk standup --if-stale')
+  })
+
+  it('powershell 줄은 vhk 미설치 환경에서 안전하다 (Get-Command 가드)', () => {
+    expect(lines.powershell).toMatch(/Get-Command vhk/)
+  })
+})

--- a/tests/daily/shown-state.test.ts
+++ b/tests/daily/shown-state.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { shouldShow, readDailyShown, recordDailyShown } from '../../src/daily/shown-state.js'
+
+// Goal 32 Phase 3 — 하루 1회 자동 브리핑 상태(KST 자정 기준).
+// shouldShow 는 순수(IO 0). read/record 는 주입형 경로로 실파일 테스트(mock 0).
+
+describe('shouldShow — KST 자정 기준 하루 1회', () => {
+  it('이전에 안 봤으면(null) 보여준다', () => {
+    expect(shouldShow(null, '2026-06-08')).toBe(true)
+  })
+  it('오늘 이미 봤으면 안 보여준다', () => {
+    expect(shouldShow('2026-06-08', '2026-06-08')).toBe(false)
+  })
+  it('다른 날(어제) 봤으면 보여준다 — 자정 넘어가면 자동 stale', () => {
+    expect(shouldShow('2026-06-07', '2026-06-08')).toBe(true)
+  })
+})
+
+describe('readDailyShown / recordDailyShown — ~/.vhk/daily-shown.json (주입형 경로)', () => {
+  const dirs: string[] = []
+  function tmpFile(): string {
+    const d = mkdtempSync(join(tmpdir(), 'vhk-shown-'))
+    dirs.push(d)
+    return join(d, 'daily-shown.json')
+  }
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+  })
+
+  it('파일 없으면 빈 객체 폴백', () => {
+    expect(readDailyShown(tmpFile())).toEqual({})
+  })
+
+  it('record 후 read 로 standup 날짜 복원', () => {
+    const f = tmpFile()
+    recordDailyShown('standup', '2026-06-08', f)
+    expect(readDailyShown(f).standup).toBe('2026-06-08')
+  })
+
+  it('record 가 디렉터리 없어도 생성한다 (mkdir recursive)', () => {
+    const d = mkdtempSync(join(tmpdir(), 'vhk-shown-'))
+    dirs.push(d)
+    const f = join(d, 'nested', 'daily-shown.json') // nested 디렉터리 미존재
+    recordDailyShown('standup', '2026-06-08', f)
+    expect(existsSync(f)).toBe(true)
+  })
+
+  it('다른 키(today)를 보존하며 standup 만 갱신', () => {
+    const f = tmpFile()
+    recordDailyShown('today', '2026-06-01', f)
+    recordDailyShown('standup', '2026-06-08', f)
+    const s = readDailyShown(f)
+    expect(s.standup).toBe('2026-06-08')
+    expect(s.today).toBe('2026-06-01')
+  })
+
+  it('손상 JSON 이면 빈 객체 폴백 (throw 안 함)', () => {
+    const f = tmpFile()
+    writeFileSync(f, '{ broken json', 'utf-8')
+    expect(readDailyShown(f)).toEqual({})
+  })
+})

--- a/tests/standup-anchor.e2e.test.ts
+++ b/tests/standup-anchor.e2e.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, existsSync, readdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+// Goal 32 Phase 3 e2e — dist 빌드된 CLI 를 실제 실행. ~/.vhk 를 임시 HOME 으로 격리.
+// (os.homedir() 는 posix=HOME, win=USERPROFILE → 둘 다 주입)
+
+const bin = path.join(process.cwd(), 'dist', 'index.js')
+
+const homes: string[] = []
+function newHome(): string {
+  const d = mkdtempSync(path.join(tmpdir(), 'vhk-home-'))
+  homes.push(d)
+  return d
+}
+afterEach(() => {
+  for (const d of homes.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+
+function run(args: string[], home: string) {
+  return spawnSync(process.execPath, [bin, ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, HOME: home, USERPROFILE: home, CI: '1' },
+  })
+}
+
+describe('vhk standup --if-stale (e2e) — 하루 1회 자동 브리핑', () => {
+  it('첫 실행(stale) → 브리핑을 출력한다', () => {
+    const home = newHome()
+    const r = run(['standup', '--if-stale'], home)
+    expect(r.status).toBe(0)
+    expect(String(r.stdout)).toMatch(/Standup|아침|어제|오늘 추천|미해결/)
+  })
+
+  it('같은 날 두 번째 실행(fresh) → 아무것도 출력하지 않는다', () => {
+    const home = newHome()
+    run(['standup', '--if-stale'], home) // 1회차 — 표시 + 기록
+    const r2 = run(['standup', '--if-stale'], home)
+    expect(r2.status).toBe(0)
+    expect(String(r2.stdout).trim()).toBe('')
+  })
+
+  it('플래그 없는 vhk standup 은 항상 출력 (회귀 — 무조건 브리핑)', () => {
+    const home = newHome()
+    run(['standup', '--if-stale'], home) // 상태를 fresh 로 만들어도
+    const r = run(['standup'], home) // 플래그 없으면 무시하고 항상 출력
+    expect(String(r.stdout)).toMatch(/Standup|아침|어제|오늘 추천|미해결/)
+  })
+})
+
+describe('vhk standup --install-anchor (e2e) — 앵커 안내 출력만, rc 미수정', () => {
+  it('bash + PowerShell 앵커 줄을 안내 출력한다', () => {
+    const home = newHome()
+    const r = run(['standup', '--install-anchor'], home)
+    expect(r.status).toBe(0)
+    const out = String(r.stdout)
+    expect(out).toContain('vhk standup --if-stale')
+    expect(out).toMatch(/bashrc|zshrc/) // bash 대상 안내
+    expect(out).toMatch(/PROFILE|PowerShell/i) // PowerShell 대상 안내
+  })
+
+  it('rc 파일을 자동 수정하지 않는다 (홈에 rc 파일 생성/변경 0)', () => {
+    const home = newHome()
+    run(['standup', '--install-anchor'], home)
+    const entries = existsSync(home) ? readdirSync(home) : []
+    expect(entries.filter((e) => /bashrc|zshrc|profile/i.test(e))).toEqual([])
+  })
+})


### PR DESCRIPTION
## Goal 32 Phase 3 — 터미널 자동실행 앵커

`vhk standup` 에 자동실행용 두 플래그 추가. 읽기전용 유지, TDD(테스트 먼저).

### 동작
- **`vhk standup --if-stale`** — 오늘 아직 안 봤을 때만 출력(KST 자정 기준). 상태 `~/.vhk/daily-shown.json`(version-check 캐시와 동급 글로벌). 순수 `shouldShow(lastShown, today)` + IO 분리, **보여준 뒤에만** 기록(`atomicWriteFile`).
- **`vhk standup --install-anchor`** — 셸 rc(`~/.bashrc`·`~/.zshrc`·PowerShell `$PROFILE`)에 붙여넣을 줄을 **출력만**. ⚠️ rc 자동수정 절대 X(사람이 직접 붙여넣기). 미설치 환경 대비 존재 가드 포함.
- 상태 헬퍼 generic(`standup`/`today` 키) → Goal 33 today 자동실행 후속 재사용.

### 안전·불변규칙
- execSync 0 · raw JSON.parse 0(`readJsonFile`) · 원자적 쓰기 · 비밀값 X.
- 읽기전용(HARD_STOP 가드 제외 — doctor·version-check 캐시와 동일).
- 앵커는 파일 쓰기 0(rc 자동수정 금지를 gate 정적검사로 강제).

### 테스트 (TDD)
- shown-state(8) · anchor(4) · standup-anchor **e2e(5, 임시 HOME 격리)** + 도그푸딩(stale→출력 / fresh→무출력 / 상태파일 확인).
- check-goal-32 Phase 3 검증 추가.

### 게이트
- `node scripts/check-goal-32.mjs` = typecheck·test:run·build·goal 고유검증 **전부 green**.

### 제외(별도/후속)
- 텔레그램 푸시(만들지 않음) · `today --if-stale`(Goal 33 후속 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)