### PR TITLE
docs(goals): G55-G61 spec drafts (audit-derived, ref 9e7681b)

### DIFF
--- a/goals/55-agent-action-ledger.md
+++ b/goals/55-agent-action-ledger.md
@@ -1,0 +1,41 @@
+---
+vhk_format: 1
+type: goal
+id: 55
+title: AI 행동 원장(agent-action-ledger) — P1
+status: NOT_STARTED
+priority: P1
+created: 2026-06-09
+leads_to: 61 (stats 집계 소스)
+---
+
+# Goal 55: AI 행동 원장 (agent-action-ledger)
+
+> 출처: 전수검사 — "AI가 무엇을 실행/차단당했나"의 레포 영속 기록 부재.
+
+## 근거 (실측)
+- `src/lib/evidence-ledger.ts` → `LEDGER_PATH_REL = .vhk/ledger.jsonl`, `LedgerEntry{version,date,status,sha,shortSha,dirty}`. 이건 릴리즈 verify 증거 요약만 기록 → AI 행동 단위 로그가 아님(별개, 중복 아님).
+- `src/lib/safety-guard.ts` → `runGuarded(action,deps,run)`이 CLI/MCP/NL 공통 단일 chokepoint. 반환 `GuardedOutcome{ran,guard,reason}`. 단 통과 대상은 위험 9종 + strict(save/sync)뿐 → read/edit/test는 미경유.
+- `src/lib/risk-policy.ts` → `HIGH_RISK_ACTIONS`(undo, deploy, publish, migrate, cloud-pull, resume, env-write, delete, restore).
+- `src/lib/hard-stop-guard.ts` → `ensureNotHardStopped(action)`(트립와이어 차단도 행동 이벤트).
+
+## 동작
+- `.vhk/events/ai-actions.jsonl` append-only 행동 원장 신설. `AiActionEntry{ts, action, channel, guard, ran, reason, target?, sha?}`.
+- `runGuarded` 반환 `outcome`을 그대로 1줄 append(`guard`/`ran`/`reason` 직매핑). `ensureNotHardStopped` 차단도 기록.
+- 기록 범위: 위험행동 + `save`/`commit`. read/edit 등 비가드 행동은 본 원장 범위 밖(정직 표기) — 필요 시 별도 후속 goal.
+- 입출력은 `evidence-ledger.ts` 패턴 재사용(`readLedger`/`appendLedgerEntry` 류 + `atomic-write.ts` + `read-json.ts` `stripBom`). raw `JSON.parse` 금지(`check-no-raw-json-parse.mjs` 게이트 준수).
+
+## 수용 기준
+- `vhk publish`/`undo` 등 위험행동 1회 → `ai-actions.jsonl`에 정확히 1줄, 6필드 채워짐.
+- 비대화형 미승인 차단 시 `reason`이 `no-confirm`/`preview-no-approve`로 기록.
+- 손상 라인 skip(읽기 안 죽음), 과거 줄 변경 0(append-only 불변).
+
+## Completion Check
+- [ ] `.vhk/events/ai-actions.jsonl` append-only 원장 + `AiActionEntry` 6필드
+- [ ] `runGuarded` outcome 매핑 + `ensureNotHardStopped` 차단 기록
+- [ ] `evidence-ledger.ts` 패턴 재사용, raw `JSON.parse` 0건
+- [ ] `node scripts/check-goal-55.mjs` 통과
+- [ ] `node scripts/check-no-raw-json-parse.mjs` 통과
+
+## Mandatory Reading
+- `src/lib/evidence-ledger.ts` · `src/lib/safety-guard.ts` · `src/lib/risk-policy.ts` · `src/lib/state-files.ts` · `src/lib/read-json.ts`

