### PR TITLE
fix(cli): 비-TTY TTY_REQUIRED 종료코드 + save --message (#153, #154)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ vhk 기획 끝났고 바로 시작
 | `vhk worktree` | `워크트리` | worktree 가드 (`add <branch>` / `check`) — 생성 시 필수 env/설정 자동 복사(파일 복사·심볼릭 X, 비밀값 미노출), 누락 점검. `--install` 로 pnpm install. Goal 29 `worktree-env` 모듈 재사용 |
 | `vhk cloud push` | `클라우드`, `올리기` | `.vhk/` 를 GitHub secret gist 로 백업 (gh CLI 인증 사용) |
 | `vhk cloud pull` | `내리기` | gist 에서 `.vhk/` 복원 (`vhk cloud pull <gistId>` 또는 cloud.json) |
-| `vhk save` | `저장`, `커밋` | git add · commit · push 한 번에 |
+| `vhk save` | `저장`, `커밋` | git add · commit · push 한 번에. 비-TTY/에이전트에선 프롬프트 없이 기본 메시지 사용(또는 `vhk save -m "<메시지>"`로 지정) — MCP `save` 도구와 동일하게 동작 |
 | `vhk undo` | `되돌리기`, `취소` | 최근 커밋 soft reset (변경은 staged 유지) |
 | `vhk diff` | `변경`, `차이` | staged / unstaged / 새 파일 요약 (줄 수 합계는 tracked·HEAD 기준) |
 | `vhk status` | `상태`, `현황` | 브랜치·변경·커밋·원격·버전 대시보드 |

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -32,7 +32,12 @@ function statusIcon(code: string): string {
   return '📄'
 }
 
-export async function save(): Promise<void> {
+export interface SaveOptions {
+  /** #154: 커밋 메시지 직접 지정 — 비-TTY/에이전트에서 MCP save 처럼 의미있는 메시지 사용. */
+  message?: string
+}
+
+export async function save(opts: SaveOptions = {}): Promise<void> {
   console.log(chalk.bold(`\n💾 ${t('save.title')}`))
   console.log(chalk.gray('─'.repeat(40)))
 
@@ -85,15 +90,19 @@ export async function save(): Promise<void> {
     console.log(`   ${statusIcon(code)} ${name}`)
   })
 
-  const message = await promptOrDefault(
-    async () => (await inquirer.prompt<{ message: string }>([{
-      type: 'input',
-      name: 'message',
-      message: t('save.commitMessage'),
-      default: formatDefaultCommitMessage(),
-    }])).message,
-    'chore: vhk save',
-  )
+  // #154: --message 제공 시 프롬프트 건너뛰고 그대로 사용(MCP save 파리티). 없으면 기존 흐름
+  // (TTY → 프롬프트 / 비-TTY → 기본 메시지).
+  const message = opts.message?.trim()
+    ? opts.message.trim()
+    : await promptOrDefault(
+        async () => (await inquirer.prompt<{ message: string }>([{
+          type: 'input',
+          name: 'message',
+          message: t('save.commitMessage'),
+          default: formatDefaultCommitMessage(),
+        }])).message,
+        'chore: vhk save',
+      )
 
   const spinner = ora(t('save.saving')).start()
   let didAdd = false

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ import { review } from './commands/review.js'
 import { missionSet, missionShow, missionCheck, missionClear } from './commands/mission.js'
 import { runGuarded } from './lib/safety-guard.js'
 import { ensureNotHardStopped } from './lib/hard-stop-guard.js'
-import { isPromptAbortError } from './lib/interactive.js'
+import { isPromptAbortError, TTY_REQUIRED_EXIT_CODE } from './lib/interactive.js'
 
 /**
  * CLI high-risk 작업 가드 — 단일 chokepoint(runGuarded) 경유.
@@ -307,8 +307,9 @@ program
   .command('save')
   .alias('저장')
   .option('--yes', '확인 없이 실행 (strict 모드 가드 명시 승인)')
+  .option('-m, --message <msg>', '커밋 메시지 직접 지정 (비-TTY/에이전트용 — 프롬프트 생략)')
   .description('변경사항 저장 (git add → commit → push)')
-  .action(async (opts: { yes?: boolean }) => { await guardCli('save', opts?.yes === true, () => save()) })
+  .action(async (opts: { yes?: boolean; message?: string }) => { await guardCli('save', opts?.yes === true, () => save({ message: opts?.message })) })
 
 program
   .command('undo')
@@ -885,11 +886,13 @@ if (isMainModule) {
     }
   } catch (err) {
     if (isPromptAbortError(err)) {
-      console.error(chalk.yellow('\n  ⚠️  대화형 입력이 취소/종료됐습니다. (비대화형 환경에서는 해당 명령을 쓸 수 없어요)'))
+      // #153: 비-TTY 프롬프트 중단도 TTY_REQUIRED 전용 코드(2)로 — generic 실패와 구분.
+      console.error(chalk.yellow('\n  ⚠️  TTY_REQUIRED — 대화형 입력이 취소/종료됐습니다 (비대화형 환경 불가).'))
+      process.exitCode = TTY_REQUIRED_EXIT_CODE
     } else {
       console.error(chalk.red(`\n❌ ${err instanceof Error ? err.message : String(err)}`))
+      process.exitCode = 1
     }
-    process.exitCode = 1
   }
 }
 

--- a/src/lib/interactive.ts
+++ b/src/lib/interactive.ts
@@ -22,11 +22,19 @@ export async function promptOrDefault<T>(ask: () => Promise<T>, fallback: T, opt
  * `ERR_USE_AFTER_CLOSE` 로 크래시하므로, 진입부에서 friendly 안내 + 비-0 종료 신호 후 중단한다.
  * 반환 true = 대화형 진행 가능. (VHK-014)
  */
+/**
+ * 비-TTY 대화형 명령 거부 시 종료 코드 — generic 실패(1)와 구분(#153, CI/에이전트 감지용).
+ * 값 2 = "자동으로 진행 불가, 사람 개입 필요" 라는 공통 의미로, blocker 의 HARD_STOP 트립
+ * (agent.ts)도 같은 2를 쓴다. 구체 사유는 stderr 마커(TTY_REQUIRED / 🛑 HARD_STOP)로 구분.
+ */
+export const TTY_REQUIRED_EXIT_CODE = 2
+
 export function ensureInteractive(hint = ''): boolean {
   if (isInteractive()) return true
-  console.error(chalk.yellow('  ⚠️  이 명령은 대화형 입력이 필요합니다 — 비-TTY/파이프 환경에서는 실행할 수 없어요.'))
+  // 'TTY_REQUIRED' 마커 — 에이전트/CI 가 stderr 로 사유를 기계 감지(#153).
+  console.error(chalk.yellow('  ⚠️  TTY_REQUIRED — 이 명령은 대화형 입력이 필요합니다 (비-TTY/파이프 환경 불가).'))
   if (hint) console.error(chalk.dim(`     ${hint}`))
-  process.exitCode = 1
+  process.exitCode = TTY_REQUIRED_EXIT_CODE
   return false
 }
 

--- a/tests/design-guard.test.ts
+++ b/tests/design-guard.test.ts
@@ -37,7 +37,7 @@ describe('design / design-palette 가드 — 비-TTY refuse-essential', () => {
     await expect(design()).resolves.not.toThrow()
     expect(mockPrompt).not.toHaveBeenCalled()
     expect(mockWriteFileSync).not.toHaveBeenCalled()
-    expect(process.exitCode).toBe(1)
+    expect(process.exitCode).toBe(2) // #153: TTY_REQUIRED 전용 코드
   })
 
   it('design-palette 비-TTY → 동일하게 거부 (design 위임)', async () => {
@@ -45,6 +45,6 @@ describe('design / design-palette 가드 — 비-TTY refuse-essential', () => {
     await expect(designPalette()).resolves.not.toThrow()
     expect(mockPrompt).not.toHaveBeenCalled()
     expect(mockWriteFileSync).not.toHaveBeenCalled()
-    expect(process.exitCode).toBe(1)
+    expect(process.exitCode).toBe(2) // #153: TTY_REQUIRED 전용 코드
   })
 })

--- a/tests/interactive.test.ts
+++ b/tests/interactive.test.ts
@@ -12,11 +12,13 @@ describe('interactive — 대화형 가드 (VHK-014)', () => {
     process.exitCode = 0
   })
 
-  it('비-TTY 면 false 반환 + exitCode 1 (크래시 대신 friendly 중단)', () => {
+  it('#153: 비-TTY 면 false + exitCode 2(TTY_REQUIRED 전용 코드) + 마커 출력', () => {
     const orig = setTTY(false)
-    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const errs: string[] = []
+    vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => { errs.push(a.join(' ')) })
     expect(ensureInteractive('hint')).toBe(false)
-    expect(process.exitCode).toBe(1)
+    expect(process.exitCode).toBe(2) // generic 실패(1)와 구분되는 전용 코드
+    expect(errs.join('\n')).toContain('TTY_REQUIRED') // 기계 감지용 마커
     vi.restoreAllMocks()
     setTTY(orig)
   })

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -108,6 +108,19 @@ describe('save', () => {
     }
   })
 
+  it('#154: --message 제공 시 프롬프트 없이 그 메시지로 커밋 (MCP save 파리티)', async () => {
+    vi.mocked(execFileSync).mockImplementation((_file, args) => {
+      if (Array.isArray(args) && args[0] === 'rev-parse') return 'true'
+      return ''
+    })
+    mockGitOut.mockImplementation((args: string[]) => (args[0] === 'status' ? ' M file.ts' : ''))
+    mockHasGitRemote.mockReturnValue(false)
+    const { save } = await import('../src/commands/save.js')
+    await save({ message: 'feat: custom MSG123' })
+    expect(vi.mocked(inquirer.prompt)).not.toHaveBeenCalled()
+    expect(mockGitRun).toHaveBeenCalledWith(['commit', '-m', 'feat: custom MSG123'], '/repo')
+  })
+
   it('commit 실패 시 staged 안내', async () => {
     vi.mocked(execFileSync).mockImplementation((_file, args) => {
       if (Array.isArray(args) && args[0] === 'rev-parse') return 'true'

--- a/tests/ship-guard.test.ts
+++ b/tests/ship-guard.test.ts
@@ -22,11 +22,11 @@ describe('ship 가드 — 비-TTY refuse-essential', () => {
     process.exitCode = 0
   })
 
-  it('비-TTY → inquirer 미호출 + exitCode 1 (크래시/멈춤 없음)', async () => {
+  it('비-TTY → inquirer 미호출 + exitCode 2 (TTY_REQUIRED, 크래시/멈춤 없음)', async () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
     const { ship } = await import('../src/commands/ship.js')
     await expect(ship()).resolves.not.toThrow()
     expect(mockPrompt).not.toHaveBeenCalled()
-    expect(process.exitCode).toBe(1)
+    expect(process.exitCode).toBe(2) // #153: TTY_REQUIRED 전용 코드
   })
 })


### PR DESCRIPTION
## 무엇 — 비-TTY/에이전트 대화형 UX 2건

### #153 — TTY 명령 비-TTY 에서 generic exit 1
gate/design/recap/save/ship 등이 비-TTY 셸에서 generic `exit 1` 로 끝나 원인 구분 불가.
→ `ensureInteractive` + index.ts 프롬프트-중단 catch 둘 다 **전용 코드 2 + stderr `TTY_REQUIRED` 마커**로 통일(CI/에이전트 기계 감지). unsettled top-level await 는 기존 parseAsync try/catch 로 이미 차단됨.

> exit 2 는 blocker 의 HARD_STOP 트립과 같은 "사람 개입 필요" 공통 의미 — 사유는 stderr 마커로 구분(주석 명시).

### #154 — CLI save 메시지 지정 불가
MCP save 는 message 파라미터가 있는데 CLI 는 없었음.
→ `vhk save -m/--message` 옵션 추가(프롬프트 생략). CLI save 는 이미 `promptOrDefault` 로 비-TTY 안전했고, 이제 의미있는 메시지 지정 가능. README 명시.

## 검증
- TDD red→green (interactive exit2·marker / save --message / design·ship 가드 exit2 갱신)
- 적대적 리뷰: exit2 공통의미·empty/whitespace 메시지·shell 안전 점검 → 결함 없음(주석 보강)
- 실제 CLI 도그푸딩: `vhk gate` 비-TTY → exit 2 + TTY_REQUIRED + unsettled await 없음 / `vhk save -m` → 지정 메시지 커밋
- 전체 게이트: `pnpm build` 성공 · **1134 tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
