### PR TITLE
fix(mcp): Windows spawn ENOENT + check CLI 위임 (#150, #161)

### DIFF
--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -1,7 +1,8 @@
 import { execFileSync } from 'node:child_process'
 
-// Windows에서 pnpm/npm/npx/yarn은 .cmd shim. execFileSync는 native 바이너리만 찾으므로 .cmd 확장자 부여.
-const SHIM_BINARIES = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+// Windows에서 pnpm/npm/npx/yarn/vhk는 .cmd shim. execFileSync는 native 바이너리만 찾으므로 .cmd 확장자 부여.
+// #150: 'vhk' 추가 — 전역 설치 시 vhk.cmd 만 노출돼 MCP 가 bare 'vhk' spawn 시 ENOENT 였음.
+const SHIM_BINARIES = new Set(['pnpm', 'npm', 'npx', 'yarn', 'vhk'])
 
 export function platformCmd(cmd: string): string {
   if (process.platform === 'win32' && SHIM_BINARIES.has(cmd)) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -362,21 +362,13 @@ export function createVhkMcpServer(): McpServer {
   })
 
   // ─── check ──────────────────────────────────────────────
-  server.registerTool('check', { description: '프로젝트 구조 점검 (필수 파일 + VHK 하네스 파일)' }, async () => {
-    const required = ['package.json', 'tsconfig.json', 'README.md', '.gitignore']
-    const recommended = ['CLAUDE.md', '.cursorrules', 'docs/PRD.md', 'docs/ARCHITECTURE.md']
-
-    const lines: string[] = ['🔍 프로젝트 점검', '', '필수:']
-    required.forEach((f) => {
-      lines.push(`  ${existsSync(f) ? '✅' : '❌'} ${f}`)
-    })
-    lines.push('', '권장 (VHK 하네스):')
-    recommended.forEach((f) => {
-      lines.push(`  ${existsSync(f) ? '✅' : '⚠️'} ${f}`)
-    })
-
-    return { content: [{ type: 'text', text: lines.join('\n') }] }
-  })
+  // #161: CLI `vhk check`(RULES.md 규칙 엔진)로 위임 — 옛 static 파일 체크리스트는 CLI 와
+  // 의미가 달라 에이전트에 거짓 신호를 줬다(harness/secure 와 동일하게 CLI 단일 출처로 통일).
+  server.registerTool(
+    'check',
+    { description: '프로젝트 규칙 점검 (vhk check — RULES.md 규칙 엔진, CLI 와 동일)' },
+    async () => runVhkCli(['check'], 'check')
+  )
 
   // ─── recap ──────────────────────────────────────────────
   server.registerTool(

--- a/tests/exec.test.ts
+++ b/tests/exec.test.ts
@@ -18,6 +18,17 @@ describe('lib/exec', () => {
     }
   })
 
+  it('#150: platformCmd Windows 에서 vhk → vhk.cmd (MCP spawn ENOENT 수정)', async () => {
+    const { platformCmd } = await import('../src/lib/exec.js')
+    const original = process.platform
+    try {
+      Object.defineProperty(process, 'platform', { value: 'win32' })
+      expect(platformCmd('vhk')).toBe('vhk.cmd')
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original })
+    }
+  })
+
   it('platformCmd: 비 Windows에서는 그대로 반환', async () => {
     const { platformCmd } = await import('../src/lib/exec.js')
     const original = process.platform

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { getRegisteredToolNames, getServerVersion } from './helpers/mcp-introspect.js'
+import { getRegisteredToolNames, getServerVersion, callTool } from './helpers/mcp-introspect.js'
 
 vi.mock('node:child_process')
 vi.mock('node:fs')
@@ -49,6 +49,19 @@ describe('MCP Server', () => {
   it('v2.0 — learn 쓰기 tool 등록 (memory v2 SoT, Evolution Loop)', async () => {
     const names = await getRegisteredToolNames()
     expect(names).toContain('learn')
+  })
+
+  it('#161: check tool 이 vhk check CLI(RULES 엔진)로 위임 — static 파일 체크리스트 아님', async () => {
+    const cp = await import('node:child_process')
+    const execFileSync = vi.mocked(cp.execFileSync)
+    execFileSync.mockReturnValue(Buffer.from('✅ RULES 5/5 통과'))
+    const res = await callTool('check')
+    // 위임됐으면 CLI 를 'check' 인자로 spawn (resolveVhkCliInvocation 의 --version + check 위임)
+    const calls = execFileSync.mock.calls.map((c) => ((c[1] as string[]) ?? []).join(' '))
+    expect(calls.some((a) => a.includes('check'))).toBe(true)
+    // CLI 출력을 표면화, 옛 static 체크리스트('필수:') 아님
+    expect(res.content[0].text).toContain('RULES 5/5 통과')
+    expect(res.content[0].text).not.toContain('필수:')
   })
 
   it('SERVER_VERSION 이 package.json 과 정합 (lib/version SoT)', async () => {


### PR DESCRIPTION
## 무엇 — MCP ↔ CLI 파리티 2건 (네 환경: Windows + Cursor MCP 직격)

### #150 — MCP harness/secure spawn `vhk` ENOENT (Windows)
전역 설치 시 Windows 는 `vhk.cmd` 만 노출하는데 MCP 가 bare `vhk` 를 spawn → `spawnSync vhk ENOENT` 로 harness/secure 가 MCP 에서만 깨짐(CLI 는 정상).
→ `SHIM_BINARIES` 에 `vhk` 추가 → `safeExecFile('vhk')` 가 `cmd.exe /d /s /c vhk.cmd` 로 래핑. 가용성 체크(resolveVhkCliInvocation) + 실제 위임(runVhkCli) 둘 다 동작. 전역 미설치(npx)면 `node dist/index.js` fallback 유지.

### #161 — MCP `check` 가 static 체크리스트
MCP check 가 정적 파일 목록(tsconfig 등)을 검사 → CLI `vhk check`(RULES.md 엔진)와 의미가 달라 거짓 신호(예: vanilla JS 에서 tsconfig 없음 fail).
→ harness/secure 처럼 `runVhkCli(['check'])` 로 위임 → CLI 단일 출처 통일.

## 검증
- TDD red→green (신규 2: platformCmd vhk→vhk.cmd, check 위임)
- 적대적 리뷰: 비-Windows 무영향·args 안전·fallback·check.ts 비대화형 → No issues
- **실기계 검증**: `cmd.exe /d /s /c vhk.cmd --version` → 2.4.2 (fix 메커니즘 동작 확인, 이전엔 bare vhk ENOENT)
- 전체 게이트: `pnpm build` 성공 · **1037 tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)