### PR TITLE
feat(goal-28): test-first 매핑 게이트 — vhk testmap (변경 기능 ↔ 테스트 누락 경고)

### DIFF
--- a/goals/28-test-first-gate.md
+++ b/goals/28-test-first-gate.md
@@ -3,9 +3,10 @@ vhk_format: 1
 type: goal
 id: 28
 title: test-first 게이트 (신규 기능 ↔ 테스트 매핑 + red→green 증거) — P2
-status: NOT_STARTED
+status: DONE
 priority: P2
 created: 2026-06-06
+completed: 2026-06-08
 ---
 
 # Goal 28: test-first 게이트
@@ -26,11 +27,18 @@ created: 2026-06-06
 - HARD 게이트(테스트 우선 미충족 시 done 차단)는 **opt-in 플래그**(`VHK_TEST_FIRST=1`)로만.
 
 ## Completion Check
-- [ ] 신규 기능 파일에 테스트 매핑 없음 → 경고 출력
-- [ ] verify 리포트에 red→green 증거 필드(옵션) 기록
-- [ ] opt-in 플래그 ON 시에만 HARD 차단, 기본은 경고
-- [ ] 기존 868 테스트 회귀 0
-- [ ] 공통 게이트 통과
+- [x] 신규 기능 파일에 테스트 매핑 없음 → 경고 출력 (`vhk testmap`)
+- [ ] verify 리포트에 red→green 증거 필드(옵션) 기록 — **deferred** (아래 결정 참조)
+- [x] opt-in 플래그 ON 시에만 HARD 차단, 기본은 경고 (`VHK_TEST_FIRST=1`)
+- [x] 기존 테스트 회귀 0
+- [x] 공통 게이트 통과
+
+## 결정 (실행 기록 2026-06-08)
+- **v0 = 매핑 + opt-in**: `src/lib/test-mapping.ts`(순수) + `vhk testmap`(read-only). git 변경(porcelain)
+  중 기능 소스(src/commands·src/lib)에 대응 `*.test.ts` 가 없으면 경고. `VHK_TEST_FIRST=1` 시 exit 1.
+- **red→green 증거 필드(item 2) deferred**: 카드에서 "(옵션)·[추론]" 으로 표기된 항목. 진짜 red→green
+  은 테스트 러너를 변경 전후 2회 계측해야 해 v0 대비 과투자(과안정화 경계). 매핑+opt-in 으로 핵심
+  수용기준("테스트 없는 신규 기능 잡힘")은 충족. 실사용에서 test-after 버그 신호 관측 시 승격.
 
 ## 범위
 - IN: 매핑 검사 + 증거 기록 + opt-in HARD 게이트.

--- a/goals/_meta.md
+++ b/goals/_meta.md
@@ -34,6 +34,8 @@ version: v1.1
 3. **tsup build** 가 성공한다 (`pnpm build`). `dist/index.js` 와
    `dist/mcp/index.js` 가 생성된다.
 4. **새 기능에 대한 테스트가 최소 1개 이상** 추가됨 (PR 단위).
+   — Goal 28: `vhk testmap` 으로 변경 기능 소스(src/commands·src/lib) ↔ 테스트 매핑을 점검한다.
+   기본은 경고만, `VHK_TEST_FIRST=1` 일 때만 HARD 차단(과안정화 경계 — 실사용 신호 전 강제 안 함).
 5. **README.md / COMMANDS.md** 명령어 표에 신규 명령어가 반영됨.
 
 각 condition 은 source-of-truth 로부터 enumerate 된다:

