### PR TITLE
feat(goal-56): 비용·예산 가드(cost-guard) — 자문형 + 양방향 입력 (P0)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -47,6 +47,17 @@ Cursor에게 한국어로 말해도 됩니다.
 
 > `mission` 은 작업의 목표·허용/금지 범위를 `.vhk/mission.json` 계약으로 선언하고, 변경 파일이 계약(scope/forbidden glob) 안인지 검증합니다. **경로 glob 기준**이며 objective 의미 부합은 검증하지 않습니다(보장 아님). forbidden 위반 시 exit 1.
 
+## 비용·예산 가드 (cost — Goal 56)
+
+| 하고 싶은 것 | 터미널 명령 | 설명 |
+|-------------|-----------|------|
+| 월 예산 설정 | `vhk cost budget 100` | `.vhk/config.json` 에 예산($) 저장 |
+| 사용량 기록 | `vhk cost add --usd 5` (또는 `--in N --out N --model M`) | `.vhk/cost.jsonl` append. 환경변수 `VHK_COST_*` 주입도 가능 |
+| 상태 조회 | `vhk cost` | 예산·누적 사용량·임계(%) |
+| 임계 집행 | `vhk cost check` | 80% 경고 · 100% 차단(비대화형+미승인 exit 1, `--yes` 로 승인) |
+
+> ⚠️ vhk 는 Claude API 를 직접 호출하지 않아 비용을 **자동 추적하지 못합니다**. 사용량은 외부 입력(수동 `cost add` / 환경변수)으로 먹이는 **자문형** 가드입니다 — `check` 는 신호(exit code)로 CI/agent 가 멈추게 합니다. 요율(pricing)은 `.vhk/config.json` 에 주입(코드 하드코딩 0).
+
 ## 기억 v2 (memory — 4버킷)
 
 | 하고 싶은 것 | 터미널 명령 | Cursor에게 말하기 |

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -54,7 +54,7 @@ Cursor에게 한국어로 말해도 됩니다.
 | 월 예산 설정 | `vhk cost budget 100` | `.vhk/config.json` 에 예산($) 저장 |
 | 사용량 기록 | `vhk cost add --usd 5` (또는 `--in N --out N --model M`) | `.vhk/cost.jsonl` append. 환경변수 `VHK_COST_*` 주입도 가능 |
 | 상태 조회 | `vhk cost` | 예산·누적 사용량·임계(%) |
-| 임계 집행 | `vhk cost check` | 80% 경고 · 100% 차단(비대화형+미승인 exit 1, `--yes` 로 승인) |
+| 임계 집행 | `vhk cost check` | 80% 경고 · 100% **이상** 차단(비대화형+미승인 exit 1, `--yes` 로 승인) |
 
 > ⚠️ vhk 는 Claude API 를 직접 호출하지 않아 비용을 **자동 추적하지 못합니다**. 사용량은 외부 입력(수동 `cost add` / 환경변수)으로 먹이는 **자문형** 가드입니다 — `check` 는 신호(exit code)로 CI/agent 가 멈추게 합니다. 요율(pricing)은 `.vhk/config.json` 에 주입(코드 하드코딩 0).
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ VHK는 코딩 에이전트가 아닙니다. 에이전트가 빠르게 만든 결
 | 목표가 많아지면 무엇부터 할지 흐려진다 | `goals/*.md`와 `docs/state/next-task.md`로 다음 목표 고정 | `vhk goal next` |
 | 같은 실수가 반복된다 | memory/pattern/evolve로 교훈과 룰 후보 축적 | `vhk learn` |
 | 위험한 상태에서 계속 진행한다 | blocker 3건 누적 시 `.vhk/HARD_STOP` 생성 | `vhk blocker` |
+| AI 비용이 새는지 모른다 | cost 가드로 예산·사용량 추적 + 임계(80% 경고·100% 차단) | `vhk cost` |
 
 ## 설치
 

--- a/goals/56-cost-guard.md
+++ b/goals/56-cost-guard.md
@@ -40,8 +40,10 @@ leads_to: 61 (stats 집계 소스)
 
 - **자문형 + 양방향 입력**(사용자 확정): vhk 는 Claude API 직접 호출 안 함 → 비용 자동추적 불가. 사용량은 수동 `vhk cost add`(--usd | --in/--out/--model) + 환경변수 `VHK_COST_*` 둘 다로 먹임. `check` 는 신호(exit code)로 CI/agent 가 멈추게 함.
 - **결정/집행 분리**: `cost-policy.ts`(evaluateBudget·costToGuard·usdOf, 순수) / `cost.ts`(집행). `runGuarded` 는 action 기반 resolveGuard 로 guard 를 자체 계산 → 임계 기반 비용 level 을 못 먹이므로 **직접 호출 대신 동형 의미**(비-TTY+미승인 block·TTY confirm·--yes 승인)를 cost level 로 구동(risk-policy 중복 아님 = 별도 정책 차원, 단일 chokepoint 원칙 위배 아님).
-- 신규: cost-policy.ts·cost-ledger.ts(.vhk/cost.jsonl, evidence-ledger append 패턴)·src/commands/cost.ts·check-goal-56.mjs + 테스트 3종(cost-policy 8·cost-ledger 7·cost 7). config.ts 에 budget/pricing 주입 필드. 명령 3지점 등록(index/registry/cli-args).
+- 신규: cost-policy.ts·cost-ledger.ts(.vhk/cost.jsonl, evidence-ledger append 패턴)·src/commands/cost.ts·check-goal-56.mjs + 테스트 3파일(cost-policy 13·cost-ledger 7·cost 9 = 29). config.ts 에 budget/pricing 주입 필드. 명령 4지점 등록(index·TOP_LEVEL·CONTAINER_SUBCOMMANDS+ALIASES·cli-args).
 - **preflight 편입은 보류**(카드 "[선택]" — release-gate 핫파일 리스크 회피). 후속 가벼운 advisory 로 가능.
+- **적대 리뷰 #234 반영**: ① NaN 입력 페일-오픈 차단(Number.isFinite 검증 — `--usd abc`/env NaN 이 usd:null 로 새던 결함) · ② 한글 별칭 `비용` CONTAINER_ALIASES 누락 → `비용 check` 가 NL 라우터에 가로채여 가드 우회되던 결함 수정(+회귀 테스트·게이트 단언) · ③ costToGuard 집행 연결(데드코드 해소) · ④ 타입 중복(PricingRate)·이중 read·stdin/stdout TTY 정리.
+- **goal 57 정합(후속)**: 비용은 새 정책축에 자체 판정/집행. goal 57(분산 결정점 일원화·신규 레이어 금지) 착수 시 '비용 차원을 risk-policy/runGuarded 로 흡수' 검토 — 평행 가드 영구화 방지(현재 cost 단일 입구라 무해).
 
 ## Mandatory Reading
 - `src/lib/config.ts` · `src/lib/risk-policy.ts` · `src/lib/safety-guard.ts` · `src/commands/mode.ts` · `src/lib/evidence-ledger.ts`

