### PR TITLE
[codex] v2.5.1 CLAUDE.md 버전 정합 수정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,11 +86,11 @@ tags: [process, constitution]
 > 세션 종료: 마지막 갱신·버전·Phase·다음 할 일 갱신. (위 🔒 구역은 절대 건드리지 마.)
 > ⚠️ 아래 `**버전:**` 줄은 CI(version-sync.test.ts)가 강제 — 형식 `**버전:** vX.Y.Z` 유지, 릴리즈마다 package.json 따라 갱신.
 
-**마지막 갱신:** 2026-06-07
-- **버전:** v2.5.0 (npm latest) — 사실 확인은 package.json·CHANGELOG
-- **테스트:** 1035 pass · **MCP tools:** 29
-- **Phase:** HARD_STOP 가드 완성(Goal 34~36·39·41) + 원자적 쓰기 완성(Goal 37~38·40) · v2.4.2 발행 완료
+**마지막 갱신:** 2026-06-08
+- **버전:** v2.5.1 (npm publish 대기) — 사실 확인은 package.json·CHANGELOG
+- **테스트:** 1162 pass · **MCP tools:** 29
+- **Phase:** v2.5.0 발행 완료 + README/npm 설명 갱신 patch 릴리즈 준비
 - **블로커:** 없음
-- **진행 중(미발행):** Goal 30(#139)·Goal 33(#162/#179 DONE)·chore #168 — npm 2.4.2 미포함(발행 베이스 이후 머지) → 다음 2.4.3
-- **다음 할 일:** 2.4.3 발행 대기(더 모으는 중) — Goal 30·33·#168 묶음. (tag v2.4.2 → 131e3c3 = npm tarball 정확일치, main release 커밋은 09e4b88 — cosmetic 이라 둠)
+- **진행 중(미발행):** v2.5.1 npm publish 대기 — README/package 설명 최신화 반영용 patch
+- **다음 할 일:** `pnpm.cmd run prepublishOnly` 통과 확인 후 사용자 2FA로 `npm.cmd publish --access public`
 - **주의:** publish는 main에서만(#119)·사용자 직접(2FA) / 직접 main push 차단 → PR 경유


### PR DESCRIPTION
## 변경 요약
- package.json 2.5.1에 맞춰 CLAUDE.md LIVE 버전 표기를 v2.5.1로 갱신
- publish 실패 원인이던 version-sync.test 불일치를 해소
- 다음 publish 단계가 사용자 2FA로 진행되도록 상태 문구 정리

## 검증
- pnpm.cmd run prepublishOnly 통과
- 117 test files, 1162 tests passed