### PR TITLE
fix(review): advisory 기본 모드 + --strict — skip/미검증만으로 거짓 실패 안 함 (#157)

### DIFF
--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -171,7 +171,10 @@ export function crossCheck(
       } else if (g.status === 'fail') {
         suspicions.push({ check: c.text, reason: `${gid} 게이트 FAIL(종료코드 ${g.exitCode ?? '?'}) — 체크됨과 모순.` })
       } else if (g.status === 'skip') {
-        suspicions.push({ check: c.text, reason: `${gid} 게이트 skip — 검증이 변경을 안 건드렸을 수 있음(거짓완료 의심).` })
+        // #157: skip 은 '강한 모순'이 아니라 '미검증 신호'(soft) — 게이트가 이번 변경을 안 건드렸을 수 있음.
+        //        suspicions(거짓완료 강한 의심)가 아니라 gaps(수동 확인)로 분류 → verify 통과 후
+        //        skip 만으로 review 가 거짓 실패(exit 1) 내던 혼란(#157) 제거.
+        gaps.push({ check: c.text, note: `${gid} 게이트 skip — 검증이 이번 변경을 안 건드렸을 수 있음(수동 확인 권장).` })
       }
     }
   }
@@ -238,8 +241,9 @@ const CONFIDENCE_LABEL: Record<ReviewAnalysis['confidence'], string> = {
   high: chalk.green.bold('높음 (의심 0 + 커버리지·신선도 충분 — 단 보장 아님)'),
 }
 
