### PR TITLE
chore(drift): Goal 19(pattern) status NOT_STARTED → DONE

### DIFF
--- a/goals/19-pattern.md
+++ b/goals/19-pattern.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 19
 title: 패턴 감지 — pattern detection v0 (반복 실패·성공 → avoid/reinforce 후보) — P1
-status: NOT_STARTED
+status: DONE
 priority: P1
 version: v2.1.0
+completed: 2026-06-04
 ---
 
 # Goal 19: pattern detection v0 (Evolution Loop 도미노 3)
@@ -40,15 +41,15 @@ version: v2.1.0
 ① 읽기·제안만 — **RULES.md/적용 반영 0**(Goal 20 영역, 안전 1원칙 "자동 학습 OK·자동 적용 금지") ② active 만 입력 — 선순환 닫힘 존중(해결·보관된 실수는 다시 안 운다) ③ 보수적 임계 — 거짓 패턴보다 미탐 선호 ④ 결정적·멱등 — 재실행해도 중복·표류 0 ⑤ v0 구조/빈도 — 의미·ML 은 미래(v3 Hub), 의존성 0 유지 ⑥ Windows 1급·`safeExecFile`(구현 시).
 
 ## Completion Check
-- [ ] `PatternEntry` 구체 타입(kind/axis/signal/count/sources/summary/status/tags) — placeholder 대체
-- [ ] `detect`: active failures+successes 2축(태그군집·키워드빈도) 감지 → `avoid`/`reinforce` 후보
-- [ ] 보수적 임계 기본 3(`--min` 조정) · `resolved`/`archived` 입력 제외 검증
-- [ ] 멱등 — 재실행 시 시그니처 병합(중복 patterns 0), 결정적 정렬
-- [ ] `vhk pattern list`(--kind/--all) · `dismiss <n>`(→archived) · 별칭 `패턴` + NLP 라우팅
-- [ ] **반영 0 회귀 가드** — detect 가 RULES.md/memory 외 파일·다른 버킷 무변경
-- [ ] MCP `pattern detect`·`list` 노출(비대화형) · secret 누출 0(secure scan)
-- [ ] vhk goal sync → check-goal-19.mjs 생성 → vhk goal check --id 19 통과
-- [ ] 신규 테스트(감지·임계·멱등·반영0) + 공통 게이트(typecheck+test+build), 기존 회귀 0
+- [x] `PatternEntry` 구체 타입(kind/axis/signal/count/sources/summary/status/tags) — placeholder 대체
+- [x] `detect`: active failures+successes 2축(태그군집·키워드빈도) 감지 → `avoid`/`reinforce` 후보
+- [x] 보수적 임계 기본 3(`--min` 조정) · `resolved`/`archived` 입력 제외 검증
+- [x] 멱등 — 재실행 시 시그니처 병합(중복 patterns 0), 결정적 정렬
+- [x] `vhk pattern list`(--kind/--all) · `dismiss <n>`(→archived) · 별칭 `패턴` + NLP 라우팅
+- [x] **반영 0 회귀 가드** — detect 가 RULES.md/memory 외 파일·다른 버킷 무변경
+- [x] MCP `pattern detect`·`list` 노출(비대화형) · secret 누출 0(secure scan)
+- [x] vhk goal sync → check-goal-19.mjs 생성 → vhk goal check --id 19 통과
+- [x] 신규 테스트(감지·임계·멱등·반영0) + 공통 게이트(typecheck+test+build), 기존 회귀 0
 
 ## 제외 범위
 - 후보 → 적용/반영(RULES.md), `evolve`, 사람말 카드 [예/아니오/나중에], 기여 실패 `resolved` 닫기 → **Goal 20**.


### PR DESCRIPTION
## 무엇

Goal 19(`vhk pattern`)의 frontmatter `status` 가 코드 현실과 어긋난 **드리프트 교정**. 단일 파일(`goals/19-pattern.md`) 변경.

## 근거

`vhk pattern`(detect/list/dismiss + MCP `pattern-detect`/`pattern-list`)은 **v2.1.0(2026-06-04) 발행 + CHANGELOG 문서화 완료**인데, goal 카드만 `status: NOT_STARTED` 로 남아 있었음.

- `src/commands/pattern.ts` + `tests/pattern.test.ts` 존재
- `check-goal-19` 게이트 통과 (typecheck + 구조 검증 19항목 전부 ✓)
- 전체 테스트 `pnpm test:run` → **1043 pass / 0 fail** (동일 코드 기준, 회귀 0)

## 변경

- `status: NOT_STARTED → DONE`
- `completed: 2026-06-04` 추가
- Completion Check 박스 9개 모두 체크(게이트로 검증된 사실 반영)

## 범위 메모

- CHANGELOG·next-task·CLAUDE·다른 goal **안 건드림** — 동시 진행 중인 릴리즈 세션(`chore/release-2.4.3-changelog`, CHANGELOG `[Unreleased]` 이미 채움)·goal32 세션과 충돌 회피.
- Goal 31·32 는 이 작업 불필요 — origin/main 에서 #177·#178 로 이미 `DONE`.
- 이 드리프트(코드는 shipped 인데 status NOT_STARTED)가 정확히 **Goal 42·43(릴리즈·드리프트 게이트)** 이 자동 차단하려는 케이스.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
