### PR TITLE
fix(theme): 바닐라/정적 PWA src/ 경로 오염 금지 — 스택 감지 분기 (#158)

### DIFF
--- a/src/commands/theme.ts
+++ b/src/commands/theme.ts
@@ -5,6 +5,7 @@ import inquirer from 'inquirer'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { promptOrDefault } from '../lib/interactive.js'
+import { detectProjectStack } from '../lib/stack-detect.js'
 
 function generateDarkCSS(): string {
   return `/* vhk theme — 다크/라이트 모드 CSS 변수 */
@@ -34,29 +35,34 @@ function generateDarkCSS(): string {
 `
 }
 
-function generateToggleUtil(): string {
+// #158: 스택 프로젝트는 TS(.ts), 바닐라/정적 PWA 는 JS(.js) 토글을 생성한다.
+function generateToggleUtil(ts: boolean): string {
+  const ret = ts ? ": 'light' | 'dark'" : ''
+  const param = ts ? ": 'light' | 'dark'" : ''
+  const cast = ts ? " as 'light' | 'dark' | null" : ''
+  const voidT = ts ? ': void' : ''
   return `// vhk theme — 다크/라이트 모드 토글 유틸리티
 
-export function getTheme(): 'light' | 'dark' {
+export function getTheme()${ret} {
   if (typeof window === 'undefined') return 'light'
-  const stored = localStorage.getItem('vhk-theme') as 'light' | 'dark' | null
+  const stored = localStorage.getItem('vhk-theme')${cast}
   if (stored === 'light' || stored === 'dark') return stored
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
 }
 
-export function setTheme(theme: 'light' | 'dark'): void {
+export function setTheme(theme${param})${voidT} {
   if (typeof document === 'undefined') return
   document.documentElement.setAttribute('data-theme', theme)
   localStorage.setItem('vhk-theme', theme)
 }
 
-export function toggleTheme(): 'light' | 'dark' {
+export function toggleTheme()${ret} {
   const next = getTheme() === 'light' ? 'dark' : 'light'
   setTheme(next)
   return next
 }
 
-export function initTheme(): void {
+export function initTheme()${voidT} {
   setTheme(getTheme())
 }
 `
@@ -67,8 +73,14 @@ export async function theme(options?: { yes?: boolean }): Promise<void> {
   console.log(chalk.bold('\n🌙 ' + t('theme.title')))
   console.log(chalk.gray('─'.repeat(40)))
 
-  const cssPath = 'src/styles/theme.css'
-  const togglePath = 'src/lib/theme-toggle.ts'
+  // #158: 스택 감지로 경로 결정 — null(바닐라/정적 PWA)이면 src/ 오염 대신 루트 + .js.
+  const stack = detectProjectStack('.')
+  const usesSrc = stack !== null
+  const styleDir = usesSrc ? 'src/styles' : 'styles'
+  const libDir = usesSrc ? 'src/lib' : 'lib'
+  const useTs = usesSrc
+  const cssPath = `${styleDir}/theme.css`
+  const togglePath = `${libDir}/theme-toggle.${useTs ? 'ts' : 'js'}`
   const conflicts = [cssPath, togglePath].filter((p) => existsSync(p))
 
   if (conflicts.length > 0) {
@@ -91,18 +103,18 @@ export async function theme(options?: { yes?: boolean }): Promise<void> {
     }
   }
 
-  mkdirSync('src/styles', { recursive: true })
-  mkdirSync('src/lib', { recursive: true })
+  mkdirSync(styleDir, { recursive: true })
+  mkdirSync(libDir, { recursive: true })
 
   writeFileSync(cssPath, generateDarkCSS(), 'utf-8')
-  console.log(chalk.green('\n✅ src/styles/theme.css 생성 (다크/라이트 모드)'))
+  console.log(chalk.green(`\n✅ ${cssPath} 생성 (다크/라이트 모드)`))
 
-  writeFileSync(togglePath, generateToggleUtil(), 'utf-8')
-  console.log(chalk.green('✅ src/lib/theme-toggle.ts 생성 (토글 유틸리티)'))
+  writeFileSync(togglePath, generateToggleUtil(useTs), 'utf-8')
+  console.log(chalk.green(`✅ ${togglePath} 생성 (토글 유틸리티)`))
 
   console.log(chalk.bold('\n📖 사용법:'))
-  console.log(chalk.gray('   1. theme.css를 글로벌 스타일에 추가'))
-  console.log(chalk.gray('   2. import { initTheme, toggleTheme } from "./lib/theme-toggle"'))
+  console.log(chalk.gray(`   1. ${cssPath} 를 글로벌 스타일에 추가`))
+  console.log(chalk.gray(`   2. import { initTheme, toggleTheme } from "./${libDir}/theme-toggle"`))
   console.log(chalk.gray('   3. 앱 진입점에서 initTheme() 호출'))
   console.log(chalk.gray('   4. 토글 버튼에서 toggleTheme() 호출'))
 

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -4,6 +4,7 @@ const mockExistsSync = vi.fn()
 const mockMkdirSync = vi.fn()
 const mockWriteFileSync = vi.fn()
 const mockPrompt = vi.fn()
+const mockDetectStack = vi.fn()
 
 vi.mock('node:fs', () => ({
   existsSync: (...a: unknown[]) => mockExistsSync(...a),
@@ -15,6 +16,11 @@ vi.mock('inquirer', () => ({
   default: { prompt: (...a: unknown[]) => mockPrompt(...a) },
 }))
 
+// #158: theme 가 스택 감지로 경로를 정한다 → detectProjectStack 모킹으로 src/ vs 루트 분기 검증.
+vi.mock('../src/lib/stack-detect.js', () => ({
+  detectProjectStack: (...a: unknown[]) => mockDetectStack(...a),
+}))
+
 // Goal 12: theme 의 덮어쓰기 확인이 promptOrDefault(stdin SoT)로 마이그됨 →
 // 대화형 확인 테스트는 TTY 모사 필요(design.test.ts 선례). 비-TTY 동작은 아래 별도 describe.
 let origTTY: boolean | undefined
@@ -23,6 +29,7 @@ describe('theme (대화형 — TTY)', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     vi.spyOn(console, 'log').mockImplementation(() => {})
+    mockDetectStack.mockReturnValue(['React', 'TypeScript']) // 기본: src/ 관례 스택
     origTTY = process.stdin.isTTY
     Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
   })
@@ -101,6 +108,7 @@ describe('theme (비대화형 — 비-TTY)', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     vi.spyOn(console, 'log').mockImplementation(() => {})
+    mockDetectStack.mockReturnValue(['React', 'TypeScript']) // 기본: src/ 관례 스택
     origTTY = process.stdin.isTTY
     Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
   })
@@ -132,5 +140,43 @@ describe('theme (비대화형 — 비-TTY)', () => {
     await theme({ yes: true })
     expect(mockPrompt).not.toHaveBeenCalled()
     expect(mockWriteFileSync).toHaveBeenCalledTimes(2)
+  })
+})
+
+// #158: 바닐라/정적 PWA(스택 감지 null) → src/ 오염 금지. 루트 경로 + .js 토글.
+describe('theme — 바닐라/정적 프로젝트 (스택 null) 경로 (#158)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    mockExistsSync.mockReturnValue(false)
+    mockDetectStack.mockReturnValue(null) // 바닐라/정적 = 감지 스택 없음
+  })
+
+  it('src/ 가 아니라 루트(styles/·lib/)에 생성한다', async () => {
+    const { theme } = await import('../src/commands/theme.js')
+    await theme({ yes: true })
+    // src/ 디렉터리 오염 금지
+    expect(mockMkdirSync).not.toHaveBeenCalledWith('src/styles', { recursive: true })
+    expect(mockMkdirSync).not.toHaveBeenCalledWith('src/lib', { recursive: true })
+    // 루트 경로 사용
+    expect(mockMkdirSync).toHaveBeenCalledWith('styles', { recursive: true })
+    expect(mockMkdirSync).toHaveBeenCalledWith('lib', { recursive: true })
+    const writes = mockWriteFileSync.mock.calls.map((c) => String(c[0]))
+    expect(writes).toContain('styles/theme.css')
+    expect(writes).toContain('lib/theme-toggle.js')
+    expect(writes.some((p) => p.includes('src/'))).toBe(false)
+  })
+
+  it('토글은 .js (타입 주석 없음)', async () => {
+    const { theme } = await import('../src/commands/theme.js')
+    await theme({ yes: true })
+    const toggleCall = mockWriteFileSync.mock.calls.find((c) => String(c[0]).endsWith('theme-toggle.js'))
+    expect(toggleCall).toBeDefined()
+    const js = String(toggleCall![1])
+    // 핵심 export 는 유지하되 TS 타입 주석은 제거됨
+    expect(js).toContain('export function toggleTheme')
+    expect(js).not.toContain(": 'light' | 'dark'")
+    expect(js).not.toContain(': void')
+    expect(js).not.toMatch(/\bas 'light'/)
   })
 })


### PR DESCRIPTION
## 무엇 (#158)
`vhk theme -y` 가 바닐라/정적 PWA(프레임워크 없음)에도 `src/styles/`·`src/lib/` 를 무조건 만들어 스택을 오염시키던 버그.

## 고침
- `detectProjectStack('.')` 로 경로 결정:
  - 스택 감지(React/Next/Vue 등) → 기존대로 `src/styles`·`src/lib` + `.ts`
  - `null`(package.json 없음/프레임워크 0 = 바닐라·정적 PWA) → 루트 `styles`·`lib` + `.js` (`src/` 안 만듦)
- 바닐라용 `.js` 토글(타입 주석 제거) 변형 추가, 출력 메시지도 실제 경로 표시.

## 테스트
- `tests/theme.test.ts`: stack-detect 모킹 추가 + 바닐라(null) → 루트경로·`.js`·`src/` 미생성 검증 2건. 기존 src-stack 케이스는 React 기본 모킹으로 유지.

## 게이트
- `pnpm build` ✓ · `pnpm test:run` **1259 pass / 0 fail**(신규 2) ✓

Fixes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)
