### PR TITLE
feat(harness/audit): 중첩 패키지 발견 — 루트+nested 점검·프로젝트별 그룹 리포트 (#171)

### DIFF
--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,10 +1,12 @@
 import { existsSync } from 'node:fs'
+import { join } from 'node:path'
 import chalk from 'chalk'
 import inquirer from 'inquirer'
 import ora from 'ora'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { safeExecFile } from '../lib/exec.js'
+import { discoverProjects } from '../lib/workspaces.js'
 
 export type PackageManager = 'npm' | 'yarn' | 'pnpm'
 
@@ -22,14 +24,21 @@ export function detectCurrentPM(): PackageManager {
   return 'npm'
 }
 
+// #171: 프로젝트 디렉터리별 PM 감지(중첩 패키지). 락파일 없으면 fallback.
+function detectPMForDir(dir: string, fallback: PackageManager): PackageManager {
+  if (existsSync(join(dir, 'pnpm-lock.yaml'))) return 'pnpm'
+  if (existsSync(join(dir, 'yarn.lock'))) return 'yarn'
+  if (existsSync(join(dir, 'package-lock.json'))) return 'npm'
+  return fallback
+}
+
 export function parseAuditOutput(output: string, pm: PackageManager): AuditSummary {
   const empty: AuditSummary = { critical: 0, high: 0, moderate: 0, low: 0, total: 0 }
   if (!output) return empty
   try {
     const json = JSON.parse(output) as Record<string, unknown>
     // npm / yarn classic: { metadata: { vulnerabilities: {...} } }
-    // pnpm: 동일한 npm-compat 출력 (npm audit JSON 포맷 그대로)
-    // yarn berry: { advisories: {...} } — total만 별도 계산
+    // pnpm: 동일한 npm-compat 출력. yarn berry: { advisories: {...} }.
     const meta = (json.metadata as { vulnerabilities?: Partial<AuditSummary> } | undefined)
       ?.vulnerabilities
     if (meta) {
@@ -45,7 +54,6 @@ export function parseAuditOutput(output: string, pm: PackageManager): AuditSumma
       }
       return summary
     }
-    // pm 별 fallback이 더 필요하면 여기에 분기
     void pm
     return empty
   } catch {
@@ -53,50 +61,88 @@ export function parseAuditOutput(output: string, pm: PackageManager): AuditSumma
   }
 }
 
