### PR TITLE
fix(preflight/harness): 스크립트 우선 + test:gate + env 선택키 (#156, #172, #173)

### DIFF
--- a/src/commands/harness.ts
+++ b/src/commands/harness.ts
@@ -57,9 +57,11 @@ function detectChecks(): CheckSpec[] {
     checks.push({ name: 'type-check', bin: 'npx', args: ['tsc', '--noEmit'] })
   }
 
-  if (s.test) {
-    // vitest --run 등 사용자가 추가 옵션 없이 동작하도록 script 호출만.
-    checks.push({ name: 'test', bin: pm, args: pmRun(pm, 'test') })
+  // #156: 풍부한 게이트 우선 — test:gate(unit+smoke 등) → test:ci → test 순으로 첫 존재 스크립트 1개만.
+  // (vitest --run 등 추가 옵션 없이 동작하도록 script 호출만.)
+  const testScript = ['test:gate', 'test:ci', 'test'].find((name) => s[name])
+  if (testScript) {
+    checks.push({ name: testScript, bin: pm, args: pmRun(pm, testScript) })
   }
   if (s.build) {
     checks.push({ name: 'build', bin: pm, args: pmRun(pm, 'build') })

--- a/src/commands/preflight.ts
+++ b/src/commands/preflight.ts
@@ -46,16 +46,32 @@ export async function preflight(opts: PreflightCliOptions = {}): Promise<void> {
     return r.ok ? { ok: true, out: r.out } : { ok: false, out: r.out, err: r.err }
   }
 
-  // lint 활성 여부 = lint 스크립트 또는 eslint 설정 존재.
-  let hasLintScript = false
+  // lint 활성 여부 = lint 스크립트 또는 eslint 설정 존재. + #173: scripts/PM/vitest 해석을 위해 pkg 전체 읽기.
+  let scripts: Record<string, string> = {}
+  let deps: Record<string, string> = {}
   try {
-    const pkg = readJsonFile<{ scripts?: Record<string, string> }>(join(cwd, 'package.json'))
-    hasLintScript = !!pkg.scripts?.lint
+    const pkg = readJsonFile<{
+      scripts?: Record<string, string>
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+    }>(join(cwd, 'package.json'))
+    scripts = pkg.scripts ?? {}
+    deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) }
   } catch {
-    // package.json 없거나 파싱 실패 → lint 스킵(아래 detectHasLinter 가 false 처리)
+    // package.json 없거나 파싱 실패 → lint/test 스킵(detectHasLinter false + testCmd null)
   }
   const hasEslintConfig = ESLINT_CONFIGS.some((f) => existsSync(join(cwd, f)))
-  const hasLinter = detectHasLinter({ hasLintScript, hasEslintConfig })
+  const hasLinter = detectHasLinter({ hasLintScript: !!scripts.lint, hasEslintConfig })
+
+  // #173: PM 감지(lockfile) + vitest 설정/설치 여부 → 하드코딩 toolchain 대신 프로젝트 실제 도구 사용.
+  const pm = existsSync(join(cwd, 'pnpm-lock.yaml'))
+    ? 'pnpm'
+    : existsSync(join(cwd, 'yarn.lock'))
+      ? 'yarn'
+      : 'npm'
+  // vitest 전용 시그널만 — vite.config 는 제외(Vite 프로젝트인데 vitest 미설치면 npx vitest 폴백 실패 오탐).
+  const VITEST_CONFIGS = ['vitest.config.ts', 'vitest.config.js', 'vitest.config.mjs', 'vitest.workspace.ts']
+  const hasVitest = !!deps.vitest || VITEST_CONFIGS.some((f) => existsSync(join(cwd, f)))
 
   const mode: PreflightOptions['mode'] = opts.publish ? 'publish' : opts.pr ? 'pr' : 'default'
   const checks = runPreflight(
@@ -65,6 +81,9 @@ export async function preflight(opts: PreflightCliOptions = {}): Promise<void> {
       nodeVersion: process.version,
       hasLinter,
       worktreeEnv: () => checkWorktreeEnvDir(cwd),
+      pm,
+      scripts,
+      hasVitest,
     }
   )
 

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -22,7 +22,14 @@ export interface PreflightDeps {
   nodeVersion: string // 예: process.version ('v20.18.0')
   hasLinter: boolean // eslint 설정/스크립트 존재 여부
   worktreeEnv: () => PreflightCheck // checkWorktreeEnvDir 래핑(주입)
+  // #173: 패키지 스크립트 우선 실행용. 없으면 기존 npx 폴백(하위호환).
+  pm?: string // 'pnpm' | 'yarn' | 'npm'
+  scripts?: Record<string, string> // package.json scripts
+  hasVitest?: boolean // vitest 설치/설정 여부 (없으면 테스트 하드코딩 강제 안 함)
 }
+
+/** 명령 실행 spec — 스크립트 우선 해석 결과. */
+export type CmdSpec = { bin: string; args: string[] }
 
 const check = (
   name: string,
@@ -30,6 +37,12 @@ const check = (
   detail: string,
   severity: Severity
 ): PreflightCheck => ({ name, status, detail, severity })
+
+// #173: 실패 명령의 캡처 출력을 증거로 한 줄 요약(요약만 — 비밀 누출 우려 적은 stderr/stdout 앞부분).
+function evidence(r: { out: string; err?: string }): string {
+  const s = (r.err || r.out || '').trim().replace(/\s+/g, ' ')
+  return s ? s.slice(0, 160) : '출력 확인'
+}
 
 // ── 순수: Node .cmd shim CVE-2024-27980 안전 버전 판정 (20.12+ / 21.7+) ──
 export function nodeMeetsShimSafe(version: string): boolean {
@@ -59,29 +72,48 @@ export function checkShim(nodeVersion: string): PreflightCheck {
   return check('shim', 'warn', `Node ${nodeVersion} — .cmd shim CVE 취약(20.12+/21.7+ 권장)`, 'high')
 }
 
-export function checkLint(run: Runner, hasLinter: boolean): PreflightCheck {
+// #173: lintCmd(패키지 스크립트) 있으면 그걸 실행, 없을 때만 npx eslint 폴백. 실패 시 출력 증거 포함.
+export function checkLint(run: Runner, hasLinter: boolean, lintCmd?: CmdSpec): PreflightCheck {
+  if (lintCmd) {
+    const r = run(lintCmd.bin, lintCmd.args)
+    return r.ok
+      ? check('lint', 'pass', '0 errors', 'critical')
+      : check('lint', 'fail', `lint 오류 — ${evidence(r)}`, 'critical')
+  }
   if (!hasLinter) {
     return check('lint', 'skip', 'eslint 미설정 — 린트 스킵', 'critical')
   }
   const r = run('npx', ['eslint', '.'])
   return r.ok
     ? check('lint', 'pass', '0 errors', 'critical')
-    : check('lint', 'fail', 'eslint 오류 — 출력 확인', 'critical')
+    : check('lint', 'fail', `eslint 오류 — ${evidence(r)}`, 'critical')
 }
 
 export function checkTypecheck(run: Runner): PreflightCheck {
   const r = run('npx', ['tsc', '--noEmit'])
   return r.ok
     ? check('typecheck', 'pass', 'tsc --noEmit pass', 'critical')
-    : check('typecheck', 'fail', 'tsc 타입 오류 — 출력 확인', 'critical')
+    : check('typecheck', 'fail', `tsc 타입 오류 — ${evidence(r)}`, 'critical')
 }
 
-export function checkTests(run: Runner, opts: { full?: boolean }): PreflightCheck {
-  const args = opts.full ? ['vitest', '--run'] : ['vitest', '--changed', '--run']
-  const r = run('npx', args)
+// #173: testCmd 우선 — {bin,args}=그 스크립트 실행, null=테스트 수단 없음→skip, undefined=npx vitest 폴백.
+export function checkTests(
+  run: Runner,
+  opts: { full?: boolean },
+  testCmd?: CmdSpec | null
+): PreflightCheck {
+  if (testCmd === null) {
+    return check('tests', 'skip', '테스트 스크립트/vitest 없음 — 스킵', 'critical')
+  }
+  const spec: CmdSpec = testCmd ?? {
+    bin: 'npx',
+    args: opts.full ? ['vitest', '--run'] : ['vitest', '--changed', '--run'],
+  }
+  const r = run(spec.bin, spec.args)
+  const passDetail = testCmd ? '통과' : opts.full ? '전체 통과' : '변경분 통과(캐시 스킵)'
   return r.ok
-    ? check('tests', 'pass', opts.full ? '전체 통과' : '변경분 통과(캐시 스킵)', 'critical')
-    : check('tests', 'fail', '테스트 실패 — 출력 확인', 'critical')
+    ? check('tests', 'pass', passDetail, 'critical')
+    : check('tests', 'fail', `테스트 실패 — ${evidence(r)}`, 'critical')
 }
 
 export function checkGitClean(run: Runner): PreflightCheck {
@@ -138,13 +170,32 @@ export function statusIcon(c: PreflightCheck): string {
 
 // ── 오케스트레이션: 8개 항목 점검(읽기 전용, Phase 1) ──
 export function runPreflight(opts: PreflightOptions, deps: PreflightDeps): PreflightCheck[] {
+  // #173: 패키지 스크립트 우선 해석. 모든 PM 이 `<pm> run <script>` 를 지원하므로 통일.
+  const pm = deps.pm ?? 'npm'
+  const scripts = deps.scripts ?? {}
+  const mkCmd = (name: string): CmdSpec => ({ bin: pm, args: ['run', name] })
+
+  const lintCmd = scripts.lint ? mkCmd('lint') : undefined
+
+  // 테스트: 일회성(run) 스크립트 우선 → vitest 폴백 → 비-vitest test 스크립트 → 없으면 skip.
+  // bare `test` 를 vitest 폴백보다 뒤에 두는 건 의도적 — `test:"vitest"`(watch) 가 preflight 를
+  // 멈추게 하는 회귀 방지. (test:run/test:ci 는 관례상 일회성.)
+  // harness(test:gate 우선)와 순서가 다른 것도 의도적 — preflight 는 읽기 전용 게이트라 deploy smoke
+  // 등 side-effect 가능성이 있는 test:gate 보다 순수 일회성 test:run 을 우선한다.
+  let testCmd: CmdSpec | null | undefined
+  const testScriptName = ['test:run', 'test:ci', 'test:gate'].find((n) => scripts[n])
+  if (testScriptName) testCmd = mkCmd(testScriptName)
+  else if (deps.hasVitest) testCmd = undefined // npx vitest --changed/--run 폴백
+  else if (scripts.test) testCmd = mkCmd('test') // 비-vitest test 스크립트(최후)
+  else testCmd = null // 테스트 수단 없음 → skip(하드코딩 강제 안 함)
+
   return [
     checkNpmAuth(deps.run),
     checkShim(deps.nodeVersion),
     deps.worktreeEnv(),
-    checkLint(deps.run, deps.hasLinter),
+    checkLint(deps.run, deps.hasLinter, lintCmd),
     checkTypecheck(deps.run),
-    checkTests(deps.run, { full: opts.full }),
+    checkTests(deps.run, { full: opts.full }, testCmd),
     checkGitClean(deps.run),
     checkBranch(deps.run),
   ]

--- a/src/lib/worktree-env.ts
+++ b/src/lib/worktree-env.ts
@@ -15,10 +15,18 @@ export interface EnvCheckResult {
   severity: Severity
 }
 
-// `KEY=value` 줄에서 KEY 만 추출. 주석(#)·빈 줄·'=' 없는 줄은 무시.
+export interface EnvKeySpec {
+  key: string
+  /** #172: 트레일링 `# ... optional ...` 주석이 붙은 키 → 누락해도 preflight 차단 안 함. */
+  optional: boolean
+}
+
+// `KEY=value [# optional]` 줄을 파싱 — 키 + 선택 여부(#172). 주석(#)·빈 줄·'=' 없는 줄은 무시.
 // `export KEY=` 접두사 허용(.env.example 관례). nested/multiline 미지원(flat 만).
-export function parseEnvKeys(content: string): string[] {
-  const keys: string[] = []
+// 선택 판정: '=' 뒤(값 영역)에 시작하는 주석(#)에 'optional' 단어가 있으면 선택 키.
+// (값 중간의 # — 예: PASS=ab#cd — 도 주석으로 보지만 'optional' 없으면 필수 유지 → 오탐 0.)
+export function parseEnvSpec(content: string): EnvKeySpec[] {
+  const specs: EnvKeySpec[] = []
   for (const raw of content.split(/\r?\n/)) {
     let line = raw.trim()
     if (!line || line.startsWith('#')) continue
@@ -26,9 +34,18 @@ export function parseEnvKeys(content: string): string[] {
     const idx = line.indexOf('=')
     if (idx <= 0) continue
     const key = line.slice(0, idx).trim()
-    if (key) keys.push(key)
+    if (!key) continue
+    const afterEq = line.slice(idx + 1)
+    const hashIdx = afterEq.indexOf('#')
+    const comment = hashIdx >= 0 ? afterEq.slice(hashIdx) : ''
+    specs.push({ key, optional: /\boptional\b/i.test(comment) })
   }
-  return keys
+  return specs
+}
+
+// `KEY=value` 줄에서 KEY 만 추출(선택 여부 무시 — present 비교용). parseEnvSpec 의 키 투영.
+export function parseEnvKeys(content: string): string[] {
+  return parseEnvSpec(content).map((s) => s.key)
 }
 
 // required 중 present 에 없는 키만 반환(순서 보존).
@@ -48,14 +65,18 @@ export function checkWorktreeEnv(input: {
   if (input.exampleContent === null) {
     return { name, status: 'skip', detail: '.env.example 없음 — 필수 키 명세 없음', severity }
   }
-  const required = parseEnvKeys(input.exampleContent)
+  // #172: `# optional` 마커가 붙은 키는 필수에서 제외 — 문서화된 선택 설정이 출고를 막지 않게.
+  const spec = parseEnvSpec(input.exampleContent)
+  const required = spec.filter((s) => !s.optional).map((s) => s.key)
+  const optionalCount = spec.length - required.length
+  const optSuffix = optionalCount ? ` (+${optionalCount} optional)` : ''
   if (required.length === 0) {
-    return { name, status: 'skip', detail: '.env.example 에 필수 키 없음', severity }
+    return { name, status: 'skip', detail: '.env.example 에 필수 키 없음' + optSuffix, severity }
   }
   const present = input.envContent === null ? [] : parseEnvKeys(input.envContent)
   const missing = missingEnvKeys(required, present)
   if (missing.length === 0) {
-    return { name, status: 'pass', detail: `${required.length}/${required.length} keys present`, severity }
+    return { name, status: 'pass', detail: `${required.length}/${required.length} required keys present${optSuffix}`, severity }
   }
   return {
     name,

--- a/tests/harness.test.ts
+++ b/tests/harness.test.ts
@@ -98,6 +98,31 @@ describe('harness', () => {
     expect(process.exitCode).toBe(0)
   })
 
+  it('#156: test:gate 우선 (test:gate > test:ci > test)', async () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ scripts: { test: 'vitest', 'test:ci': 'ci', 'test:gate': 'run all gates' } })
+    )
+    mockExistsSync.mockReturnValue(false)
+    mockSafeExecFile.mockReturnValue({ ok: true, out: '' })
+    const { harness } = await import('../src/commands/harness.js')
+    await harness()
+    const scripts = mockSafeExecFile.mock.calls.map((c) => (c[1] as string[]).join(' '))
+    expect(scripts).toContain('run test:gate')
+    expect(scripts).not.toContain('run test') // bare test 안 돔
+    expect(scripts).not.toContain('run test:ci')
+  })
+
+  it('#156: test:gate 없으면 test:ci 우선', async () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ scripts: { test: 'vitest', 'test:ci': 'ci' } }))
+    mockExistsSync.mockReturnValue(false)
+    mockSafeExecFile.mockReturnValue({ ok: true, out: '' })
+    const { harness } = await import('../src/commands/harness.js')
+    await harness()
+    const scripts = mockSafeExecFile.mock.calls.map((c) => (c[1] as string[]).join(' '))
+    expect(scripts).toContain('run test:ci')
+    expect(scripts).not.toContain('run test')
+  })
+
   it('pnpm-lock.yaml 감지 시 pnpm으로 실행', async () => {
     mockReadFileSync.mockReturnValue(JSON.stringify({ scripts: { build: 'tsup' } }))
     mockExistsSync.mockImplementation((p: unknown) => String(p) === 'pnpm-lock.yaml')

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -124,6 +124,58 @@ describe('checkTests', () => {
   })
 })
 
+describe('#173 — 스크립트 우선 + 출력 증거', () => {
+  it('lint 스크립트 있으면 npx eslint 대신 스크립트 실행', () => {
+    const { run, calls } = mockRunner({ 'pnpm run lint': { ok: true, out: '' } })
+    const r = checkLint(run, true, { bin: 'pnpm', args: ['run', 'lint'] })
+    expect(r.status).toBe('pass')
+    expect(calls).toContain('pnpm run lint')
+    expect(calls).not.toContain('npx eslint .')
+  })
+
+  it('lint 실패 시 출력 증거(detail)에 캡처', () => {
+    const { run } = mockRunner({ 'npx eslint .': { ok: false, out: '', err: '5 problems (5 errors)' } })
+    const r = checkLint(run, true)
+    expect(r.status).toBe('fail')
+    expect(r.detail).toContain('5 problems')
+  })
+
+  it('test:run 스크립트 있으면 vitest 대신 스크립트 실행', () => {
+    const { run, calls } = mockRunner({ 'pnpm run test:run': { ok: true, out: '' } })
+    const r = checkTests(run, {}, { bin: 'pnpm', args: ['run', 'test:run'] })
+    expect(r.status).toBe('pass')
+    expect(calls).toContain('pnpm run test:run')
+    expect(calls).not.toContain('npx vitest --changed --run')
+  })
+
+  it('테스트 도구/스크립트 없으면 skip (하드코딩 vitest 강제 안 함)', () => {
+    const { run, calls } = mockRunner({})
+    const r = checkTests(run, {}, null)
+    expect(r.status).toBe('skip')
+    expect(calls).toEqual([])
+  })
+
+  it('runPreflight 가 test:run/lint 스크립트를 우선 실행 (하드코딩 회피)', () => {
+    const { run, calls } = mockRunner({})
+    runPreflight(
+      {},
+      {
+        run,
+        nodeVersion: 'v20.18.0',
+        hasLinter: true,
+        worktreeEnv: (): PreflightCheck => ({ name: 'worktree env', status: 'pass', detail: '', severity: 'critical' }),
+        pm: 'pnpm',
+        scripts: { lint: 'eslint', 'test:run': 'vitest --run' },
+        hasVitest: true,
+      }
+    )
+    expect(calls).toContain('pnpm run lint')
+    expect(calls).toContain('pnpm run test:run')
+    expect(calls).not.toContain('npx eslint .')
+    expect(calls).not.toContain('npx vitest --changed --run')
+  })
+})
+
 describe('checkGitClean', () => {
   it('변경 없음 → pass', () => {
     const { run } = mockRunner({ 'git status --porcelain': { ok: true, out: '' } })

--- a/tests/worktree-env.test.ts
+++ b/tests/worktree-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parseEnvKeys, missingEnvKeys, checkWorktreeEnv } from '../src/lib/worktree-env.js'
+import { parseEnvKeys, parseEnvSpec, missingEnvKeys, checkWorktreeEnv } from '../src/lib/worktree-env.js'
 
 describe('parseEnvKeys', () => {
   it('KEY=value 줄에서 키만 뽑는다', () => {
@@ -20,6 +20,51 @@ describe('parseEnvKeys', () => {
 
   it('export 접두사를 허용한다', () => {
     expect(parseEnvKeys('export TOKEN=xyz')).toEqual(['TOKEN'])
+  })
+})
+
+describe('parseEnvSpec — 필수/선택 구분 (#172)', () => {
+  it('트레일링 # optional 마커는 선택 키로 표시', () => {
+    const spec = parseEnvSpec('REQUIRED=\nOPT= # optional\nOPT2=val # optional override')
+    expect(spec).toEqual([
+      { key: 'REQUIRED', optional: false },
+      { key: 'OPT', optional: true },
+      { key: 'OPT2', optional: true },
+    ])
+  })
+
+  it('일반 키는 optional=false', () => {
+    expect(parseEnvSpec('A=1')).toEqual([{ key: 'A', optional: false }])
+  })
+
+  it('값 안의 # 은 주석 아님 (오탐 방지)', () => {
+    // PASS=ab#cd 의 #cd 는 optional 아님
+    expect(parseEnvSpec('PASS=ab#cd')).toEqual([{ key: 'PASS', optional: false }])
+  })
+})
+
+describe('checkWorktreeEnv — 선택 키 (#172)', () => {
+  it('선택 키 누락은 차단하지 않음 (필수만 검사)', () => {
+    const r = checkWorktreeEnv({
+      exampleContent: 'REQ=\nOPT1= # optional\nOPT2= # optional',
+      envContent: 'REQ=1',
+    })
+    expect(r.status).toBe('pass')
+  })
+
+  it('필수 누락은 여전히 fail (선택 마커 있어도)', () => {
+    const r = checkWorktreeEnv({
+      exampleContent: 'REQ1=\nREQ2=\nOPT= # optional',
+      envContent: 'REQ1=1',
+    })
+    expect(r.status).toBe('fail')
+    expect(r.detail).toContain('REQ2')
+    expect(r.detail).not.toContain('OPT')
+  })
+
+  it('전부 선택이면 skip (필수 키 없음)', () => {
+    const r = checkWorktreeEnv({ exampleContent: 'A= # optional\nB= # optional', envContent: null })
+    expect(r.status).toBe('skip')
   })
 })
 


### PR DESCRIPTION
## 무엇 — preflight/harness 품질 게이트 3건

### #172 — preflight 가 .env.example 선택 키를 필수로 강제
문서화된 선택/기본 설정(예: Notion 속성 매핑 15개)이 .env.example 에 있다는 이유만으로 출고 차단.
→ `parseEnvSpec` 가 값 뒤 `# optional` 주석 인식 → 해당 키는 필수에서 제외, `(+N optional)` 표기. 필수 누락은 여전히 critical fail. 값 중간 # (PASS=ab#cd)는 오탐 0.

### #156 — harness 가 test:gate 를 못 잡음
`test` 스크립트만 실행 → 풍부한 게이트(test:gate = unit+smoke 등) 누락.
→ detectChecks 가 `test:gate → test:ci → test` 우선순위로 첫 존재 스크립트 실행.

### #173 — preflight 가 하드코딩 eslint/vitest 강제
lint 스크립트가 있어도 `npx eslint`, test:run 이 있어도 `npx vitest` 실행 → 다른 toolchain 프로젝트를 harness/verify 는 통과시키는데 preflight 만 차단.
→ 패키지 스크립트 우선(없을 때만 npx 폴백), 실패 시 캡처 출력을 증거로 표기.
→ 테스트 해석: `test:run → test:ci → test:gate → vitest폴백 → test → skip`. bare `test` 를 vitest 폴백 뒤에 둬 `test:vitest`(watch) 가 preflight 를 멈추는 회귀 방지.

## 적대적 리뷰 반영
- hasVitest 감지에서 `vite.config` 제외 → Vite-but-no-vitest 프로젝트 npx vitest 폴백 오탐 수정.
- harness/preflight test 순서 차이는 의도(읽기전용 preflight 는 side-effect 가능한 test:gate 회피) — 주석 명시.

## 검증
- TDD red→green (신규 13: #172 ×6, #156 ×2, #173 ×5)
- 적대적 리뷰(오탐/watch-hang/시크릿/skip 점검) → 실버그 1건(hasVitest) 수정
- 실제 CLI 도그푸딩: 선택키 제외(+2 optional)·lint/tests 스크립트 경유 전부 확인
- 전체 게이트: `pnpm build` 성공 · **1048 tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)