--- a/scripts/check-goal-28.mjs
+++ b/scripts/check-goal-28.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// scripts/check-goal-28.mjs — 자동 생성(vhk goal sync) 후 goal 고유 검증 손추가.
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역.
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 28 gate.')
+  process.exit(1)
+}
+
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 28] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 28 고유 검증 (test-first 매핑 게이트) ─────────────────────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+const map = read('src/lib/test-mapping.ts') ?? ''
+must(/export function isFeatureSource/.test(map), 'test-mapping.ts isFeatureSource export')
+must(/export function expectedTestBasename/.test(map), 'expectedTestBasename export')
+must(/export function findUntested/.test(map), 'findUntested export')
+must(/export function collectTestBasenames/.test(map), 'collectTestBasenames export')
+const cmd = read('src/commands/testmap.ts') ?? ''
+must(/export async function testmap/.test(cmd), 'testmap.ts testmap export')
+must(/export function changedFeatureSources/.test(cmd), 'changedFeatureSources export')
+must(/VHK_TEST_FIRST/.test(cmd), 'opt-in VHK_TEST_FIRST 플래그')
+must(/process\.exitCode = 1/.test(cmd), 'HARD 모드에서 exit 1')
+must(/gitOut/.test(cmd) && !/execSync/.test(cmd), 'testmap 이 gitOut 통로 사용(새 execSync 없음)')
+must(!/ensureNotHardStopped/.test(cmd), 'testmap 은 read-only(HARD_STOP 가드 없음)')
+// 등록·발견성
+must(/\.command\('testmap'\)/.test(read('src/index.ts') ?? ''), "index.ts 에 testmap 등록")
+must(/name: 'testmap'/.test(read('src/lib/command-registry.ts') ?? ''), 'TOP_LEVEL_COMMANDS 에 testmap')
+// _meta 강화
+must(/testmap/.test(read('goals/_meta.md') ?? '') && /VHK_TEST_FIRST/.test(read('goals/_meta.md') ?? ''), '_meta.md 테스트 게이트에 testmap 반영')
+// 회귀 테스트
+must(existsSync('tests/test-mapping.test.ts'), 'tests/test-mapping.test.ts 존재')
+
+if (pass) { console.log('✅ goal 28 gate passes'); process.exit(0) }
+console.log('❌ goal 28 gate failed'); process.exit(1)