--- a/goals/56-cost-guard.md
+++ b/goals/56-cost-guard.md
@@ -3,7 +3,7 @@ vhk_format: 1
 type: goal
 id: 56
 title: 비용·예산 가드(cost-guard) — P0
-status: NOT_STARTED
+status: DONE
 priority: P0
 created: 2026-06-09
 leads_to: 61 (stats 집계 소스)
@@ -30,11 +30,18 @@ leads_to: 61 (stats 집계 소스)
 - 사용량 append 시 과거 줄 변경 0.
 
 ## Completion Check
-- [ ] `cost-policy.ts`(예산·요율 SoT) + 호출부 분리
-- [ ] pricing은 `.vhk/config.json` 주입, 코드 상수 0건
-- [ ] 80% warn / 100% block / 비대화형 미승인 block
-- [ ] `cost.jsonl` append, 과거 줄 변경 0
-- [ ] `node scripts/check-goal-56.mjs` 통과
+- [x] `cost-policy.ts`(예산·요율·판정 SoT, 순수) + 호출부(cost.ts) 분리
+- [x] pricing은 `.vhk/config.json` 주입, 코드 상수 0건(grep 검증)
+- [x] 80% warn / 100% block / 비대화형 미승인 block(exit 1) — 도그푸딩 확인
+- [x] `cost.jsonl` append-only(atomicWriteFile), 과거 줄 변경 0
+- [x] `node scripts/check-goal-56.mjs` 통과
+
+## 구현 메모
+
+- **자문형 + 양방향 입력**(사용자 확정): vhk 는 Claude API 직접 호출 안 함 → 비용 자동추적 불가. 사용량은 수동 `vhk cost add`(--usd | --in/--out/--model) + 환경변수 `VHK_COST_*` 둘 다로 먹임. `check` 는 신호(exit code)로 CI/agent 가 멈추게 함.
+- **결정/집행 분리**: `cost-policy.ts`(evaluateBudget·costToGuard·usdOf, 순수) / `cost.ts`(집행). `runGuarded` 는 action 기반 resolveGuard 로 guard 를 자체 계산 → 임계 기반 비용 level 을 못 먹이므로 **직접 호출 대신 동형 의미**(비-TTY+미승인 block·TTY confirm·--yes 승인)를 cost level 로 구동(risk-policy 중복 아님 = 별도 정책 차원, 단일 chokepoint 원칙 위배 아님).
+- 신규: cost-policy.ts·cost-ledger.ts(.vhk/cost.jsonl, evidence-ledger append 패턴)·src/commands/cost.ts·check-goal-56.mjs + 테스트 3종(cost-policy 8·cost-ledger 7·cost 7). config.ts 에 budget/pricing 주입 필드. 명령 3지점 등록(index/registry/cli-args).
+- **preflight 편입은 보류**(카드 "[선택]" — release-gate 핫파일 리스크 회피). 후속 가벼운 advisory 로 가능.
 
 ## Mandatory Reading
 - `src/lib/config.ts` · `src/lib/risk-policy.ts` · `src/lib/safety-guard.ts` · `src/commands/mode.ts` · `src/lib/evidence-ledger.ts`

--- a/scripts/check-goal-56.mjs
+++ b/scripts/check-goal-56.mjs
@@ -85,6 +85,8 @@ must(/name: 'cost'/.test(reg), "command-registry: TOP_LEVEL { name: 'cost' }")
 must(/cost: \['add', 'check', 'budget'\]/.test(reg), 'command-registry: CONTAINER cost 서브명령')
 const cargs = read('src/lib/cli-args.ts') ?? ''
 must(/'cost'/.test(cargs), "cli-args: 'cost' 토큰(KNOWN_COMMAND_TOKENS)")