-export async function review(opts: { id?: string } = {}): Promise<void> {
+export async function review(opts: { id?: string; strict?: boolean } = {}): Promise<void> {
   if (!ensureNotHardStopped('review')) return
+  const strict = opts.strict === true
 
   const cwd = process.cwd()
   const goals = listGoals(GOALS_DIR)
@@ -305,6 +309,11 @@ export async function review(opts: { id?: string } = {}): Promise<void> {
     )
   )
   console.log(chalk.dim(`  증거 신선도: ${result.freshness.note}`))
+  // #157: 게이트 증거 키 매핑 — 어떤 게이트가 pass/skip/fail/부재인지 한눈에(미검증 위치 명확화).
+  const gateLine = report.gates.length
+    ? report.gates.map((g) => `${g.id}:${g.status}`).join(' · ')
+    : '(게이트 없음)'
+  console.log(chalk.dim(`  게이트 증거: ${gateLine}  ·  모드: ${strict ? 'strict(엄격)' : 'advisory(권고·기본)'}`))
 
   if (result.checkedCount === 0) {
     console.log(chalk.yellow('\n  ⚪ 완료 주장 없음(체크된 완료조건 0개) — 심문할 대상이 없습니다(vacuous).'))
@@ -347,13 +356,16 @@ export async function review(opts: { id?: string } = {}): Promise<void> {
     return
   }
 
-  // exit code 정책 (테스트로 고정):
-  //  - exit 0 = 통과로 봐도 되는 경우만 → ① vacuous(완료 주장 없음) ② cleanHigh(의심 0 + 미검증 0 + high)
-  //  - exit 1 = 그 외 전부 → 강한 거짓완료 의심 / 증거 불충분(medium·low: stale·미검증·커버리지 부족) / 병합 실패
-  //  stale·unmapped·coverage 부족은 절대 "통과"로 취급하지 않는다(거짓 안심 금지).
+  // exit code 정책 (#157, 테스트로 고정):
+  //  - 기본(advisory): exit 0 = vacuous(완료 주장 없음) 또는 강한 모순(suspicions) 0. → verify 통과 후
+  //    skip/미검증/커버리지 부족만으로는 거짓 실패(exit 1) 내지 않는다(혼란 제거). 미검증은 경고로만.
+  //  - --strict: exit 0 = vacuous 또는 cleanHigh(의심 0 + 미검증 0 + high)만. 그 외 exit 1(엄격 게이트).
+  //  어느 모드든 강한 모순(suspicions: FAIL·증거부재·DONE↔FAIL)은 exit 1.
   const vacuous = result.checkedCount === 0
-  const cleanHigh = result.suspicions.length === 0 && result.gaps.length === 0 && result.confidence === 'high'
-  process.exitCode = vacuous || cleanHigh ? 0 : 1
+  const cleanHigh =
+    result.suspicions.length === 0 && result.gaps.length === 0 && result.confidence === 'high'
+  const softOnlyPass = result.suspicions.length === 0 // 강한 모순 없음(gaps 는 있을 수 있음)
+  process.exitCode = strict ? (vacuous || cleanHigh ? 0 : 1) : (vacuous || softOnlyPass ? 0 : 1)
 
   if (vacuous) {
     // 완료 주장 자체가 없음 → 실패 아님(0), 단 goal done 안내도 안 함.
@@ -377,12 +389,23 @@ export async function review(opts: { id?: string } = {}): Promise<void> {
       command: `vhk goal done --id ${goalId}`,
       cursorHint: 'goal 완료 처리해줘',
     })
+  } else if (!strict) {
+    // advisory: 강한 모순 없음 + (skip/미검증/커버리지 부족) → 통과(exit 0)지만 수동 확인 권장.
+    if (result.gaps.length > 0) {
+      console.log(chalk.dim('\n  ℹ️  강한 모순 없음 — advisory 통과(exit 0). 아래 미검증은 수동 확인 권장:'))
+      console.log(chalk.cyan(result.reprompt.split('\n').map((l) => `    ${l}`).join('\n')))
+    }
+    printNextStep({
+      message: `심문 통과(advisory·신뢰도 ${result.confidence}, 보장 아님). 엄격 검증은 vhk review --strict. 완료 처리:`,
+      command: `vhk goal done --id ${goalId}`,
+      cursorHint: 'goal 완료 처리해줘',
+    })
   } else {
-    // medium/low (의심은 없지만 stale·미검증·커버리지 부족) → "통과" 아님(exit 1). goal done 안내 금지.
+    // --strict: medium/low (의심은 없지만 stale·미검증·커버리지 부족) → "통과" 아님(exit 1). goal done 금지.
     console.log(chalk.dim('\n  AI 재질문 프롬프트:'))
     console.log(chalk.cyan(result.reprompt.split('\n').map((l) => `    ${l}`).join('\n')))
     printNextStep({
-      message: `증거 불충분(신뢰도 ${result.confidence}) — goal done 금지. 커버리지/신선도 보강 후 재검증:`,
+      message: `증거 불충분(strict·신뢰도 ${result.confidence}) — goal done 금지. 커버리지/신선도 보강 후 재검증:`,
       command: 'vhk verify',
       cursorHint: '증거 보강 후 다시 검증해줘',
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -529,8 +529,9 @@ program
   .command('review')
   .alias('검토')
   .option('--id <id>', '대상 goal id (없으면 active goal)')
+  .option('--strict', '엄격 모드 — 미검증/커버리지 부족도 실패 (기본 advisory: 강한 모순만 실패) (#157)')
   .description('적대적 자기검증 — latest.json ↔ goal 완료조건 교차검증 (거짓완료 의심 탐지, 보장 아님)')
-  .action(async (opts: { id?: string }) => { await review(opts) })
+  .action(async (opts: { id?: string; strict?: boolean }) => { await review(opts) })
 
 // prev 기본 [] — default 미지정이라 옵션 미제공 시 opts 에 키 자체가 없음(undefined = 보존 신호).
 const collectGlob = (v: string, prev: string[] = []): string[] => prev.concat([v])

--- a/tests/review.test.ts
+++ b/tests/review.test.ts
@@ -88,9 +88,11 @@ describe('review — crossCheck (순수)', () => {
     expect(r.suspicions.some((s) => /DONE/.test(s.check))).toBe(true)
   })
 
-  it('체크된 테스트 항목인데 test 게이트 skip → 의심', () => {
+  it('체크된 테스트 항목인데 test 게이트 skip → 미검증(gap, 강한 의심 아님) (#157)', () => {
     const r = crossCheck([checked('테스트 추가')], 'IN_PROGRESS', report('WARN', [gate('test', 'skip', null)]), FRESH)
-    expect(r.suspicions.some((s) => /skip/.test(s.reason))).toBe(true)
+    // #157: skip 은 거짓완료 '강한 의심'이 아니라 '미검증'(수동 확인) — gaps 로 분류.
+    expect(r.suspicions).toHaveLength(0)
+    expect(r.gaps.some((g) => /skip/.test(g.note))).toBe(true)
   })
 
   it('전 게이트 pass + 매핑 충분 + 신선 → confidence high + disclaimer', () => {
@@ -246,12 +248,12 @@ ${checks.map((c) => `- [x] ${c}`).join('\n')}
     fs.rmSync(d, { recursive: true, force: true })
   })
 
-  it('증거 불충분(미검증 다수 → coverage 낮음, 의심 0) → exit 1 (통과 취급 안 함)', async () => {
+  it('증거 불충분(미검증 다수, 의심 0) → --strict 면 exit 1 (#157)', async () => {
     const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-review-'))
     seedGoal(d, 9, 'IN_PROGRESS', ['tsc 통과', '문서 업데이트', 'UX 개선'])
     seedReport(d, report('PASS', [gate('typecheck', 'pass')], new Date().toISOString()))
     process.chdir(d)
-    await review({ id: '9' })
+    await review({ id: '9', strict: true })
     expect(process.exitCode).toBe(1)
     const merged = JSON.parse(fs.readFileSync(path.join(d, '.vhk', 'reports', 'latest.json'), 'utf-8'))
     expect(merged.review.suspicions).toHaveLength(0)
@@ -260,16 +262,51 @@ ${checks.map((c) => `- [x] ${c}`).join('\n')}
     fs.rmSync(d, { recursive: true, force: true })
   })
 
-  it('stale 증거(의심 0, 커버리지 충분이라도) → exit 1', async () => {
+  it('#157 advisory(기본): 강한 모순 없으면 미검증 있어도 exit 0', async () => {
     const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-review-'))
-    seedGoal(d, 9, 'IN_PROGRESS', ['tsc 통과'])
-    // generatedAt 옛날 → stale → high 금지 → exit 1.
-    seedReport(d, report('PASS', [gate('typecheck', 'pass')], '2020-01-01T00:00:00.000Z'))
+    seedGoal(d, 9, 'IN_PROGRESS', ['tsc 통과', '문서 업데이트', 'UX 개선'])
+    seedReport(d, report('PASS', [gate('typecheck', 'pass')], new Date().toISOString()))
     process.chdir(d)
-    await review({ id: '9' })
+    await review({ id: '9' }) // 기본 = advisory
+    expect(process.exitCode).toBe(0)
+    const merged = JSON.parse(fs.readFileSync(path.join(d, '.vhk', 'reports', 'latest.json'), 'utf-8'))
+    expect(merged.review.suspicions).toHaveLength(0)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('강한 모순(게이트 FAIL) → advisory 라도 exit 1 (#157)', async () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-review-'))
+    seedGoal(d, 9, 'DONE', ['tsc 통과'])
+    seedReport(d, report('FAIL', [gate('typecheck', 'fail', 1)], new Date().toISOString()))
+    process.chdir(d)
+    await review({ id: '9' }) // advisory 여도 강한 모순은 실패
     expect(process.exitCode).toBe(1)
     process.chdir(origCwd)
     fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('stale 증거(의심 0) → --strict 면 exit 1, advisory 면 exit 0 (#157)', async () => {
+    const mk = () => {
+      const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-review-'))
+      seedGoal(d, 9, 'IN_PROGRESS', ['tsc 통과'])
+      seedReport(d, report('PASS', [gate('typecheck', 'pass')], '2020-01-01T00:00:00.000Z'))
+      return d
+    }
+    const d1 = mk()
+    process.chdir(d1)
+    await review({ id: '9', strict: true })
+    expect(process.exitCode).toBe(1)
+    process.chdir(origCwd)
+    fs.rmSync(d1, { recursive: true, force: true })
+
+    const d2 = mk()
+    process.chdir(d2)
+    process.exitCode = 0
+    await review({ id: '9' })
+    expect(process.exitCode).toBe(0)
+    process.chdir(origCwd)
+    fs.rmSync(d2, { recursive: true, force: true })
   })
 
   it('vacuous(체크 0) → exit 0', async () => {


### PR DESCRIPTION
## 무엇 (#157)
`vhk review` 가 `vhk verify` 통과 후에도 자주 `exit 1` 을 내 혼란을 줌 — 게이트 `skip`(검증이 이번 변경을 안 건드림)을 '거짓완료 강한 의심'으로 취급했기 때문.

## 고침
- **skip → 미검증(gap)**: `skip` 게이트는 강한 모순(suspicions)이 아니라 '미검증(수동 확인)'으로 분류. verify 통과 후 skip 만으로 `exit 1` 나던 거짓 실패 제거.
- **advisory 기본 + `--strict`**:
  - 기본(advisory): 강한 모순(게이트 FAIL·증거 부재·DONE↔FAIL) 없으면 `exit 0`. 미검증/커버리지/신선도 부족은 **경고로만**.
  - `--strict`: 기존 엄격 정책(`vacuous` 또는 `cleanHigh` 만 통과) — CI 강제 게이트용.
  - 강한 모순은 **어느 모드든 `exit 1`** 유지(적대 검증 핵심 보존).
- **증거 키 매핑 출력**: `게이트 증거: typecheck:pass · test:skip · …` + 모드 표시 → 어떤 증거가 빠졌는지 명확(#157 요구 3).

## 테스트
- `crossCheck`: skip → gaps(의심 0).
- 통합: advisory 기본 미검증 → `exit 0` / `--strict` 미검증 → `exit 1` / 강한 모순(FAIL) → 어느 모드든 `exit 1` / stale advisory vs strict.

## 게이트
- `pnpm build` ✓ · `pnpm test:run` **1273 pass / 0 fail** ✓

Fixes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)
