### PR TITLE
docs(changelog): [Unreleased] → [2.5.0] 승격 (publish 빈 스텁 본문 채움)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ## [Unreleased]
 
-> 2.4.2 발행 이후 main 에 머지된 항목 — 다음 릴리즈 포함 예정.
+_다음 릴리즈 예정 항목 없음._
+
+## [2.5.0] - 2026-06-08
+
+> **생산성 5종 마무리 + 증거 체인 + self-gate 자동화.** preflight·worktree·doctor·standup·today(생산성 5종) Phase 2~3 완성 + goal↔코드 드리프트·증거↔커밋 SHA·증거 원장·test-first 매핑 게이트 + git-access 단일 통로화.
 
 ### Added
 
@@ -34,10 +38,6 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 - **git-access 단일 통로화** (Goal 46, #198) — git-repo 접근을 `safeExecFile` 경유로 통일 + 중복 통합.
 - **CI** — CodeQL action v3 → v4 (#120).
 - **드리프트 교정** — Goal 19(pattern) status `NOT_STARTED` → `DONE` 반영 (#190).
-
-## [2.5.0] - 2026-06-08
-
-_변경 내역 작성 필요._
 
 ## [2.4.2] - 2026-06-07
 


### PR DESCRIPTION
## 목적
`vhk publish` 가 `[2.5.0]` 빈 스텁('_변경 내역 작성 필요._')만 삽입하고 `[Unreleased]` 내용은 그대로 둠 → 발행된 13개 항목을 `[2.5.0]` 섹션으로 승격 + `[Unreleased]` 비움.

## 변경
- `[2.5.0] - 2026-06-08` ← Added(9)/Fixed(8)/내부(3) + 릴리즈 요약 blockquote
- `[Unreleased]` → 빈 상태(`_다음 릴리즈 예정 항목 없음._`)
- 중복 빈 스텁 제거

## 비고
- 2.5.0 은 **이미 npm 발행 완료**(latest=2.5.0, tarball 검증 OK). 이 PR 은 레포 CHANGELOG 정확성 정리만(코드 변경 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)