### PR TITLE
fix(cli): ref add --title 별칭 + memory add --content 폴백 (#151, #148)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -410,9 +410,10 @@ const refCmd = program
 refCmd
   .command('add <url>')
   .option('--memo <memo>', '메모 추가')
+  .option('--title <title>', '메모 별칭 (--memo 와 동일) — #151')
   .description('레퍼런스 URL 추가')
-  .action(async (url: string, opts: { memo?: string }) => {
-    await refAdd(url, opts.memo)
+  .action(async (url: string, opts: { memo?: string; title?: string }) => {
+    await refAdd(url, opts.memo ?? opts.title)
   })
 
 refCmd
@@ -574,16 +575,21 @@ const memoryCmd = program
   .action(async () => { await memoryList() })
 
 memoryCmd
-  .command('add <content>')
+  .command('add [content]')
+  // #148: 대시(--)로 시작하는 본문은 positional 로 못 넘긴다(commander 가 옵션으로 파싱) →
+  //       `--content=<본문>` 폴백 제공. 예: vhk memory add --content=--on-accent ... --type decision
+  .option('--content <text>', '본문 (대시 시작 등 positional 불가 시) — 예: --content=--on-accent ...')
   .option('--type <type>', '버킷: decision|failure|success (기본 decision)')
   .option('--tags <tags>', '태그 (쉼표 구분)')
   .option('--why <why>', '원인 (failure/success)')
   .option('--lesson <lesson>', '교훈 (failure)')
   .description('기억 저장 (--type 으로 결정/실패/성공 구분)')
-  .action(async (content: string, opts: { type?: string; tags?: string; why?: string; lesson?: string }) => {
+  .action(async (content: string | undefined, opts: { content?: string; type?: string; tags?: string; why?: string; lesson?: string }) => {
+    const body = content ?? opts.content ?? ''
     const tags = opts.tags ? opts.tags.split(',').map((s) => s.trim()) : undefined
     // 잘못된 --type 은 강등하지 않고 그대로 넘긴다 — memoryAdd 가 검증·거부(입력 유실 방지).
-    await memoryAdd(content, { type: opts.type, tags, why: opts.why, lesson: opts.lesson })
+    // 빈 본문(positional·--content 둘 다 없음)도 memoryAdd 가 안내+exit 1 처리.
+    await memoryAdd(body, { type: opts.type, tags, why: opts.why, lesson: opts.lesson })
   })
 
 memoryCmd

--- a/tests/cli-arg-dx.e2e.test.ts
+++ b/tests/cli-arg-dx.e2e.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import fs from 'node:fs'
+import os from 'node:os'
+import { readJsonFile } from '../src/lib/read-json.js'
+
+// 실제 빌드된 CLI 를 spawn 해서 commander 인자 파싱을 검증한다(#148/#151 은 파싱 레이어 결함이라
+// 함수 단위 mock 으론 재현 불가 — dist 필요).
+const bin = path.join(process.cwd(), 'dist', 'index.js')
+function runCli(args: string[], cwd: string) {
+  return spawnSync(process.execPath, [bin, ...args], {
+    encoding: 'utf-8',
+    cwd,
+    env: { ...process.env, CI: '1' },
+  })
+}
+
+describe('ref add --title 별칭 (#151)', () => {
+  it('--title 은 --memo 별칭으로 저장된다 (unknown option 없음)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-ref-title-'))
+    try {
+      const r = runCli(['ref', 'add', 'https://ex.com', '--title', '제목메모'], tmp)
+      expect(String(r.stderr ?? '')).not.toMatch(/unknown option/i)
+      const refs = readJsonFile<Array<{ url: string; memo: string }>>(
+        path.join(tmp, '.vhk', 'refs.json'),
+      )
+      expect(refs[0].url).toBe('https://ex.com')
+      expect(refs[0].memo).toBe('제목메모')
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('--memo 도 그대로 동작 (회귀)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-ref-memo-'))
+    try {
+      runCli(['ref', 'add', 'https://ex.com', '--memo', '메모값'], tmp)
+      const refs = readJsonFile<Array<{ memo: string }>>(path.join(tmp, '.vhk', 'refs.json'))
+      expect(refs[0].memo).toBe('메모값')
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('memory add --content — 대시(--) 시작 본문 (#148)', () => {
+  it('--content= 로 -- 시작 본문 저장 (unknown option/too many arguments 없음)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mem-content-'))
+    try {
+      const r = runCli(['memory', 'add', '--content=--on-accent CSS 변수', '--type', 'decision'], tmp)
+      expect(String(r.stderr ?? '')).not.toMatch(/unknown option|too many arguments/i)
+      expect(String(r.stdout ?? '')).toMatch(/기억 저장됨/)
+      const raw = fs.readFileSync(path.join(tmp, '.vhk', 'memory.json'), 'utf-8')
+      expect(raw).toContain('--on-accent')
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('일반 positional 본문도 그대로 동작 (회귀)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mem-pos-'))
+    try {
+      const r = runCli(['memory', 'add', '보통 결정 내용', '--type', 'decision'], tmp)
+      expect(String(r.stdout ?? '')).toMatch(/기억 저장됨/)
+      const raw = fs.readFileSync(path.join(tmp, '.vhk', 'memory.json'), 'utf-8')
+      expect(raw).toContain('보통 결정 내용')
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## 무엇
commander 인자 파싱 DX 결함 2건 — 둘 다 실제 CLI(dist)에서만 재현되는 파싱 레이어 문제.

- **#151** `ref add --title` → `unknown option` 에러. `--memo` 별칭으로 수용(`opts.memo ?? opts.title`).
- **#148** `memory add` 본문이 `--`로 시작하면(예: `--on-accent`) commander 가 옵션으로 오인해 거부. `add [content]` 선택형 + `--content=<본문>` 폴백 추가. 일반 positional 경로는 그대로.

## 테스트
`tests/cli-arg-dx.e2e.test.ts` — 실제 `dist/index.js` 를 임시 디렉터리에 spawn 해 파싱 검증(함수 mock으론 재현 불가한 레이어). 신규 옵션 + 회귀(--memo·positional) 각 2케이스.

## 게이트
- `pnpm build` ✓ · `pnpm test:run` **1257 pass / 0 fail**(신규 4) ✓

Fixes #151, #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)
