### PR TITLE
fix(deploy): Cloudflare Pages vs Workers 구분 + npx + MCP 통일 (#152)

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,7 +1,8 @@
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import chalk from 'chalk'
 import inquirer from 'inquirer'
 import { safeExecFile, safeExecFileStream } from '../lib/exec.js'
+import { readJsonFile } from '../lib/read-json.js'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 
@@ -52,6 +53,60 @@ export function detectPlatform(): Platform | null {
   return null
 }
 
+// #152: Cloudflare 는 Workers/Pages 둘 다 wrangler.toml 을 쓴다 — 무조건 Workers 로 보면
+// Pages 프로젝트에 `wrangler deploy`(틀린 명령)를 제시. toml 의 pages 표식 또는 deploy
+// 스크립트의 `wrangler pages deploy` 로 Pages 를 식별. (순수 함수 — 내용만 받아 fs 무관)
+export function isCloudflarePages(
+  tomlContent: string | null,
+  scripts: Record<string, string> = {}
+): boolean {
+  if (tomlContent && /pages_build_output_dir|\[\[?pages/i.test(tomlContent)) return true
+  return Object.values(scripts).some((s) => /wrangler\s+pages\s+deploy/.test(s))
+}
+
+// #152: Cloudflare 배포 설정 해석 — Pages/Workers 구분 + `npx wrangler`(전역 미설치 대응).
+export function cloudflareDeployConfig(
+  tomlContent: string | null,
+  scripts: Record<string, string> = {}
+): PlatformConfig {
+  const pages = isCloudflarePages(tomlContent, scripts)
+  return {
+    name: pages ? 'Cloudflare Pages' : 'Cloudflare Workers',
+    detectFiles: ['wrangler.toml'],
+    command: 'npx',
+    commandArgs: pages ? ['wrangler', 'pages', 'deploy'] : ['wrangler', 'deploy'],
+    checkArgs: ['wrangler', '--version'],
+    installHint: 'npx 가 wrangler 를 자동 설치합니다 (또는 npm i -D wrangler)',
+  }
+}
+
+// wrangler.toml 내용 읽기 — 가드(존재+읽기 try/catch) 단일화. 부재/읽기실패 → null(TOCTOU 안전).
+function readWranglerToml(): string | null {
+  try {
+    return existsSync('wrangler.toml') ? readFileSync('wrangler.toml', 'utf-8') : null
+  } catch {
+    return null
+  }
+}
+
+function readPkgScripts(): Record<string, string> {
+  try {
+    return readJsonFile<{ scripts?: Record<string, string> }>('package.json').scripts ?? {}
+  } catch {
+    return {}
+  }
+}
+
+// #152: CLI/MCP 공용 배포 타깃 해석 — 감지 + Cloudflare Pages/Workers 세분(통일된 단일 출처).
+export function resolveDeployTarget(): { platform: Platform; config: PlatformConfig } | null {
+  const platform = detectPlatform()
+  if (!platform) return null
+  if (platform === 'cloudflare') {
+    return { platform, config: cloudflareDeployConfig(readWranglerToml(), readPkgScripts()) }
+  }
+  return { platform, config: PLATFORMS[platform] }
+}
+
 function isCLIAvailable(cmd: string, checkArgs: string[]): boolean {
   return safeExecFile(cmd, checkArgs).ok
 }
@@ -60,10 +115,12 @@ export async function deploy(): Promise<void> {
   console.log(chalk.bold('\n🚀 ' + t('deploy.title')))
   console.log(chalk.gray('─'.repeat(40)))
 
-  let platform: Platform | null = detectPlatform()
+  const target = resolveDeployTarget()
+  let config: PlatformConfig
 
-  if (platform) {
-    console.log(chalk.cyan(`\n🔍 감지된 플랫폼: ${PLATFORMS[platform].name}`))
+  if (target) {
+    config = target.config
+    console.log(chalk.cyan(`\n🔍 감지된 플랫폼: ${config.name}`))
   } else {
     const { selected } = await inquirer.prompt<{ selected: Platform }>([
       {
@@ -73,14 +130,16 @@ export async function deploy(): Promise<void> {
         choices: [
           { name: '▲ Vercel', value: 'vercel' as Platform },
           { name: '◆ Netlify', value: 'netlify' as Platform },
-          { name: '☁ Cloudflare Workers', value: 'cloudflare' as Platform },
+          { name: '☁ Cloudflare (Workers/Pages 자동 구분)', value: 'cloudflare' as Platform },
         ],
       },
     ])
-    platform = selected
+    // #152: Cloudflare 수동 선택 시에도 Pages/Workers 세분 + npx.
+    config =
+      selected === 'cloudflare'
+        ? cloudflareDeployConfig(readWranglerToml(), readPkgScripts())
+        : PLATFORMS[selected]
   }
-
-  const config = PLATFORMS[platform]
 
   if (!isCLIAvailable(config.command, config.checkArgs)) {
     console.log(chalk.red(`\n❌ ${config.name} CLI가 설치되어 있지 않습니다.`))

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import { existsSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs'
 import { safeExecFile, NETWORK_EXEC_TIMEOUT_MS } from '../lib/exec.js'
 import { parseEnvKeys } from '../commands/env.js'
-import { detectPlatform } from '../commands/deploy.js'
+import { resolveDeployTarget } from '../commands/deploy.js'
 import { bumpVersion } from '../commands/publish.js'
 import { detectCurrentPM, parseAuditOutput, runAuditJson } from '../commands/audit.js'
 import { readJsonFile } from '../lib/read-json.js'
@@ -559,8 +559,10 @@ export function createVhkMcpServer(): McpServer {
         '배포 플랫폼 자동 감지 + CLI 설치 확인 (MCP 모드: 실제 배포 미수행 — `vhk deploy` 안내)',
     },
     async () => {
-      const platform = detectPlatform()
-      if (!platform) {
+      // #152: resolveDeployTarget 로 CLI 와 동일 감지(Cloudflare Pages/Workers 구분). 과거엔
+      // platform 키('cloudflare')를 CLI 명령으로 오용해 `cloudflare --version`(존재X)로 항상 실패했음.
+      const target = resolveDeployTarget()
+      if (!target) {
         return {
           content: [
             {
@@ -570,15 +572,17 @@ export function createVhkMcpServer(): McpServer {
           ],
         }
       }
-      const cliCheck = safeExecFile(platform, ['--version'])
+      const { config } = target
+      const cliCheck = safeExecFile(config.command, config.checkArgs)
+      const cmdLabel = `${config.command} ${config.commandArgs.join(' ')}`
       const cliStatus = cliCheck.ok
-        ? `✓ ${platform} CLI 설치됨 (${cliCheck.out})`
-        : `✗ ${platform} CLI 미설치 — npm i -g ${platform}`
+        ? `✓ CLI 사용 가능 (${cliCheck.out.split('\n')[0]})`
+        : `✗ CLI 미설치 — ${config.installHint}`
       return {
         content: [
           {
             type: 'text',
-            text: `🚀 감지된 플랫폼: ${platform}\n${cliStatus}\n\n실제 배포는 터미널에서: vhk deploy`,
+            text: `🚀 감지된 플랫폼: ${config.name}\n배포 명령: ${cmdLabel}\n${cliStatus}\n\n실제 배포는 터미널에서: vhk deploy`,
           },
         ],
       }

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -56,3 +56,37 @@ describe('deploy', () => {
     expect(detectPlatform()).toBeNull()
   })
 })
+
+describe('#152 — Cloudflare Pages vs Workers 감지', () => {
+  it('wrangler.toml 에 pages_build_output_dir → Pages', async () => {
+    const { isCloudflarePages } = await import('../src/commands/deploy.js')
+    expect(isCloudflarePages('name = "x"\npages_build_output_dir = "dist"\n', {})).toBe(true)
+  })
+  it('wrangler.toml 에 [pages] 섹션 → Pages', async () => {
+    const { isCloudflarePages } = await import('../src/commands/deploy.js')
+    expect(isCloudflarePages('[pages]\n', {})).toBe(true)
+  })
+  it('deploy 스크립트가 wrangler pages deploy → Pages', async () => {
+    const { isCloudflarePages } = await import('../src/commands/deploy.js')
+    expect(isCloudflarePages(null, { 'deploy:cf': 'npx wrangler pages deploy dist' })).toBe(true)
+  })
+  it('일반 wrangler.toml(Workers) → Pages 아님', async () => {
+    const { isCloudflarePages } = await import('../src/commands/deploy.js')
+    expect(isCloudflarePages('name = "worker"\nmain = "src/index.ts"\n', {})).toBe(false)
+  })
+
+  it('cloudflareDeployConfig: Pages → npx wrangler pages deploy', async () => {
+    const { cloudflareDeployConfig } = await import('../src/commands/deploy.js')
+    const c = cloudflareDeployConfig('pages_build_output_dir = "dist"', {})
+    expect(c.name).toContain('Pages')
+    expect(c.command).toBe('npx')
+    expect(c.commandArgs).toEqual(['wrangler', 'pages', 'deploy'])
+  })
+  it('cloudflareDeployConfig: Workers → npx wrangler deploy', async () => {
+    const { cloudflareDeployConfig } = await import('../src/commands/deploy.js')
+    const c = cloudflareDeployConfig('main = "src/index.ts"', {})
+    expect(c.name).toContain('Workers')
+    expect(c.command).toBe('npx')
+    expect(c.commandArgs).toEqual(['wrangler', 'deploy'])
+  })
+})


### PR DESCRIPTION
## 무엇 (#152)
`wrangler.toml` 을 무조건 **Cloudflare Workers**(`wrangler deploy`)로 감지 → 실제 **Pages** 프로젝트에 틀린 명령 제시. 또 MCP deploy 는 platform 키(`cloudflare`)를 CLI 명령으로 오용해 `cloudflare --version`(존재X)로 항상 "CLI 미설치".

## 고친 곳
- `isCloudflarePages`(순수): toml 의 `pages_build_output_dir`/`[pages]` 또는 deploy 스크립트의 `wrangler pages deploy` 로 Pages 식별.
- `cloudflareDeployConfig`: Pages → `npx wrangler pages deploy`, Workers → `npx wrangler deploy`. 전역 wrangler 대신 **npx**(전역 미설치 대응).
- `resolveDeployTarget`: CLI/MCP **공용 단일 출처**(감지 + Cloudflare 세분). `deploy()` 와 MCP deploy 둘 다 위임 → 감지 통일, MCP 가 올바른 명령으로 가용성 체크.

## 검증
- TDD red→green (신규 6: Pages/Workers 감지 + config)
- 적대적 리뷰: regex 오탐(`[mypages]` 미매칭 확인)·TOCTOU·npx 회귀·비-cloudflare 무영향 → `readWranglerToml` 헬퍼로 TOCTOU/중복 해소
- 전체 게이트: `pnpm build` 성공 · **1144 tests passed**
- 참고: CLI e2e 도그푸딩은 deploy 안전가드(guardCli) + `npx wrangler` 다운로드로 막혀, 감지 로직은 순수 유닛으로 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)