--- a/goals/56-cost-guard.md
+++ b/goals/56-cost-guard.md
@@ -1,0 +1,40 @@
+---
+vhk_format: 1
+type: goal
+id: 56
+title: 비용·예산 가드(cost-guard) — P0
+status: NOT_STARTED
+priority: P0
+created: 2026-06-09
+leads_to: 61 (stats 집계 소스)
+---
+
+# Goal 56: 비용·예산 가드 (cost-guard)
+
+> 출처: 전수검사 — 5대 자기개선 루프 중 비용 루프만 전무(최우선 공백).
+
+## 근거 (실측)
+- `src/commands/` 디렉터리 실측: `cost.ts`/`budget.ts` 없음. `src/lib/`에도 없음.
+- 나머지 4루프는 존재: 맥락(`context.ts`/`memory.ts`), 위험(`risk-policy.ts`/`safety-guard.ts`), 학습(`evolve.ts`/`pattern.ts`), 증거(`verify.ts`/`evidence-ledger.ts`). 비용만 0.
+- 모드 연동 자원: `src/lib/config.ts`(`.vhk/config.json`), `src/commands/mode.ts`(safety mode).
+
+## 동작
+- token/$ 예산 가드. `cost-policy.ts`(예산·요율 SoT) + 호출부로 결정/집행 분리(`risk-policy`와 동형).
+- pricing table은 `.vhk/config.json` 주입값 사용 — 코드 하드코딩 금지.
+- 임계 초과 시 safety mode 연동: warn → confirm → block(비대화형 + 미승인은 block).
+- 사용량 누적은 `cost.jsonl`(G55 패턴 재사용) append.
+
+## 수용 기준
+- 예산 80%에서 warn, 100%에서 block, 비대화형 + 미승인은 block.
+- pricing 코드 상수 0건(grep 검증) — 전부 config 주입.
+- 사용량 append 시 과거 줄 변경 0.
+
+## Completion Check
+- [ ] `cost-policy.ts`(예산·요율 SoT) + 호출부 분리
+- [ ] pricing은 `.vhk/config.json` 주입, 코드 상수 0건
+- [ ] 80% warn / 100% block / 비대화형 미승인 block
+- [ ] `cost.jsonl` append, 과거 줄 변경 0
+- [ ] `node scripts/check-goal-56.mjs` 통과
+
+## Mandatory Reading
+- `src/lib/config.ts` · `src/lib/risk-policy.ts` · `src/lib/safety-guard.ts` · `src/commands/mode.ts` · `src/lib/evidence-ledger.ts`

--- a/goals/57-risk-policy-glob.md
+++ b/goals/57-risk-policy-glob.md
@@ -1,0 +1,40 @@
+---
+vhk_format: 1
+type: goal
+id: 57
+title: 위험 정책 글롭 확장·통합(risk-policy-glob) — P1
+status: NOT_STARTED
+priority: P1
+created: 2026-06-09
+leads_to: 60
+---
+
+# Goal 57: 위험 정책 글롭 확장 + 결정점 통합 (risk-policy-glob)
+
+> 출처: 전수검사 — 권한 게이트는 "부재"가 아니라 "액션 문자열 기반 + 결정점 분산"이 진짜 문제.
+
+## 근거 (실측 — 기존 초안 모순 정정)
+- 단일 chokepoint 이미 존재: `src/lib/safety-guard.ts` `runGuarded` + 정책 SoT `src/lib/risk-policy.ts`(`resolveGuard`, `HIGH_RISK_ACTIONS` 9종, `NL_GUARDED_ACTIONS`). → 기존 "전용 레이어 없음" 주장 폐기.
+- 한계 1: risk-policy는 액션 문자열(9종) 기반, 파일·경로 글롭 차원 없음.
+- 한계 2: 위험 결정이 `runGuarded`와 별개 메커니즘으로 분산 — HARD_STOP(`src/lib/hard-stop-guard.ts` 트립와이어), publish preflight(`src/commands/preflight.ts` + `src/lib/preflight.ts` + `publish.ts`), secure scan(`src/commands/secure.ts` + verify `runSecureGate`), mission forbidden(`src/commands/mission.ts`).
+
+## 동작
+- 신규 레이어 생성 금지(기존 chokepoint 유지).
+- (1) risk-policy에 path/glob 위험 차원 추가 — 예: `RULES.md`/`AGENTS.md` 자동수정, `rm -rf` 경로, `.env` 경로. `resolveGuard`가 action + target 평가.
+- (2) 분산 결정점(HARD_STOP/preflight/secure)이 risk-policy를 참조하도록 일원화 — 중복 정책 상수 제거.
+- (3) 완전성 가드 테스트(현 `NL_GUARDED_ACTIONS` ↔ dispatch 교차검증 패턴)를 글롭 정책으로 확장.
+
+## 수용 기준
+- 새 위험 경로(예: `AGENTS.md` 자동수정 시도)가 CLI=confirm / MCP=preview로 차단됨(테스트).
+- HARD_STOP/preflight/secure의 중복 정책 상수 0건(grep), risk-policy 단일 참조.
+- 기존 9종 액션 가드 회귀 0(기존 테스트 green 유지).
+
+## Completion Check
+- [ ] risk-policy에 path/glob 위험 차원 추가, `resolveGuard`가 action+target 평가
+- [ ] HARD_STOP/preflight/secure 중복 정책 상수 0건, risk-policy 단일 참조
+- [ ] 글롭 차단 테스트(CLI confirm / MCP preview)
+- [ ] 기존 9종 액션 회귀 0
+- [ ] `node scripts/check-goal-57.mjs` 통과
+
+## Mandatory Reading
+- `src/lib/risk-policy.ts` · `src/lib/safety-guard.ts` · `src/lib/hard-stop-guard.ts` · `src/commands/preflight.ts` · `src/commands/secure.ts` · `src/commands/mission.ts`