--- a/src/commands/testmap.ts
+++ b/src/commands/testmap.ts
@@ -1,0 +1,68 @@
+import chalk from 'chalk'
+import { join } from 'node:path'
+import { gitOut } from '../lib/git-repo.js'
+import { parsePorcelainLines } from '../lib/git-porcelain.js'
+import {
+  collectTestBasenames,
+  findUntested,
+  isFeatureSource,
+  expectedTestBasename,
+  toPosix,
+} from '../lib/test-mapping.js'
+import { printNextStep } from '../lib/next-step.js'
+
+// Goal 28: test-first 매핑 점검 명령(read-only).
+// git 변경(staged/unstaged/untracked) 중 기능 소스에 대응 테스트가 없으면 경고.
+// 기본 경고만(exit 0), VHK_TEST_FIRST=1 일 때만 HARD 차단(exit 1) — 과안정화 경계.
+
+/** git status --porcelain 에서 변경/신규 기능 소스 경로 추출. */
+export function changedFeatureSources(cwd: string): string[] {
+  let porcelain: string
+  try {
+    // --untracked-files=all: 새 디렉터리 통째를 "?? dir/" 로 collapse 하지 않고 개별 파일까지 나열.
+    porcelain = gitOut(['status', '--porcelain', '--untracked-files=all'], cwd)
+  } catch {
+    return [] // git 레포 아님 → 검사 대상 없음
+  }
+  const out: string[] = []
+  for (const line of parsePorcelainLines(porcelain)) {
+    // 형식: "XY path" (상태 2글자 + 공백 + 경로). rename 은 "old -> new".
+    let p = line.slice(3).trim()
+    if (p.includes(' -> ')) p = p.split(' -> ')[1] // rename 은 새 경로 기준
+    p = toPosix(p.replace(/^"(.*)"$/, '$1')) // 공백 포함 경로의 따옴표 해제
+    if (isFeatureSource(p)) out.push(p)
+  }
+  return out
+}
+
+export async function testmap(): Promise<void> {
+  console.log(chalk.bold('\n🧭 test-first 매핑 점검 (testmap)'))
+  const cwd = process.cwd()
+  const hard = process.env.VHK_TEST_FIRST === '1'
+  const changed = changedFeatureSources(cwd)
+  if (changed.length === 0) {
+    console.log(chalk.dim('  변경된 기능 소스 없음 — 검사할 것 없음.'))
+    return
+  }
+  const testBasenames = collectTestBasenames(join(cwd, 'tests'))
+  const untested = findUntested(changed, testBasenames)
+  if (untested.length === 0) {
+    console.log(chalk.green(`  ✅ 변경 기능 ${changed.length}개 전부 대응 테스트 있음.`))
+    return
+  }
+  console.log(`  ${hard ? chalk.red('❌') : chalk.yellow('⚠️')} 테스트 없는 기능 변경 ${untested.length}건:`)
+  for (const f of untested) {
+    console.log(chalk.dim(`     - ${f}  →  tests/**/${expectedTestBasename(f)} 필요`))
+  }
+  if (hard) {
+    console.log(chalk.red('\n  VHK_TEST_FIRST=1 — test-first 미충족으로 차단(exit 1).'))
+    process.exitCode = 1
+  } else {
+    console.log(chalk.dim('\n  (경고만 — HARD 차단하려면 VHK_TEST_FIRST=1)'))
+    printNextStep({
+      message: '먼저 실패 테스트를 작성하세요(red→green):',
+      command: 'vhk testmap',
+      cursorHint: '테스트 매핑 점검해줘',
+    })
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import { start } from './commands/start.js'
 import { mode } from './commands/mode.js'
 import { verify } from './commands/verify.js'
 import { preflight } from './commands/preflight.js'
+import { testmap } from './commands/testmap.js'
 import { worktreeAdd, worktreeCheck } from './commands/worktree.js'
 import { standup } from './commands/standup.js'
 import { today } from './commands/today.js'
@@ -482,6 +483,12 @@ program
   .option('--full', '테스트 전체 실행 (--changed 캐시 미사용)')
   .description('출고 전 안전점검 — 2FA·shim·env·lint·타입·테스트·git 8개 항목, 치명 실패 시 차단')
   .action(async (opts: { publish?: boolean; pr?: boolean; full?: boolean }) => { await preflight(opts) })
+
+program
+  .command('testmap')
+  .alias('테스트매핑')
+  .description('test-first 매핑 점검 — 변경 기능 소스에 대응 테스트 누락 경고 (VHK_TEST_FIRST=1 시 exit 1)')
+  .action(async () => { await testmap() })
 
 const worktreeCmd = program
   .command('worktree')

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -44,6 +44,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'mode', '모드',
   'verify', '사전점검',
   'preflight', '출고점검',
+  'testmap', '테스트매핑',
   'worktree', '워크트리',
   'standup', '아침',
   'today', '자축',

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -82,6 +82,7 @@ export const TOP_LEVEL_COMMANDS: ReadonlyArray<{ name: string; desc: string }> =
   { name: 'mode', desc: 'Safety Mode 조회/변경 (lite|standard|strict)' },
   { name: 'verify', desc: '검증 게이트 실행 + 증거 기록' },
   { name: 'preflight', desc: '출고 전 안전점검 (2FA·shim·env·lint·타입·테스트·git, 치명 시 차단)' },
+  { name: 'testmap', desc: 'test-first 매핑 점검 (변경 기능 ↔ 테스트 누락 경고)' },
   { name: 'worktree', desc: 'worktree 가드 — 생성 시 env/설정 자동 복사·누락 점검 (add/check)' },
   { name: 'standup', desc: '아침 브리핑 (어제 한 일 + 오늘 추천 goal + 미해결)' },
   { name: 'today', desc: '저녁 자축·회고 (오늘 커밋·완료 goal 카운트 + 격려)' },

--- a/src/lib/test-mapping.ts
+++ b/src/lib/test-mapping.ts
@@ -1,0 +1,63 @@
+import { existsSync, readdirSync, statSync } from 'node:fs'
+import { join, basename } from 'node:path'
+
+// Goal 28: test-first 매핑.
+// "신규 기능 파일(src/commands·src/lib 의 .ts)에 대응 테스트가 있는가" 를 검사한다.
+// v0 철학(과안정화 경계): 기본은 **경고만**. VHK_TEST_FIRST=1 일 때만 HARD(exit 1).
+// 커밋 타임스탬프로 "정말 먼저 썼는지" 는 증명 안 함(위양성·우회 쉬움 — 카드 OUT 범위).
+
+/** 테스트가 요구되는 기능 소스 디렉터리(POSIX 표기, 경로 매칭용). */
+export const FEATURE_DIRS = ['src/commands', 'src/lib'] as const
+
+/** 경로 구분자 정규화(Windows \ → /). */
+export function toPosix(p: string): string {
+  return p.replace(/\\/g, '/')
+}
+
+/** 기능 소스인가 — FEATURE_DIRS 하위 .ts (단, *.test.ts / *.d.ts / types 전용 제외). */
+export function isFeatureSource(rel: string): boolean {
+  const p = toPosix(rel)
+  if (!p.endsWith('.ts')) return false
+  if (p.endsWith('.test.ts') || p.endsWith('.d.ts')) return false
+  return FEATURE_DIRS.some((d) => p.startsWith(d + '/'))
+}
+
+/** 기능 소스에 대응하는 테스트 파일 basename (예: src/commands/foo.ts → foo.test.ts). */
+export function expectedTestBasename(rel: string): string {
+  const base = basename(toPosix(rel)).replace(/\.ts$/, '')
+  return `${base}.test.ts`
+}
+
+/**
+ * srcRels 중 대응 테스트가 없는 기능 소스를 반환(순수).
+ * @param testBasenames tests/ 아래 모든 *.test.ts 의 basename 집합.
+ */
+export function findUntested(srcRels: string[], testBasenames: Set<string>): string[] {
+  const out: string[] = []
+  for (const rel of srcRels) {
+    if (!isFeatureSource(rel)) continue
+    if (!testBasenames.has(expectedTestBasename(rel))) out.push(toPosix(rel))
+  }
+  return out
+}
+
+/** tests/ 디렉터리를 재귀 스캔해 모든 *.test.ts basename 집합을 만든다(IO). */
+export function collectTestBasenames(testsDir: string): Set<string> {
+  const out = new Set<string>()
+  if (!existsSync(testsDir)) return out
+  const walk = (dir: string): void => {
+    for (const name of readdirSync(dir)) {
+      const fp = join(dir, name)
+      let isDir = false
+      try {
+        isDir = statSync(fp).isDirectory()
+      } catch {
+        continue
+      }
+      if (isDir) walk(fp)
+      else if (name.endsWith('.test.ts')) out.add(name)
+    }
+  }
+  walk(testsDir)
+  return out
+}

--- a/tests/test-mapping.test.ts
+++ b/tests/test-mapping.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  isFeatureSource,
+  expectedTestBasename,
+  findUntested,
+  collectTestBasenames,
+} from '../src/lib/test-mapping.js'
+
+describe('test-mapping 순수 함수', () => {
+  it('isFeatureSource: commands/lib .ts 만 true', () => {
+    expect(isFeatureSource('src/commands/foo.ts')).toBe(true)
+    expect(isFeatureSource('src/lib/bar.ts')).toBe(true)
+    expect(isFeatureSource('src\\commands\\win.ts')).toBe(true) // Windows 경로
+    expect(isFeatureSource('src/commands/foo.test.ts')).toBe(false)
+    expect(isFeatureSource('src/types/x.ts')).toBe(false)
+    expect(isFeatureSource('src/index.ts')).toBe(false) // src 루트는 기능 디렉터리 아님
+    expect(isFeatureSource('README.md')).toBe(false)
+  })
+
+  it('expectedTestBasename: foo.ts → foo.test.ts', () => {
+    expect(expectedTestBasename('src/commands/foo.ts')).toBe('foo.test.ts')
+    expect(expectedTestBasename('src/lib/git-repo.ts')).toBe('git-repo.test.ts')
+  })
+
+  it('findUntested: 대응 테스트 없는 기능 소스만', () => {
+    const tests = new Set(['foo.test.ts'])
+    const r = findUntested(['src/commands/foo.ts', 'src/lib/bar.ts', 'src/types/x.ts'], tests)
+    expect(r).toEqual(['src/lib/bar.ts']) // foo 는 있음, x 는 기능 아님
+  })
+})
+
+describe('collectTestBasenames', () => {
+  it('tests/ 재귀 스캔으로 *.test.ts basename 수집', () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-tm-'))
+    fs.mkdirSync(path.join(d, 'sub'), { recursive: true })
+    fs.writeFileSync(path.join(d, 'a.test.ts'), '')
+    fs.writeFileSync(path.join(d, 'sub', 'b.test.ts'), '')
+    fs.writeFileSync(path.join(d, 'notatest.ts'), '')
+    const set = collectTestBasenames(d)
+    expect(set.has('a.test.ts')).toBe(true)
+    expect(set.has('b.test.ts')).toBe(true)
+    expect(set.has('notatest.ts')).toBe(false)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})

--- a/tests/testmap.test.ts
+++ b/tests/testmap.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { changedFeatureSources } from '../src/commands/testmap.js'
+
+describe('changedFeatureSources (git porcelain 파싱)', () => {
+  it('untracked 기능 소스 감지, 비-기능 제외', () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-tmrepo-'))
+    const g = (args: string[]): void => execFileSync('git', args, { cwd: d, stdio: 'pipe' })
+    g(['init'])
+    g(['config', 'user.email', 't@t'])
+    g(['config', 'user.name', 't'])
+    fs.mkdirSync(path.join(d, 'src', 'commands'), { recursive: true })
+    fs.writeFileSync(path.join(d, 'src', 'commands', 'newcmd.ts'), 'export const x = 1\n')
+    fs.writeFileSync(path.join(d, 'README.md'), 'hi\n') // 비-기능
+    const changed = changedFeatureSources(d)
+    expect(changed).toContain('src/commands/newcmd.ts')
+    expect(changed.some((p) => p.includes('README'))).toBe(false)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('git 레포 아니면 빈 배열', () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-nogit-'))
+    expect(changedFeatureSources(d)).toEqual([])
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})


### PR DESCRIPTION
## 무엇

Goal 28 — **test-first 매핑 게이트**. `_meta` 공통 게이트의 테스트 조건이 "새 기능에 테스트 1개"뿐이라 test-after 도 통과하던 걸 보완. 변경된 기능 소스(src/commands·src/lib)에 대응 테스트가 없으면 잡아낸다.

## 변경

- **`src/lib/test-mapping.ts`**(순수) — `isFeatureSource`·`expectedTestBasename`·`findUntested`·`collectTestBasenames`. basename 매핑(`foo.ts` ↔ `foo.test.ts`).
- **`src/commands/testmap.ts`** — `vhk testmap`(read-only). `git status --porcelain --untracked-files=all`(gitOut 통로, 새 execSync 0)로 변경/신규 기능 소스를 모아 대응 테스트 없으면 경고. **기본 exit 0(경고만)**, `VHK_TEST_FIRST=1` 일 때만 **HARD(exit 1)** — 과안정화 경계.
- 등록: `index.ts`·`TOP_LEVEL_COMMANDS`·`KNOWN_COMMAND_TOKENS` + 별칭 `테스트매핑`.
- `goals/_meta.md` 테스트 게이트 조건 4 에 `testmap`·`VHK_TEST_FIRST` 반영.
- tests: `test-mapping`(순수 매핑)·`testmap`(porcelain 파싱·비-git).

## 검증

- 전체 `pnpm test:run` → **1144 pass / 0 fail** · `pnpm build` 성공 · `check-goal-28` 통과(고유검증 14항목 ✓)
- `vhk testmap` 도그푸딩 — 변경 기능 4개 전부 테스트 매핑 확인(exit 0). 새 `src/` 디렉터리 collapse 버그(`-uall` 누락)도 발견·수정.

## 범위 / deferred

- **red→green 증거 필드** (카드 "(옵션)·[추론]") — v0 범위 밖. 테스트 러너 변경 전후 2회 계측은 과투자. 매핑+opt-in 으로 핵심 수용기준 충족. 실사용 test-after 버그 신호 시 승격(goal 카드 결정란 기록).
- `verify.ts`·`publish.ts`·`ci.yml` 안 건드림.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