-export function runAuditJson(pm: PackageManager): string {
+export function runAuditJson(pm: PackageManager, cwd?: string): string {
   // 취약점 발견 시 exit code !=0지만 stdout에 JSON 출력. safeExecFile은 err 경로에서도 out 반환.
-  const result = safeExecFile(pm, ['audit', '--json'])
+  const result = safeExecFile(pm, ['audit', '--json'], cwd ? { cwd } : {})
   return result.out
 }
 
-function runAuditFix(pm: PackageManager): { ok: boolean; err?: string } {
-  // pnpm은 `audit --fix` 미지원 → audit만 다시 안내. yarn classic은 `audit fix` 미지원.
-  // npm만 자동 fix 지원.
+function runAuditFix(pm: PackageManager, cwd?: string): { ok: boolean; err?: string } {
+  // pnpm/yarn classic 은 audit fix 미지원 → npm만 자동 fix.
   if (pm !== 'npm') {
     return { ok: false, err: `${pm}은 자동 fix를 지원하지 않습니다. npm 환경에서만 동작합니다.` }
   }
-  const result = safeExecFile('npm', ['audit', 'fix'])
+  const result = safeExecFile('npm', ['audit', 'fix'], cwd ? { cwd } : {})
   return result.ok ? { ok: true } : { ok: false, err: result.err }
+}
+
+const addSummary = (a: AuditSummary, b: AuditSummary): AuditSummary => ({
+  critical: a.critical + b.critical,
+  high: a.high + b.high,
+  moderate: a.moderate + b.moderate,
+  low: a.low + b.low,
+  total: a.total + b.total,
+})
+
+function printSummary(summary: AuditSummary, indent = '  '): void {
+  if (summary.critical > 0) console.log(chalk.red(`${indent}🔴 Critical: ${summary.critical}`))
+  if (summary.high > 0) console.log(chalk.red(`${indent}🟠 High: ${summary.high}`))
+  if (summary.moderate > 0) console.log(chalk.yellow(`${indent}🟡 Moderate: ${summary.moderate}`))
+  if (summary.low > 0) console.log(chalk.gray(`${indent}⚪ Low: ${summary.low}`))
 }
 
 export async function audit(autoFix = false): Promise<void> {
   console.log(chalk.bold('\n🛡️  ' + t('audit.title')))
   console.log(chalk.gray('─'.repeat(40)))
 
-  const pm = detectCurrentPM()
-  console.log(chalk.cyan(`📦 패키지 매니저: ${pm}`))
+  // #171: 루트 + 중첩 패키지를 모두 감사. discoverProjects 가 비면(package.json 못 읽는 환경) 루트 cwd 폴백.
+  const discovered = discoverProjects('.')
+  const targets = discovered.length > 0 ? discovered : [{ path: '.', name: '.', scripts: {} }]
+  const multi = targets.length > 1
+  const rootPm = detectCurrentPM()
 
-  const spinner = ora('보안 감사 실행 중...').start()
-  const output = runAuditJson(pm)
-  spinner.stop()
+  const perProject: { path: string; pm: PackageManager; summary: AuditSummary }[] = []
+  let aggregate: AuditSummary = { critical: 0, high: 0, moderate: 0, low: 0, total: 0 }
 
-  const summary = parseAuditOutput(output, pm)
+  for (const tgt of targets) {
+    const dir = join('.', tgt.path)
+    const pm = detectPMForDir(dir, rootPm)
+    const spinner = ora(`${multi ? tgt.path + ' ' : ''}보안 감사 실행 중...`).start()
+    const output = runAuditJson(pm, tgt.path === '.' ? undefined : dir)
+    spinner.stop()
+    const summary = parseAuditOutput(output, pm)
+    perProject.push({ path: tgt.path, pm, summary })
+    aggregate = addSummary(aggregate, summary)
+  }
 
-  if (summary.total === 0) {
+  if (!multi) {
+    console.log(chalk.cyan(`📦 패키지 매니저: ${perProject[0].pm}`))
+  }
+
+  if (aggregate.total === 0) {
     console.log(chalk.green.bold('\n🎉 취약점이 발견되지 않았습니다!'))
+    if (multi) {
+      console.log(chalk.gray(`   (점검 ${targets.length}개: ${targets.map((p) => p.path).join(', ')})`))
+    }
     return
   }
 
   console.log(chalk.bold('\n📊 취약점 요약:'))
-  if (summary.critical > 0) console.log(chalk.red(`  🔴 Critical: ${summary.critical}`))
-  if (summary.high > 0) console.log(chalk.red(`  🟠 High: ${summary.high}`))
-  if (summary.moderate > 0) console.log(chalk.yellow(`  🟡 Moderate: ${summary.moderate}`))
-  if (summary.low > 0) console.log(chalk.gray(`  ⚪ Low: ${summary.low}`))
-  console.log(chalk.bold(`\n  총 ${summary.total}개의 취약점`))
+  if (multi) {
+    for (const p of perProject) {
+      if (p.summary.total === 0) continue
+      console.log(chalk.bold(`  📦 ${p.path} (${p.pm}) — 총 ${p.summary.total}`))
+      printSummary(p.summary, '    ')
+    }
+    console.log(chalk.bold(`\n  합계 ${aggregate.total}개의 취약점`))
+  } else {
+    printSummary(aggregate)
+    console.log(chalk.bold(`\n  총 ${aggregate.total}개의 취약점`))
+  }
 
   const shouldRunFix = autoFix
     ? true
-    : summary.critical > 0 || summary.high > 0
+    : aggregate.critical > 0 || aggregate.high > 0
       ? (
           await inquirer.prompt<{ shouldFix: boolean }>([
             {
@@ -110,12 +156,17 @@ export async function audit(autoFix = false): Promise<void> {
       : false
 
   if (shouldRunFix) {
-    const fixSpinner = ora('자동 수정 중...').start()
-    const result = runAuditFix(pm)
-    if (result.ok) {
-      fixSpinner.succeed('자동 수정 완료!')
+    const npmProjects = perProject.filter((p) => p.pm === 'npm')
+    if (npmProjects.length === 0) {
+      const fixSpinner = ora('자동 수정 중...').start()
+      fixSpinner.warn(`${perProject[0].pm}은 자동 fix를 지원하지 않습니다. npm 환경에서만 동작합니다.`)
     } else {
-      fixSpinner.warn(result.err ?? '일부 취약점은 수동 수정이 필요합니다.')
+      for (const p of npmProjects) {
+        const fixSpinner = ora(`${multi ? p.path + ' ' : ''}자동 수정 중...`).start()
+        const result = runAuditFix('npm', p.path === '.' ? undefined : join('.', p.path))
+        if (result.ok) fixSpinner.succeed(`${multi ? p.path + ' ' : ''}자동 수정 완료!`)
+        else fixSpinner.warn(result.err ?? '일부 취약점은 수동 수정이 필요합니다.')
+      }
     }
   }
 

--- a/src/commands/harness.ts
+++ b/src/commands/harness.ts
@@ -1,26 +1,38 @@
 import { existsSync } from 'node:fs'
+import { join } from 'node:path'
 import chalk from 'chalk'
 import ora from 'ora'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { safeExecFile } from '../lib/exec.js'
-import { readJsonFile } from '../lib/read-json.js'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
+import { discoverProjects, type DiscoveredProject } from '../lib/workspaces.js'
 
-type CheckSpec = { name: string; bin: string; args: string[] }
+type CheckSpec = { name: string; bin: string; args: string[]; cwd: string; project: string }
 
 interface CheckResult {
   name: string
+  project: string
   command: string
   passed: boolean
   duration: number
   error?: string
 }
 
-function detectPM(): 'pnpm' | 'yarn' | 'npm' {
+type PM = 'pnpm' | 'yarn' | 'npm'
+
+function rootPM(): PM {
   if (existsSync('pnpm-lock.yaml')) return 'pnpm'
   if (existsSync('yarn.lock')) return 'yarn'
   return 'npm'
+}
+
+// #171: 프로젝트 디렉터리별 PM 감지. 중첩 패키지에 락파일이 없으면 루트 PM 으로 폴백(워크스페이스 관례).
+function detectPMIn(dir: string, fallback: PM): PM {
+  if (existsSync(join(dir, 'pnpm-lock.yaml'))) return 'pnpm'
+  if (existsSync(join(dir, 'yarn.lock'))) return 'yarn'
+  if (existsSync(join(dir, 'package-lock.json'))) return 'npm'
+  return fallback
 }
 
 function pmRun(pm: string, script: string): string[] {
@@ -28,43 +40,38 @@ function pmRun(pm: string, script: string): string[] {
   return pm === 'npm' ? ['run', script] : [script]
 }
 
-function detectChecks(): CheckSpec[] {
+// #171: 한 프로젝트(루트 또는 중첩)의 점검 목록 — 해당 디렉터리 기준으로 cwd 부여.
+function detectChecksForProject(root: string, project: DiscoveredProject, fallbackPM: PM): CheckSpec[] {
   const checks: CheckSpec[] = []
-  let pkg: { scripts?: Record<string, string> } = {}
-  try {
-    pkg = readJsonFile<{ scripts?: Record<string, string> }>('package.json')
-  } catch {
-    return checks
+  const dir = join(root, project.path)
+  const s = project.scripts
+  const pm = detectPMIn(dir, fallbackPM)
+  const has = (f: string): boolean => existsSync(join(dir, f))
+  const push = (name: string, bin: string, args: string[]): void => {
+    checks.push({ name, bin, args, cwd: dir, project: project.path })
   }
-  const s = pkg.scripts ?? {}
-  const pm = detectPM()
 
   if (s.lint) {
-    checks.push({ name: 'lint', bin: pm, args: pmRun(pm, 'lint') })
-  } else if (
-    existsSync('.eslintrc.js') ||
-    existsSync('.eslintrc.json') ||
-    existsSync('eslint.config.js')
-  ) {
-    checks.push({ name: 'lint', bin: 'npx', args: ['eslint', '.', '--ext', '.ts,.tsx'] })
+    push('lint', pm, pmRun(pm, 'lint'))
+  } else if (has('.eslintrc.js') || has('.eslintrc.json') || has('eslint.config.js')) {
+    push('lint', 'npx', ['eslint', '.', '--ext', '.ts,.tsx'])
   }
 
   if (s['type-check']) {
-    checks.push({ name: 'type-check', bin: pm, args: pmRun(pm, 'type-check') })
+    push('type-check', pm, pmRun(pm, 'type-check'))
   } else if (s.typecheck) {
-    checks.push({ name: 'type-check', bin: pm, args: pmRun(pm, 'typecheck') })
-  } else if (existsSync('tsconfig.json')) {
-    checks.push({ name: 'type-check', bin: 'npx', args: ['tsc', '--noEmit'] })
+    push('type-check', pm, pmRun(pm, 'typecheck'))
+  } else if (has('tsconfig.json')) {
+    push('type-check', 'npx', ['tsc', '--noEmit'])
   }
 
-  // #156: 풍부한 게이트 우선 — test:gate(unit+smoke 등) → test:ci → test 순으로 첫 존재 스크립트 1개만.
-  // (vitest --run 등 추가 옵션 없이 동작하도록 script 호출만.)
+  // #156: 풍부한 게이트 우선 — test:gate → test:ci → test 순으로 첫 존재 스크립트 1개만.
   const testScript = ['test:gate', 'test:ci', 'test'].find((name) => s[name])
   if (testScript) {
-    checks.push({ name: testScript, bin: pm, args: pmRun(pm, testScript) })
+    push(testScript, pm, pmRun(pm, testScript))
   }
   if (s.build) {
-    checks.push({ name: 'build', bin: pm, args: pmRun(pm, 'build') })
+    push('build', pm, pmRun(pm, 'build'))
   }
 
   return checks
@@ -75,32 +82,44 @@ export async function harness(): Promise<void> {
   console.log(chalk.bold('\n🔧 ' + t('harness.title')))
   console.log(chalk.gray('─'.repeat(40)))
 
-  const checks = detectChecks()
+  // #171: 루트 + 중첩 패키지를 모두 점검 대상으로 (이전엔 루트 package.json 만 봄).
+  const projects = discoverProjects('.')
+  const fallbackPM = rootPM()
+  const checks = projects.flatMap((p) => detectChecksForProject('.', p, fallbackPM))
+  const multi = projects.length > 1
 
   if (checks.length === 0) {
     console.log(chalk.yellow('\n⚠️  실행할 수 있는 스크립트가 없습니다.'))
     console.log(chalk.gray('   package.json에 lint, test, build 스크립트를 추가해주세요.'))
+    if (multi) {
+      console.log(chalk.gray(`   (점검 대상 ${projects.length}개: ${projects.map((p) => p.path).join(', ')})`))
+    }
     return
   }
 
+  if (multi) {
+    console.log(chalk.cyan(`\n📦 프로젝트 ${projects.length}개: ${projects.map((p) => p.path).join(', ')}`))
+  }
   console.log(chalk.cyan(`\n🏃 ${checks.length}개 점검 시작:\n`))
 
   const results: CheckResult[] = []
 
   for (const check of checks) {
+    const label = multi ? `${check.project} › ${check.name}` : check.name
     const display = `${check.bin} ${check.args.join(' ')}`
-    const spinner = ora(`${check.name} 실행 중...`).start()
+    const spinner = ora(`${label} 실행 중...`).start()
     const start = Date.now()
-    const result = safeExecFile(check.bin, check.args)
+    const result = safeExecFile(check.bin, check.args, { cwd: check.cwd })
     const duration = Date.now() - start
     const sec = (duration / 1000).toFixed(1)
     if (result.ok) {
-      spinner.succeed(`${check.name} ${chalk.gray(`(${sec}s)`)}`)
-      results.push({ name: check.name, command: display, passed: true, duration })
+      spinner.succeed(`${label} ${chalk.gray(`(${sec}s)`)}`)
+      results.push({ name: check.name, project: check.project, command: display, passed: true, duration })
     } else {
-      spinner.fail(`${check.name} ${chalk.gray(`(${sec}s)`)}`)
+      spinner.fail(`${label} ${chalk.gray(`(${sec}s)`)}`)
       results.push({
         name: check.name,
+        project: check.project,
         command: display,
         passed: false,
         duration,
@@ -111,10 +130,16 @@ export async function harness(): Promise<void> {
 
   console.log(chalk.bold('\n📊 통합 리포트:'))
   console.log(chalk.gray('─'.repeat(40)))
+  let lastProject = ''
   for (const r of results) {
+    if (multi && r.project !== lastProject) {
+      console.log(chalk.bold(`  📦 ${r.project}`))
+      lastProject = r.project
+    }
     const icon = r.passed ? chalk.green('✅') : chalk.red('❌')
     const sec = (r.duration / 1000).toFixed(1)
-    console.log(`  ${icon} ${r.name.padEnd(15)} ${chalk.gray(`${sec}s`)}`)
+    const indent = multi ? '    ' : '  '
+    console.log(`${indent}${icon} ${r.name.padEnd(15)} ${chalk.gray(`${sec}s`)}`)
   }
 
   const passed = results.filter((r) => r.passed).length

--- a/src/lib/workspaces.ts
+++ b/src/lib/workspaces.ts
@@ -1,0 +1,89 @@
+import { existsSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { readJsonFile } from './read-json.js'
+
+/**
+ * #171: harness/audit 가 루트 package.json 만 보고 중첩 패키지(예: dashboard/)를 놓치던 문제.
+ * 점검 대상 프로젝트(루트 + 중첩)를 한 곳에서 발견해 harness·audit 가 공유한다.
+ */
+
+export interface DiscoveredProject {
+  /** 루트 기준 상대 경로 (루트는 '.'). 슬래시 구분. */
+  path: string
+  /** package.json name (없으면 path) */
+  name: string
+  /** package.json scripts (없으면 {}) */
+  scripts: Record<string, string>
+}
+
+interface PkgJson {
+  name?: string
+  scripts?: Record<string, string>
+  vhk?: { projects?: unknown }
+}
+
+// 스캔에서 제외할 디렉터리 (산출물·의존성·VCS·툴 캐시).
+const SKIP_DIRS = new Set([
+  'node_modules', '.git', 'dist', 'build', 'out', 'coverage',
+  '.next', '.nuxt', '.svelte-kit', '.vercel', '.vhk', '.turbo',
+])
+
+function readPkg(dir: string): PkgJson | null {
+  // existsSync 로 선-게이트하지 않는다 — 부재 시 readJsonFile 이 throw → catch 에서 null.
+  // (선-게이트하면 fs 를 통째 mock 한 환경에서 readdirSync/existsSync 불일치로 오작동.)
+  try {
+    return readJsonFile<PkgJson>(join(dir, 'package.json'))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * 점검 대상 프로젝트 목록 — 루트 + 중첩 패키지.
+ *  1) 루트 package.json 의 `vhk.projects` 배열(명시 오버라이드)이 있으면 → 루트 + 그 경로들만.
+ *  2) 없으면 자동: 루트 + 하위 디렉터리 스캔으로 nested package.json (깊이 ≤ maxDepth, SKIP_DIRS·dotdir 제외).
+ * 루트에 package.json 이 없으면 빈 배열(점검 대상 없음).
+ */
+export function discoverProjects(root = '.', maxDepth = 2): DiscoveredProject[] {
+  const out: DiscoveredProject[] = []
+  const seen = new Set<string>()
+
+  const add = (rel: string): void => {
+    const norm = rel === '' ? '.' : rel.replace(/\\/g, '/')
+    if (seen.has(norm)) return
+    const pkg = readPkg(join(root, norm))
+    if (!pkg) return
+    seen.add(norm)
+    out.push({ path: norm, name: pkg.name ?? norm, scripts: pkg.scripts ?? {} })
+  }
+
+  const rootPkg = readPkg(root)
+  if (!rootPkg) return out // 루트가 패키지가 아니면 대상 없음
+  add('.')
+
+  // 1) 명시 오버라이드 — 자동 스캔 건너뜀.
+  const explicit = rootPkg.vhk?.projects
+  if (Array.isArray(explicit) && explicit.length > 0) {
+    for (const rel of explicit) if (typeof rel === 'string' && rel.trim()) add(rel.trim())
+    return out
+  }
+
+  // 2) 자동 중첩 스캔.
+  const walk = (relDir: string, depth: number): void => {
+    if (depth > maxDepth) return
+    let entries
+    try {
+      entries = readdirSync(join(root, relDir || '.'), { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const e of entries) {
+      if (!e.isDirectory() || e.name.startsWith('.') || SKIP_DIRS.has(e.name)) continue
+      const childRel = relDir ? `${relDir}/${e.name}` : e.name
+      if (existsSync(join(root, childRel, 'package.json'))) add(childRel)
+      walk(childRel, depth + 1)
+    }
+  }
+  walk('', 1)
+  return out
+}

--- a/tests/workspaces.test.ts
+++ b/tests/workspaces.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { discoverProjects } from '../src/lib/workspaces.js'
+
+function tmp(): string {
+  const d = join(tmpdir(), `vhk-ws-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  mkdirSync(d, { recursive: true })
+  return d
+}
+function pkg(dir: string, obj: object): void {
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'package.json'), JSON.stringify(obj), 'utf-8')
+}
+
+describe('discoverProjects (#171)', () => {
+  let root: string
+  beforeEach(() => { root = tmp() })
+  afterEach(() => { rmSync(root, { recursive: true, force: true }) })
+
+  it('루트만 있으면 루트 1개 (scripts 보존)', () => {
+    pkg(root, { name: 'root', scripts: { build: 'x' } })
+    const ps = discoverProjects(root)
+    expect(ps.map((p) => p.path)).toEqual(['.'])
+    expect(ps[0].scripts.build).toBe('x')
+  })
+
+  it('중첩 package.json(dashboard/) 을 발견', () => {
+    pkg(root, { name: 'root' })
+    pkg(join(root, 'dashboard'), { name: 'dash', scripts: { lint: 'eslint' } })
+    const ps = discoverProjects(root)
+    expect(ps.map((p) => p.path).sort()).toEqual(['.', 'dashboard'])
+    expect(ps.find((p) => p.path === 'dashboard')?.scripts.lint).toBe('eslint')
+  })
+
+  it('node_modules·.git·dist 는 스캔 제외', () => {
+    pkg(root, { name: 'root' })
+    pkg(join(root, 'node_modules', 'dep'), { name: 'dep' })
+    pkg(join(root, 'dist'), { name: 'built' })
+    pkg(join(root, '.git', 'x'), { name: 'g' })
+    const ps = discoverProjects(root)
+    expect(ps.map((p) => p.path)).toEqual(['.'])
+  })
+
+  it('vhk.projects 명시 오버라이드 시 그 경로 + 루트만 (자동스캔 무시)', () => {
+    pkg(root, { name: 'root', vhk: { projects: ['apps/web'] } })
+    pkg(join(root, 'apps', 'web'), { name: 'web' })
+    pkg(join(root, 'other'), { name: 'other' }) // 오버라이드면 자동스캔 제외돼 안 잡혀야
+    const ps = discoverProjects(root)
+    expect(ps.map((p) => p.path).sort()).toEqual(['.', 'apps/web'])
+  })
+
+  it('package.json 없는 디렉터리는 무시', () => {
+    pkg(root, { name: 'root' })
+    mkdirSync(join(root, 'docs'), { recursive: true })
+    const ps = discoverProjects(root)
+    expect(ps.map((p) => p.path)).toEqual(['.'])
+  })
+
+  it('루트에 package.json 없으면 빈 배열', () => {
+    const ps = discoverProjects(root)
+    expect(ps).toEqual([])
+  })
+})


### PR DESCRIPTION
## 무엇 (#171)
`vhk harness`·`vhk audit` 가 루트 `package.json` 만 보고 중첩 패키지(예: `dashboard/`)를 놓치던 문제.

## 고침
- **`src/lib/workspaces.ts`** (신규) `discoverProjects(root)` — 루트 + 중첩 `package.json` 자동 발견(깊이 ≤2, `node_modules`·`dist`·`.git`·`.next` 등 제외) + `vhk.projects` 명시 오버라이드. harness·audit 공유.
- **harness**: 프로젝트별 `detectChecks` + **cwd 분리 실행** + 프로젝트별 그룹 리포트. 단일 프로젝트는 기존 출력 그대로(하위호환). HARD_STOP 가드 유지.
- **audit**: 프로젝트별 감사 + 합계, npm 프로젝트별 `audit fix`. `discoverProjects` 가 비면(package.json 못 읽는 환경) 루트 cwd 폴백.

## 테스트
- `tests/workspaces.test.ts`(6): 루트만/중첩 발견/제외 디렉터리/`vhk.projects` 오버라이드/package.json 없는 루트.
- 기존 harness·audit 테스트 전부 유지(단일 프로젝트 경로).
- **도그푸딩**: 임시 nested 프로젝트(`.` build + `dashboard` lint)에서 `vhk harness` → `📦 프로젝트 2개` + 프로젝트별 cwd 실행·그룹 리포트 확인.

## 게이트
- `pnpm build` ✓ · `pnpm test:run` **1277 pass / 0 fail**(신규 6) ✓ · 도그푸딩 ✓

## 범위 밖(후속)
- `doctor` 의 audit 진단도 동일하게 per-project 적용 — 별도 PR 권장(본 PR은 명령 2개에 집중).
- npm `workspaces`/`pnpm-workspace.yaml` glob 전개는 미포함(디렉터리 스캔 + 명시 오버라이드로 커버). 필요 시 후속.

Fixes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)
