### PR TITLE
fix: cloud 하위폴더 경고 + blocker dogfood 완화 + goal check DONE 스킵 (#160, #159, #155)

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1,11 +1,15 @@
 import chalk from 'chalk'
+import { existsSync, readFileSync } from 'node:fs'
 import { ko } from '../i18n/ko.js'
 import { listGoals } from '../lib/goal-frontmatter.js'
 import {
   appendBlocker,
   clearHardStop,
+  countActiveBlockers,
   isHardStopActive,
   readHardStopReason,
+  BLOCKERS_PATH,
+  HARD_STOP_BLOCKER_THRESHOLD,
 } from '../lib/state-files.js'
 import { recordLesson } from './memory.js'
 import { selectActiveId } from './goal.js'
@@ -16,12 +20,24 @@ function activeGoalId(): number | undefined {
   return id ?? undefined
 }
 
-export async function blocker(description: string): Promise<void> {
+export async function blocker(description: string, opts: { dryRun?: boolean } = {}): Promise<void> {
   console.log(chalk.bold(`\n${ko.agent.blockerTitle}\n`))
   if (!description || !description.trim()) {
     console.log(chalk.red('  ❌ 블로커 설명을 입력해 주세요.'))
     console.log(chalk.dim('  예: vhk blocker "tsc 에러 — simple-git 타입 호환"'))
     process.exitCode = 1
+    return
+  }
+  // #159: --dry-run — blockers.md/HARD_STOP 변경 없이 기록 시 결과만 미리보기.
+  if (opts.dryRun) {
+    const current = existsSync(BLOCKERS_PATH) ? readFileSync(BLOCKERS_PATH, 'utf-8') : ''
+    const active = countActiveBlockers(current)
+    const isDogfood = /\[(dogfood|skip-hardstop)\]/i.test(description)
+    const projected = active + (isDogfood ? 0 : 1)
+    console.log(chalk.cyan(`  🔎 --dry-run — 기록하지 않음. 현재 활성 ${active}건 → 기록 시 ${projected}건${isDogfood ? ' ([dogfood] 태그: 임계값 제외)' : ''}.`))
+    if (!isDogfood && projected >= HARD_STOP_BLOCKER_THRESHOLD) {
+      console.log(chalk.yellow(`     ⚠️  기록하면 임계값(${HARD_STOP_BLOCKER_THRESHOLD}) 도달 → HARD_STOP 트립. ([dogfood] 태그로 회피 가능)`))
+    }
     return
   }
   const goalId = activeGoalId()

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -9,6 +9,7 @@ import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
 import {
   VHK_DIR,
   collectVhkFiles,
+  collectVhkSubdirs,
   loadVhkignore,
   partitionGistFiles,
   readCloudConfig,
@@ -67,6 +68,12 @@ export async function cloudPush(): Promise<void> {
 
   const filePaths = files.map(f => path.join(cwd, VHK_DIR, f))
   console.log(chalk.dim(`  📦 백업 대상 ${files.length}개: ${files.join(', ')}\n`))
+
+  // #160: 평면 파일만 백업 — 하위 폴더(.vhk/evolve/ 등)는 제외되므로 명시적으로 경고.
+  const subdirs = collectVhkSubdirs(cwd)
+  if (subdirs.length > 0) {
+    console.log(chalk.yellow(`  ${ko.cloud.flatOnlyWarn(subdirs.join(', '))}\n`))
+  }
 
   const existing = readCloudConfig(cwd)
   const desc = `vhk .vhk backup — ${path.basename(cwd)}`

--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -256,7 +256,7 @@ function warnIfBashOnWindows(scriptPath: string): void {
   }
 }
 
-export async function goalCheck(opts: { id?: string }): Promise<void> {
+export async function goalCheck(opts: { id?: string; force?: boolean }): Promise<void> {
   console.log(chalk.bold(`\n${ko.goal.checkTitle}\n`))
   const goals = listGoals(GOALS_DIR)
   const id = resolveGoalId(opts.id, goals)
@@ -268,9 +268,17 @@ export async function goalCheck(opts: { id?: string }): Promise<void> {
     return
   }
   // ② 없는 goal id 는 게이트 검사 전에 통일된 메시지로 거부 (done 과 동일).
-  if (!goals.some((g) => g.frontmatter.id === id)) {
+  const target = goals.find((g) => g.frontmatter.id === id)
+  if (!target) {
     console.log(chalk.red(`  ❌ ${ko.goal.notFound(id)}`))
     process.exitCode = 1
+    return
+  }
+  // #155: DONE goal 은 게이트 재실행을 스킵한다 — mission.json 등 외부 상태 드리프트로 이미
+  //       완료된 goal 이 재실패하지 않게. 재검증이 필요하면 --force.
+  if (target.frontmatter.status === 'DONE' && !opts.force) {
+    console.log(chalk.green(`  ✅ Goal ${id} 는 DONE — 게이트 재검증 스킵.`))
+    console.log(chalk.dim(`     (재실행하려면: vhk goal check --id ${id} --force)`))
     return
   }
   const scriptPath = findGateScript(id)

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -325,6 +325,8 @@ export const ko = {
     pullDone: '✅ 클라우드 복원 완료',
     pushFail: '❌ 백업 실패',
     pullFail: '❌ 복원 실패',
+    flatOnlyWarn: (dirs: string) =>
+      `⚠️  평면 파일만 백업됩니다 — 하위 폴더(${dirs})는 제외 (spec v1). 그 안의 파일(예: evolve/queue.json)은 로컬에만 남습니다.`,
   },
   ship: {
     title: '🚀 배포 체크리스트',

--- a/src/index.ts
+++ b/src/index.ts
@@ -680,8 +680,9 @@ goalCmd
   .command('check')
   .alias('검증')
   .option('--id <id>', 'goal id 지정 (생략 시 active goal)')
+  .option('--force', 'DONE goal 도 게이트 재실행 (#155 — 기본은 DONE 스킵)')
   .description('scripts/check-goal-<id>.{mjs,sh} 실행 + exit code 전달 (.mjs 우선)')
-  .action(async (opts: { id?: string }) => { await goalCheck(opts) })
+  .action(async (opts: { id?: string; force?: boolean }) => { await goalCheck(opts) })
 
 goalCmd
   .command('done')
@@ -706,8 +707,9 @@ program
   // #147: variadic — 따옴표 없는 다단어 본문도 받는다 (vhk blocker sync 중단 증상). join 으로 원문 복원.
   .command('blocker <description...>')
   .alias('블로커')
-  .description('블로커 기록 → docs/state/blockers.md append (3건 누적 시 HARD_STOP 자동 생성)')
-  .action(async (description: string[]) => { await blocker(description.join(' ')) })
+  .option('--dry-run', '미리보기만 — blockers.md/HARD_STOP 변경 없음 (#159)')
+  .description('블로커 기록 → docs/state/blockers.md append (3건 누적 시 HARD_STOP 자동 생성). [dogfood] 태그는 임계값 제외.')
+  .action(async (description: string[], opts: { dryRun?: boolean }) => { await blocker(description.join(' '), { dryRun: opts?.dryRun }) })
 
 program
   // #147: variadic — 따옴표 없는 다단어 교훈도 받는다 (vhk learn dogfood lesson without sync keyword).

--- a/src/lib/state-files.ts
+++ b/src/lib/state-files.ts
@@ -32,10 +32,14 @@ function isoDate(): string {
 // resolved 로 간주 → 카운트 제외.
 const ACTIVE_BLOCKER_RE = /^- (?!~~)\[/
 
+// #159: 도그푸딩/테스트용 blocker([dogfood] 또는 [skip-hardstop] 태그)는 HARD_STOP 임계값
+//       카운트에서 제외 — 명령 흐름 점검이 3건 누적되어 자동화를 멈추는 자기방해 방지.
+const SKIP_HARDSTOP_RE = /\[(dogfood|skip-hardstop)\]/i
+
 export function countActiveBlockers(content: string): number {
   let count = 0
   for (const line of content.split(/\r?\n/)) {
-    if (ACTIVE_BLOCKER_RE.test(line)) count++
+    if (ACTIVE_BLOCKER_RE.test(line) && !SKIP_HARDSTOP_RE.test(line)) count++
   }
   return count
 }

--- a/src/lib/vhk-cloud.ts
+++ b/src/lib/vhk-cloud.ts
@@ -63,6 +63,22 @@ export function collectVhkFiles(
 }
 
 /**
+ * `.vhk/` 안의 하위 디렉터리 이름 목록 (#160). collectVhkFiles 는 평면 파일만 백업하므로
+ * 하위 폴더(예: evolve/queue.json)는 제외된다 — cloudPush 가 이 목록으로 사용자에게 경고한다.
+ */
+export function collectVhkSubdirs(rootDir: string): string[] {
+  const vhkDir = path.join(rootDir, VHK_DIR)
+  try {
+    return fs.readdirSync(vhkDir, { withFileTypes: true })
+      .filter(e => e.isDirectory())
+      .map(e => e.name)
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+/**
  * gist 에 존재하는 파일명을 현재 제외 규칙(ig) 기준으로 분리한다.
  * - keep: 백업/복원 대상 (제외 규칙에 안 걸림)
  * - excluded: 제외 대상 (privacy purge / 복원 스킵 대상)

--- a/tests/cloud.test.ts
+++ b/tests/cloud.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import {
   DEFAULT_CLOUD_EXCLUDES,
   collectVhkFiles,
+  collectVhkSubdirs,
   loadVhkignore,
   partitionGistFiles,
   readCloudConfig,
@@ -67,6 +68,25 @@ describe('vhk-cloud — collectVhkFiles', () => {
     const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-empty-'))
     expect(collectVhkFiles(empty)).toEqual([])
     fs.rmSync(empty, { recursive: true, force: true })
+  })
+})
+
+describe('vhk-cloud — collectVhkSubdirs (하위 폴더 감지, #160)', () => {
+  it('.vhk/ 안의 하위 디렉터리 이름만 반환 (파일 제외)', () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-sub-'))
+    fs.mkdirSync(path.join(repo, '.vhk', 'evolve'), { recursive: true })
+    fs.writeFileSync(path.join(repo, '.vhk', 'evolve', 'queue.json'), '[]\n')
+    fs.writeFileSync(path.join(repo, '.vhk', 'context.md'), '# ctx\n')
+    expect(collectVhkSubdirs(repo)).toEqual(['evolve'])
+    fs.rmSync(repo, { recursive: true, force: true })
+  })
+
+  it('하위 폴더 없으면 빈 배열', () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-nosub-'))
+    fs.mkdirSync(path.join(repo, '.vhk'), { recursive: true })
+    fs.writeFileSync(path.join(repo, '.vhk', 'context.md'), '# ctx\n')
+    expect(collectVhkSubdirs(repo)).toEqual([])
+    fs.rmSync(repo, { recursive: true, force: true })
   })
 })
 

--- a/tests/goal.test.ts
+++ b/tests/goal.test.ts
@@ -301,6 +301,56 @@ describe('goalDone — Forbidden: 게이트 실패 시 frontmatter 변경 금지
   })
 })
 
+describe('goalCheck — DONE goal 게이트 스킵 (#155)', () => {
+  let origCwd: string
+  let origExitCode: number | string | undefined
+  beforeEach(() => {
+    origCwd = process.cwd()
+    origExitCode = process.exitCode
+    process.exitCode = 0
+    mockSafeExecFile.mockReset()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    process.exitCode = origExitCode
+    vi.restoreAllMocks()
+  })
+
+  it('DONE goal 은 게이트 실행 없이 스킵 (exit 0)', async () => {
+    const dir = tmpProject('check-done-skip')
+    makeGoalFile(dir, 5, 'DONE')
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    process.chdir(dir)
+    try {
+      const { goalCheck } = await import('../src/commands/goal.js')
+      await goalCheck({ id: '5' })
+      expect(process.exitCode).not.toBe(1)
+      expect(mockSafeExecFile).not.toHaveBeenCalled() // 게이트 미실행
+      const out = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(out).toContain('스킵')
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('--force 면 DONE goal 도 게이트 실행 (스크립트 없으면 실패 exit 1)', async () => {
+    const dir = tmpProject('check-done-force')
+    makeGoalFile(dir, 5, 'DONE')
+    process.chdir(dir)
+    try {
+      const { goalCheck } = await import('../src/commands/goal.js')
+      await goalCheck({ id: '5', force: true })
+      // DONE 스킵 무시 → findGateScript 진입, 스크립트 없음 → exit 1
+      expect(process.exitCode).toBe(1)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
 describe('goalSync — 누락 게이트 스크립트 백필 (goal 7)', () => {
   let origCwd: string
   beforeEach(() => {

--- a/tests/state-files.test.ts
+++ b/tests/state-files.test.ts
@@ -42,6 +42,15 @@ describe('countActiveBlockers', () => {
   it('빈 문서면 0', () => {
     expect(countActiveBlockers('# Blockers\n')).toBe(0)
   })
+
+  it('[dogfood]/[skip-hardstop] 태그 항목은 카운트 제외 (#159)', () => {
+    const md = [
+      '- [2026-05-01 goal-0] 진짜 블로커',
+      '- [2026-05-02 goal-0] [dogfood] 테스트용 블로커',
+      '- [2026-05-03 goal-1] [skip-hardstop] 도그푸딩',
+    ].join('\n')
+    expect(countActiveBlockers(md)).toBe(1)
+  })
 })
 
 describe('appendBlocker — Forbidden append-only 보장', () => {
@@ -84,6 +93,15 @@ describe('appendBlocker — Forbidden append-only 보장', () => {
     expect(r.count).toBe(HARD_STOP_BLOCKER_THRESHOLD)
     expect(r.hardStopTripped).toBe(true)
     expect(existsSync(HARD_STOP_PATH)).toBe(true)
+  })
+
+  it('[dogfood] 3건은 임계값 산입 제외 → HARD_STOP 미트립 (#159)', () => {
+    appendBlocker('[dogfood] b1', 2)
+    appendBlocker('[dogfood] b2', 2)
+    const r = appendBlocker('[dogfood] b3', 2)
+    expect(r.count).toBe(0)
+    expect(r.hardStopTripped).toBe(false)
+    expect(existsSync(HARD_STOP_PATH)).toBe(false)
   })
 
   it('이미 HARD_STOP 있으면 재작성 안 함 (덮어쓰기 X)', () => {


### PR DESCRIPTION
## 무엇
독립적인 소규모 버그/UX 수정 3건 (서로 다른 파일, disjoint).

- **#160** `cloud push` 가 `.vhk/` 하위 폴더(`evolve/queue.json` 등)를 평면 백업에서 조용히 누락 → 하위 폴더 존재 시 경고 출력(`collectVhkSubdirs` + i18n `cloud.flatOnlyWarn`).
- **#159** 도그푸딩/테스트용 `blocker` 가 3건 쌓이면 HARD_STOP 이 의도치 않게 트립 → `[dogfood]`/`[skip-hardstop]` 태그는 임계값 카운트 제외 + `blocker --dry-run`(미기록 미리보기) 추가.
- **#155** `goal check` 가 DONE goal 을 mission.json 드리프트 시 재실패시킴 → DONE goal 은 게이트 재실행 스킵, 재검증은 `--force`.

## 테스트
- `state-files.test.ts`: `[dogfood]` 카운트 제외 + 3건 미트립
- `cloud.test.ts`: `collectVhkSubdirs` 하위폴더 감지
- `goal.test.ts`: DONE goal 게이트 스킵 + `--force` 재실행

## 게이트
- `pnpm build` ✓ · `pnpm test:run` **1263 pass / 0 fail**(신규 6) ✓

Fixes #160, #159, #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)
