### PR TITLE
fix(doctor): npm 프로젝트에서 pnpm 부재 오차단 수정 (#175)

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -19,6 +19,7 @@ import { diagOs } from '../doctor/diagnostics/os.js'
 import { buildVhkDiag } from '../doctor/diagnostics/vhk.js'
 import { buildMcpDiag, mcpToolCount } from '../doctor/diagnostics/mcp.js'
 import { buildAuditDiag } from '../doctor/diagnostics/audit.js'
+import { readSelectedPM } from '../doctor/pm.js'
 import type { DiagDeps, DoctorOptions, DiagFn } from '../doctor/types.js'
 // 업데이트 체크 함수는 version-check.ts 단일 소스로 이동(메뉴와 공용). 여기선 import + re-export
 // (doctor.test.ts 의 `from doctor.js` import 경로 보존) + 내부 사용.
@@ -75,6 +76,7 @@ export async function doctor(opts: DoctorOptions = {}) {
     nodeVersion: process.version,
     platform: process.platform,
     osRelease: os.release(),
+    selectedPM: readSelectedPM(process.cwd()), // #175 — 미사용 PM 부재를 fail 로 올리지 않게
   }
   // Phase 2: VHK 설치/업데이트 · MCP 서버 무결성 · 의존성 audit(--audit 시) 추가.
   const auditPm = fs.existsSync(path.join(cwd, 'pnpm-lock.yaml'))

--- a/src/doctor/diagnostics/pnpm.ts
+++ b/src/doctor/diagnostics/pnpm.ts
@@ -1,10 +1,15 @@
 import type { Diagnostic, DoctorOptions, DiagDeps } from '../types.js'
 
 // 패키지 매니저(pnpm) 진단.
+// #175: pnpm 부재는 프로젝트가 pnpm 을 쓸 때만 critical fail. npm/yarn 프로젝트면 skip(선택 정보)
+// 으로 처리해 exit 1 을 유발하지 않는다.
 export function diagPnpm(_opts: DoctorOptions, deps: DiagDeps): Diagnostic {
   const r = deps.run('pnpm', ['--version'])
   if (r.ok && r.out.trim()) {
     return { name: 'pnpm', status: 'ok', value: r.out.trim().split('\n')[0] }
   }
-  return { name: 'pnpm', status: 'fail', value: '없음', advice: '설치: npm i -g pnpm' }
+  if (deps.selectedPM === 'pnpm') {
+    return { name: 'pnpm', status: 'fail', value: '없음', advice: '설치: npm i -g pnpm (이 프로젝트는 pnpm 사용)' }
+  }
+  return { name: 'pnpm', status: 'skip', value: '미사용 (선택 사항)' }
 }

--- a/src/doctor/pm.ts
+++ b/src/doctor/pm.ts
@@ -1,0 +1,36 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { readJsonFile } from '../lib/read-json.js'
+
+// #175 — 프로젝트가 선택한 패키지 매니저 감지. doctor 가 사용 안 하는 PM 부재를 critical fail 로
+// 처리하지 않도록(npm 프로젝트인데 pnpm 없음 = 정상) 선택 PM 을 판별한다.
+
+export type SelectedPM = 'pnpm' | 'yarn' | 'npm'
+
+// 순수: packageManager 필드(corepack) 우선 → 락파일 → 기본 npm. (테스트 가능 seam)
+export function detectSelectedPM(input: {
+  packageManager?: string
+  hasPnpmLock: boolean
+  hasYarnLock: boolean
+}): SelectedPM {
+  const declared = input.packageManager?.trim().toLowerCase().split('@')[0]
+  if (declared === 'pnpm' || declared === 'yarn' || declared === 'npm') return declared
+  if (input.hasPnpmLock) return 'pnpm'
+  if (input.hasYarnLock) return 'yarn'
+  return 'npm' // package-lock.json 또는 락파일 없음 → npm 기준선
+}
+
+// 실제 cwd 에서 package.json(packageManager) + 락파일을 읽어 선택 PM 판별(IO 래퍼).
+export function readSelectedPM(cwd: string): SelectedPM {
+  let packageManager: string | undefined
+  try {
+    packageManager = readJsonFile<{ packageManager?: string }>(join(cwd, 'package.json')).packageManager
+  } catch {
+    // package.json 없음/파싱 실패 → 락파일로만 판별
+  }
+  return detectSelectedPM({
+    packageManager,
+    hasPnpmLock: existsSync(join(cwd, 'pnpm-lock.yaml')),
+    hasYarnLock: existsSync(join(cwd, 'yarn.lock')),
+  })
+}

--- a/src/doctor/types.ts
+++ b/src/doctor/types.ts
@@ -24,6 +24,8 @@ export interface DiagDeps {
   nodeVersion: string // process.version
   platform: string // process.platform
   osRelease: string // os.release()
+  // #175 — 프로젝트가 선택한 PM. 미사용 PM 부재를 fail 로 올리지 않기 위함(옵션, 미지정 시 pnpm 미사용 간주).
+  selectedPM?: 'pnpm' | 'yarn' | 'npm'
 }
 
 export type DiagFn = (opts: DoctorOptions, deps: DiagDeps) => Diagnostic | Promise<Diagnostic>

--- a/tests/doctor/diagnostics.test.ts
+++ b/tests/doctor/diagnostics.test.ts
@@ -52,10 +52,20 @@ describe('diagPnpm', () => {
     expect(r.status).toBe('ok')
     expect(r.value).toContain('9.12.0')
   })
-  it('없음 → fail + 설치 안내', () => {
-    const r = diagPnpm({}, deps({}, { 'pnpm --version': { ok: false, out: '', err: 'not found' } }))
+  it('없음 + 프로젝트가 pnpm 사용 → fail + 설치 안내', () => {
+    const r = diagPnpm({}, deps({ selectedPM: 'pnpm' }, { 'pnpm --version': { ok: false, out: '', err: 'not found' } }))
     expect(r.status).toBe('fail')
     expect(r.advice).toBeTruthy()
+  })
+
+  it('#175: 없음 + pnpm 미사용(npm 프로젝트) → skip (fail 아님 → exit 1 유발 X)', () => {
+    const r = diagPnpm({}, deps({ selectedPM: 'npm' }, { 'pnpm --version': { ok: false, out: '', err: 'not found' } }))
+    expect(r.status).toBe('skip')
+  })
+
+  it('#175: 설치돼 있으면 PM 선택과 무관하게 ok', () => {
+    const r = diagPnpm({}, deps({ selectedPM: 'npm' }, { 'pnpm --version': { ok: true, out: '9.12.0' } }))
+    expect(r.status).toBe('ok')
   })
 })
 

--- a/tests/doctor/pm.test.ts
+++ b/tests/doctor/pm.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { detectSelectedPM } from '../../src/doctor/pm.js'
+
+describe('detectSelectedPM (#175)', () => {
+  it('packageManager 필드 우선', () => {
+    expect(detectSelectedPM({ packageManager: 'pnpm@8.1.0', hasPnpmLock: false, hasYarnLock: false })).toBe('pnpm')
+  })
+  it('pnpm-lock.yaml → pnpm', () => {
+    expect(detectSelectedPM({ hasPnpmLock: true, hasYarnLock: false })).toBe('pnpm')
+  })
+  it('yarn.lock → yarn', () => {
+    expect(detectSelectedPM({ hasPnpmLock: false, hasYarnLock: true })).toBe('yarn')
+  })
+  it('락파일/필드 없음 → npm 기준선', () => {
+    expect(detectSelectedPM({ hasPnpmLock: false, hasYarnLock: false })).toBe('npm')
+  })
+  it('packageManager 필드가 락파일보다 우선', () => {
+    expect(detectSelectedPM({ packageManager: 'npm@10', hasPnpmLock: true, hasYarnLock: false })).toBe('npm')
+  })
+  it('알 수 없는 packageManager 값은 무시하고 락파일로 폴백', () => {
+    expect(detectSelectedPM({ packageManager: 'bun@1', hasPnpmLock: true, hasYarnLock: false })).toBe('pnpm')
+  })
+  it('대문자 packageManager 도 정규화해서 감지 (리뷰 반영)', () => {
+    expect(detectSelectedPM({ packageManager: 'Pnpm@8', hasPnpmLock: false, hasYarnLock: false })).toBe('pnpm')
+  })
+})


### PR DESCRIPTION
## 무엇 (#175)
pnpm 미설치인 **npm 전용 프로젝트**(package-lock.json, pnpm-lock/packageManager 없음)에서 `vhk doctor` 가 `pnpm 없음` 을 🔴 fail + **exit 1** 로 보고하던 문제. 그 프로젝트는 pnpm 을 쓰지 않으므로 차단할 이유가 없음.

## 고친 곳
- **doctor/pm.ts** (신규): `detectSelectedPM` — packageManager 필드 → 락파일 → npm 기준선 순으로 선택 PM 판별(대소문자 정규화).
- **diagPnpm**: pnpm 부재 시 `selectedPM==='pnpm'` 일 때만 critical fail, 아니면 ⚪ skip(선택 사항) → exit 1 유발 안 함. 설치돼 있으면 PM 무관 ok.
- **npm 은 불변** — vhk 자체(publish·업데이트)가 npm 의존이라 항상 required.

## 검증
- TDD red→green (신규 9: PM 감지 7 + diagPnpm skip/fail 갱신)
- 적대적 리뷰: 대문자 packageManager 오감지 → toLowerCase 정규화 수정
- **실제 CLI 도그푸딩**: 가짜 실패 pnpm + npm 프로젝트 → `⚪ pnpm 미사용 (선택 사항)` + **exit 0** 확인 (이전엔 🔴 + exit 1)
- 전체 게이트: `pnpm build` 성공 · **1044 tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)