### PR TITLE
feat(goal-43): goal 상태↔코드 드리프트 게이트 — shipped인데 NOT_STARTED 차단

### DIFF
--- a/goals/19-pattern.md
+++ b/goals/19-pattern.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 19
 title: 패턴 감지 — pattern detection v0 (반복 실패·성공 → avoid/reinforce 후보) — P1
-status: NOT_STARTED
+status: DONE
 priority: P1
 version: v2.1.0
+completed: 2026-06-04
 ---
 
 # Goal 19: pattern detection v0 (Evolution Loop 도미노 3)
@@ -40,15 +41,15 @@ version: v2.1.0
 ① 읽기·제안만 — **RULES.md/적용 반영 0**(Goal 20 영역, 안전 1원칙 "자동 학습 OK·자동 적용 금지") ② active 만 입력 — 선순환 닫힘 존중(해결·보관된 실수는 다시 안 운다) ③ 보수적 임계 — 거짓 패턴보다 미탐 선호 ④ 결정적·멱등 — 재실행해도 중복·표류 0 ⑤ v0 구조/빈도 — 의미·ML 은 미래(v3 Hub), 의존성 0 유지 ⑥ Windows 1급·`safeExecFile`(구현 시).
 
 ## Completion Check
-- [ ] `PatternEntry` 구체 타입(kind/axis/signal/count/sources/summary/status/tags) — placeholder 대체
-- [ ] `detect`: active failures+successes 2축(태그군집·키워드빈도) 감지 → `avoid`/`reinforce` 후보
-- [ ] 보수적 임계 기본 3(`--min` 조정) · `resolved`/`archived` 입력 제외 검증
-- [ ] 멱등 — 재실행 시 시그니처 병합(중복 patterns 0), 결정적 정렬
-- [ ] `vhk pattern list`(--kind/--all) · `dismiss <n>`(→archived) · 별칭 `패턴` + NLP 라우팅
-- [ ] **반영 0 회귀 가드** — detect 가 RULES.md/memory 외 파일·다른 버킷 무변경
-- [ ] MCP `pattern detect`·`list` 노출(비대화형) · secret 누출 0(secure scan)
-- [ ] vhk goal sync → check-goal-19.mjs 생성 → vhk goal check --id 19 통과
-- [ ] 신규 테스트(감지·임계·멱등·반영0) + 공통 게이트(typecheck+test+build), 기존 회귀 0
+- [x] `PatternEntry` 구체 타입(kind/axis/signal/count/sources/summary/status/tags) — placeholder 대체
+- [x] `detect`: active failures+successes 2축(태그군집·키워드빈도) 감지 → `avoid`/`reinforce` 후보
+- [x] 보수적 임계 기본 3(`--min` 조정) · `resolved`/`archived` 입력 제외 검증
+- [x] 멱등 — 재실행 시 시그니처 병합(중복 patterns 0), 결정적 정렬
+- [x] `vhk pattern list`(--kind/--all) · `dismiss <n>`(→archived) · 별칭 `패턴` + NLP 라우팅
+- [x] **반영 0 회귀 가드** — detect 가 RULES.md/memory 외 파일·다른 버킷 무변경
+- [x] MCP `pattern detect`·`list` 노출(비대화형) · secret 누출 0(secure scan)
+- [x] vhk goal sync → check-goal-19.mjs 생성 → vhk goal check --id 19 통과
+- [x] 신규 테스트(감지·임계·멱등·반영0) + 공통 게이트(typecheck+test+build), 기존 회귀 0
 
 ## 제외 범위
 - 후보 → 적용/반영(RULES.md), `evolve`, 사람말 카드 [예/아니오/나중에], 기여 실패 `resolved` 닫기 → **Goal 20**.

--- a/goals/43-goal-code-drift-gate.md
+++ b/goals/43-goal-code-drift-gate.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 43
 title: goal 상태↔코드 현실 드리프트 게이트 — shipped인데 NOT_STARTED 차단 — P1
-status: NOT_STARTED
+status: DONE
 priority: P1
 created: 2026-06-07
+completed: 2026-06-08
 leads_to: goal 상태 신뢰성 (Goal 19 정정 포함)
 ---
 
@@ -27,12 +28,12 @@ leads_to: goal 상태 신뢰성 (Goal 19 정정 포함)
 - 코드 shipped인데 goal 상태 NOT_STARTED로 남으면 CI/preflight가 잡는다.
 
 ## Completion Check