--- a/goals/58-evolve-schema-v2.md
+++ b/goals/58-evolve-schema-v2.md
@@ -1,0 +1,35 @@
+---
+vhk_format: 1
+type: goal
+id: 58
+title: 진화 제안 스키마 v2(evolve-schema-v2) — P2
+status: NOT_STARTED
+priority: P2
+created: 2026-06-09
+leads_to: 61
+---
+
+# Goal 58: 진화 제안 스키마 v2 (evolve-schema-v2)
+
+> 출처: 전수검사 — 진화 큐가 규칙(rule) 단일 종류만 표현, 5계층 자기개선과 불일치.
+
+## 근거 (실측)
+- `src/commands/evolve.ts`(18674B, SHA `06d6e7c`) → `QUEUE = .vhk/evolve/queue.json`, `EvolveQueueItem{id, patternId, kind:'rule', status, draft, dedupeKey, createdAt, appliedAt?, rulesBackupPath?}`. `kind`가 `'rule'` 단일, `targetLayer` 없음.
+
+## 동작
+- `kind` → `targetLayer` 5종 확장(memory / rule / workflow / code / product).
+- queue.json v1 → v2 breaking 마이그레이션: 필드 추가 + 기본값 매핑(`kind:'rule'` → `targetLayer:'rule'`). `.bak` 백업 후 원자적 치환(`atomic-write.ts`).
+
+## 수용 기준
+- v1 fixture → v2 마이그레이션 무손실 라운드트립(필드 보존 assert).
+- 마이그레이션 실패 시 `.bak` 복원, 큐 손상 0.
+- 신규 `targetLayer` 항목 `dedupeKey` 충돌 0.
+
+## Completion Check
+- [ ] `kind` → `targetLayer` 5종 확장
+- [ ] queue.json v1→v2 마이그레이션 + `.bak` 백업 + 원자적 치환
+- [ ] 무손실 라운드트립 / 실패 시 복원 / dedupe 충돌 0
+- [ ] `node scripts/check-goal-58.mjs` 통과
+
+## Mandatory Reading
+- `src/commands/evolve.ts` · `src/lib/read-json.ts` · `src/lib/atomic-write.ts`