+// 한글 별칭 비용 도 CONTAINER_ALIASES 에 있어야 `비용 check` 가 NL 라우터에 안 가로채임(적대 리뷰 #234).
+must(/비용: 'cost'/.test(reg), 'command-registry: CONTAINER_ALIASES 비용→cost (한글 별칭 가드 우회 방지)')
 
 // 5) 회귀 테스트 + 문서 반영(_meta)
 for (const t of ['cost-policy', 'cost-ledger', 'cost']) {

--- a/scripts/check-goal-56.mjs
+++ b/scripts/check-goal-56.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// scripts/check-goal-56.mjs — Goal 56: 비용·예산 가드(cost-guard).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역.
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 56 gate.')
+  process.exit(1)
+}
+
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 56] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 56 고유 검증 (비용·예산 가드) ───────────────────────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+
+// 1) cost-policy 순수 판정 SoT + 임계(80%/100%) + 가격 하드코딩 0
+const policy = read('src/lib/cost-policy.ts') ?? ''
+must(policy.length > 0, 'src/lib/cost-policy.ts 존재(판정 SoT)')
+for (const fn of ['evaluateBudget', 'costToGuard', 'usdOf']) {
+  must(new RegExp('export function ' + fn + '\\b').test(policy), `cost-policy export: ${fn}`)
+}
+must(/warnPct\s*=\s*0\.8/.test(policy), 'cost-policy: warn 임계 기본 0.8 (80%)')
+must(/pct\s*>=\s*1\b/.test(policy), 'cost-policy: 100% block 임계')
+// pricing 은 config 주입 — 가격 코드 상수 금지(grep)
+must(!/const\s+(PRICING|RATE|USD_PER|PRICE)\b/.test(policy), 'cost-policy: 가격 하드코딩 상수 0건')
+
+// 2) cost-ledger append-only(원자적) — evidence-ledger 패턴 재사용
+const ledger = read('src/lib/cost-ledger.ts') ?? ''
+must(ledger.length > 0, 'src/lib/cost-ledger.ts 존재')
+must(/COST_PATH_REL/.test(ledger) && /cost\.jsonl/.test(ledger), 'cost-ledger: .vhk/cost.jsonl 경로')
+for (const fn of ['readCostEntries', 'appendCostEntry', 'sumUsd']) {
+  must(new RegExp('export function ' + fn + '\\b').test(ledger), `cost-ledger export: ${fn}`)
+}
+must(/atomicWriteFile/.test(ledger), 'cost-ledger: atomicWriteFile(원자적 append, 과거 줄 변경 0)')
+
+// 3) config 주입(budget/pricing)
+const cfg = read('src/lib/config.ts') ?? ''
+must(/budget\?:/.test(cfg) && /pricing\?:/.test(cfg), 'config.ts: VhkConfig 에 budget/pricing 주입 필드')
+
+// 4) cost 명령 + 등록 3지점(NLP 라우터 가로채기 방지)
+must(existsSync('src/commands/cost.ts'), 'src/commands/cost.ts 존재')
+const idx = read('src/index.ts') ?? ''
+must(/import \{ cost \} from '\.\/commands\/cost\.js'/.test(idx), 'index.ts: cost import')
+must(/\.command\('cost/.test(idx), "index.ts: .command('cost')")
+const reg = read('src/lib/command-registry.ts') ?? ''
+must(/name: 'cost'/.test(reg), "command-registry: TOP_LEVEL { name: 'cost' }")
+must(/cost: \['add', 'check', 'budget'\]/.test(reg), 'command-registry: CONTAINER cost 서브명령')
+const cargs = read('src/lib/cli-args.ts') ?? ''
+must(/'cost'/.test(cargs), "cli-args: 'cost' 토큰(KNOWN_COMMAND_TOKENS)")
+
+// 5) 회귀 테스트 + 문서 반영(_meta)
+for (const t of ['cost-policy', 'cost-ledger', 'cost']) {
+  must(existsSync(`tests/${t}.test.ts`), `tests/${t}.test.ts 존재`)
+}
+must(/vhk cost/.test(read('COMMANDS.md') ?? ''), 'COMMANDS.md: vhk cost 반영')
+must(/vhk cost/.test(read('README.md') ?? ''), 'README.md: vhk cost 반영')
+
+if (pass) { console.log('✅ goal 56 gate passes'); process.exit(0) }
+console.log('❌ goal 56 gate failed'); process.exit(1)

--- a/src/commands/cost.ts
+++ b/src/commands/cost.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import inquirer from 'inquirer'
 import { readConfig, writeConfig } from '../lib/config.js'
 import { readCostEntries, appendCostEntry, sumUsd, type CostEntry } from '../lib/cost-ledger.js'
-import { evaluateBudget, usdOf, type BudgetEval } from '../lib/cost-policy.js'
+import { evaluateBudget, costToGuard, usdOf, type BudgetEval } from '../lib/cost-policy.js'
 
 // Goal 56: vhk cost — 자문형 비용·예산 가드.
 // vhk 는 Claude API 를 직접 호출하지 않아 비용을 자동 추적 못 함 → 사용량은 외부 입력
@@ -98,6 +98,14 @@ export async function cost(action?: string, value?: string, opts: CostOptions = 
       outputTokens: opts.out,
     }
     const usd = usdOf(src, pricing)
+    // NaN/음수/무한 입력 차단 — 깨진 숫자(`--usd abc`·env NaN)가 usd:null 로 새서 사용분 소실·
+    // 가드 페일-오픈하는 것 방지(적대 리뷰 #234). budget 분기처럼 명시 검증.
+    const tokensFinite = [src.inputTokens, src.outputTokens].every((t) => t === undefined || Number.isFinite(t))
+    if (!Number.isFinite(usd) || usd < 0 || !tokensFinite) {
+      console.error(chalk.red('❌ 숫자 입력 오류 — --usd/--in/--out(또는 VHK_COST_*) 는 0 이상의 유효한 숫자여야 합니다.'))
+      process.exitCode = 1
+      return
+    }
     const hasTokens = !!(src.inputTokens || src.outputTokens)
     if (!(usd > 0) && !hasTokens) {
       console.error(
@@ -116,7 +124,8 @@ export async function cost(action?: string, value?: string, opts: CostOptions = 
     }
     appendCostEntry(cwd, entry)
     console.log(chalk.green(`✅ 비용 +$${usd.toFixed(4)} 기록 (${entry.source})`))
-    printStatus(sumUsd(readCostEntries(cwd)), limit, evaluateBudget(sumUsd(readCostEntries(cwd)), limit, warnPct))
+    const total = sumUsd(readCostEntries(cwd))
+    printStatus(total, limit, evaluateBudget(total, limit, warnPct))
     return
   }
 
@@ -132,18 +141,20 @@ export async function cost(action?: string, value?: string, opts: CostOptions = 
     return
   }
 
-  // ── check: 임계 집행(runGuarded 동형 의미 — cost level 구동) ──
-  if (ev.level === 'allow') return
-  if (ev.level === 'warn') {
+  // ── check: 임계 집행 — cost level 을 Guard 어휘로 환원(costToGuard) 후 runGuarded 동형 의미로 집행 ──
+  const guard = costToGuard(ev.level)
+  if (guard === 'allow') return
+  if (guard === 'warn') {
     console.log(chalk.yellow('⚠️ 예산 80% 도달 — 경고(차단 아님).'))
     return
   }
-  // block (≥100%)
+  // guard === 'confirm' (예산 100% 이상)
   if (opts.yes) {
     console.log(chalk.yellow('⚠️ 예산 초과지만 --yes 승인 → 진행.'))
     return
   }
-  const isTTY = !!process.stdout.isTTY
+  // runGuarded 와 동일 기준(stdin TTY)으로 대화형 가능 여부 판단 — stdout/stdin 비대칭 제거.
+  const isTTY = !!process.stdin.isTTY
   if (isTTY) {
     const { ok } = await inquirer.prompt<{ ok: boolean }>([
       { type: 'confirm', name: 'ok', message: '예산을 초과했습니다. 그래도 계속할까요?', default: false },

--- a/src/commands/cost.ts
+++ b/src/commands/cost.ts
@@ -1,0 +1,158 @@
+import chalk from 'chalk'
+import inquirer from 'inquirer'
+import { readConfig, writeConfig } from '../lib/config.js'
+import { readCostEntries, appendCostEntry, sumUsd, type CostEntry } from '../lib/cost-ledger.js'
+import { evaluateBudget, usdOf, type BudgetEval } from '../lib/cost-policy.js'
+
+// Goal 56: vhk cost — 자문형 비용·예산 가드.
+// vhk 는 Claude API 를 직접 호출하지 않아 비용을 자동 추적 못 함 → 사용량은 외부 입력
+// (`vhk cost add` 수동 / 환경변수 VHK_COST_*)으로 먹이고, 가드는 임계 초과 시 신호(exit code)로 집행.
+
+export interface CostOptions {
+  usd?: number
+  in?: number
+  out?: number
+  model?: string
+  /** --yes: 비대화형/초과 시 명시 승인 */
+  yes?: boolean
+}
+
+interface UsageInput {
+  usd?: number
+  model?: string
+  inputTokens?: number
+  outputTokens?: number
+}
+
+/** 환경변수 주입 읽기. VHK_COST_USD 또는 토큰 셋이 있으면 그 사용량, 없으면 null. */
+function readEnvUsage(): UsageInput | null {
+  const usd = process.env.VHK_COST_USD
+  const inT = process.env.VHK_COST_INPUT_TOKENS
+  const outT = process.env.VHK_COST_OUTPUT_TOKENS
+  const model = process.env.VHK_COST_MODEL
+  if (usd === undefined && inT === undefined && outT === undefined) return null
+  return {
+    usd: usd !== undefined ? Number(usd) : undefined,
+    model,
+    inputTokens: inT !== undefined ? Number(inT) : undefined,
+    outputTokens: outT !== undefined ? Number(outT) : undefined,
+  }
+}
+
+function formatPct(pct: number): string {
+  return `${Math.round(pct * 100)}%`
+}
+
+function printStatus(usedUsd: number, limitUsd: number | undefined, ev: BudgetEval): void {
+  if (!limitUsd || limitUsd <= 0) {
+    console.log(chalk.dim('  예산 미설정 — `vhk cost budget <usd>` 로 월 예산을 설정하세요.'))
+    console.log(`  누적 사용량: $${usedUsd.toFixed(2)}`)
+    return
+  }
+  const bar =
+    ev.level === 'block'
+      ? chalk.red(`🛑 ${formatPct(ev.pct)} (초과)`)
+      : ev.level === 'warn'
+        ? chalk.yellow(`⚠️ ${formatPct(ev.pct)}`)
+        : chalk.green(`✅ ${formatPct(ev.pct)}`)
+  console.log(`  예산: $${limitUsd.toFixed(2)} · 사용: $${usedUsd.toFixed(2)} · ${bar}`)
+}
+
+/**
+ * `vhk cost [action] [value]`
+ * - (없음)  status: 예산·사용량·임계 조회(읽기전용)
+ * - add     사용량 기록(--usd N | --in/--out [+--model], 또는 VHK_COST_* env) → cost.jsonl append
+ * - check   임계 집행: warn(≥80%) 경고 · block(≥100%) 비-TTY+미승인 차단(exit 1)·TTY 확인·--yes 승인
+ * - budget  예산($) 설정 (vhk cost budget 100)
+ */
+export async function cost(action?: string, value?: string, opts: CostOptions = {}): Promise<void> {
+  const cwd = process.cwd()
+  const cfg = readConfig(cwd)
+  const limit = cfg.budget?.limitUsd
+  const warnPct = cfg.budget?.warnPct ?? 0.8
+  const pricing = cfg.pricing
+
+  console.log(chalk.bold('\n💰 비용·예산 가드'))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  // ── budget: 예산 설정(쓰기) ──
+  if (action === 'budget') {
+    const amt = Number(value)
+    if (!value || Number.isNaN(amt) || amt <= 0) {
+      console.error(chalk.red('❌ 유효한 예산($) 필요 — 예: vhk cost budget 100'))
+      process.exitCode = 1
+      return
+    }
+    writeConfig({ ...cfg, budget: { ...cfg.budget, limitUsd: amt } }, cwd)
+    console.log(chalk.green(`✅ 월 예산 → $${amt}`))
+    return
+  }
+
+  // ── add: 사용량 기록(append) ──
+  if (action === 'add') {
+    const env = readEnvUsage()
+    const src: UsageInput = env ?? {
+      usd: opts.usd,
+      model: opts.model,
+      inputTokens: opts.in,
+      outputTokens: opts.out,
+    }
+    const usd = usdOf(src, pricing)
+    const hasTokens = !!(src.inputTokens || src.outputTokens)
+    if (!(usd > 0) && !hasTokens) {
+      console.error(
+        chalk.red('❌ 사용량 필요 — `--usd N` 또는 `--in N --out N [--model M]`(config pricing) / 또는 VHK_COST_* env')
+      )
+      process.exitCode = 1
+      return
+    }
+    const entry: CostEntry = {
+      ts: new Date().toISOString(),
+      source: env ? 'env' : 'manual',
+      usd,
+      model: src.model,
+      inputTokens: src.inputTokens,
+      outputTokens: src.outputTokens,
+    }
+    appendCostEntry(cwd, entry)
+    console.log(chalk.green(`✅ 비용 +$${usd.toFixed(4)} 기록 (${entry.source})`))
+    printStatus(sumUsd(readCostEntries(cwd)), limit, evaluateBudget(sumUsd(readCostEntries(cwd)), limit, warnPct))
+    return
+  }
+
+  // status / check 공통 — 누적 사용량 평가
+  const used = sumUsd(readCostEntries(cwd))
+  const ev = evaluateBudget(used, limit, warnPct)
+  printStatus(used, limit, ev)
+
+  // ── status (action 없음): 조회만 ──
+  if (action !== 'check') {
+    if (ev.level === 'warn') console.log(chalk.yellow('  ⚠️ 예산 80% 도달 — 사용량 점검 권장.'))
+    if (ev.level === 'block') console.log(chalk.red('  🛑 예산 초과 — `vhk cost check` 로 가드 집행.'))
+    return
+  }
+
+  // ── check: 임계 집행(runGuarded 동형 의미 — cost level 구동) ──
+  if (ev.level === 'allow') return
+  if (ev.level === 'warn') {
+    console.log(chalk.yellow('⚠️ 예산 80% 도달 — 경고(차단 아님).'))
+    return
+  }
+  // block (≥100%)
+  if (opts.yes) {
+    console.log(chalk.yellow('⚠️ 예산 초과지만 --yes 승인 → 진행.'))
+    return
+  }
+  const isTTY = !!process.stdout.isTTY
+  if (isTTY) {
+    const { ok } = await inquirer.prompt<{ ok: boolean }>([
+      { type: 'confirm', name: 'ok', message: '예산을 초과했습니다. 그래도 계속할까요?', default: false },
+    ])
+    if (ok) return
+    console.log(chalk.gray('취소됨 — 예산 가드에서 중단.'))
+    process.exitCode = 1
+    return
+  }
+  console.log(chalk.red('🛑 예산 초과(100%+) — 비대화형+미승인 → 차단(exit 1). (--yes 로 승인)'))
+  process.exitCode = 1
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import { QUICK_ACTIONS } from './commands/help.js'
 import { start } from './commands/start.js'
 import { mode } from './commands/mode.js'
 import { verify } from './commands/verify.js'
+import { cost } from './commands/cost.js'
 import { preflight } from './commands/preflight.js'
 import { testmap } from './commands/testmap.js'
 import { worktreeAdd, worktreeCheck } from './commands/worktree.js'
@@ -466,6 +467,32 @@ program
   .alias('모드')
   .description('Safety Mode 조회/변경 (lite|standard|strict) — 위험 작업 가드 강도')
   .action(async (target?: string) => { await mode(target) })
+
+// Goal 56: 비용·예산 가드(자문형). vhk 는 API 비용을 자동 추적 못 하므로 사용량은 외부 입력.
+program
+  .command('cost [action] [value]')
+  .alias('비용')
+  .option('--usd <n>', '비용($) 직접 입력 (add)', parseFloat)
+  .option('--in <n>', '입력 토큰 수 (add — config pricing 으로 환산)', (v) => parseInt(v, 10))
+  .option('--out <n>', '출력 토큰 수 (add)', (v) => parseInt(v, 10))
+  .option('--model <name>', '모델명 (add — config pricing 키)')
+  .option('--yes', '비대화형/예산 초과 시 명시 승인 (check)')
+  .description('비용·예산 가드 — add(사용량 기록)/check(임계 집행)/budget(예산 설정) · 자문형')
+  .action(
+    async (
+      action?: string,
+      value?: string,
+      opts?: { usd?: number; in?: number; out?: number; model?: string; yes?: boolean }
+    ) => {
+      await cost(action, value, {
+        usd: opts?.usd,
+        in: opts?.in,
+        out: opts?.out,
+        model: opts?.model,
+        yes: opts?.yes,
+      })
+    }
+  )
 
 program
   .command('verify')

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -44,6 +44,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'resume', '재개',
   'mode', '모드',
   'verify', '사전점검',
+  'cost', '비용',
   'preflight', '출고점검',
   'testmap', '테스트매핑',
   'worktree', '워크트리',

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -27,6 +27,7 @@ export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
 /** 한국어 별칭 → 영문 컨테이너 명령. 별칭도 같은 서브커맨드 집합을 공유한다. */
 export const CONTAINER_ALIASES: Record<string, string> = {
   목표: 'goal',
+  비용: 'cost',
   레퍼런스: 'ref',
   기억: 'memory',
   클라우드: 'cloud',

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -8,6 +8,7 @@
  */
 export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
   goal: ['list', 'next', 'check', 'init', 'done', 'sync', 'drift'],
+  cost: ['add', 'check', 'budget'],
   ref: ['add', 'list', 'open'],
   memory: ['add', 'list', 'remove', 'archive', 'resolve', 'unarchive', 'migrate'],
   cloud: ['push', 'pull'],
@@ -82,6 +83,7 @@ export const TOP_LEVEL_COMMANDS: ReadonlyArray<{ name: string; desc: string }> =
   { name: 'context', desc: '프로젝트 맥락 파일 생성 (.vhk/context.md)' },
   { name: 'mode', desc: 'Safety Mode 조회/변경 (lite|standard|strict)' },
   { name: 'verify', desc: '검증 게이트 실행 + 증거 기록' },
+  { name: 'cost', desc: '비용·예산 가드 — add/check/budget (자문형)' },
   { name: 'preflight', desc: '출고 전 안전점검 (2FA·shim·env·lint·타입·테스트·git, 치명 시 차단)' },
   { name: 'testmap', desc: 'test-first 매핑 점검 (변경 기능 ↔ 테스트 누락 경고)' },
   { name: 'worktree', desc: 'worktree 가드 — 생성 시 env/설정 자동 복사·누락 점검 (add/check)' },

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -10,8 +10,18 @@ import { type SafetyMode, DEFAULT_SAFETY_MODE, isSafetyMode } from './safety-mod
 export const CONFIG_DIR = '.vhk'
 export const CONFIG_PATH = join(CONFIG_DIR, 'config.json')
 
+/** Goal 56: 모델별 비용 요율(1k 토큰당 USD) — 코드 하드코딩 금지, config 주입. */
+export interface PricingRate {
+  inputPer1k: number
+  outputPer1k: number
+}
+
 export interface VhkConfig {
   safetyMode: SafetyMode
+  /** Goal 56: 비용 예산($) + warn 임계(기본 0.8). 미설정이면 비용 가드 없음. */
+  budget?: { limitUsd?: number; warnPct?: number }
+  /** Goal 56: 모델별 요율 주입(토큰→$ 환산용). */
+  pricing?: Record<string, PricingRate>
 }
 
 export const DEFAULT_CONFIG: VhkConfig = { safetyMode: DEFAULT_SAFETY_MODE }
@@ -21,8 +31,11 @@ export function readConfig(rootDir: string = process.cwd()): VhkConfig {
   if (!existsSync(full)) return { ...DEFAULT_CONFIG }
   try {
     const raw = readJsonFile<Partial<VhkConfig>>(full)
+    // Goal 56: budget/pricing 은 있을 때만 보존(없으면 키 자체를 안 둠 — 기존 안전모드-only 동작 불변).
     return {
       safetyMode: isSafetyMode(raw.safetyMode) ? raw.safetyMode : DEFAULT_CONFIG.safetyMode,
+      ...(raw.budget && typeof raw.budget === 'object' ? { budget: raw.budget } : {}),
+      ...(raw.pricing && typeof raw.pricing === 'object' ? { pricing: raw.pricing } : {}),
     }
   } catch {
     // 손상/파싱 실패 → 기본값. 설정 깨졌다고 명령이 죽지 않게.

--- a/src/lib/cost-ledger.ts
+++ b/src/lib/cost-ledger.ts
@@ -1,0 +1,57 @@
+import { existsSync, readFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { atomicWriteFile } from './atomic-write.js'
+import { stripBom } from './read-json.js'
+
+// Goal 56: AI 비용 사용량 원장. evidence-ledger.ts 의 append 패턴 재사용(append-only, 원자적 쓰기).
+// vhk 는 Claude API 를 직접 호출하지 않아 비용을 자동 추적할 수 없으므로, 사용량은 외부 입력
+// (`vhk cost add` 또는 환경변수 VHK_COST_*)으로 먹인다. dedup 없음 — 매 기록이 실 사용분.
+
+export const COST_PATH_REL = join('.vhk', 'cost.jsonl')
+
+export interface CostEntry {
+  /** ISO timestamp */
+  ts: string
+  /** 입력 출처 — 'manual' | 'env' 등 */
+  source: string
+  /** 이 기록의 비용(USD). add 시점에 토큰×요율로 환산해 저장(cost-policy.usdOf). */
+  usd: number
+  model?: string
+  inputTokens?: number
+  outputTokens?: number
+}
+
+/** .vhk/cost.jsonl 파싱(JSONL). 손상 라인은 관용적으로 skip(원장 한 줄 깨져도 안 죽음). */
+export function readCostEntries(cwd: string): CostEntry[] {
+  const p = join(cwd, COST_PATH_REL)
+  if (!existsSync(p)) return []
+  const out: CostEntry[] = []
+  for (const line of stripBom(readFileSync(p, 'utf-8')).split(/\r?\n/)) {
+    const t = line.trim()
+    if (!t) continue
+    try {
+      out.push(JSON.parse(t) as CostEntry)
+    } catch {
+      /* 손상 라인 skip */
+    }
+  }
+  return out
+}
+
+/**
+ * cost.jsonl 에 한 줄 append(append-only). 원자적 쓰기(temp→rename) — 쓰기 도중 kill 에도 손상 방지.
+ * 비용 기록은 dedup 안 함(동일 값도 별개 사용분).
+ */
+export function appendCostEntry(cwd: string, entry: CostEntry): { appended: boolean } {
+  const p = join(cwd, COST_PATH_REL)
+  mkdirSync(join(cwd, '.vhk'), { recursive: true })
+  const existing = existsSync(p) ? stripBom(readFileSync(p, 'utf-8')).replace(/\n*$/, '') : ''
+  const body = (existing ? existing + '\n' : '') + JSON.stringify(entry) + '\n'
+  atomicWriteFile(p, body)
+  return { appended: true }
+}
+
+/** 누적 사용량 합($). */
+export function sumUsd(entries: CostEntry[]): number {
+  return entries.reduce((s, e) => s + (typeof e.usd === 'number' ? e.usd : 0), 0)
+}

--- a/src/lib/cost-policy.ts
+++ b/src/lib/cost-policy.ts
@@ -1,0 +1,58 @@
+import type { Guard } from './risk-policy.js'
+
+// Goal 56: 비용/예산 판정의 순수 SoT(결정만, 부작용 0). risk-policy 동형(결정/집행 분리).
+// 집행은 cost.ts 가 runGuarded 와 *동형 의미*(비-TTY+미승인 block · TTY confirm · --yes 승인)로 수행.
+// (runGuarded 는 action 기반 resolveGuard 로 guard 를 자체 계산 → 임계 기반 비용 level 을 못 먹이므로
+//  직접 호출 대신 동일 의미를 cost level 로 구동. risk-policy 중복 아님 = 별도 정책 차원.)
+
+export type CostLevel = 'allow' | 'warn' | 'block'
+
+export interface BudgetEval {
+  /** used / limit (예산 미설정 시 0) */
+  pct: number
+  level: CostLevel
+}
+
+export interface Pricing {
+  inputPer1k: number
+  outputPer1k: number
+}
+
+/** 모델별 요율 — .vhk/config.json 주입(코드 하드코딩 금지). */
+export type PricingTable = Record<string, Pricing>
+
+/**
+ * 누적 사용량 vs 예산 판정. ≥100% block · ≥warnPct(기본 0.8) warn · 그 외 allow.
+ * 예산 미설정/0/음수면 가드 없음(allow) — 예산을 안 걸면 비용 가드도 없다.
+ */
+export function evaluateBudget(
+  usedUsd: number,
+  limitUsd: number | undefined,
+  warnPct = 0.8
+): BudgetEval {
+  if (!limitUsd || limitUsd <= 0) return { pct: 0, level: 'allow' }
+  const pct = usedUsd / limitUsd
+  const level: CostLevel = pct >= 1 ? 'block' : pct >= warnPct ? 'warn' : 'allow'
+  return { pct, level }
+}
+
+/** 비용 level → 기존 Guard 어휘(집행 의미 통일). */
+export function costToGuard(level: CostLevel): Guard {
+  return level === 'block' ? 'confirm' : level === 'warn' ? 'warn' : 'allow'
+}
+
+/**
+ * 한 기록의 비용($). usd 명시되면 그대로, 아니면 model+토큰×config 요율로 환산.
+ * 요율 없으면(pricing 미주입 또는 모델 미매칭) 0 — 추정 금지(없는 비용 지어내지 않음).
+ */
+export function usdOf(
+  input: { usd?: number; model?: string; inputTokens?: number; outputTokens?: number },
+  pricing?: PricingTable
+): number {
+  if (typeof input.usd === 'number') return input.usd
+  const rate = input.model && pricing ? pricing[input.model] : undefined
+  if (!rate) return 0
+  const inK = (input.inputTokens ?? 0) / 1000
+  const outK = (input.outputTokens ?? 0) / 1000
+  return inK * rate.inputPer1k + outK * rate.outputPer1k
+}

--- a/src/lib/cost-policy.ts
+++ b/src/lib/cost-policy.ts
@@ -1,4 +1,5 @@
 import type { Guard } from './risk-policy.js'
+import type { PricingRate } from './config.js'
 
 // Goal 56: 비용/예산 판정의 순수 SoT(결정만, 부작용 0). risk-policy 동형(결정/집행 분리).
 // 집행은 cost.ts 가 runGuarded 와 *동형 의미*(비-TTY+미승인 block · TTY confirm · --yes 승인)로 수행.
@@ -13,13 +14,8 @@ export interface BudgetEval {
   level: CostLevel
 }
 
-export interface Pricing {
-  inputPer1k: number
-  outputPer1k: number
-}
-
-/** 모델별 요율 — .vhk/config.json 주입(코드 하드코딩 금지). */
-export type PricingTable = Record<string, Pricing>
+/** 모델별 요율 — .vhk/config.json 주입(코드 하드코딩 금지). 타입 SoT = config.PricingRate 재사용(중복 제거). */
+export type PricingTable = Record<string, PricingRate>
 
 /**
  * 누적 사용량 vs 예산 판정. ≥100% block · ≥warnPct(기본 0.8) warn · 그 외 allow.

--- a/tests/cost-ledger.test.ts
+++ b/tests/cost-ledger.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  COST_PATH_REL,
+  readCostEntries,
+  appendCostEntry,
+  sumUsd,
+  type CostEntry,
+} from '../src/lib/cost-ledger.js'
+
+// Goal 56: cost.jsonl 은 evidence-ledger append 패턴 재사용 — append-only, atomicWriteFile,
+// 과거 줄 변경 0. (단 evidence-ledger 의 dedup-last 는 미적용 — 비용 기록은 매 건이 실 사용.)
+
+const E = (usd: number, source = 'manual'): CostEntry => ({ ts: '2026-06-09T00:00:00Z', source, usd })
+
+describe('cost-ledger', () => {
+  let dir = ''
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'vhk-cost-'))
+  })
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true })
+    dir = ''
+  })
+
+  it('COST_PATH_REL = .vhk/cost.jsonl', () => {
+    expect(COST_PATH_REL).toBe(join('.vhk', 'cost.jsonl'))
+  })
+
+  it('파일 없으면 빈 배열', () => {
+    expect(readCostEntries(dir)).toEqual([])
+  })
+
+  it('append → read 왕복', () => {
+    expect(appendCostEntry(dir, E(5))).toEqual({ appended: true })
+    const got = readCostEntries(dir)
+    expect(got).toHaveLength(1)
+    expect(got[0].usd).toBe(5)
+  })
+
+  it('append-only — 2번째 append 후 과거 줄 보존(순서 유지)', () => {
+    appendCostEntry(dir, E(5, 'first'))
+    const afterFirst = readFileSync(join(dir, COST_PATH_REL), 'utf-8')
+    appendCostEntry(dir, E(7, 'second'))
+    const all = readCostEntries(dir)
+    expect(all).toHaveLength(2)
+    expect(all[0].source).toBe('first')
+    expect(all[1].source).toBe('second')
+    // 첫 줄이 그대로 유지(과거 변경 0)
+    expect(readFileSync(join(dir, COST_PATH_REL), 'utf-8').startsWith(afterFirst.replace(/\n$/, ''))).toBe(true)
+  })
+
+  it('동일 값도 매번 append(비용 기록은 dedup 안 함)', () => {
+    appendCostEntry(dir, E(5))
+    appendCostEntry(dir, E(5))
+    expect(readCostEntries(dir)).toHaveLength(2)
+  })
+
+  it('손상 라인은 skip(원장 한 줄 깨져도 안 죽음)', () => {
+    mkdirSync(join(dir, '.vhk'), { recursive: true })
+    writeFileSync(join(dir, COST_PATH_REL), '{"ts":"t","source":"ok","usd":3}\n{깨진 줄\n{"ts":"t","source":"ok2","usd":4}\n')
+    const got = readCostEntries(dir)
+    expect(got).toHaveLength(2)
+    expect(got.map(e => e.usd)).toEqual([3, 4])
+  })
+
+  it('sumUsd — usd 합산', () => {
+    expect(sumUsd([E(5), E(7), E(0.5)])).toBeCloseTo(12.5)
+    expect(sumUsd([])).toBe(0)
+  })
+})

--- a/tests/cost-policy.test.ts
+++ b/tests/cost-policy.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { evaluateBudget, costToGuard, usdOf } from '../src/lib/cost-policy.js'
+
+// Goal 56: cost-policy 는 비용/예산 판정의 순수 SoT(결정만, 부작용 0). risk-policy 동형.
+// 임계: 예산의 80%(warn) / 100%(block). 예산 미설정(0/undefined)이면 가드 없음(allow).
+
+describe('cost-policy — evaluateBudget (임계 판정)', () => {
+  it('예산 미설정(undefined) → 가드 없음(allow, pct 0)', () => {
+    expect(evaluateBudget(50, undefined)).toEqual({ pct: 0, level: 'allow' })
+  })
+
+  it('예산 0/음수 → allow (의미 없는 예산은 가드 안 함)', () => {
+    expect(evaluateBudget(50, 0).level).toBe('allow')
+    expect(evaluateBudget(50, -10).level).toBe('allow')
+  })
+
+  it('79% → allow (warn 임계 미만)', () => {
+    expect(evaluateBudget(79, 100).level).toBe('allow')
+  })
+
+  it('80% → warn (경계 포함)', () => {
+    const r = evaluateBudget(80, 100)
+    expect(r.level).toBe('warn')
+    expect(r.pct).toBeCloseTo(0.8)
+  })
+
+  it('99% → warn', () => {
+    expect(evaluateBudget(99, 100).level).toBe('warn')
+  })
+
+  it('100% → block (경계 포함)', () => {
+    expect(evaluateBudget(100, 100).level).toBe('block')
+  })
+
+  it('120% → block', () => {
+    const r = evaluateBudget(120, 100)
+    expect(r.level).toBe('block')
+    expect(r.pct).toBeCloseTo(1.2)
+  })
+
+  it('warnPct 커스텀(0.5) → 50%에서 warn', () => {
+    expect(evaluateBudget(49, 100, 0.5).level).toBe('allow')
+    expect(evaluateBudget(50, 100, 0.5).level).toBe('warn')
+  })
+})
+
+describe('cost-policy — costToGuard (level → Guard 매핑)', () => {
+  it('block → confirm, warn → warn, allow → allow', () => {
+    expect(costToGuard('block')).toBe('confirm')
+    expect(costToGuard('warn')).toBe('warn')
+    expect(costToGuard('allow')).toBe('allow')
+  })
+})
+
+describe('cost-policy — usdOf (토큰→$ 환산, config 요율 주입)', () => {
+  const pricing = { 'claude-x': { inputPer1k: 3, outputPer1k: 15 } }
+
+  it('usd 명시 시 그대로 사용(요율 무시)', () => {
+    expect(usdOf({ usd: 5 }, pricing)).toBe(5)
+  })
+
+  it('usd 0(명시) → 0', () => {
+    expect(usdOf({ usd: 0 }, pricing)).toBe(0)
+  })
+
+  it('토큰 + 모델 + 요율 → 환산($)', () => {
+    // 1k input × 3 + 2k output × 15 = 3 + 30 = 33
+    expect(usdOf({ model: 'claude-x', inputTokens: 1000, outputTokens: 2000 }, pricing)).toBe(33)
+  })
+
+  it('요율 없으면(pricing 미주입 또는 모델 미매칭) → 0', () => {
+    expect(usdOf({ model: 'claude-x', inputTokens: 1000 })).toBe(0)
+    expect(usdOf({ model: 'unknown', inputTokens: 1000 }, pricing)).toBe(0)
+  })
+})

--- a/tests/cost.test.ts
+++ b/tests/cost.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { detectNaturalLanguageInput } from '../src/lib/cli-args.js'
 
 // Goal 56: vhk cost — 자문형 비용 가드. vitest 는 비-TTY → check 의 비대화형 차단 경로 검증.
 vi.mock('inquirer')
@@ -84,5 +85,22 @@ describe('vhk cost', () => {
     const { cost } = await import('../src/commands/cost.js')
     await cost('budget', 'abc')
     expect(process.exitCode).toBe(1)
+  })
+
+  it('add: 깨진 숫자(--usd NaN + 토큰) → 거부(exitCode 1, NaN 기록 안 함)', async () => {
+    // 적대 리뷰 #234: NaN 이 usd:null 로 새서 사용분 소실·가드 페일-오픈하는 것 방지.
+    const { cost } = await import('../src/commands/cost.js')
+    await cost('add', undefined, { usd: NaN, out: 100 })
+    expect(process.exitCode).toBe(1)
+    expect(existsSync(join(dir, '.vhk', 'cost.jsonl'))).toBe(false)
+  })
+})
+
+describe('vhk cost — 한글 별칭 라우팅 (가드 우회 방지)', () => {
+  it('`비용 check` 가 NLP 라우터에 안 가로채임(실명령 경로 → null)', () => {
+    // 적대 리뷰 #234: CONTAINER_ALIASES 에 비용→cost 누락 시 `비용 check`가 NL 라우터로 새서
+    // cost 가드가 침묵 우회됐다. 별칭 등록 후 실명령으로 인식돼야 함(detectNaturalLanguageInput=null).
+    expect(detectNaturalLanguageInput(['node', 'vhk', '비용', 'check'])).toBeNull()
+    expect(detectNaturalLanguageInput(['node', 'vhk', '비용', 'budget', '100'])).toBeNull()
   })
 })

--- a/tests/cost.test.ts
+++ b/tests/cost.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// Goal 56: vhk cost — 자문형 비용 가드. vitest 는 비-TTY → check 의 비대화형 차단 경로 검증.
+vi.mock('inquirer')
+
+describe('vhk cost', () => {
+  let dir = ''
+  let orig = ''
+  beforeEach(() => {
+    orig = process.cwd()
+    dir = mkdtempSync(join(tmpdir(), 'vhk-cost-cmd-'))
+    process.chdir(dir)
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(orig)
+    if (dir) rmSync(dir, { recursive: true, force: true })
+    dir = ''
+    process.exitCode = 0
+    delete process.env.VHK_COST_USD
+    delete process.env.VHK_COST_MODEL
+    delete process.env.VHK_COST_INPUT_TOKENS
+    delete process.env.VHK_COST_OUTPUT_TOKENS
+  })
+
+  it('budget 설정 + add(--usd) → cost.jsonl 기록', async () => {
+    const { cost } = await import('../src/commands/cost.js')
+    await cost('budget', '100')
+    await cost('add', undefined, { usd: 50 })
+    const p = join(dir, '.vhk', 'cost.jsonl')
+    expect(existsSync(p)).toBe(true)
+    expect(readFileSync(p, 'utf-8')).toContain('"usd":50')
+  })
+
+  it('check: 예산 초과(100%+) + 비대화형 + 미승인 → exitCode 1 (block)', async () => {
+    const { cost } = await import('../src/commands/cost.js')
+    await cost('budget', '100')
+    await cost('add', undefined, { usd: 120 })
+    process.exitCode = 0
+    await cost('check')
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('check: 예산 초과 + --yes(승인) → 차단 안 함(exitCode 0)', async () => {
+    const { cost } = await import('../src/commands/cost.js')
+    await cost('budget', '100')
+    await cost('add', undefined, { usd: 120 })
+    process.exitCode = 0
+    await cost('check', undefined, { yes: true })
+    expect(process.exitCode).toBe(0)
+  })
+
+  it('check: warn(80~99%) → 차단 안 함(exitCode 0)', async () => {
+    const { cost } = await import('../src/commands/cost.js')
+    await cost('budget', '100')
+    await cost('add', undefined, { usd: 85 })
+    process.exitCode = 0
+    await cost('check')
+    expect(process.exitCode).toBe(0)
+  })
+
+  it('check: 예산 미설정 → 가드 없음(exitCode 0)', async () => {
+    const { cost } = await import('../src/commands/cost.js')
+    await cost('add', undefined, { usd: 9999 })
+    process.exitCode = 0
+    await cost('check')
+    expect(process.exitCode).toBe(0)
+  })
+
+  it('env 주입(VHK_COST_USD) → add 기록(source=env)', async () => {
+    process.env.VHK_COST_USD = '7'
+    const { cost } = await import('../src/commands/cost.js')
+    await cost('add')
+    const txt = readFileSync(join(dir, '.vhk', 'cost.jsonl'), 'utf-8')
+    expect(txt).toContain('"usd":7')
+    expect(txt).toContain('"source":"env"')
+  })
+
+  it('budget: 유효하지 않은 값 → exitCode 1', async () => {
+    const { cost } = await import('../src/commands/cost.js')
+    await cost('budget', 'abc')
+    expect(process.exitCode).toBe(1)
+  })
+})


### PR DESCRIPTION
## Goal 56 — 비용·예산 가드 (cost-guard) · P0

5대 자기개선 루프(맥락·위험·학습·증거·**비용**) 중 비용만 전무(실측 0). 최우선 공백 P0. token/$ 예산 가드 추가.

### 결정 (사용자 확정: 자문형 + 양방향 입력)
**탐색 결론**: vhk 는 Claude API 를 직접 호출하지 않아 비용을 **자동 추적 불가**(기존 usage/token 코드 0). → 사용량은 외부 입력으로 먹이고(수동 `vhk cost add` + 환경변수 `VHK_COST_*`), 가드는 **자문형**(임계 초과 시 exit code 로 CI/agent halt).

### 변경
- **신규** `src/lib/cost-policy.ts` — 순수 판정 SoT: `evaluateBudget`(≥80% warn·≥100% block)·`costToGuard`·`usdOf`(토큰×config 요율).
- **신규** `src/lib/cost-ledger.ts` — `.vhk/cost.jsonl` append-only(evidence-ledger 패턴·`atomicWriteFile`, 과거 줄 변경 0).
- **신규** `src/commands/cost.ts` — `vhk cost [status|add|check|budget]`. check: 80% 경고 · 100% 차단(비-TTY+미승인 **exit 1**, TTY 확인, `--yes` 승인).
- `config.ts` — VhkConfig 에 `budget`/`pricing` 주입 필드(코드 가격 상수 0).
- 명령 3지점 등록(index.ts·command-registry.ts·cli-args.ts) — NLP 라우터 가로채기 방지.
- `scripts/check-goal-56.mjs`(25항) · 테스트 3종(cost-policy 8·cost-ledger 7·cost 7) · README/COMMANDS 반영.

### 설계 메모
`runGuarded` 는 action 기반 `resolveGuard` 로 guard 를 자체 계산 → 임계 기반 비용 level 을 못 먹이므로 **직접 재사용 대신 동형 의미**(비-TTY+미승인 block·TTY confirm·--yes 승인)를 cost level 로 구동. risk-policy 중복 아님(별도 정책 차원, 단일 chokepoint 원칙 유지). preflight 편입은 보류(카드 [선택]).

### 검증
typecheck + lint(0) + test(**전체 0 fail**, 신규 22) + build green · `check-goal-56` 25항 통과 · `vhk cost` 전체 흐름 도그푸딩(budget→add→warn→block exit 1→env 경로 실증).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
