### PR TITLE
chore(goal-47): engines.node >=22 정직화 — CI 매트릭스 하한과 일치

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ vhk mcp
 
 ## 요구 사항
 
-- Node.js >= 20
+- Node.js >= 22
 - Git
 - 선택: `gh` CLI (`vhk cloud push/pull` 사용 시)
 - 선택: pnpm/yarn/npm 중 프로젝트 패키지 매니저

--- a/goals/47-ci-os-node-matrix.md
+++ b/goals/47-ci-os-node-matrix.md
@@ -39,9 +39,8 @@ leads_to: 툴링 3→4 · 주 사용환경 회귀 봉쇄
 > **🔎 goal 47 실측 발견**: node 하한을 20 으로 잡았더니 `test (ubuntu, 20)` 즉시 실패 —
 > `packageManager: pnpm@11.2.2` 가 `node:sqlite` 의존으로 **Node ≥22.13 요구**(Node 20 에선
 > pnpm 자체가 `ERR_UNKNOWN_BUILTIN_MODULE`). → 매트릭스 하한을 **22** 로 조정(툴체인 현실).
-> 런타임 `engines.node(>=20)`는 별개로 유지(vhk 실행은 node 20 호환). 후속 선택지:
-> ① engines 를 >=22 로 정직화 ② node-20 런타임 smoke 잡을 npm 으로 별도 추가 ③ pnpm 다운그레이드.
-> (이 결정은 사용자 판단 — 본 goal 은 매트릭스 인프라 구축 + win32 검증에 집중.)
+> 런타임 `engines.node` 후속 — **✅ ① engines 를 >=22 로 정직화 채택**(2026-06-09, 사용자 판단).
+> 근거: CI 매트릭스가 node 22·24 만 돌고 Node 20 은 2026-04 EOL → `>=22` 가 정직(README·check-goal-47 동기화). 별도 PR 처리.
 
 ## Mandatory Reading
 - .github/workflows/ci.yml · src/lib/exec.ts (시프 분기) · CLAUDE.md(win32 규칙)

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "url": "git+https://github.com/byh3071-cpu/vhk.git"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/scripts/check-goal-47.mjs
+++ b/scripts/check-goal-47.mjs
@@ -61,6 +61,8 @@ must(/runs-on:\s*\$\{\{\s*matrix\.os\s*\}\}/.test(ci), 'runs-on 이 matrix.os �
 must(/\[\s*22\s*,\s*24\s*\]/.test(ci), 'node 하한 22 + 24 매트릭스 (pnpm@11 툴체인 하한)')
 must((ci.match(/windows-latest/g) ?? []).length >= 2, 'test + dogfood 둘 다 windows-latest 포함')
 must((ci.match(/ubuntu-latest/g) ?? []).length >= 2, 'test + dogfood 둘 다 ubuntu-latest 포함')
+// 후속 ① 채택: engines.node 를 매트릭스 하한(22)과 일치시켜 정직화 (Node 20 은 2026-04 EOL).
+must((pkg.engines?.node ?? '').includes('>=22'), 'engines.node >=22 (매트릭스 하한과 일치 · Node 20 EOL)')
 
 if (pass) { console.log('✅ goal 47 gate passes'); process.exit(0) }
 console.log('❌ goal 47 gate failed'); process.exit(1)


### PR DESCRIPTION
## goal 47 후속 — engines.node >=22 정직화

goal 47(CI 멀티 OS/Node 매트릭스)서 남긴 미결 결정. CI 매트릭스는 **node 22·24** 만 돌고 Node 20 은 **2026-04 EOL** 인데 `package.json` `engines.node` 가 `>=20` 이라 불일치였다.

후속 선택지 ①②③ 중 **① engines >=22 정직화** 채택(사용자 판단).

### 변경
- `package.json` — `engines.node >=20 → >=22`
- `README.md` — 요구사항 `Node.js >= 20 → >= 22`
- `scripts/check-goal-47.mjs` — engines.node >=22 단언 추가(매트릭스 하한 일치 봉쇄)
- `goals/47-ci-os-node-matrix.md` — 미결 노트 → 결정 기록(① 채택)

### 검증
typecheck + lint + test(**1296 pass**) + build green, check-goal-47 전 항목 통과. 설정 변경뿐(명령 동작 무변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