--- a/goals/59-secure-incomplete-signal.md
+++ b/goals/59-secure-incomplete-signal.md
@@ -1,0 +1,37 @@
+---
+vhk_format: 1
+type: goal
+id: 59
+title: secure 불완전 신호(secure-incomplete-signal) — P1
+status: NOT_STARTED
+priority: P1
+created: 2026-06-09
+leads_to: 55
+---
+
+# Goal 59: secure 불완전 신호 (secure-incomplete-signal)
+
+> 출처: 전수검사 — 스캔이 잘려도(truncated) secure 게이트가 PASS로 처리(거짓 green).
+
+## 근거 (실측)
+- `src/commands/verify.ts`(SHA `2d72745`) → `runSecureGate`가 `severe===0`이면 PASS. 스캔이 한도 도달로 잘려도 PASS.
+- 3대 truncation: `src/lib/scan-secrets.ts` `MAX_SECRET_FINDINGS=200` / `MAX_LINE_CHARS=4000`, `src/lib/scan-files.ts` `MAX_SCAN_FILE_BYTES=512KB`.
+- `ReportStatus`는 이미 PASS/WARN/FAIL 3값 보유(`evidence-ledger.ts`가 import) → incomplete → WARN 저비용 매핑 가능.
+
+## 동작
+- 스캔이 한도 도달(truncated)인데 `severe===0`이면 PASS 금지 → WARN(incomplete) + 사유 노출.
+- WARN을 `.vhk/ledger.jsonl` status에 전파.
+
+## 수용 기준
+- findings 200 초과 / 파일 512KB 초과 / 라인 4000자 초과 케이스에서 status=WARN, 사유 `scan-incomplete` 노출.
+- truncation 없으면 기존 PASS 동작 회귀 0.
+- WARN이 `.vhk/ledger.jsonl`에 그대로 기록.
+
+## Completion Check
+- [ ] truncated + `severe===0` → WARN(incomplete) + 사유 노출
+- [ ] WARN을 `.vhk/ledger.jsonl` status에 전파
+- [ ] 정상 스캔 PASS 회귀 0
+- [ ] `node scripts/check-goal-59.mjs` 통과
+
+## Mandatory Reading
+- `src/commands/verify.ts` · `src/lib/scan-secrets.ts` · `src/lib/scan-files.ts` · `src/lib/evidence-ledger.ts`

--- a/goals/60-stub-gate-fill.md
+++ b/goals/60-stub-gate-fill.md
@@ -1,0 +1,40 @@
+---
+vhk_format: 1
+type: goal
+id: 60
+title: 빈 스텁·누락 게이트 채움(stub-gate-fill) — P1
+status: NOT_STARTED
+priority: P1
+created: 2026-06-09
+leads_to: 61
+---
+
+# Goal 60: 빈 스텁·누락 게이트 채움 + 메타게이트 (stub-gate-fill)
+
+> 출처: 전수검사 — "check-goal 통과"가 빈 스텁 또는 파일 부재로 무의미한 goal 다수.
+
+## 근거 (실측 scripts/ ref 9e7681b)
+- 동일 3167B 빈 스텁 10개: `check-goal-34,35,36,37,38,50,51,52,53,54.mjs`(goal 번호만 다른 템플릿, 고유 검증 0).
+- 게이트 파일 아예 없음 5개: `check-goal-22,23,24,25,26.mjs`(21 다음 27로 점프).
+- 대조군 실 게이트: `check-goal-20.mjs`(5816B), `check-goal-48.mjs`(5056B, 최근 채움), `check-goal-13.mjs`(3836B).
+- 모순: `check-goal-34`-`38`은 status DONE인데 게이트가 스텁 → 헛통과 DONE.
+
+## 동작
+- (1) 스텁 10 + 누락 5 게이트를 각 goal 고유 수용기준 검증으로 채움(번호만 다른 템플릿 금지).
+- (2) `scripts/check-meta.mjs`에 "활성 goal은 비스텁 게이트 필수" 메타 규칙 추가 → 스텁/누락 자동 검출 FAIL.
+- (3) DONE이면서 스텁인 goal(34-38)은 해소 또는 정직 재오픈.
+
+## 수용 기준
+- `check-meta`가 현재 스텁 10 + 누락 5 = 15건을 정확히 검출(FAIL 리스트 일치).
+- 채운 게이트는 각 goal 수용기준과 1:1 매핑.
+- 34-38 DONE-스텁 전수 해소 또는 재오픈.
+
+## Completion Check
+- [ ] 스텁 10 + 누락 5 게이트를 goal 고유 검증으로 채움(템플릿 금지)
+- [ ] `check-meta.mjs`에 비스텁 필수 메타 규칙 추가, 15건 검출
+- [ ] 34-38 DONE-스텁 해소 또는 재오픈
+- [ ] `node scripts/check-goal-60.mjs` 통과
+- [ ] `node scripts/check-meta.mjs` 확장 규칙 통과
+
+## Mandatory Reading
+- `scripts/check-meta.mjs` · `scripts/check-goal-20.mjs`(실 게이트 모범) · `scripts/check-goal-48.mjs` · `scripts/_lib.mjs`