-- [ ] Goal 19 status를 DONE(+version)으로 정정
-- [ ] goal status↔코드 드리프트 점검 게이트 구현
-- [ ] shipped인데 NOT_STARTED면 fail/경고
-- [ ] 회귀 테스트
-- [ ] check-goal-43.mjs 통과
-- [ ] 공통 게이트(typecheck+test+build) 통과, 회귀 0
+- [x] Goal 19 status를 DONE(+version)으로 정정
+- [x] goal status↔코드 드리프트 점검 게이트 구현
+- [x] shipped인데 NOT_STARTED면 fail/경고
+- [x] 회귀 테스트
+- [x] check-goal-43.mjs 통과
+- [x] 공통 게이트(typecheck+test+build) 통과, 회귀 0
 
 ## Mandatory Reading
 - src/commands/goal.ts

--- a/scripts/check-goal-43.mjs
+++ b/scripts/check-goal-43.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// scripts/check-goal-43.mjs — 자동 생성(vhk goal sync) 후 goal 고유 검증 손추가.
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역.
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 43 gate.')
+  process.exit(1)
+}
+
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 43] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 43 고유 검증 (goal 상태↔코드 드리프트 게이트) ───────────────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// 순수 감지 lib
+const drift = read('src/lib/goal-drift.ts') ?? ''
+must(drift !== '', 'src/lib/goal-drift.ts 존재')
+must(/export function hasCustomGateAssertions/.test(drift), 'hasCustomGateAssertions export')
+must(/export function findStatusDriftCandidates/.test(drift), 'findStatusDriftCandidates export')
+must(!/execSync/.test(drift), 'goal-drift.ts execSync 없음(순수)')
+must(!/JSON\.parse\(\s*(?:fs\.)?readFileSync/.test(drift), 'goal-drift.ts raw JSON.parse(readFileSync) 없음')
+// CLI 명령
+const goal = read('src/commands/goal.ts') ?? ''
+must(/export async function goalDrift/.test(goal), 'goal.ts goalDrift export')
+must(/findStatusDriftCandidates/.test(goal), 'goal.ts 가 findStatusDriftCandidates 사용')
+must(/ensureNotHardStopped/.test(goal) ? !/goalDrift[\s\S]*?ensureNotHardStopped/.test(goal.slice(goal.indexOf('export async function goalDrift'), goal.indexOf('export async function goalDone'))) : true, 'goalDrift 는 HARD_STOP 가드 없음(read-only)')
+// 등록·발견성
+must(/'drift'/.test(read('src/lib/command-registry.ts') ?? ''), "command-registry 에 'drift' 등록")
+const idx = read('src/index.ts') ?? ''
+must(/\.command\('drift'\)/.test(idx), "index.ts 에 goal drift 서브커맨드 등록")
+must(/goalDrift/.test(idx), 'index.ts 가 goalDrift import·호출')
+// i18n
+must(/driftTitle/.test(read('src/i18n/ko.ts') ?? ''), 'ko.ts 에 goal.driftTitle 메시지')
+// 회귀 테스트
+must(existsSync('tests/goal-drift.test.ts'), 'tests/goal-drift.test.ts 존재')
+
+if (pass) { console.log('✅ goal 43 gate passes'); process.exit(0) }
+console.log('❌ goal 43 gate failed'); process.exit(1)

--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -15,6 +15,7 @@ import {
   type GoalStatus,
   type ParsedGoal,
 } from '../lib/goal-frontmatter.js'
+import { findStatusDriftCandidates } from '../lib/goal-drift.js'
 
 const GOALS_DIR = 'goals'
 const STATE_DIR = 'docs/state'
@@ -291,6 +292,29 @@ export async function goalCheck(opts: { id?: string }): Promise<void> {
     if (gate.err && !gate.out) console.log(chalk.dim(gate.err.slice(0, 500)))
     process.exitCode = 1
   }
+}
+
+// Goal 43: goal 상태 ↔ 코드 현실 드리프트 점검 (read-only — HARD_STOP 가드 없음, check/list 와 동일).
+// "shipped 인데 status: NOT_STARTED" 인 goal 을 잡아 exit 1. 깨끗하면 exit 0.
+export async function goalDrift(): Promise<void> {
+  console.log(chalk.bold(`\n${ko.goal.driftTitle}\n`))
+  const candidates = findStatusDriftCandidates(GOALS_DIR, SCRIPTS_DIR)
+  if (candidates.length === 0) {
+    console.log(chalk.green(`  ✅ ${ko.goal.driftClean}`))
+    return
+  }
+  console.log(chalk.red(`  ❌ ${ko.goal.driftFound(candidates.length)}\n`))
+  for (const c of candidates) {
+    console.log(chalk.yellow(`  [${c.id}] ${c.title}`))
+    console.log(chalk.dim(`      ${c.reason}`))
+    console.log(chalk.dim(`      ${c.goalFile} · ${c.scriptFile}`))
+  }
+  console.log(
+    chalk.dim(
+      '\n  → 구현됐다면 `vhk goal done --id <n>` 로 DONE 전환, 아니라면 게이트의 goal 고유 검증을 제거하세요.'
+    )
+  )
+  process.exitCode = 1
 }
 
 export async function goalDone(opts: { id?: string }): Promise<void> {

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -456,6 +456,10 @@ export const ko = {
     skippedFiles: (n: number) =>
       `⚠ 스키마 불일치로 무시된 파일 ${n}개 (goal 로 안 잡힘 — silent skip):`,
     notFound: (id: number) => `goal id ${id} 없음 — vhk goal list 로 확인하세요.`,
+    driftTitle: '🔍 Goal 상태↔코드 드리프트 점검',
+    driftClean: 'goal 상태 드리프트 없음 (구현 흔적 있는데 NOT_STARTED 인 goal 0건)',
+    driftFound: (n: number) =>
+      `드리프트 의심 ${n}건 — check-goal 게이트에 goal 고유 검증이 있는데 status: NOT_STARTED:`,
   },
   agent: {
     blockerTitle: '🛑 Blocker 기록',

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ async function guardCliDefer(
   )
 }
 import { cloudPush, cloudPull } from './commands/cloud.js'
-import { goalCheck, goalDone, goalInit, goalList, goalNext, goalSync } from './commands/goal.js'
+import { goalCheck, goalDone, goalDrift, goalInit, goalList, goalNext, goalSync } from './commands/goal.js'
 import { blocker, learn, resume } from './commands/agent.js'
 import { patternDetect, patternList, patternDismiss } from './commands/pattern.js'
 import { evolveSuggest, evolveList, evolveApply, evolveReject, evolveUndo } from './commands/evolve.js'
@@ -638,7 +638,7 @@ workCmd
 const goalCmd = program
   .command('goal')
   .alias('목표')
-  .description('Goal 단계별 미션 관리 (init / list / next / check / done / sync)')
+  .description('Goal 단계별 미션 관리 (init / list / next / check / done / sync / drift)')
   .action(async () => { await goalList() })
 
 goalCmd
@@ -678,6 +678,12 @@ goalCmd
   .alias('동기화')
   .description('goals/*.md 스캔 → 누락된 check-goal-<id>.mjs 게이트 스크립트 백필 (idempotent)')
   .action(async () => { await goalSync() })
+
+goalCmd
+  .command('drift')
+  .alias('드리프트')
+  .description('goal 상태↔코드 드리프트 점검 — 구현됐는데 NOT_STARTED 인 goal 탐지 (read-only, 발견 시 exit 1)')
+  .action(async () => { await goalDrift() })
 
 program
   .command('blocker <description>')

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -7,7 +7,7 @@
  * 드리프트 가드 테스트가 실패해 R1(자연어 라우터가 명령 가로채기) 재발을 사전에 잡는다.
  */
 export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
-  goal: ['list', 'next', 'check', 'init', 'done', 'sync'],
+  goal: ['list', 'next', 'check', 'init', 'done', 'sync', 'drift'],
   ref: ['add', 'list', 'open'],
   memory: ['add', 'list', 'remove', 'archive', 'resolve', 'unarchive', 'migrate'],
   cloud: ['push', 'pull'],

--- a/src/lib/goal-drift.ts
+++ b/src/lib/goal-drift.ts
@@ -1,0 +1,75 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { listGoals, type GoalStatus } from './goal-frontmatter.js'
+
+// Goal 43: goal 상태 ↔ 코드 현실 드리프트 게이트.
+//
+// 불변 규칙: "goal 고유 게이트 검증(custom must() 호출)이 있는 goal 은 status: NOT_STARTED 이면 안 된다."
+//   근거: check-goal-<id>.mjs 는 `vhk goal sync` 가 백필하는데, 스캐폴드 상태에는 must() **정의**와
+//         **주석 처리된 예시**만 있다. 실제 must() **호출**은 그 goal 을 구현하면서 손으로 추가한다.
+//         즉 custom must() = "코드 구현 흔적". 그게 있는데 status 가 NOT_STARTED 면 드리프트.
+//   실측: Goal 19(pattern)가 src/commands/pattern.ts 풀구현 + v2.1.0 출시인데 status: NOT_STARTED 로
+//         남아 이 규칙을 위반했다(이 게이트가 막으려는 원형 사례).
+//
+// 보수적 설계(거짓 양성보다 미탐 선호):
+//   - NOT_STARTED 만 본다. IN_PROGRESS/DONE/BLOCKED 는 대상 아님.
+//   - 게이트 스크립트가 없으면(예: 아직 sync 안 한 SEO goal 21~26) 후보 아님.
+//   - 스캐폴드(정의/주석만)면 후보 아님 → 새 goal 무더기 오탐 0.
+
+/**
+ * check-goal 스크립트 본문에 goal 고유 검증(custom `must()` 호출)이 있는지.
+ * - 주석(`//`) 라인 무시.
+ * - `const must = ...` **정의** 라인 제외(호출이 아님).
+ * - 그 외 라인에 `must(` 가 있으면 = goal 고유 assertion = 구현 흔적.
+ */
+export function hasCustomGateAssertions(scriptContent: string): boolean {
+  for (const raw of scriptContent.split(/\r?\n/)) {
+    const line = raw.trim()
+    if (!line || line.startsWith('//')) continue
+    if (/const\s+must\s*=/.test(line)) continue // must 헬퍼 정의 라인 — 호출 아님
+    if (line.includes('must(')) return true // goal 고유 검증 호출 발견
+  }
+  return false
+}
+
+export interface DriftCandidate {
+  id: number
+  title: string
+  status: GoalStatus
+  goalFile: string
+  scriptFile: string
+  reason: string
+}
+
+/**
+ * goals/ ↔ scripts/ 를 대조해 "shipped 인데 NOT_STARTED" 드리프트 후보를 찾는다(순수, fs 읽기만).
+ * 판정: status === NOT_STARTED 이고 check-goal-<id>.mjs 가 존재하며 custom must() 호출이 있는 goal.
+ */
+export function findStatusDriftCandidates(goalsDir: string, scriptsDir: string): DriftCandidate[] {
+  const out: DriftCandidate[] = []
+  for (const g of listGoals(goalsDir)) {
+    const status = (g.frontmatter.status ?? 'NOT_STARTED') as GoalStatus
+    if (status !== 'NOT_STARTED') continue
+    const id = g.frontmatter.id
+    if (typeof id !== 'number') continue
+    const scriptFile = join(scriptsDir, `check-goal-${id}.mjs`)
+    if (!existsSync(scriptFile)) continue
+    let content: string
+    try {
+      content = readFileSync(scriptFile, 'utf-8')
+    } catch {
+      continue
+    }
+    if (!hasCustomGateAssertions(content)) continue
+    out.push({
+      id,
+      title: g.frontmatter.title ?? '',
+      status,
+      goalFile: g.filePath,
+      scriptFile,
+      reason:
+        'status: NOT_STARTED 인데 check-goal 게이트에 goal 고유 검증(코드 구현 흔적)이 있음 — 구현됐는데 status 만 안 바뀐 드리프트 의심',
+    })
+  }
+  return out
+}

--- a/tests/goal-drift.test.ts
+++ b/tests/goal-drift.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { hasCustomGateAssertions, findStatusDriftCandidates } from '../src/lib/goal-drift.js'
+
+// `vhk goal sync` 가 생성하는 스캐폴드 게이트의 핵심(must 정의 + 주석 예시만 — 고유 검증 0).
+const SCAFFOLD = `#!/usr/bin/env node
+const must = (cond, label) => { console.log((cond ? '  ✓ ' : '  ✗ ') + label); if (!cond) pass = false }
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+`
+// 구현하면서 손으로 추가한 goal 고유 검증 호출.
+const CUSTOM = SCAFFOLD + "must(existsSync('src/commands/pattern.ts'), 'pattern.ts 존재')\n"
+
+describe('hasCustomGateAssertions', () => {
+  it('스캐폴드(정의 + 주석 예시만) → false', () => {
+    expect(hasCustomGateAssertions(SCAFFOLD)).toBe(false)
+  })
+  it('goal 고유 must() 호출 있으면 → true', () => {
+    expect(hasCustomGateAssertions(CUSTOM)).toBe(true)
+  })
+  it('주석 처리된 must() 호출은 무시 → false', () => {
+    expect(hasCustomGateAssertions(SCAFFOLD + "// must(read('x'), 'x')\n")).toBe(false)
+  })
+})
+
+describe('findStatusDriftCandidates', () => {
+  function setup(
+    goals: Record<string, string>,
+    scripts: Record<string, string>
+  ): { root: string; gdir: string; sdir: string } {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-drift-'))
+    const gdir = path.join(root, 'goals')
+    const sdir = path.join(root, 'scripts')
+    fs.mkdirSync(gdir)
+    fs.mkdirSync(sdir)
+    for (const [name, content] of Object.entries(goals)) fs.writeFileSync(path.join(gdir, name), content)
+    for (const [name, content] of Object.entries(scripts)) fs.writeFileSync(path.join(sdir, name), content)
+    return { root, gdir, sdir }
+  }
+  const goalCard = (id: number, status: string): string =>
+    `---\nvhk_format: 1\ntype: goal\nid: ${id}\ntitle: G${id}\nstatus: ${status}\npriority: P1\n---\n\n# Goal ${id}\n`
+
+  it('NOT_STARTED + custom 게이트 → 드리프트로 잡음', () => {
+    const { root, gdir, sdir } = setup({ '5-x.md': goalCard(5, 'NOT_STARTED') }, { 'check-goal-5.mjs': CUSTOM })
+    expect(findStatusDriftCandidates(gdir, sdir).map((x) => x.id)).toEqual([5])
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('NOT_STARTED + 스캐폴드 게이트 → 통과(오탐 0)', () => {
+    const { root, gdir, sdir } = setup({ '6-y.md': goalCard(6, 'NOT_STARTED') }, { 'check-goal-6.mjs': SCAFFOLD })
+    expect(findStatusDriftCandidates(gdir, sdir)).toEqual([])
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('DONE + custom 게이트 → 통과(정상 완료)', () => {
+    const { root, gdir, sdir } = setup({ '7-z.md': goalCard(7, 'DONE') }, { 'check-goal-7.mjs': CUSTOM })
+    expect(findStatusDriftCandidates(gdir, sdir)).toEqual([])
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('NOT_STARTED + 게이트 스크립트 없음 → 통과(아직 sync 안 한 goal)', () => {
+    const { root, gdir, sdir } = setup({ '8-w.md': goalCard(8, 'NOT_STARTED') }, {})
+    expect(findStatusDriftCandidates(gdir, sdir)).toEqual([])
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('실제 repo goals/ ↔ scripts/ 드리프트 0 (회귀 가드)', () => {
+    expect(findStatusDriftCandidates('goals', 'scripts')).toEqual([])
+  })
+})


### PR DESCRIPTION
## 무엇

Goal 43 — **goal 상태↔코드 현실 드리프트 게이트**. "구현은 shipped 됐는데 goal frontmatter `status: NOT_STARTED`" 인 드리프트를 자동 탐지·차단.

> 동기: Goal 19(pattern)가 `src/commands/pattern.ts` 풀구현 + v2.1.0 출시인데 status 가 `NOT_STARTED` 로 남아있던 산 증거(이번 세션에서 발견). 사람이 status 갱신을 깜빡해도 아무도 안 막던 병.

## 불변 규칙

**"check-goal 게이트에 goal 고유 검증(custom `must()` 호출)이 있는 goal 은 `status: NOT_STARTED` 이면 안 된다."**

`vhk goal sync` 가 만드는 스캐폴드 게이트에는 `must()` **정의**와 **주석 예시**만 있다. 실제 `must()` **호출**은 그 goal 을 구현하며 손으로 추가 → custom `must()` = 구현 흔적.

## 변경

- `src/lib/goal-drift.ts` — 순수 감지(`hasCustomGateAssertions`, `findStatusDriftCandidates`). fs 읽기만, execSync·raw JSON.parse 0. **보수적**(거짓양성보다 미탐 선호): NOT_STARTED + 게이트 존재 + custom `must()` 만 잡음 → 스캐폴드/스크립트없음/DONE 통과(오탐 0).
- `vhk goal drift` — read-only 점검 명령(별칭 `드리프트`), 드리프트 발견 시 exit 1. preflight/CI 에서 호출 가능.
- `tests/goal-drift.test.ts` — 단위(스캐폴드/custom/주석/DONE/스크립트없음) + **실제 repo 드리프트 0 회귀 가드**(goal 게이트가 CI 미연결이라 vitest 가 enforcement).
- `scripts/check-goal-43.mjs` + goals/43 DONE.

## 검증

- 전체 `pnpm test:run` → **1063 pass / 0 fail**, `pnpm build` 성공
- `check-goal-43` 통과(typecheck+test+build+고유검증 13항목 ✓)
- `vhk goal drift` 도그푸딩 → clean repo exit 0, 한국어 출력 정상

## 스택 / 범위

- **#190 위에 쌓임** — 불변 테스트(repo 드리프트 0)가 통과하려면 Goal 19 가 DONE 이어야 해서 #190 의 goal-19 커밋을 포함. #190 먼저 머지하면 이 PR rebase 시 해당 커밋 자동 소거됨.
- `ci.yml`·`publish.ts`·`CHANGELOG` **안 건드림** — 진행 중 2.4.3 릴리즈 세션과 비충돌.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
