### PR TITLE
feat(recall): recall 검증 하네스 — 사용 로그 + eval(Recall@5/MRR) (RFC 0049 ③④)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ dist/
 
 # VHK 개인 메모/참고링크 — 로컬 전용 (docs/spec.md 트래킹 정책)
 .vhk/memory.json
+# recall 사용 로그·평가셋 (RFC 0049) — 개인 쿼리/기억 참조, 로컬 전용
+.vhk/recall-log.jsonl
+.vhk/eval/
 # 백업·원자적 쓰기 임시 파일 (.bak / .v1.bak / .tmp) 도 로컬 전용 — 절대 커밋 금지
 .vhk/memory.json.*
 .vhk/refs.json

--- a/src/commands/memory-eval.ts
+++ b/src/commands/memory-eval.ts
@@ -1,0 +1,113 @@
+import { existsSync, mkdirSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import chalk from 'chalk'
+import inquirer from 'inquirer'
+import { readMemory, recallMemories, type FailEntry } from './memory.js'
+import { scoreEval, RECALL_EVAL_THRESHOLD, type EvalLabel } from '../lib/recall-eval.js'
+import { readRecallLog } from '../lib/recall-log.js'
+import { readJsonFile } from '../lib/read-json.js'
+import { atomicWriteFile } from '../lib/atomic-write.js'
+import { ensureInteractive } from '../lib/interactive.js'
+
+/**
+ * recall 검증 명령 (RFC 0049 ③). 별도 파일 = memory↔recall-eval 순환 의존 회피.
+ * `vhk memory eval`        — 라벨셋으로 Recall@5/MRR + Kill-gate 판정 출력
+ * `vhk memory eval --init` — 사용 로그의 실쿼리로 대화형 라벨링 → 라벨셋 생성
+ */
+
+export const EVAL_PATH_REL = join('.vhk', 'eval', 'recall-eval.json')
+interface EvalFile {
+  labels: EvalLabel[]
+}
+
+function entryText(e: { content?: string; lesson?: string; id: string }): string {
+  const f = e as FailEntry
+  return e.content || f.lesson || e.id
+}
+
+export async function memoryEval(opts: { init?: boolean } = {}): Promise<void> {
+  if (opts.init) return memoryEvalInit()
+
+  console.log(chalk.bold('\n📐 기억 회상 검증 (eval)'))
+  console.log(chalk.gray('─'.repeat(40)))
+  const cwd = process.cwd()
+  const p = join(cwd, EVAL_PATH_REL)
+  if (!existsSync(p)) {
+    console.log(chalk.yellow('\n📭 평가셋이 없습니다.'))
+    console.log(chalk.gray('   먼저 vhk recall 로 쿼리를 쌓고 → vhk memory eval --init 으로 라벨링하세요.'))
+    return
+  }
+  let labels: EvalLabel[]
+  try {
+    labels = readJsonFile<EvalFile>(p).labels ?? []
+  } catch {
+    console.log(chalk.red(`❌ ${EVAL_PATH_REL} 읽기/파싱 실패 (손상 의심).`))
+    process.exitCode = 1
+    return
+  }
+  if (labels.length === 0) {
+    console.log(chalk.yellow('\n📭 평가 라벨이 비었습니다 — vhk memory eval --init 으로 추가하세요.'))
+    return
+  }
+
+  const r = scoreEval(readMemory(cwd), labels)
+  const pct = (n: number) => `${(n * 100).toFixed(0)}%`
+  console.log(chalk.cyan(`\n라벨 ${r.n}개 · Recall@5 ${chalk.bold(pct(r.recallAt5))} · MRR ${r.mrr.toFixed(2)}\n`))
+  for (const q of r.perQuery) {
+    const mark = q.found ? chalk.green(`✅ rank ${q.rank}`) : chalk.red('❌ 미발견')
+    console.log(`  ${mark}  ${q.query}`)
+  }
+  console.log('')
+  if (r.verdict === 'sufficient') {
+    console.log(chalk.green(`✅ Recall@5 ≥ ${pct(RECALL_EVAL_THRESHOLD)} — 키워드 회상 충분. ML(임베딩) 불필요.`))
+  } else {
+    console.log(chalk.yellow(`⚠️  Recall@5 < ${pct(RECALL_EVAL_THRESHOLD)} — Kill-gate 신호. 누적 반복되면 2차(임베딩) 검토 대상.`))
+  }
+}
+
+async function memoryEvalInit(): Promise<void> {
+  console.log(chalk.bold('\n📐 평가셋 라벨링 (--init)'))
+  console.log(chalk.gray('─'.repeat(40)))
+  if (!ensureInteractive('vhk recall 로 쿼리를 먼저 쌓은 뒤 다시 실행하세요.')) return
+
+  const cwd = process.cwd()
+  const queries = [...new Set(readRecallLog(cwd).filter((e) => e.source === 'recall').map((e) => e.query))]
+  if (queries.length === 0) {
+    console.log(chalk.yellow('\n📭 사용 로그에 쿼리가 없습니다.'))
+    console.log(chalk.gray('   vhk recall "<찾을 내용>" 을 몇 번 써서 실쿼리를 쌓은 뒤 다시 실행하세요.'))
+    return
+  }
+
+  const mem = readMemory(cwd)
+  const labels: EvalLabel[] = []
+  console.log(chalk.dim(`\n최근 쿼리 ${Math.min(queries.length, 20)}개를 라벨링합니다. 각 쿼리의 정답 기억 번호를 입력하세요.\n`))
+
+  for (const query of queries.slice(-20)) {
+    const hits = recallMemories(mem, query, 5)
+    console.log(chalk.cyan(`\n🔎 "${query}"`))
+    if (hits.length === 0) {
+      console.log(chalk.dim('   (후보 없음 — skip)'))
+      continue
+    }
+    hits.forEach((h, i) => console.log(`   [${i + 1}] ${entryText(h.entry)}`))
+    const { ans } = await inquirer.prompt<{ ans: string }>([
+      { type: 'input', name: 'ans', message: '정답 기억 번호 (쉼표 구분, 없으면 엔터로 skip):' },
+    ])
+    const ids = String(ans || '')
+      .split(',')
+      .map((s) => parseInt(s.trim(), 10))
+      .filter((n) => Number.isInteger(n) && n >= 1 && n <= hits.length)
+      .map((n) => hits[n - 1].entry.id)
+    if (ids.length > 0) labels.push({ query, expectIds: [...new Set(ids)] })
+  }
+
+  if (labels.length === 0) {
+    console.log(chalk.yellow('\n📭 라벨이 하나도 없어 평가셋을 만들지 않았습니다.'))
+    return
+  }
+  const p = join(cwd, EVAL_PATH_REL)
+  mkdirSync(dirname(p), { recursive: true })
+  atomicWriteFile(p, JSON.stringify({ labels } satisfies EvalFile, null, 2) + '\n')
+  console.log(chalk.green(`\n✅ 평가셋 저장됨 (${labels.length}개 라벨) → ${EVAL_PATH_REL}`))
+  console.log(chalk.gray('   점수 보기: vhk memory eval'))
+}

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -5,6 +5,7 @@ import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { readJsonFile, stripBom } from '../lib/read-json.js'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
+import { logRecall } from '../lib/recall-log.js'
 
 /**
  * Goal 18: memory schema v2 — 평면 배열 → 4버킷(decisions/failures/successes/patterns).
@@ -692,9 +693,13 @@ export async function memoryRecall(query: string): Promise<void> {
     process.exitCode = 1
     return
   }
-  const hits = recallMemories(readMemory(process.cwd()), query.trim())
+  const cwd = process.cwd()
+  const q = query.trim()
+  const hits = recallMemories(readMemory(cwd), q)
+  // RFC 0049 ④: 실쿼리 축적(검증·미래 데이터). best-effort — 실패해도 recall 안 막음.
+  logRecall(cwd, { source: 'recall', query: q, hitIds: hits.map((h) => h.entry.id), topScore: hits[0]?.score ?? 0 })
   if (hits.length === 0) {
-    console.log(chalk.yellow(`\n📭 "${query.trim()}" 관련 기억이 없습니다.`))
+    console.log(chalk.yellow(`\n📭 "${q}" 관련 기억이 없습니다.`))
     return
   }
   console.log(chalk.cyan(`\n${hits.length}개 관련 기억:\n`))

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import { migrate } from './commands/migrate.js'
 import { update } from './commands/update.js'
 import { context, contextShow } from './commands/context.js'
 import { memoryAdd, memoryList, memoryRemove, memoryArchive, memoryResolve, memoryUnarchive, memoryMigrate, memoryRecall } from './commands/memory.js'
+import { memoryEval } from './commands/memory-eval.js'
 import { brief } from './commands/brief.js'
 import { work, workHandoff } from './commands/work.js'
 import { getUpdateInfo } from './lib/version-check.js'
@@ -633,6 +634,13 @@ memoryCmd
   .alias('마이그레이션')
   .description('memory.json v1 → v2 마이그레이션 (기존 v1 있으면 .v1.bak 원본 백업, 멱등)')
   .action(async () => { await memoryMigrate() })
+
+memoryCmd
+  .command('eval')
+  .alias('검증')
+  .option('--init', '사용 로그의 실쿼리로 대화형 라벨링 → 평가셋 생성')
+  .description('recall 회상 품질 측정 (Recall@5/MRR + Kill-gate 판정, RFC 0049)')
+  .action(async (opts: { init?: boolean }) => { await memoryEval({ init: opts.init }) })
 
 program
   .command('recall [query...]')

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -9,7 +9,7 @@
 export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
   goal: ['list', 'next', 'check', 'init', 'done', 'sync', 'drift'],
   ref: ['add', 'list', 'open'],
-  memory: ['add', 'list', 'remove', 'archive', 'resolve', 'unarchive', 'migrate'],
+  memory: ['add', 'list', 'remove', 'archive', 'resolve', 'unarchive', 'migrate', 'eval'],
   cloud: ['push', 'pull'],
   secure: ['scan'],
   design: ['palette'],

--- a/src/lib/recall-eval.ts
+++ b/src/lib/recall-eval.ts
@@ -1,0 +1,50 @@
+import { recallMemories, type MemoryFileV2 } from '../commands/memory.js'
+
+/**
+ * recall 검증 채점 (RFC 0049 ③) — 키워드 회상이 '충분한지' 측정.
+ * Kill-gate: recallAt5 < 0.7 누적 증명 전까지 ML(임베딩·벡터) 도입 금지.
+ * 순수 함수 — recallMemories(결정적) 재사용.
+ */
+
+export const RECALL_EVAL_THRESHOLD = 0.7
+export const EVAL_K = 5
+
+export interface EvalLabel {
+  query: string
+  expectIds: string[]
+}
+
+export interface EvalPerQuery {
+  query: string
+  found: boolean
+  rank: number | null
+}
+
+export interface EvalResult {
+  n: number
+  recallAt5: number
+  mrr: number
+  perQuery: EvalPerQuery[]
+  verdict: 'sufficient' | 'ml-signal'
+}
+
+export function scoreEval(
+  mem: MemoryFileV2,
+  labels: EvalLabel[],
+  nowMs: number = Date.now()
+): EvalResult {
+  const perQuery: EvalPerQuery[] = labels.map((label) => {
+    const ids = recallMemories(mem, label.query, EVAL_K, nowMs).map((h) => h.entry.id)
+    const idx = ids.findIndex((id) => label.expectIds.includes(id))
+    const rank = idx >= 0 ? idx + 1 : null
+    return { query: label.query, found: rank !== null, rank }
+  })
+
+  const n = labels.length
+  const foundCount = perQuery.filter((p) => p.found).length
+  const recallAt5 = n === 0 ? 0 : foundCount / n
+  const mrr = n === 0 ? 0 : perQuery.reduce((s, p) => s + (p.rank ? 1 / p.rank : 0), 0) / n
+  const verdict = recallAt5 >= RECALL_EVAL_THRESHOLD ? 'sufficient' : 'ml-signal'
+
+  return { n, recallAt5, mrr, perQuery, verdict }
+}

--- a/src/lib/recall-log.ts
+++ b/src/lib/recall-log.ts
@@ -1,0 +1,48 @@
+import { existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { atomicWriteFile } from './atomic-write.js'
+
+/**
+ * recall 사용 로그 (RFC 0049 ④) — 실쿼리 축적으로 정직한 검증(eval) 가능케 + 미래 데이터 씨앗.
+ * best-effort: 기록 실패는 recall 본 기능을 절대 막지 않는다. maxSize 1000줄(초과 시 오래된 것 trim).
+ */
+
+export const RECALL_LOG_REL = join('.vhk', 'recall-log.jsonl')
+export const RECALL_LOG_MAX = 1000
+
+export interface RecallLogEntry {
+  ts: string
+  source: 'recall' | 'jit'
+  query: string
+  hitIds: string[]
+  topScore: number
+}
+
+/** 한 건 append. ts 는 내부에서 부여. 1000줄 cap. 실패해도 throw 안 함(best-effort). */
+export function logRecall(cwd: string, entry: Omit<RecallLogEntry, 'ts'>): void {
+  try {
+    const p = join(cwd, RECALL_LOG_REL)
+    mkdirSync(join(cwd, '.vhk'), { recursive: true })
+    const lines = existsSync(p) ? readFileSync(p, 'utf-8').split('\n').filter((l) => l.trim()) : []
+    lines.push(JSON.stringify({ ts: new Date().toISOString(), ...entry }))
+    atomicWriteFile(p, lines.slice(-RECALL_LOG_MAX).join('\n') + '\n')
+  } catch {
+    /* best-effort — recall 본 기능 보호 */
+  }
+}
+
+/** 로그 읽기 — 손상 줄은 skip(부분 파싱 안전). 없으면 빈 배열. */
+export function readRecallLog(cwd: string): RecallLogEntry[] {
+  const p = join(cwd, RECALL_LOG_REL)
+  if (!existsSync(p)) return []
+  const out: RecallLogEntry[] = []
+  for (const line of readFileSync(p, 'utf-8').split('\n')) {
+    if (!line.trim()) continue
+    try {
+      out.push(JSON.parse(line) as RecallLogEntry)
+    } catch {
+      /* 손상 줄 skip */
+    }
+  }
+  return out
+}

--- a/src/lib/safety-guard.ts
+++ b/src/lib/safety-guard.ts
@@ -2,6 +2,7 @@ import { readConfig } from './config.js'
 import { resolveGuard, type Channel, type Guard } from './risk-policy.js'
 import type { SafetyMode } from './safety-mode.js'
 import { readMemory, recallForAction } from '../commands/memory.js'
+import { logRecall } from './recall-log.js'
 
 /**
  * 위험 작업 가드의 **단일 chokepoint**.
@@ -47,9 +48,15 @@ export async function runGuarded<T>(
   // precision 우선(약매칭 침묵) · 회상 실패는 가드 동작을 절대 막지 않는다.
   if (guard !== 'allow') {
     try {
-      for (const h of recallForAction(readMemory(deps.cwd ?? process.cwd()), action)) {
-        const e = h.entry as { lesson?: string; content?: string; id: string }
-        log(`🧠 과거 교훈(${action}): ${e.lesson || e.content || e.id}`)
+      const jitCwd = deps.cwd ?? process.cwd()
+      const hits = recallForAction(readMemory(jitCwd), action)
+      if (hits.length > 0) {
+        for (const h of hits) {
+          const e = h.entry as { lesson?: string; content?: string; id: string }
+          log(`🧠 과거 교훈(${action}): ${e.lesson || e.content || e.id}`)
+        }
+        // RFC 0049 ④: just-in-time 발화도 실쿼리로 축적(best-effort).
+        logRecall(jitCwd, { source: 'jit', query: action, hitIds: hits.map((h) => h.entry.id), topScore: hits[0].score })
       }
     } catch {
       /* 회상 실패는 무시 — 가드 본 기능 보호 */

--- a/tests/recall-eval.test.ts
+++ b/tests/recall-eval.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { scoreEval, RECALL_EVAL_THRESHOLD, type EvalLabel } from '../src/lib/recall-eval.js'
+import { type MemoryFileV2, type FailEntry } from '../src/commands/memory.js'
+
+const NOW = Date.parse('2026-06-09T00:00:00Z')
+
+function fail(id: string, lesson: string, tags: string[]): FailEntry {
+  return { id, content: '', tags, createdAt: '2026-06-01T00:00:00Z', status: 'active', lesson }
+}
+function mem(failures: FailEntry[]): MemoryFileV2 {
+  return { schemaVersion: 2, decisions: [], failures, successes: [], patterns: [] }
+}
+
+const M = mem([
+  fail('f1', 'publish 가드가 feature 브랜치 발행 차단', ['publish']),
+  fail('f2', 'CHANGELOG 드리프트 발생', ['changelog']),
+  fail('f3', 'deploy 환경변수 누락', ['deploy']),
+])
+
+describe('scoreEval (순수)', () => {
+  it('정답이 top-5 안 → found + rank 정확', () => {
+    const r = scoreEval(M, [{ query: 'publish', expectIds: ['f1'] }], NOW)
+    expect(r.perQuery[0]).toMatchObject({ found: true, rank: 1 })
+    expect(r.recallAt5).toBe(1)
+    expect(r.mrr).toBe(1)
+  })
+
+  it('무매칭 → found:false, rank:null', () => {
+    const r = scoreEval(M, [{ query: '데이터베이스 마이그레이션', expectIds: ['f1'] }], NOW)
+    expect(r.perQuery[0]).toMatchObject({ found: false, rank: null })
+    expect(r.recallAt5).toBe(0)
+    expect(r.mrr).toBe(0)
+  })
+
+  it('여러 label 평균 (하나 맞고 하나 틀림 → 0.5)', () => {
+    const labels: EvalLabel[] = [
+      { query: 'publish', expectIds: ['f1'] }, // rank 1
+      { query: '관계없는쿼리', expectIds: ['f2'] }, // 무매칭
+    ]
+    const r = scoreEval(M, labels, NOW)
+    expect(r.n).toBe(2)
+    expect(r.recallAt5).toBe(0.5)
+    expect(r.mrr).toBe(0.5)
+  })
+
+  it('verdict: recallAt5 ≥ 0.7 → sufficient', () => {
+    const r = scoreEval(M, [{ query: 'publish', expectIds: ['f1'] }], NOW)
+    expect(r.recallAt5).toBeGreaterThanOrEqual(RECALL_EVAL_THRESHOLD)
+    expect(r.verdict).toBe('sufficient')
+  })
+
+  it('verdict: recallAt5 < 0.7 → ml-signal', () => {
+    const r = scoreEval(M, [{ query: '관계없는쿼리', expectIds: ['f2'] }], NOW)
+    expect(r.verdict).toBe('ml-signal')
+  })
+
+  it('빈 label → n=0, recallAt5=0', () => {
+    const r = scoreEval(M, [], NOW)
+    expect(r.n).toBe(0)
+    expect(r.recallAt5).toBe(0)
+  })
+})

--- a/tests/recall-log.test.ts
+++ b/tests/recall-log.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { logRecall, readRecallLog, RECALL_LOG_REL, RECALL_LOG_MAX } from '../src/lib/recall-log.js'
+
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-rlog-'))
+}
+
+describe('recall-log (사용 로그)', () => {
+  it('recall 1건 append + 읽기', () => {
+    const dir = tmp()
+    logRecall(dir, { source: 'recall', query: 'publish', hitIds: ['f1'], topScore: 3.2 })
+    const log = readRecallLog(dir)
+    expect(log).toHaveLength(1)
+    expect(log[0]).toMatchObject({ source: 'recall', query: 'publish', hitIds: ['f1'], topScore: 3.2 })
+    expect(typeof log[0].ts).toBe('string')
+  })
+
+  it('jit source 도 기록', () => {
+    const dir = tmp()
+    logRecall(dir, { source: 'jit', query: 'deploy', hitIds: ['f2'], topScore: 2.1 })
+    expect(readRecallLog(dir)[0].source).toBe('jit')
+  })
+
+  it('1000줄 초과 시 오래된 것부터 trim (maxSize)', () => {
+    const dir = tmp()
+    for (let i = 0; i < RECALL_LOG_MAX + 5; i++) {
+      logRecall(dir, { source: 'recall', query: `q${i}`, hitIds: [], topScore: 0 })
+    }
+    const log = readRecallLog(dir)
+    expect(log).toHaveLength(RECALL_LOG_MAX)
+    expect(log[0].query).toBe('q5') // q0~q4 trim
+    expect(log[log.length - 1].query).toBe(`q${RECALL_LOG_MAX + 4}`)
+  })
+
+  it('손상된 줄은 skip (부분 파싱 안전)', () => {
+    const dir = tmp()
+    fs.mkdirSync(path.join(dir, '.vhk'), { recursive: true })
+    fs.writeFileSync(
+      path.join(dir, RECALL_LOG_REL),
+      ['{"ts":"t","source":"recall","query":"ok","hitIds":[],"topScore":1}', '{깨진 줄', ''].join('\n'),
+      'utf-8'
+    )
+    const log = readRecallLog(dir)
+    expect(log).toHaveLength(1)
+    expect(log[0].query).toBe('ok')
+  })
+
+  it('파일 없으면 빈 배열', () => {
+    expect(readRecallLog(tmp())).toEqual([])
+  })
+})


### PR DESCRIPTION
## 요약

`vhk recall` MVP를 **빌드**에서 **검증**으로. 사용자 결론("1 사이클로 안 확실 — 10+ 실사용 사이클로 검증")을 실행 가능케 하는 하네스. RFC 0049 ③·④. **경로 B 연장** — ML·벡터는 여전히 OUT.

## 왜

recall이 충분한지 **측정**하려면 실제 쿼리 + 라벨(정답)이 필관리자데 0개였음. 이 PR이 그 측정 루프를 만든다: 실쿼리 축적(로그) → 대화형 라벨링 → Recall@5/MRR → **Kill-gate 판정**(`<0.7` 누적 시에만 2차 ML 검토).

## 변경

- **`recall-log.ts`** — `.vhk/recall-log.jsonl` 사용 로그. best-effort(recall 안 막음)·maxSize 1000(오래된 것 trim)·손상줄 skip.
- **`recall-eval.ts`** — `scoreEval` 순수함수: Recall@5 · MRR · per-query rank · `verdict`(sufficient / ml-signal, 임계 0.7).
- **`vhk memory eval`** — 라벨셋으로 점수 + Kill-gate 판정 출력.
- **`vhk memory eval --init`** — 사용 로그의 실쿼리를 하나씩 보여주고 "정답 기억 번호?" 물어 라벨 자동 생성(대화형, 비-TTY 가드 exit 2).
- `logRecall` 배선: `memoryRecall` + safety-guard just-in-time 블록.
- `CONTAINER_SUBCOMMANDS` 에 `memory.eval` 동기화(R1 드리프트 가드 — 지난번 도그푸딩이 잡은 NL 가로채기 재발 방지).
- `.gitignore`: `.vhk/recall-log.jsonl` · `.vhk/eval/` (개인 쿼리/기억 참조, 로컬 전용).

## 검증

- TDD red→green: `recall-log`(5) · `recall-eval`(6) = 신규 **11개**, 전체 **1327 green**
- `pnpm build` · `pnpm typecheck` 통과
- 스모크: `vhk recall publish` → 로그 1줄 적재 / `vhk memory eval` → 평가셋 없음 안내 / `--init` 비-TTY → 안 멈춤

## 범위 밖 (Kill-gate 뒤)

임베딩·bge-m3·벡터검색·ACT-R·제안2/3. eval이 Recall@5<0.7 누적 증명할 때만 2차.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
