### PR TITLE
feat(recall): 기억 회상 MVP — 키워드 검색 + just-in-time 경고 (RFC 0049)

### DIFF
--- a/docs/rfc/0049-memory-recall-mvp.md
+++ b/docs/rfc/0049-memory-recall-mvp.md
@@ -1,0 +1,96 @@
+# RFC 0049 — 기억 회상 MVP (키워드 우선·진통제 우선, ML 없음)
+
+> 상태: Draft · 작성: 2026-06-09 · 출처: VHK 정체성·기억 레이어 설계 세션(2026-06-09, 다중 관점 적대 검토 + 레포 실측)
+> 목적: "VHK = AI가 일하는 동안 사람의 의도·결정·기억을 시간 너머로 보존하는 레이어" 정체성을, **측정 가능한 최소 단위(MVP)**로 착지. 임베딩·벡터DB·ACT-R는 측정이 정당화할 때까지 의도적으로 연기.
+> 연동: 실행 단위 = `goals/<n>`(추후). 데이터 = `.vhk/memory.json`(SoT, 그대로). 훅 = `src/lib/risk-policy.ts:resolveGuard`.
+
+---
+
+## §0. 한 줄 결론
+
+기억 N=18(실측). **임베딩·벡터DB·bge-m3는 18개에 과설계다.** 키워드 회상 + 위험행동 직전 자동 경고(진통제)부터 만들고, ML은 "키워드가 부족함"을 eval로 증명한 뒤에만 얹는다.
+
+---
+
+## §1. 동기 (실측)
+
+- `.vhk/memory.json` 현재 **총 18개**(failure 18 · pattern 13 · decision/success 0 · 평균 163자). *(2026-06-09 집계)*
+- N=18에 임베딩·sqlite-vec·bge-m3(수백MB~2GB) 도입 = 과설계. 카파시("측정 전 ML 금지")·Linus("자료구조 먼저")·안티레즈("한 기능 검증 후 확장") 합의.
+- **진짜 결함은 검색 정확도가 아니라 회상률 0** — 18개를 쌓기만 하고 안 꺼내 씀(`vhk memory list`는 전체 나열일 뿐 상황 회상 아님).
+- 핵심 가치(진통제) = 되돌리기 어려운 행동 직전 "이 실패 또 하지 마"를 기계가 자동으로 띄움.
+
+## §2. 적대 검토에서 도출된 원칙 (다중 관점)
+
+| 관점 | 적용 |
+|------|------|
+| **카파시** (측정·단순) | N 측정 → 키워드부터. eval 없이 모델 선택 금지. ML은 kill-criteria 통과 후만. |
+| **Linus** (자료구조·데이터 안전) | 진실=memory.json 그대로(기존 안전장치 재활용). 인덱스는 파생·버려도 됨. SoT가 로컬전용 SPOF인 점을 export로 완화. |
+| **Peter Thiel** (해자·진통제) | 검색은 commodity. 해자=축적되는 사용 로그(미래 복리 씨앗). 바이타민(recall)보다 진통제(just-in-time)를 1순위. |
+| **Rich Hickey** (Simple≠Easy) | 점수를 한 숫자로 땋지 말 것 — 신호 분리·투명·디버그 가능. |
+| **Don Norman** (UX) | 오경보가 침묵보다 나쁨. precision ≫ recall. 약매칭은 침묵. |
+
+## §3. 범위
+
+### IN (이번 MVP)
+1. **키워드 recall** — 순수 JS, 의존성 0
+2. **just-in-time 경고** — `resolveGuard()` 훅 (진통제, 1순위)
+3. **eval 하네스** — 키워드 충분성 측정 + ML 도입 kill-criteria
+4. **내구성** — memory.json SPOF 완화: sanitized export
+
+### OUT (측정 후 2차 — 폐기 아님, 연기)
+- 임베딩 · bge-m3 · Transformers.js · sqlite-vec · 벡터검색 · flat 코사인
+- ACT-R 풀(접근강화·연결성 그래프) · 결정 계보 bi-temporal 그래프
+- 구조화 스키마 v3(상황·결정·이유·결과 필드)
+
+### Kill-gate (조기최적화 차단을 문서에 박음)
+> **eval Recall@5 < 0.7 (또는 실사용 "안 떠오름" 반복)을 측정하기 전까지 임베딩·벡터·ML 도입 금지.**
+> 미래의 구현자(사람·AI)가 측정 없이 벡터DB를 다시 끌어오는 것을 이 줄이 막는다.
+
+## §4. 설계
+
+### ① 키워드 recall (순수 JS, 의존성 0)
+- N≤수백 → full-scan 무방. 토큰 overlap + **tag 가중**(태그 정확매치 점수↑).
+- 신규 순수함수 `recallMemories(mem, query, k): Hit[]` (memory.ts).
+- **4신호 분리(Hickey):** 결과에 `{keyword, tagMatch, recency, status}`를 각각 노출 — 한 숫자로 합치지 않음(왜 떠올랐는지 설명 가능).
+- status 반영: `archived`/`resolved`는 **강등**(제외 아님). 번복 항목은 `[번복됨 → 최신]` 플래그(append-only 정합).
+- 한국어 토큰화 = 공백 분리 + 소문자/조사 단순 정규화(결정적, 라이브러리 0).
+
+### ② just-in-time 경고 (진통제 · 핵심)
+- **훅 지점:** `resolveGuard(action, mode, channel)` ([risk-policy.ts:60](../../src/lib/risk-policy.ts#L60))가 `confirm`/`preview`/`warn`을 반환할 때 **그 직전**, `action`(undo/deploy/publish/migrate/cloud-pull/resume/env-write/delete/restore)을 쿼리로 recall.
+- 예: `publish` 직전 → tag/lesson에 publish 관련 과거 실패가 있으면 팝("⚠️ 과거: …").
+- **precision ≫ recall(Norman):** 점수 임계값 높게. 약매칭=침묵. 오경보=신뢰 즉사이므로 기본은 침묵.
+- 빈도제한: 동일 경고 세션당 1회. 채널 cli/mcp/nl 공통.
+
+### ③ eval 하네스
+- 라벨 20쌍(쿼리 → 기대 기억 id). 신규 `vhk memory eval`.
+- 메트릭: Recall@5 · MRR. 출력에 kill-criteria 대비 현재 점수 표시.
+- N=18인 현재는 거의 전수 검토 수준이나, N이 늘면 ML 도입 판단의 객관 근거가 됨.
+
+### ④ 내구성 (Linus 지적 — SPOF 완화)
+- 문제: `.vhk/memory.json`은 gitignore·로컬전용 → 디스크 장애 시 기억 전손.
+- MVP: `vhk memory export` — **secret-scan(scan-secrets) 통과본**만 백업/공유 가능 파일로. 기존 `.bak`/`.v1.bak` 유지.
+- git 커밋·클라우드 동기화는 secret 위험으로 OUT(2차 opt-in).
+
+## §5. 데이터 모델
+- **신규 필드 0.** 기존 `{content, lesson, why, tags, status, createdAt}` 재사용.
+- 진실 = `memory.json` 그대로(원자적 쓰기·`.bak`·손상가드·멱등 마이그레이션 전부 유지).
+- **인덱스·DB 불필요**(N 작음, full-scan이 <10ms).
+- 구조화(상황·결정·이유·결과)는 **선택적 보강**(호출자=Claude가 채우면 좋고, raw 항상 작동) — 2차.
+
+## §6. 확정 결정 반영 (설계 세션 산출)
+- D5 번복 플래그 · D7 저장/export 전 secret scan · D12 raw 항상(구조화 선택) · D19 status 강등
+- Hickey(4신호 분리) · Norman(precision 우선·기본 침묵) · Thiel(recall/경고 사용 로그 = 미래 복리 데이터 씨앗)
+
+## §7. 수용 기준
+- recall: 18개에서 쿼리 → 관련 실패 top-k 반환, <10ms.
+- just-in-time: publish/deploy 직전 관련 과거 실패 표시(있으면) · 없으면 침묵.
+- eval: Recall@5 측정값 + kill-criteria 대비 출력.
+- export: secret-scan 통과한 백업본 생성.
+- **의존성 추가 0.** 공통 게이트(build·test) 통과 · 회귀 0.
+
+## §8. 다음 (2차 — 측정이 정당화할 때만)
+eval이 키워드 부족을 증명하면: Transformers.js **WASM**(네이티브 컴파일 0) + multilingual-MiniLM 번들 폴백, **flat 임베딩 파일 + 순수 JS 코사인**(벡터DB 없이) → 이후 ACT-R(접근강화·연결성)·결정 계보 그래프. **측정 없이는 진행 금지(§3 Kill-gate).**
+
+---
+
+> 참고: 본 RFC의 상위 전략 맥락(VHK 정체성 = "AI는 손, VHK는 기억" / 도구중립 거짓완료 가드레일 / 6개월 churn 생존)은 코파일럿 세션 분석 페이지(2026-06-09)에 기록됨.

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -578,3 +578,135 @@ export function recordLesson(cwd: string, lesson: string, goalId?: number): Fail
   writeMemory(cwd, mem)
   return entry
 }
+
+// ── 키워드 회상 (RFC 0049 ① · 순수 JS · 의존성 0) ──
+// N≤수백 full-scan. 임베딩·벡터DB 없음(RFC 0049 Kill-gate: eval Recall@5<0.7 측정 전 ML 금지).
+
+/** 회상 1건 — 4신호를 한 숫자로 안 땋고 분리 노출(왜 떠올랐는지 설명 가능 · Hickey). */
+export interface RecallHit {
+  bucket: MemBucket
+  entry: MemEntry
+  score: number
+  signals: { keyword: number; tagMatch: number; recency: number; status: number }
+}
+
+const JOSA = /(은|는|이|가|을|를|에|의|도|로|으로|에서|까지|부터|와|과|만)$/
+const STOP = new Set(['그', '저', '것', '수', '등', '및', '때'])
+
+/** 결정적 한국어/영어 토크나이저 — 소문자·기호분리·긴 단어의 짧은 조사 제거. 라이브러리 0. */
+export function tokenize(text: string): string[] {
+  return (text.toLowerCase().match(/[a-z0-9]+|[가-힣]+/g) ?? [])
+    .map((w) => (w.length > 2 ? w.replace(JOSA, '') : w))
+    .filter((w) => w.length >= 2 && !STOP.has(w))
+}
+
+function entryText(e: MemEntry): string {
+  const f = e as FailEntry
+  return [e.content, f.lesson, f.why].filter(Boolean).join(' ')
+}
+
+/** corpus IDF — N 작아 매 호출 계산해도 <1ms. df↑(흔한 단어)일수록 가중↓. tags 제외(본문만). */
+function buildIdf(entries: MemEntry[]): Map<string, number> {
+  const df = new Map<string, number>()
+  for (const e of entries) {
+    for (const tok of new Set(tokenize(entryText(e)))) df.set(tok, (df.get(tok) ?? 0) + 1)
+  }
+  const N = entries.length || 1
+  const idf = new Map<string, number>()
+  for (const [tok, d] of df) idf.set(tok, Math.log(1 + N / d))
+  return idf
+}
+
+/** 생성시점 기반 약한 최근성 보너스(주신호 아님) — 90일 반감기. 파싱 실패 시 0. */
+function recencyScore(createdAt: string, nowMs: number): number {
+  const ts = Date.parse(createdAt)
+  if (Number.isNaN(ts)) return 0
+  const days = (nowMs - ts) / 86_400_000
+  return Math.exp(-days / 90)
+}
+
+/**
+ * 키워드 회상. 토큰 IDF overlap + 태그 정확매치 가중 + 약한 최근성, status 강등.
+ * 정렬 결정적: score DESC → createdAt DESC → id ASC.
+ */
+export function recallMemories(
+  mem: MemoryFileV2,
+  query: string,
+  k = 5,
+  nowMs: number = Date.now()
+): RecallHit[] {
+  const all = orderedAll(mem)
+  const qTokens = new Set(tokenize(query))
+  if (qTokens.size === 0) return []
+  const idf = buildIdf(all.map((x) => x.entry))
+
+  const hits: RecallHit[] = all.map(({ bucket, entry }) => {
+    const bodyTokens = new Set(tokenize(entryText(entry)))
+    let keyword = 0
+    for (const tok of qTokens) if (bodyTokens.has(tok)) keyword += idf.get(tok) ?? 0
+    const tagMatch = entry.tags.filter((tg) => qTokens.has(tg.toLowerCase())).length
+    const recency = recencyScore(entry.createdAt, nowMs)
+    const status = isActive(entry) ? 1 : 0.3 // D19: archived/resolved 강등
+    // 관련성(keyword+tag)이 0이면 매칭 아님 — 최근성은 '이미 매칭된 것'만 가산(유령 매칭 방지).
+    const relevance = keyword + tagMatch * 2.0
+    const score = relevance > 0 ? (relevance + recency * 0.3) * status : 0
+    return { bucket, entry, score, signals: { keyword, tagMatch, recency, status } }
+  })
+
+  return hits
+    .filter((h) => h.score > 0)
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        Date.parse(b.entry.createdAt) - Date.parse(a.entry.createdAt) ||
+        a.entry.id.localeCompare(b.entry.id)
+    )
+    .slice(0, k)
+}
+
+// ── just-in-time 회상 (RFC 0049 ② · 진통제 · precision ≫ recall) ──
+/** 약매칭은 침묵(오경보 = 신뢰 즉사 · Norman). RFC default — 추후 eval 로 보정. */
+const JIT_MIN_SCORE = 1.5
+
+/**
+ * 위험행동 직전 회상. resolveGuard() 가 confirm/preview/warn 낼 때 직전 호출.
+ * 강한 매칭 + 활성 항목만 반환(없으면 빈 배열 = 침묵).
+ */
+export function recallForAction(
+  mem: MemoryFileV2,
+  action: string,
+  context = '',
+  nowMs: number = Date.now()
+): RecallHit[] {
+  return recallMemories(mem, `${action} ${context}`, 3, nowMs).filter(
+    (h) => h.score >= JIT_MIN_SCORE && isActive(h.entry)
+  )
+}
+
+/** vhk recall <자연어> — 키워드 회상 결과 출력(왜 떠올랐는지 신호 동반). I/O 글루(로직=recallMemories). */
+export async function memoryRecall(query: string): Promise<void> {
+  console.log(chalk.bold('\n🔎 기억 회상'))
+  console.log(chalk.gray('─'.repeat(40)))
+  if (!query || !query.trim()) {
+    console.log(chalk.red('❌ 찾을 내용을 입력해주세요. 예: vhk recall "배포 막힘"'))
+    process.exitCode = 1
+    return
+  }
+  const hits = recallMemories(readMemory(process.cwd()), query.trim())
+  if (hits.length === 0) {
+    console.log(chalk.yellow(`\n📭 "${query.trim()}" 관련 기억이 없습니다.`))
+    return
+  }
+  console.log(chalk.cyan(`\n${hits.length}개 관련 기억:\n`))
+  for (const h of hits) {
+    const f = h.entry as FailEntry
+    const text = h.entry.content || f.lesson || h.entry.id
+    console.log(`  ${STATUS_ICON[h.entry.status] ?? '🟢'} (${BUCKET_LABEL[h.bucket]}) ${text}`)
+    if (h.entry.content && f.lesson) console.log(chalk.dim(`      💡 ${f.lesson}`))
+    if (h.entry.tags.length) console.log(chalk.blue(`      🏷️  ${h.entry.tags.join(', ')}`))
+    const s = h.signals
+    console.log(
+      chalk.gray(`      ↳ 점수 ${h.score.toFixed(2)} (키워드 ${s.keyword.toFixed(2)}·태그 ${s.tagMatch}·최근 ${s.recency.toFixed(2)}·상태 ${s.status})`)
+    )
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import { audit } from './commands/audit.js'
 import { migrate } from './commands/migrate.js'
 import { update } from './commands/update.js'
 import { context, contextShow } from './commands/context.js'
-import { memoryAdd, memoryList, memoryRemove, memoryArchive, memoryResolve, memoryUnarchive, memoryMigrate } from './commands/memory.js'
+import { memoryAdd, memoryList, memoryRemove, memoryArchive, memoryResolve, memoryUnarchive, memoryMigrate, memoryRecall } from './commands/memory.js'
 import { brief } from './commands/brief.js'
 import { work, workHandoff } from './commands/work.js'
 import { getUpdateInfo } from './lib/version-check.js'
@@ -633,6 +633,12 @@ memoryCmd
   .alias('마이그레이션')
   .description('memory.json v1 → v2 마이그레이션 (기존 v1 있으면 .v1.bak 원본 백업, 멱등)')
   .action(async () => { await memoryMigrate() })
+
+program
+  .command('recall [query...]')
+  .alias('회상')
+  .description('기억 회상 — 자연어로 관련 결정·실패·교훈 검색 (키워드, RFC 0049)')
+  .action(async (query: string[]) => { await memoryRecall((query ?? []).join(' ')) })
 
 program
   .command('brief')

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -35,6 +35,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'context', '맥락',
   'context-show', '맥락보기',
   'memory', '기억',
+  'recall', '회상',
   'brief', '브리핑',
   'cloud', '클라우드',
   'goal', '목표',

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -91,6 +91,7 @@ export const TOP_LEVEL_COMMANDS: ReadonlyArray<{ name: string; desc: string }> =
   { name: 'mission', desc: '미션 계약 — 작업 목표·허용/금지 범위 선언·검증' },
   { name: 'context-show', desc: '컨텍스트 파일 내용 출력' },
   { name: 'memory', desc: '기억 관리 v2 (decisions/failures/successes)' },
+  { name: 'recall', desc: '기억 회상 (자연어 키워드 검색 — RFC 0049)' },
   { name: 'brief', desc: '프로젝트 요약 보고서 생성' },
   { name: 'work', desc: 'AI 작업 시작/이어하기 (+ handoff)' },
   { name: 'goal', desc: 'Goal 단계별 미션 관리' },

--- a/src/lib/safety-guard.ts
+++ b/src/lib/safety-guard.ts
@@ -1,6 +1,7 @@
 import { readConfig } from './config.js'
 import { resolveGuard, type Channel, type Guard } from './risk-policy.js'
 import type { SafetyMode } from './safety-mode.js'
+import { readMemory, recallForAction } from '../commands/memory.js'
 
 /**
  * 위험 작업 가드의 **단일 chokepoint**.
@@ -23,6 +24,8 @@ export interface GuardDeps {
   approved?: boolean
   /** 사용자 안내 출력 */
   log?: (msg: string) => void
+  /** just-in-time 회상 기준 디렉터리 (기본 process.cwd()) — RFC 0049 */
+  cwd?: string
 }
 
 export interface GuardedOutcome {
@@ -39,6 +42,19 @@ export async function runGuarded<T>(
   const mode: SafetyMode = deps.mode ?? readConfig().safetyMode
   const log = deps.log ?? (() => {})
   const guard = resolveGuard(action, mode, deps.channel)
+
+  // RFC 0049 ②: 위험 작업 직전, 관련 과거 실패를 회상해 경고로 표출(just-in-time).
+  // precision 우선(약매칭 침묵) · 회상 실패는 가드 동작을 절대 막지 않는다.
+  if (guard !== 'allow') {
+    try {
+      for (const h of recallForAction(readMemory(deps.cwd ?? process.cwd()), action)) {
+        const e = h.entry as { lesson?: string; content?: string; id: string }
+        log(`🧠 과거 교훈(${action}): ${e.lesson || e.content || e.id}`)
+      }
+    } catch {
+      /* 회상 실패는 무시 — 가드 본 기능 보호 */
+    }
+  }
 
   if (guard === 'allow') {
     return { outcome: { ran: true, guard, reason: 'low-risk' }, result: await run() }

--- a/tests/jit-recall.test.ts
+++ b/tests/jit-recall.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { runGuarded } from '../src/lib/safety-guard.js'
+
+interface SeedFail {
+  id: string
+  lesson: string
+  tags: string[]
+  status?: 'active' | 'resolved' | 'archived'
+}
+
+function seedMem(dir: string, failures: SeedFail[]): void {
+  fs.mkdirSync(path.join(dir, '.vhk'), { recursive: true })
+  const full = failures.map((f) => ({
+    id: f.id,
+    content: '',
+    tags: f.tags,
+    createdAt: '2026-06-01T00:00:00Z',
+    status: f.status ?? 'active',
+    lesson: f.lesson,
+  }))
+  fs.writeFileSync(
+    path.join(dir, '.vhk', 'memory.json'),
+    JSON.stringify({ schemaVersion: 2, decisions: [], failures: full, successes: [], patterns: [] }),
+    'utf-8'
+  )
+}
+
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-jit-'))
+}
+
+describe('runGuarded — just-in-time 기억 경고 (RFC 0049 ②)', () => {
+  it('위험작업 직전 관련 과거 실패를 경고로 표출', async () => {
+    const dir = tmp()
+    seedMem(dir, [{ id: 'f1', lesson: 'publish 가드가 feature 브랜치 발행을 차단', tags: ['publish'] }])
+    const logs: string[] = []
+    await runGuarded('publish', { channel: 'cli', mode: 'standard', isTTY: false, cwd: dir, log: (m) => logs.push(m) }, async () => 'x')
+    expect(logs.join('\n')).toContain('publish 가드')
+  })
+
+  it('관련 기억 없으면 침묵 (무관한 기억은 안 뜸)', async () => {
+    const dir = tmp()
+    seedMem(dir, [{ id: 'f1', lesson: '디자인 토큰 정리', tags: ['design'] }])
+    const logs: string[] = []
+    await runGuarded('publish', { channel: 'cli', mode: 'standard', isTTY: false, cwd: dir, log: (m) => logs.push(m) }, async () => 'x')
+    expect(logs.join('\n')).not.toContain('디자인 토큰')
+  })
+
+  it('저위험(allow)은 회상하지 않음', async () => {
+    const dir = tmp()
+    seedMem(dir, [{ id: 'f1', lesson: 'publish 가드 발행 차단', tags: ['publish'] }])
+    const logs: string[] = []
+    await runGuarded('status', { channel: 'cli', mode: 'standard', cwd: dir, log: (m) => logs.push(m) }, async () => 'x')
+    expect(logs.join('\n')).not.toContain('publish 가드')
+  })
+
+  it('resolved 기억은 just-in-time 에서 제외', async () => {
+    const dir = tmp()
+    seedMem(dir, [{ id: 'f1', lesson: 'publish 가드 발행 차단', tags: ['publish'], status: 'resolved' }])
+    const logs: string[] = []
+    await runGuarded('publish', { channel: 'cli', mode: 'standard', isTTY: false, cwd: dir, log: (m) => logs.push(m) }, async () => 'x')
+    expect(logs.join('\n')).not.toContain('publish 가드')
+  })
+})

--- a/tests/memory-recall.test.ts
+++ b/tests/memory-recall.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest'
+import {
+  tokenize,
+  recallMemories,
+  recallForAction,
+  type MemoryFileV2,
+  type FailEntry,
+} from '../src/commands/memory.js'
+import { detectNaturalLanguageInput } from '../src/lib/cli-args.js'
+
+const NOW = Date.parse('2026-06-09T00:00:00Z')
+
+function fail(id: string, lesson: string, tags: string[], opts: Partial<FailEntry> = {}): FailEntry {
+  return {
+    id,
+    content: '',
+    tags,
+    createdAt: '2026-06-01T00:00:00Z',
+    status: 'active',
+    lesson,
+    ...opts,
+  }
+}
+
+function mem(failures: FailEntry[]): MemoryFileV2 {
+  return { schemaVersion: 2, decisions: [], failures, successes: [], patterns: [] }
+}
+
+describe('tokenize (순수)', () => {
+  it('한국어·영어 분리 + 소문자', () => {
+    const t = tokenize('Publish 배포 막힘')
+    expect(t).toContain('publish')
+    expect(t).toContain('배포')
+    expect(t).toContain('막힘')
+  })
+
+  it('긴 단어의 짧은 조사 제거', () => {
+    expect(tokenize('배포가')).toEqual(['배포'])
+  })
+
+  it('빈 문자열 → 빈 배열', () => {
+    expect(tokenize('')).toEqual([])
+  })
+
+  it('1글자 토큰 제거', () => {
+    expect(tokenize('a 그 배포')).toEqual(['배포'])
+  })
+})
+
+describe('recallMemories (순수)', () => {
+  it('쿼리 토큰 매칭 항목만 반환', () => {
+    const m = mem([
+      fail('f1', 'publish 가드가 feature 브랜치 발행 차단', ['publish']),
+      fail('f2', 'CHANGELOG 드리프트 발생', ['changelog']),
+    ])
+    const hits = recallMemories(m, 'publish', 5, NOW)
+    expect(hits.map((h) => h.entry.id)).toEqual(['f1'])
+  })
+
+  it('태그 정확매치가 본문만 매치보다 상위', () => {
+    const m = mem([
+      fail('f1', '본문에 publish 단어만 있음', ['misc']),
+      fail('f2', '관련 없는 본문', ['publish']),
+    ])
+    const hits = recallMemories(m, 'publish', 5, NOW)
+    expect(hits[0].entry.id).toBe('f2') // 태그 매치가 더 강함
+  })
+
+  it('archived 항목은 강등 (active 가 상위)', () => {
+    const m = mem([
+      fail('f1', 'publish 차단', ['publish'], { status: 'archived' }),
+      fail('f2', 'publish 차단', ['publish'], { status: 'active' }),
+    ])
+    const hits = recallMemories(m, 'publish', 5, NOW)
+    expect(hits[0].entry.id).toBe('f2')
+  })
+
+  it('빈 쿼리 → 빈 배열', () => {
+    const m = mem([fail('f1', 'publish 차단', ['publish'])])
+    expect(recallMemories(m, '', 5, NOW)).toEqual([])
+  })
+
+  it('무매칭 → 빈 배열', () => {
+    const m = mem([fail('f1', 'publish 차단', ['publish'])])
+    expect(recallMemories(m, '데이터베이스 마이그레이션', 5, NOW)).toEqual([])
+  })
+
+  it('4신호를 분리 노출 (한 숫자로 안 땋음)', () => {
+    const m = mem([fail('f1', 'publish 차단', ['publish'])])
+    const [hit] = recallMemories(m, 'publish', 5, NOW)
+    expect(hit.signals).toEqual(
+      expect.objectContaining({
+        keyword: expect.any(Number),
+        tagMatch: expect.any(Number),
+        recency: expect.any(Number),
+        status: expect.any(Number),
+      })
+    )
+  })
+
+  it('결정적 — 동일 입력 동일 출력', () => {
+    const m = mem([
+      fail('f1', 'publish 차단', ['publish']),
+      fail('f2', 'publish 인증', ['publish', 'auth']),
+    ])
+    const a = recallMemories(m, 'publish', 5, NOW).map((h) => h.entry.id)
+    const b = recallMemories(m, 'publish', 5, NOW).map((h) => h.entry.id)
+    expect(a).toEqual(b)
+  })
+})
+
+describe('recallForAction (just-in-time · precision 우선)', () => {
+  it('약매칭은 침묵 → 빈 배열', () => {
+    const m = mem([fail('f1', '디자인 토큰 정리', ['design'])])
+    expect(recallForAction(m, 'publish', '', NOW)).toEqual([])
+  })
+
+  it('강매칭은 반환', () => {
+    const m = mem([
+      fail('f1', 'publish 가드가 feature 브랜치 발행을 차단', ['publish']),
+    ])
+    const hits = recallForAction(m, 'publish', '', NOW)
+    expect(hits.length).toBeGreaterThan(0)
+    expect(hits[0].entry.id).toBe('f1')
+  })
+
+  it('archived/resolved 항목은 just-in-time 에서 제외', () => {
+    const m = mem([
+      fail('f1', 'publish 가드 발행 차단', ['publish'], { status: 'resolved' }),
+    ])
+    expect(recallForAction(m, 'publish', '', NOW)).toEqual([])
+  })
+})
+
+// 통합 드리프트 가드: recall 명령이 NL 선라우터에 자연어로 오판돼 commander 로 안 가는 사고 재발 차단.
+// (유닛 테스트가 못 잡고 도그푸딩이 잡았던 갭 — KNOWN_COMMAND_TOKENS 누락 시 여기서 FAIL.)
+describe('recall 명령 NL 라우팅 가드 (RFC 0049)', () => {
+  it('recall <쿼리> 는 자연어로 오판되지 않고 commander 로 위임된다 (null)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'recall', 'publish'])).toBeNull()
+  })
+
+  it('회상 <쿼리>(한국어 별칭)도 commander 로 위임된다 (null)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '회상', '배포'])).toBeNull()
+  })
+})


### PR DESCRIPTION
## 요약

VHK 정체성("AI는 손, VHK는 기억")의 **기억 회상 레이어 MVP**. 설계 세션(정체성·포지셔닝 → 기억 공학 → 다중관점 적대검토)의 착지점 = **경로 B**(키워드 우선·진통제 우선, ML 없음). RFC 0049.

## 왜 ML 없이 키워드부터인가 (측정 기반)

`.vhk/memory.json` **실측 N=18** (failure 18·평균 163자). → 임베딩·벡터DB·bge-m3는 18개에 과설계. 카파시("측정 전 ML 금지")·Linus("자료구조 먼저")·안티레즈("한 기능 검증 후 확장") 합의. ML은 `eval Recall@5 < 0.7` 측정 후에만 도입(RFC 0049 **Kill-gate** — 조기최적화 차단을 문서에 박음).

## 변경

- **순수 함수** (`memory.ts`): `tokenize`·`recallMemories`·`recallForAction`
  - 토큰 IDF overlap + 태그 정확매치 가중 + 약한 최근성, **status 강등**(D19)
  - **4신호 분리**(keyword/tagMatch/recency/status) — 한 숫자로 안 땋음(Hickey), 결정적 정렬
  - 유령매칭 방지: 관련성 0이면 최근성 보너스 무효
- **`vhk recall <자연어>`** 명령(별칭 `회상`) 배선
- **just-in-time 경고**(RFC 0049 ②): `resolveGuard()` 단일 chokepoint 훅 — 위험행동(publish/deploy/…) 직전 관련 과거 실패 자동 표출. **precision ≫ recall**(약매칭 침묵·Norman), 회상 실패는 가드 동작 안 막음
- SoT 동기화: `KNOWN_COMMAND_TOKENS`·`TOP_LEVEL_COMMANDS` 에 `recall` 추가
- **드리프트 가드**: `detectNaturalLanguageInput`가 recall 을 NL 로 오판 안 하는지 회귀 테스트(유닛 1314개가 못 잡고 도그푸딩이 잡은 통합갭 봉쇄)

## 검증

- 신규 테스트 **20개**(recall 16 + just-in-time 4), 전체 **1316 green**
- `pnpm build` · `pnpm typecheck` 통과
- 실제 CLI 스모크: `vhk recall publish` → 실제 기억 1건 회상 + 4신호 노출 확인

## 범위 밖 (측정 후 2차 — 폐기 아님)

임베딩·bge-m3·Transformers.js·sqlite-vec·벡터검색·ACT-R 풀·결정 계보 그래프·구조화 v3. 전부 `docs/rfc/0049-memory-recall-mvp.md` §3 Kill-gate 통과 후.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