--- a/goals/61-stats-blocks.md
+++ b/goals/61-stats-blocks.md
@@ -1,0 +1,37 @@
+---
+vhk_format: 1
+type: goal
+id: 61
+title: 통계·대시보드 집계(stats-blocks) — P2
+status: NOT_STARTED
+priority: P2
+created: 2026-06-09
+leads_to: 0 (대시보드 종착)
+---
+
+# Goal 61: 통계·대시보드 집계 (stats-blocks)
+
+> 출처: 전수검사 — 패스율/차단율/진화 적용율을 한 눈에 보는 집계 부재.
+
+## 근거 (실측)
+- `src/commands/`에 `stats.ts` 없음.
+- 집계 소스 분산: `.vhk/ledger.jsonl`(릴리즈 verify 요약, `readLedger`), evolve queue(`.vhk/evolve/queue.json`), pattern(`pattern.ts`).
+- 보류 해소: `evidence-ledger.ts`는 version/status/sha만 기록 → AI 차단/승인 이벤트 집계 소스 아님. `runGuarded` outcome은 현재 어디에도 영속되지 않음.
+
+## 동작
+- `vhk stats` 신규 명령(읽기전용). `readLedger` + `ai-actions.jsonl`(G55) + evolve queue 집계 → 패스율/차단율/진화 적용율 블록 출력.
+- 선행 의존: G55(행동 원장) 필수 — 없으면 차단율 집계 불가.
+
+## 수용 기준
+- ledger N줄 → PASS/WARN/FAIL 카운트 정확.
+- `ai-actions.jsonl` 차단율(`ran=false`/total) 정확.
+- 읽기전용 — 파일 쓰기 0건(grep + 테스트 검증).
+
+## Completion Check
+- [ ] `vhk stats` 읽기전용 명령(파일 쓰기 0건)
+- [ ] `readLedger` + `ai-actions.jsonl` + evolve queue 집계
+- [ ] 패스율/차단율/진화 적용율 카운트 정확
+- [ ] `node scripts/check-goal-61.mjs` 통과
+
+## Mandatory Reading
+- `src/lib/evidence-ledger.ts`(`readLedger`) · `src/commands/evolve.ts`(queue) · `src/commands/status.ts`(출력 패턴 모범)


### PR DESCRIPTION
## 개요
전수검사(레포 main `9e7681b` 실측)로 보강한 신규 goal 스펙 7건을 `goals/`에 등록합니다. **스펙 문서만** 포함했고, `scripts/check-goal-NN.mjs`는 "번호만 바꾼 빈 스텁 금지" 규칙 때문에 일부러 제외 — goal별 구현 PR에서 고유 검증으로 작성합니다.

## 포함 파일
- `goals/55-agent-action-ledger.md` (P1) — AI 행동 원장
- `goals/56-cost-guard.md` (P0) — 비용·예산 가드
- `goals/57-risk-policy-glob.md` (P1) — 위험 정책 글롭 확장+통합 (reframed)
- `goals/58-evolve-schema-v2.md` (P2) — 진화 큐 v2
- `goals/59-secure-incomplete-signal.md` (P1) — secure truncated→WARN
- `goals/60-stub-gate-fill.md` (P1) — 빈 스텁 10 + 누락 5 + 메타게이트
- `goals/61-stats-blocks.md` (P2) — stats 집계 (G55 의존)

## 전수검사로 정정한 핵심
- **G57 모순 정정**: `runGuarded`(safety-guard.ts)+`risk-policy.ts`가 이미 단일 chokepoint. "전용 레이어 없음" 폐기 → 글롭 확장+분산 결정점 통합으로 재정의.
- **G55 논리 보정**: runGuarded는 위험 9종+save/sync만 경유. 기록 범위를 위험행동+save/commit로 한정.
- **G60 정정**: 스텁은 34-38·50-54(10개), 누락은 22-26(5개). check-goal-48/49는 채워짐. 34-38 DONE-스텁 모순 포함.
- **G61 보류 해소**: ledger는 verify 요약뿐, 차단 이벤트 집계 소스 아님 → G55 선행 의존.
- 경로 `lib/` → `src/lib/`·`src/commands/` 정정, 수용기준 측정 가능화.

## 권장 후속 (구현)
한 PR = 한 goal, 순서 G56 → G55 → G59 → G60 → G57 → G58 → G61. publish/배포는 사람만, main에서만.

> 머지는 사람 검토 후. AI는 main 직접 푸시/배포하지 않음.