### PR TITLE
docs(state): 2.5.1 발행 반영 — CHANGELOG [2.5.1] 승격 + LIVE/next-task 동기화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ## [Unreleased]
 
+_다음 릴리즈 예정 항목 없음._
+
+## [2.5.1] - 2026-06-08
+
 ### Changed
 
 - README와 npm package 설명을 v2.5.0 구현 기준으로 갱신: goal/trust/memory/rules 루프, MCP 29 tools, 최신 명령 표면을 전면 재정리.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,10 +87,10 @@ tags: [process, constitution]
 > ⚠️ 아래 `**버전:**` 줄은 CI(version-sync.test.ts)가 강제 — 형식 `**버전:** vX.Y.Z` 유지, 릴리즈마다 package.json 따라 갱신.
 
 **마지막 갱신:** 2026-06-08
-- **버전:** v2.5.1 (npm publish 대기) — 사실 확인은 package.json·CHANGELOG
+- **버전:** v2.5.1 (발행 완료) — 사실 확인은 package.json·CHANGELOG
 - **테스트:** 1162 pass · **MCP tools:** 29
-- **Phase:** v2.5.0 발행 완료 + README/npm 설명 갱신 patch 릴리즈 준비
+- **Phase:** v2.5.1 발행 완료 (npm latest=2.5.1) — 생산성 5종(Phase 2~3) + 증거 체인(goal 44 SHA·45 ledger) + self-gate(goal 28 testmap·43 drift·46 git-access 단일화) + README/npm 갱신.
 - **블로커:** 없음
-- **진행 중(미발행):** v2.5.1 npm publish 대기 — README/package 설명 최신화 반영용 patch
-- **다음 할 일:** `pnpm.cmd run prepublishOnly` 통과 확인 후 사용자 2FA로 `npm.cmd publish --access public`
+- **진행 중(미발행):** 없음
+- **다음 할 일:** 미완 goal(silent-fallback 린트 Goal 25/27·#128, SEO 묶음 21~26) + 열린 이슈 10개 트리아지(불확실 4: #157·#155·#171·#148 해결확인 후 close).
 - **주의:** publish는 main에서만(#119)·사용자 직접(2FA) / 직접 main push 차단 → PR 경유

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -2,12 +2,12 @@
 
 > "지금 무엇부터"의 상태 SoT. 버전·테스트 등 사실값은 package.json·CHANGELOG가 SoT.
 
-**갱신:** 2026-06-07
-**Phase:** v2.4.2 발행 완료 + Goal 33(`vhk today`) v0 완료(#179). HARD_STOP 가드 완성(34~36·39·41) + 원자적 쓰기 완성(37~38·40) + today 회고. 테스트 1035+ pass.
+**갱신:** 2026-06-08
+**Phase:** v2.5.1 발행 완료 (npm latest=2.5.1). 생산성 5종(preflight·worktree·doctor·standup·today Phase 2~3) + 증거 체인(goal 44 SHA·45 ledger) + self-gate(goal 28 testmap·43 drift·46 git-access 단일화) 완료. 테스트 1162 pass.
 
 ## 다음 할 일
-- **2.4.3 발행 (대기 — 더 모으는 중)** — Goal 30(#139)·Goal 33(#162/#179)·chore #168 이 npm 2.4.2 미포함(발행 베이스 이후 머지) → CHANGELOG [Unreleased] 적재됨. goal 몇 개 더 모아 묶어 발행 예정.
-- 나머지 미완 goal (goals/ 동적 계산 — `vhk goal next`).
+- **미완 goal** (goals/ 동적 계산 — `vhk goal next`): silent-fallback 린트(Goal 25/27 영역·#128) · SEO 묶음(Goal 21~26) 등.
+- **열린 이슈 10개 트리아지** — 불확실 해결분 4개(#157 verify UX·#155 goal check mission drift·#171 nested pkg audit·#148 memory add `--`) 재현/해결확인 후 close. 백로그: #160·#159·#158·#151·#38.
 
 ## 블로커
 - 없음


### PR DESCRIPTION
## 목적
다른 세션이 2.5.1 발행만 하고 문서가 미동기 → 정리(코드 변경 0).

## 변경
- **CHANGELOG** — `[Unreleased]` 의 2.5.1 내용(README/npm 갱신)을 `[2.5.1] - 2026-06-08` 으로 승격 + `[Unreleased]` 비움 (publish 빈 스텁 패턴 보정).
- **CLAUDE.md LIVE** — `v2.5.1 (npm publish 대기)` → `(발행 완료)`, Phase/다음할일 2.5.1 기준 갱신. (버전 번호 불변 → version-sync 유지)
- **next-task.md** — 2.4.2 시대 서술 → 2.5.1 발행 완료 + 다음 할 일(미완 goal·이슈 트리아지) 갱신.

🤖 Generated with [Claude Code](https://claude.com/claude-code)