### PR TITLE
feat(goal-50): diff-coverage 측정 — vhk diff-cover 자문 명령 (RFC 0050 PR1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ dist/
 
 # Serena MCP 로컬 캐시/프로젝트 메모 — 머신별 툴 산출물, 커밋 금지
 .serena/
+
+# coverage 리포트 — 파생 산출물(vitest --coverage), 버려도 됨 (Goal 50 / RFC 0050)
+coverage/

--- a/docs/log/2026-06-10-diff-coverage.md
+++ b/docs/log/2026-06-10-diff-coverage.md
@@ -1,0 +1,42 @@
+# 2026-06-10 — diff-coverage PR1 (RFC 0050, Goal 50) — 측정 도구 + 도그푸딩
+
+> append-only dev log. 추가만, 수정·삭제 금지.
+
+## 한 일 (feat/diff-coverage 브랜치, PR 예정)
+
+"이번 변경이 테스트로 실제 실행됐나"를 측정하는 자문형 `vhk diff-cover` + coverage 인프라. review.ts:40 자백("git diff 미사용 — 테스트 green이어도 이번 변경 미커버 가능") 구멍을 측정으로 메우는 첫 단계.
+
+- **설계**: RFC 0050(measure-first — 게이트부터 안 짓고 숫자로 구멍 실재 증명 후 승격). 적대 다관점 리뷰(워크플로는 spend限 중도실패 → 직접 검토)로 모순 3건 수정 후 확정.
+- **구현(TDD red→green, 커밋 7+)**:
+  - coverage 인프라: `@vitest/coverage-v8@4.1.7` + vitest.config v8 블록(json reporter). coverage/ gitignore.
+  - `git-session.diffUnified0`(단일 SoT 확장 — 라인단위 diff).
+  - 순수 3모듈: `diff-hunks.addedLinesByFile`(diff→추가라인) · `coverage-parse.fileCoverageByFile`(v8 json→{covered,executable}) · `diff-coverage.diffCoverage`(교차→미검증 변경분).
+  - `vhk diff-cover` 명령 + 5지점 등록(import·별칭맵·command·command-registry·cli-args KNOWN_COMMAND_TOKENS). 한글별칭 '커버리지'.
+- 테스트 1376→1381. 빌드·typecheck·lint·전체 green.
+
+## 측정 (도그푸딩 — measure-first 루프가 결함 잡음)
+
+PR1 코드 자체(vs main)에 도구를 돌림:
+
+1. **1차**: 미검증 118/213(44%). 그런데 미커버 목록이 import·주석·타입·닫는중괄호 투성이 → **지표가 노이즈에 묻힘**(false-completion 가드가 늑대소년 됨).
+2. **결함 수정**: v8 statementMap 검사로 확인 — 비실행 라인(주석/import)은 statement 아님. `coverage-parse`가 `executable`(statement 라인) 노출, `diff-coverage`가 **실행가능 추가라인만** 분모로. 재측정 → 미검증 30(전부 `diffCover()` IO 오케스트레이션 — formatReport만 테스트했음).
+3. **자기 dogfood 먹기**: 도구가 가리킨 구멍(diffCover 미테스트)에 통합 테스트 4분기 추가 → 재측정 **미검증 0 / 132 실행가능추가 = 100% diff-coverage**.
+
+→ 빌드→측정→지표결함→수정→진짜구멍→봉합. 합성/단일표본 1건.
+
+## 핵심 결정
+
+- **measure-first 유지**: review 통합·CI 게이트·차단은 PR1 도그푸딩이 "구멍 실재"를 ≥5 실제 코드 diff(며칠)로 증명한 뒤 PR2(RFC 0050 §5 관찰 프로토콜). 단일 표본으론 승격 안 함.
+- **"미검증 변경분" = 실행가능 추가라인 중 미커버만**. 비실행(주석·import·타입·중괄호)은 분모에서 제외 — 안 그러면 신호가 노이즈에 묻힘(이번 도그푸딩이 정확히 이걸 잡음).
+- Goal 50 카드 "신규분 차단"은 PR2로 미룸(카드↔RFC 정합 표기). status NOT_STARTED→IN_PROGRESS.
+
+## 교훈
+
+- **도그푸딩이 유닛테스트가 못 본 지표 결함을 잡았다** — 1381 유닛테스트 전부 green인데도, 실제 diff에 돌리니 "미검증" 정의가 노이즈(주석/import)를 셈. 신규기능은 실사용 1회로 통합결함 검출(과거 Goal 19 SnapContext 선례 반복).
+- **측정 도구도 측정당해야 한다** — diff-cover가 자기 자신을 측정해 자기 미테스트 구멍을 드러냄. 도구가 외친 신호를 무시하면 위선.
+- **measure-first가 또 보상** — recall(56/92)에 이어, 게이트 짓기 전에 측정부터 한 덕에 지표 결함을 출하 전에 잡음.
+
+## 다음
+
+1. **며칠 `vhk diff-cover` 실사용** — 실제 코드 작업 diff ≥5건 누적해 미검증 변경분 분포 측정(RFC 0050 §5). 유의미하면 PR2(review 통합 + CI), ≈0이면 "이론적 구멍" 문서화 후 중단.
+2. recall 실측(RFC 0049 §5)과 병행 — 둘 다 measure-first 대기.

--- a/docs/rfc/0050-diff-coverage-gate.md
+++ b/docs/rfc/0050-diff-coverage-gate.md
@@ -31,16 +31,16 @@
 
 ## §3. 아키텍처 (순수 seam — review.crossCheck 패턴 재사용)
 
-```
-git diff --unified=0 HEAD ──▶ git-session.changedLines() ──┐
-                                                            ├─▶ diffCoverage()  (순수)  ──▶ 파일별 미검증 변경분
-coverage-final.json ──▶ coverage-parse.coveredLinesByFile() ┘
+```text
+git diff -U0 HEAD ─▶ git-session.diffUnified0 ─▶ diff-hunks.addedLinesByFile() ──┐
+                                                                                  ├─▶ diffCoverage() (순수) ─▶ 파일별 미검증 변경분
+coverage-final.json ─▶ coverage-parse.coveredLinesByFile() ───────────────────────┘
                                                             └─▶ vhk diff-cover (자문 출력)
 ```
 
 - **`src/lib/git-session.ts` 확장** (단일 SoT): `diffUnified0(cwd)` = `git diff --unified=0 HEAD` (ExecResult). 라인번호 보존 위해 `trimOutput:false`.
-- **`src/lib/diff-hunks.ts`** (신규·순수): unified-diff 텍스트 → `Map<파일(rel posix), Set<추가라인번호>>`. `@@ -a,b +c,d @@` 헌트 파싱, `+`(컨텍스트 아닌 추가)만. `isFeatureSource`(test-mapping.ts 재사용)로 src/commands·src/lib만 대상.
-- **`src/lib/coverage-parse.ts`** (신규·IO+파싱): v8 coverage-final.json → `Map<파일(rel posix), Set<커버된라인번호>>`. statement `s[k]>0`인 statementMap 라인 펼침. abs경로 → cwd 상대 posix 정규화.
+- **`src/lib/diff-hunks.ts`** (신규·순수): `addedLinesByFile(diffText)` = unified-diff 텍스트 → `Map<파일(rel posix), Set<추가라인번호>>`. `@@ -a,b +c,d @@` 헌트 파싱, `+`(컨텍스트 아닌 추가)만. `isFeatureSource`(test-mapping.ts 재사용)로 src/commands·src/lib만 대상.
+- **`src/lib/coverage-parse.ts`** (신규·IO+파싱): `coveredLinesByFile(jsonPath, cwd)` = v8 coverage-final.json → `Map<파일(rel posix), Set<커버된라인번호>>`. statement `s[k]>0`인 statementMap 라인 펼침. abs경로 → cwd 상대 posix 정규화.
 - **`src/lib/diff-coverage.ts`** (신규·**순수**): (추가라인 맵, 커버라인 맵) → 파일별 `{ added, covered, uncoveredNew[], ratio }` + 총계. fs/실시간 부수효과 0 → TDD 쉬움(crossCheck 선례).
 - **`src/commands/diff-cover.ts`** (신규): 위를 조립. coverage-final.json 없으면 안내(`pnpm test:run --coverage` 먼저) 후 종료 — **새 coverage 실행 강제 안 함**(명령은 빠르고 결정적, 무거운 coverage run은 명시적).
 
@@ -50,17 +50,28 @@ coverage-final.json ──▶ coverage-parse.coveredLinesByFile() ┘
 
 1. **coverage 인프라**: `@vitest/coverage-v8@^4.1.7`(vitest 동일 버전) devDep + `vitest.config.ts` coverage 블록 (provider `v8`, reporter `['text-summary','json']`, exclude `dist`·`.claude`·`tests`·`*.config.*`). `pnpm test:run --coverage`로 `coverage/coverage-final.json` 생성.
 2. **순수 모듈 3종 + git-session 확장** (§3) — 전부 TDD(red→green).
-3. **`vhk diff-cover` 자문 명령**: HEAD 대비 변경된 기능소스별로 "추가 N라인 중 M라인 미검증" 출력. 차단·exit1 없음(advisory). 4지점 명령 등록(메모리: CONTAINER_ALIASES + 한글별칭 — 단 diff-cover는 서브커맨드 없는 단순명령이라 표준 등록).
-4. **도그푸딩 측정**: 최근 실제 diff(예: 이 RFC 작업 자체)에 돌려 "미검증 변경분 비율" 실측 → dev log 기록. **이게 PR2를 거는 숫자.**
+3. **`vhk diff-cover` 자문 명령**: HEAD 대비 변경된 기능소스별로 "추가 N라인 중 M라인 미검증" 출력. 차단·exit1 없음(advisory). 단순명령(서브커맨드 없음) → 표준 등록(NL 라우터 + help + 한글별칭). ※ CONTAINER_ALIASES는 서브커맨드 있는 명령용이라 diff-cover엔 불필요.
+4. **도그푸딩 측정**: **코드** diff에 돌린다 — 이 RFC(문서)는 기능소스 변경 0이라 vacuous(측정 대상 아님). 1차 표본 = PR1 구현 자체의 src 변경, 이후 며칠간 실제 코드 작업 diff들을 누적. **이게 PR2를 거는 숫자**(단일 표본 금지 — §5 프로토콜).
 
 **비목표(PR1 OUT)**: review/verify 통합, CI 게이트, 차단, 임계 강제, 브랜치(vs origin/main) diff, 라인 정밀 reporter(html).
 
 ## §5. PR2 결정 잠금 (recall Kill-gate 방식)
 
-PR1 도그푸딩 실측이 아래를 보이면 **그때만** 승격:
-- **승격 신호**: 실제 작업 diff들에서 미검증 변경분이 반복적으로 유의미(추가 로직 라인이 테스트에 안 닿고 통과). → ① review.ts:40 자백 제거 + verify가 diffCoverage를 증거로 기록 + review가 "미검증 변경분 N라인"을 새 gap/suspicion 분류 ② CI Summary 노출 + 신규분 무커버 경고(차단은 여전히 opt-in, Goal 28 패턴).
-- **기각 신호**: 실측 미검증 변경분 ≈ 0 (이미 TDD로 다 닿음). → "구멍은 이론적" 문서화하고 **중단**(YAGNI). coverage 리포트는 가시성으로만 남김.
-- 잠긴 PR2 설계(승격 시 부활): verify 증거스키마에 `diffCoverage` 필드, review confidence 캡 규칙에 "미검증 변경분>0 → high 금지", CI diff-coverage Summary.
+> recall의 임계(Recall@5<0.7)만큼 crisp하진 못함 — diff-coverage 승격은 본질적으로 판단 게이트다. 자의성을 막으려 **관찰 프로토콜**으로 임계를 고정한다.
+
+**관찰 프로토콜(임계 정의):**
+- 표본 = **실제 코드 작업 diff ≥5건**(며칠, 단일·합성 표본 금지 — recall "1~2 사이클로 판단 금지" 답습).
+- 분자 = 추가된 **실로직** 미검증 라인. trivial(로그·타입선언·주석·단순 위임/재노출)은 제외(노이즈 차단).
+- **승격 임계**: ≥5건 중 과반에서 실로직 미검증 라인 > 0 (= 테스트 통과한 코드가 실제로 새 로직을 안 닿음이 반복 관측).
+- **기각 임계**: 위 표본에서 실로직 미검증 라인이 사실상 0 (TDD로 이미 다 닿음).
+
+**승격 시(부활할 잠긴 설계):**
+- ① review.ts:40 자백 제거 + verify가 `diffCoverage`를 증거로 기록 + review가 "미검증 변경분 N라인"을 새 gap/suspicion 분류(confidence 캡: 미검증 변경분>0 → high 금지).
+- ② CI Summary 노출 + 신규분 무커버 경고(차단은 여전히 opt-in, Goal 28 `VHK_TEST_FIRST` 패턴).
+
+**기각 시**: "구멍은 이론적" 문서화 후 **중단**(YAGNI). coverage 리포트는 가시성으로만 남김.
+
+**Goal 50 카드 정합**: 카드 Completion Check `diff-coverage(신규분 차단) 도입`은 *차단*을 함의 → RFC는 이를 **PR2(승격 시)**로 미룬다. PR1 머지 시 Goal 50 카드의 해당 항목을 "차단은 PR2/opt-in"으로 갱신(카드↔RFC 드리프트 방지).
 
 ## §6. 범위
 
@@ -70,8 +81,10 @@ PR1 도그푸딩 실측이 아래를 보이면 **그때만** 승격:
 ## §7. 위험 / 엣지
 
 - **추적 안 된 새 파일**: `git diff HEAD`에 안 잡힘 → "추적 안 됨(git add 후 재측정)"으로 별도 경고. PR1은 fully-new 라인 계산 안 함(정직).
+- **diff-hunks 파서 엣지**: `@@ -a,b +c,d @@`에서 추가라인 = c..c+d-1. **count 생략형 `@@ +c @@` = 1줄**, **순수삭제 헌트(d=0) = 추가 0**, **한 파일 멀티헌트 = Set 누적**, **rename(R)/binary diff = 추가라인 무의미 → 스킵**. 단위테스트로 각 형태 고정.
+- **coverage에 부재한 파일**: 테스트가 한 번도 import 안 한 변경 파일은 coverage-final.json에 **부재** → 빈 커버집합 → 전 추가라인 미검증(정확한 측정). 단 "리포트 파일 자체 부재"(먼저 `--coverage`)와 **구분**해 메시지.
 - **sourcemap 좌표**: v8 provider는 coverage-final.json에 **소스(TS) 좌표**로 기록(vitest 기본 sourcemap) — 빌드 산출물 좌표 아님. 구현 시 실측 1회 확인(샘플 파일 라인 대조).
-- **경로 정규화**: git(rel posix) ↔ coverage(abs) 불일치가 매칭 실패의 1순위 버그원 → `toPosix` + cwd 상대화 단일화, 매칭 0건이면 명시 경고(조용한 거짓 100% 금지).
+- **경로 정규화**: git(rel posix) ↔ coverage(abs) 불일치가 매칭 실패의 1순위 버그원 → `path.relative(cwd, abs)` + `toPosix` 단일화. 윈도우 함정(drive 문자 대소문자·8.3 단축명)은 `realpathSync.native`로 정규화 후 비교(CI matrix 교훈). 매칭 0건이면 명시 경고(조용한 거짓 100% 금지).
 - **성능**: coverage run은 plain test보다 느림 → 명령은 기존 리포트 *읽기만*. 리포트 신선도(파일 mtime) 노출, 오래되면 재생성 권장.
 - **빈 diff / 리포트 부재**: 각각 "변경 없음" / "리포트 없음(먼저 --coverage)" 안내 후 exit 0.
 

--- a/docs/rfc/0050-diff-coverage-gate.md
+++ b/docs/rfc/0050-diff-coverage-gate.md
@@ -1,0 +1,84 @@
+# RFC 0050 — diff-coverage: "이번 변경이 테스트로 닿았나" 측정 (measure-first, 게이트는 나중)
+
+> 상태: Draft · 작성: 2026-06-09 · 출처: review.ts:40 자백 + 13-에이전트 감사(RFC 0048 §2 테스트 차원) + recall(RFC 0049) 교훈 이식
+> 목적: review/verify의 미측정 가설("기존 테스트가 green이어도 이번 변경을 커버 못 했을 수 있음")을 **측정 가능한 숫자**로 바꾼다. 게이트(차단)·review 통합·CI는 그 숫자가 정당화한 뒤에만.
+> 연동: 실행 단위 = `goals/50-coverage-diff-gate.md`. 데이터 = `coverage/coverage-final.json`(v8, 파생·버려도 됨) + `git diff`. git 통로 = `src/lib/git-session.ts`(Goal 48 단일 SoT).
+
+---
+
+## §0. 한 줄 결론
+
+`vhk review`는 "이번 변경이 실제로 테스트에 실행됐는지"를 **모른다**(review.ts:40 스스로 자백). 이걸 **순수 측정 도구**(`vhk diff-cover`)로 먼저 만들어 실제 diff에서 "미검증 변경분(테스트 안 닿은 추가 라인)"을 숫자로 보고한다. 그 숫자가 "구멍이 실재한다"를 증명하면 그때 review 통합·CI 게이트로 승격. **측정 전 게이트 금지** — recall과 동일 규율.
+
+---
+
+## §1. 동기 (실측)
+
+- **review.ts:40 자백**: `git diff 미사용(v0) — 기존 테스트가 green 이어도 이번 변경을 커버하지 못했을 수 있습니다.` → review의 거짓완료 심문에 **구조적 사각지대**. 완료조건이 게이트(test green)에 매핑돼도, 그 test가 이번 변경 라인을 한 번도 실행 안 했을 수 있음.
+- **Goal 28 `vhk testmap`은 파일단위만**: 변경 src에 `*.test.ts`가 *존재*하는지만 봄. 파일이 있어도 그 테스트가 새 함수/분기를 *실행*했는지는 모름 → 프록시(존재 ≠ 실행).
+- **coverage 측정 전무**: `vitest.config.ts`에 coverage 키 없고 `@vitest/coverage-v8` 부재(확인). 1162 pass는 분자뿐, line 분모 없음 → "안 짠 경로"가 시스템에 비가시.
+- **핵심**: "이번 변경이 테스트로 닿았나"는 **결정적으로 계산 가능**(git diff 추가라인 ∩ coverage 미커버라인). ML 0. 측정 블로커 0.
+
+## §2. 원칙 (recall 교훈 이식)
+
+| 관점 | 적용 |
+|------|------|
+| **measure-first** (카파시) | 게이트부터 짓지 않는다. review.ts:40은 *가설*. 실제 diff에서 미검증 변경분을 숫자로 본 뒤에만 차단/통합 정당. |
+| **신호 분리** (Hickey) | "미검증 변경분"을 한 점수로 안 땋음 — 파일별 (추가라인 / 커버된라인 / 미커버 추가라인 / 비율) 4신호 그대로 노출. |
+| **과안정화 경계** (헌법) | PR1은 **자문형(advisory)·차단 0**. 실사용 신호가 "구멍 실재"를 보이기 전엔 HARD 게이트 안 만듦(Goal 28과 동일 보수성). |
+| **단일 SoT** (Goal 48) | git 라인 질문도 `git-session.ts` 한 곳에 추가 — MCP/CLI 인라인 재구현 금지. |
+| **파생 데이터** (Linus) | coverage-final.json은 버려도 되는 파생(진실 = 소스+테스트). 새 영구 상태 안 만듦. |
+
+## §3. 아키텍처 (순수 seam — review.crossCheck 패턴 재사용)
+
+```
+git diff --unified=0 HEAD ──▶ git-session.changedLines() ──┐
+                                                            ├─▶ diffCoverage()  (순수)  ──▶ 파일별 미검증 변경분
+coverage-final.json ──▶ coverage-parse.coveredLinesByFile() ┘
+                                                            └─▶ vhk diff-cover (자문 출력)
+```
+
+- **`src/lib/git-session.ts` 확장** (단일 SoT): `diffUnified0(cwd)` = `git diff --unified=0 HEAD` (ExecResult). 라인번호 보존 위해 `trimOutput:false`.
+- **`src/lib/diff-hunks.ts`** (신규·순수): unified-diff 텍스트 → `Map<파일(rel posix), Set<추가라인번호>>`. `@@ -a,b +c,d @@` 헌트 파싱, `+`(컨텍스트 아닌 추가)만. `isFeatureSource`(test-mapping.ts 재사용)로 src/commands·src/lib만 대상.
+- **`src/lib/coverage-parse.ts`** (신규·IO+파싱): v8 coverage-final.json → `Map<파일(rel posix), Set<커버된라인번호>>`. statement `s[k]>0`인 statementMap 라인 펼침. abs경로 → cwd 상대 posix 정규화.
+- **`src/lib/diff-coverage.ts`** (신규·**순수**): (추가라인 맵, 커버라인 맵) → 파일별 `{ added, covered, uncoveredNew[], ratio }` + 총계. fs/실시간 부수효과 0 → TDD 쉬움(crossCheck 선례).
+- **`src/commands/diff-cover.ts`** (신규): 위를 조립. coverage-final.json 없으면 안내(`pnpm test:run --coverage` 먼저) 후 종료 — **새 coverage 실행 강제 안 함**(명령은 빠르고 결정적, 무거운 coverage run은 명시적).
+
+**경계 질문(각 단위)**: diff-hunks=텍스트→라인집합(git 모름). coverage-parse=json→라인집합(diff 모름). diff-coverage=두 집합 교차(IO 모름·순수). command=조립+출력. 서로 내부 안 봐도 됨.
+
+## §4. PR1 스코프 (측정 전용 — 차단 0)
+
+1. **coverage 인프라**: `@vitest/coverage-v8@^4.1.7`(vitest 동일 버전) devDep + `vitest.config.ts` coverage 블록 (provider `v8`, reporter `['text-summary','json']`, exclude `dist`·`.claude`·`tests`·`*.config.*`). `pnpm test:run --coverage`로 `coverage/coverage-final.json` 생성.
+2. **순수 모듈 3종 + git-session 확장** (§3) — 전부 TDD(red→green).
+3. **`vhk diff-cover` 자문 명령**: HEAD 대비 변경된 기능소스별로 "추가 N라인 중 M라인 미검증" 출력. 차단·exit1 없음(advisory). 4지점 명령 등록(메모리: CONTAINER_ALIASES + 한글별칭 — 단 diff-cover는 서브커맨드 없는 단순명령이라 표준 등록).
+4. **도그푸딩 측정**: 최근 실제 diff(예: 이 RFC 작업 자체)에 돌려 "미검증 변경분 비율" 실측 → dev log 기록. **이게 PR2를 거는 숫자.**
+
+**비목표(PR1 OUT)**: review/verify 통합, CI 게이트, 차단, 임계 강제, 브랜치(vs origin/main) diff, 라인 정밀 reporter(html).
+
+## §5. PR2 결정 잠금 (recall Kill-gate 방식)
+
+PR1 도그푸딩 실측이 아래를 보이면 **그때만** 승격:
+- **승격 신호**: 실제 작업 diff들에서 미검증 변경분이 반복적으로 유의미(추가 로직 라인이 테스트에 안 닿고 통과). → ① review.ts:40 자백 제거 + verify가 diffCoverage를 증거로 기록 + review가 "미검증 변경분 N라인"을 새 gap/suspicion 분류 ② CI Summary 노출 + 신규분 무커버 경고(차단은 여전히 opt-in, Goal 28 패턴).
+- **기각 신호**: 실측 미검증 변경분 ≈ 0 (이미 TDD로 다 닿음). → "구멍은 이론적" 문서화하고 **중단**(YAGNI). coverage 리포트는 가시성으로만 남김.
+- 잠긴 PR2 설계(승격 시 부활): verify 증거스키마에 `diffCoverage` 필드, review confidence 캡 규칙에 "미검증 변경분>0 → high 금지", CI diff-coverage Summary.
+
+## §6. 범위
+
+- **IN (PR1)**: coverage 인프라 + 순수 측정 3모듈 + git-session 라인 확장 + `vhk diff-cover` 자문 + 도그푸딩 실측.
+- **OUT**: 차단/HARD 게이트(측정 전), review/verify 통합(PR2), CI 배선(PR2), 전체 100% 강제(솔로 부담·Goal 50 명시), 커밋 단위 "정말 먼저 썼나" 증명(Goal 28 OUT 답습).
+
+## §7. 위험 / 엣지
+
+- **추적 안 된 새 파일**: `git diff HEAD`에 안 잡힘 → "추적 안 됨(git add 후 재측정)"으로 별도 경고. PR1은 fully-new 라인 계산 안 함(정직).
+- **sourcemap 좌표**: v8 provider는 coverage-final.json에 **소스(TS) 좌표**로 기록(vitest 기본 sourcemap) — 빌드 산출물 좌표 아님. 구현 시 실측 1회 확인(샘플 파일 라인 대조).
+- **경로 정규화**: git(rel posix) ↔ coverage(abs) 불일치가 매칭 실패의 1순위 버그원 → `toPosix` + cwd 상대화 단일화, 매칭 0건이면 명시 경고(조용한 거짓 100% 금지).
+- **성능**: coverage run은 plain test보다 느림 → 명령은 기존 리포트 *읽기만*. 리포트 신선도(파일 mtime) 노출, 오래되면 재생성 권장.
+- **빈 diff / 리포트 부재**: 각각 "변경 없음" / "리포트 없음(먼저 --coverage)" 안내 후 exit 0.
+
+## §8. 수용 기준 (PR1)
+
+- `pnpm test:run --coverage` → `coverage/coverage-final.json` 생성.
+- `vhk diff-cover`가 변경 기능소스별 미검증 변경분 정확 보고(순수 모듈 단위테스트 + 실제 diff 스모크로 검증).
+- 경로 매칭 0건일 때 거짓 "100% 커버" 대신 경고.
+- 공통 게이트(build·typecheck·test·secure) 통과, 회귀 0.
+- 도그푸딩 실측치 dev log 기록(PR2 결정 입력).

--- a/docs/rfc/0050-diff-coverage-gate.md
+++ b/docs/rfc/0050-diff-coverage-gate.md
@@ -34,14 +34,14 @@
 ```text
 git diff -U0 HEAD ─▶ git-session.diffUnified0 ─▶ diff-hunks.addedLinesByFile() ──┐
                                                                                   ├─▶ diffCoverage() (순수) ─▶ 파일별 미검증 변경분
-coverage-final.json ─▶ coverage-parse.coveredLinesByFile() ───────────────────────┘
+coverage-final.json ─▶ coverage-parse.fileCoverageByFile() ───────────────────────┘
                                                             └─▶ vhk diff-cover (자문 출력)
 ```
 
 - **`src/lib/git-session.ts` 확장** (단일 SoT): `diffUnified0(cwd)` = `git diff --unified=0 HEAD` (ExecResult). 라인번호 보존 위해 `trimOutput:false`.
 - **`src/lib/diff-hunks.ts`** (신규·순수): `addedLinesByFile(diffText)` = unified-diff 텍스트 → `Map<파일(rel posix), Set<추가라인번호>>`. `@@ -a,b +c,d @@` 헌트 파싱, `+`(컨텍스트 아닌 추가)만. `isFeatureSource`(test-mapping.ts 재사용)로 src/commands·src/lib만 대상.
-- **`src/lib/coverage-parse.ts`** (신규·IO+파싱): `coveredLinesByFile(jsonPath, cwd)` = v8 coverage-final.json → `Map<파일(rel posix), Set<커버된라인번호>>`. statement `s[k]>0`인 statementMap 라인 펼침. abs경로 → cwd 상대 posix 정규화.
-- **`src/lib/diff-coverage.ts`** (신규·**순수**): (추가라인 맵, 커버라인 맵) → 파일별 `{ added, covered, uncoveredNew[], ratio }` + 총계. fs/실시간 부수효과 0 → TDD 쉬움(crossCheck 선례).
+- **`src/lib/coverage-parse.ts`** (신규·IO+파싱): `fileCoverageByFile(jsonPath, cwd)` = v8 coverage-final.json → `Map<파일(rel posix), {covered, executable}>`. `executable` = statementMap 모든 라인(실행가능 코드), `covered` = 그중 `s[k]>0`. abs경로 → cwd 상대 posix 정규화. **executable 분리 이유: 미검증 변경분은 *실행가능* 추가라인만 세야 함**(아래 §7 — 도그푸딩이 잡은 결함).
+- **`src/lib/diff-coverage.ts`** (신규·**순수**): (추가라인 맵, 커버리지 맵) → 파일별 `{ added, covered, uncoveredNew[], ratio, inCoverage }` + 총계. 분모 = 추가라인 ∩ executable(비실행 라인 제외). fs/실시간 부수효과 0 → TDD 쉬움(crossCheck 선례).
 - **`src/commands/diff-cover.ts`** (신규): 위를 조립. coverage-final.json 없으면 안내(`pnpm test:run --coverage` 먼저) 후 종료 — **새 coverage 실행 강제 안 함**(명령은 빠르고 결정적, 무거운 coverage run은 명시적).
 
 **경계 질문(각 단위)**: diff-hunks=텍스트→라인집합(git 모름). coverage-parse=json→라인집합(diff 모름). diff-coverage=두 집합 교차(IO 모름·순수). command=조립+출력. 서로 내부 안 봐도 됨.
@@ -82,7 +82,8 @@ coverage-final.json ─▶ coverage-parse.coveredLinesByFile() ─────�
 
 - **추적 안 된 새 파일**: `git diff HEAD`에 안 잡힘 → "추적 안 됨(git add 후 재측정)"으로 별도 경고. PR1은 fully-new 라인 계산 안 함(정직).
 - **diff-hunks 파서 엣지**: `@@ -a,b +c,d @@`에서 추가라인 = c..c+d-1. **count 생략형 `@@ +c @@` = 1줄**, **순수삭제 헌트(d=0) = 추가 0**, **한 파일 멀티헌트 = Set 누적**, **rename(R)/binary diff = 추가라인 무의미 → 스킵**. 단위테스트로 각 형태 고정.
-- **coverage에 부재한 파일**: 테스트가 한 번도 import 안 한 변경 파일은 coverage-final.json에 **부재** → 빈 커버집합 → 전 추가라인 미검증(정확한 측정). 단 "리포트 파일 자체 부재"(먼저 `--coverage`)와 **구분**해 메시지.
+- **coverage에 부재한 파일**: 테스트가 한 번도 import 안 한 변경 파일은 coverage-final.json에 **부재** → executable 판별 불가 → 전 추가라인을 coarse 미검증 + `inCoverage:false` 플래그(메시지 구분). "리포트 파일 자체 부재"(먼저 `--coverage`)와도 구분.
+- **비실행 라인 노이즈(구현서 도그푸딩이 잡음·2026-06-10)**: 미검증 변경분을 "모든 추가라인 중 미커버"로 세면 import·주석·타입·중괄호까지 잡혀 신호가 묻힌다(실측 118 거짓 미검증). **분모는 실행가능(statementMap) 추가라인만** — 그래야 false-completion 신호가 진짜 미테스트 로직만 가리킴. (수정 후 PR1 자체 = 100% diff-coverage.)
 - **sourcemap 좌표**: v8 provider는 coverage-final.json에 **소스(TS) 좌표**로 기록(vitest 기본 sourcemap) — 빌드 산출물 좌표 아님. 구현 시 실측 1회 확인(샘플 파일 라인 대조).
 - **경로 정규화**: git(rel posix) ↔ coverage(abs) 불일치가 매칭 실패의 1순위 버그원 → `path.relative(cwd, abs)` + `toPosix` 단일화. 윈도우 함정(drive 문자 대소문자·8.3 단축명)은 `realpathSync.native`로 정규화 후 비교(CI matrix 교훈). 매칭 0건이면 명시 경고(조용한 거짓 100% 금지).
 - **성능**: coverage run은 plain test보다 느림 → 명령은 기존 리포트 *읽기만*. 리포트 신선도(파일 mtime) 노출, 오래되면 재생성 권장.

--- a/docs/superpowers/plans/2026-06-09-diff-coverage.md
+++ b/docs/superpowers/plans/2026-06-09-diff-coverage.md
@@ -1,0 +1,762 @@
+# diff-coverage (RFC 0050 PR1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** "이번 변경(HEAD 대비)이 실제로 테스트에 실행됐나"를 측정하는 자문형 `vhk diff-cover` 명령 + coverage 인프라. 차단 0 (advisory).
+
+**Architecture:** 순수 seam 4단(diff-hunks=git텍스트→추가라인 / coverage-parse=v8json→커버라인 / diff-coverage=교차 / command=조립·출력). git 호출은 git-session 단일 SoT 확장. review.ts의 crossCheck 순수함수 패턴 답습.
+
+**Tech Stack:** TypeScript, vitest 4.1.7, @vitest/coverage-v8(v8 provider), commander(CLI), chalk. git `diff --unified=0 HEAD`.
+
+**참조:** 설계 = [docs/rfc/0050-diff-coverage-gate.md](../../rfc/0050-diff-coverage-gate.md). 미션카드 = [goals/50-coverage-diff-gate.md](../../../goals/50-coverage-diff-gate.md).
+
+---
+
+## File Structure
+
+| 파일 | 책임 | 신규/수정 |
+|------|------|-----------|
+| `vitest.config.ts` | coverage 블록(v8, json reporter) | 수정 |
+| `package.json` | `@vitest/coverage-v8` devDep | 수정 |
+| `src/lib/git-session.ts` | `diffUnified0()` — 라인번호 보존 git diff (단일 SoT) | 수정 |
+| `src/lib/diff-hunks.ts` | `addedLinesByFile()` — diff텍스트→기능소스별 추가라인 (순수) | 신규 |
+| `src/lib/coverage-parse.ts` | `coveredLinesByFile()` — coverage-final.json→커버라인 (IO+파싱) | 신규 |
+| `src/lib/diff-coverage.ts` | `diffCoverage()` — 두 맵 교차→미검증 변경분 (순수) | 신규 |
+| `src/commands/diff-cover.ts` | `formatReport()`(순수) + `diffCover()`(조립·출력) | 신규 |
+| `src/index.ts` | 명령 등록(import·별칭맵·`.command()`) | 수정 |
+| `tests/diff-hunks.test.ts` `tests/coverage-parse.test.ts` `tests/diff-coverage.test.ts` `tests/diff-cover.test.ts` | 단위테스트 | 신규 |
+
+---
+
+## Task 1: coverage 인프라
+
+**Files:**
+- Modify: `package.json` (devDependencies)
+- Modify: `vitest.config.ts`
+
+- [ ] **Step 1: @vitest/coverage-v8 설치 (vitest와 동일 버전)**
+
+Run: `pnpm add -D @vitest/coverage-v8@4.1.7`
+Expected: package.json devDependencies에 `"@vitest/coverage-v8": "^4.1.7"` 추가, 설치 성공.
+
+- [ ] **Step 2: vitest.config.ts coverage 블록 추가**
+
+`vitest.config.ts` 전체를 아래로 교체:
+
+```ts
+import { defineConfig } from 'vitest/config'
+
+// vitest 기본 exclude 에 .claude/** 추가(워크트리 복사본 중복수집 차단).
+export default defineConfig({
+  test: {
+    exclude: ['**/node_modules/**', '**/dist/**', '**/.claude/**'],
+    // Goal 50 / RFC 0050: coverage 측정(차단 아님, 리포트+diff-cover 입력용).
+    coverage: {
+      provider: 'v8',
+      reporter: ['text-summary', 'json'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['dist/**', '.claude/**', 'tests/**', '**/*.config.*', 'src/**/*.d.ts', 'src/index.ts'],
+    },
+  },
+})
+```
+
+(`src/index.ts`는 CLI 엔트리·commander 배선이라 coverage 분모에서 제외 — diff-cover 대상도 src/commands·src/lib뿐.)
+
+- [ ] **Step 3: coverage 생성 확인**
+
+Run: `pnpm test:run --coverage`
+Expected: 전체 테스트 PASS + `coverage/coverage-final.json` 생성. 콘솔에 text-summary 표시.
+
+- [ ] **Step 4: coverage 산출물 gitignore 확인**
+
+Run: `git check-ignore coverage/coverage-final.json`
+Expected: `coverage/...` 출력(이미 무시됨). 안 되면 `.gitignore`에 `coverage/` 추가.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml vitest.config.ts .gitignore
+git commit -m "feat(goal-50): coverage 인프라 — @vitest/coverage-v8 + vitest.config v8 블록"
+```
+
+---
+
+## Task 2: git-session.diffUnified0 (라인번호 보존 diff)
+
+**Files:**
+- Modify: `src/lib/git-session.ts`
+- Test: `tests/git-session.test.ts`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/git-session.test.ts`의 마지막 `it(...)` 뒤(같은 describe 안)에 추가:
+
+```ts
+  it('diffUnified0 → git diff --unified=0 HEAD (raw 보존)', () => {
+    session.diffUnified0('/repo')
+    expect(lastBin()).toBe('git')
+    expect(lastArgv()).toEqual(['diff', '--unified=0', 'HEAD'])
+    // 헌트 헤더 라인번호 보존 위해 trimOutput:false.
+    expect(lastOpts()).toMatchObject({ cwd: '/repo', trimOutput: false })
+  })
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `pnpm test:run -- tests/git-session.test.ts`
+Expected: FAIL — `session.diffUnified0 is not a function`.
+
+- [ ] **Step 3: 구현**
+
+`src/lib/git-session.ts`의 `numstatHead` 함수 바로 뒤에 추가:
+
+```ts
+/** git diff --unified=0 HEAD — 헌트 헤더(@@ -a,b +c,d @@)로 추가 라인번호 추출용. raw 보존. */
+export function diffUnified0(cwd: string = process.cwd()): ExecResult {
+  return safeExecFile('git', ['diff', '--unified=0', 'HEAD'], { cwd, trimOutput: false })
+}
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `pnpm test:run -- tests/git-session.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/git-session.ts tests/git-session.test.ts
+git commit -m "feat(goal-50): git-session.diffUnified0 — 라인단위 diff (단일 SoT 확장)"
+```
+
+---
+
+## Task 3: diff-hunks.addedLinesByFile (순수 파서)
+
+**Files:**
+- Create: `src/lib/diff-hunks.ts`
+- Test: `tests/diff-hunks.test.ts`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/diff-hunks.test.ts` 생성:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { addedLinesByFile } from '../src/lib/diff-hunks.js'
+
+describe('addedLinesByFile — unified=0 diff → 기능소스별 추가 라인', () => {
+  it('단일 헌트(+c,d) 추가 라인을 c..c+d-1로 펼친다', () => {
+    const diff = [
+      'diff --git a/src/lib/foo.ts b/src/lib/foo.ts',
+      '--- a/src/lib/foo.ts',
+      '+++ b/src/lib/foo.ts',
+      '@@ -10,0 +11,3 @@',
+      '+a',
+      '+b',
+      '+c',
+    ].join('\n')
+    const m = addedLinesByFile(diff)
+    expect([...(m.get('src/lib/foo.ts') ?? [])]).toEqual([11, 12, 13])
+  })
+
+  it('count 생략형 @@ +c @@ = 1줄', () => {
+    const diff = 'diff --git a/src/lib/x.ts b/src/lib/x.ts\n+++ b/src/lib/x.ts\n@@ -5 +5 @@\n+one'
+    expect([...(addedLinesByFile(diff).get('src/lib/x.ts') ?? [])]).toEqual([5])
+  })
+
+  it('순수 삭제 헌트(+c,0)는 추가 0', () => {
+    const diff = 'diff --git a/src/lib/x.ts b/src/lib/x.ts\n+++ b/src/lib/x.ts\n@@ -5,3 +4,0 @@'
+    expect(addedLinesByFile(diff).has('src/lib/x.ts')).toBe(false)
+  })
+
+  it('한 파일 멀티헌트는 누적된다', () => {
+    const diff = [
+      'diff --git a/src/commands/c.ts b/src/commands/c.ts',
+      '+++ b/src/commands/c.ts',
+      '@@ -1,0 +1,1 @@',
+      '+x',
+      '@@ -10,0 +20,2 @@',
+      '+y',
+      '+z',
+    ].join('\n')
+    expect([...(addedLinesByFile(diff).get('src/commands/c.ts') ?? [])]).toEqual([1, 20, 21])
+  })
+
+  it('기능소스 아닌 파일(테스트·문서·tests/)은 무시', () => {
+    const diff = [
+      'diff --git a/docs/x.md b/docs/x.md\n+++ b/docs/x.md\n@@ -1,0 +1,1 @@\n+m',
+      'diff --git a/src/lib/x.test.ts b/src/lib/x.test.ts\n+++ b/src/lib/x.test.ts\n@@ -1,0 +1,1 @@\n+t',
+    ].join('\n')
+    expect(addedLinesByFile(diff).size).toBe(0)
+  })
+
+  it('삭제 파일(+++ /dev/null)은 무시', () => {
+    const diff = 'diff --git a/src/lib/g.ts b/src/lib/g.ts\n--- a/src/lib/g.ts\n+++ /dev/null\n@@ -1,2 +0,0 @@'
+    expect(addedLinesByFile(diff).size).toBe(0)
+  })
+
+  it('빈 diff → 빈 맵', () => {
+    expect(addedLinesByFile('').size).toBe(0)
+  })
+})
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `pnpm test:run -- tests/diff-hunks.test.ts`
+Expected: FAIL — `Cannot find module '../src/lib/diff-hunks.js'`.
+
+- [ ] **Step 3: 구현**
+
+`src/lib/diff-hunks.ts` 생성:
+
+```ts
+import { isFeatureSource, toPosix } from './test-mapping.js'
+
+/**
+ * `git diff --unified=0 HEAD` 텍스트 → 기능소스(src/commands·src/lib)별 추가 라인번호 집합.
+ * 순수 함수. 헌트 헤더(@@ -a,b +c,d @@)만으로 추가 라인을 계산한다(본문 +라인 셀 필요 없음, -U0이라 컨텍스트 0).
+ * 파일 경계는 `diff --git` 에서 리셋, 대상 파일은 `+++ b/<path>` 에서 확정(삭제=+++ /dev/null → 제외).
+ */
+export function addedLinesByFile(diffText: string): Map<string, Set<number>> {
+  const out = new Map<string, Set<number>>()
+  let curFile: string | null = null
+  for (const raw of diffText.split(/\r?\n/)) {
+    if (raw.startsWith('diff --git ')) {
+      curFile = null // 파일 경계 — 다음 +++ 로 다시 확정(binary/rename은 +++ 없음 → null 유지).
+      continue
+    }
+    const plus = raw.match(/^\+\+\+ (?:b\/)?(.+)$/)
+    if (plus) {
+      const path = plus[1].trim()
+      curFile = path !== '/dev/null' && isFeatureSource(path) ? toPosix(path) : null
+      continue
+    }
+    if (!curFile) continue
+    const hunk = raw.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/)
+    if (!hunk) continue
+    const start = Number(hunk[1])
+    const count = hunk[2] === undefined ? 1 : Number(hunk[2])
+    if (count <= 0) continue // 순수 삭제 헌트(+c,0).
+    const set = out.get(curFile) ?? new Set<number>()
+    for (let i = 0; i < count; i++) set.add(start + i)
+    out.set(curFile, set)
+  }
+  return out
+}
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `pnpm test:run -- tests/diff-hunks.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/diff-hunks.ts tests/diff-hunks.test.ts
+git commit -m "feat(goal-50): diff-hunks.addedLinesByFile — unified=0 diff 파서(순수)"
+```
+
+---
+
+## Task 4: coverage-parse.coveredLinesByFile (v8 json → 커버 라인)
+
+**Files:**
+- Create: `src/lib/coverage-parse.ts`
+- Test: `tests/coverage-parse.test.ts`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/coverage-parse.test.ts` 생성 (임시 파일에 v8 형식 json 써서 파싱 검증):
+
+```ts
+import { describe, it, expect, afterEach } from 'vitest'
+import { writeFileSync, rmSync, mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { coveredLinesByFile } from '../src/lib/coverage-parse.js'
+
+const dirs: string[] = []
+function tmpJson(obj: unknown): { jsonPath: string; cwd: string } {
+  const cwd = mkdtempSync(join(tmpdir(), 'covtest-'))
+  dirs.push(cwd)
+  const jsonPath = join(cwd, 'coverage-final.json')
+  writeFileSync(jsonPath, JSON.stringify(obj), 'utf-8')
+  return { jsonPath, cwd }
+}
+afterEach(() => { while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true }) })
+
+describe('coveredLinesByFile — v8 coverage-final.json → 커버 라인', () => {
+  it('s[k]>0 인 statement 의 start..end 라인만 커버로 펼친다', () => {
+    const { jsonPath, cwd } = tmpJson({
+      [join(cwd0(), 'src/lib/foo.ts')]: {
+        path: join(cwd0(), 'src/lib/foo.ts'),
+        statementMap: { '0': { start: { line: 1 }, end: { line: 1 } }, '1': { start: { line: 5 }, end: { line: 6 } } },
+        s: { '0': 3, '1': 0 },
+      },
+    })
+    function cwd0() { return cwd }
+    const m = coveredLinesByFile(jsonPath, cwd)
+    expect(m).not.toBeNull()
+    expect([...(m!.get('src/lib/foo.ts') ?? [])]).toEqual([1]) // 5,6은 s=0 → 미커버
+  })
+
+  it('리포트 파일 부재 → null (측정 불가, 빈 맵과 구분)', () => {
+    expect(coveredLinesByFile('/no/such/coverage-final.json', '/x')).toBeNull()
+  })
+
+  it('손상된 json → null', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'covtest-')); dirs.push(cwd)
+    const p = join(cwd, 'coverage-final.json'); writeFileSync(p, '{not json', 'utf-8')
+    expect(coveredLinesByFile(p, cwd)).toBeNull()
+  })
+
+  it('기능소스 아닌 파일(tests/·index.ts)은 제외', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'covtest-')); dirs.push(cwd)
+    const p = join(cwd, 'coverage-final.json')
+    writeFileSync(p, JSON.stringify({
+      [join(cwd, 'tests/a.test.ts')]: { path: join(cwd, 'tests/a.test.ts'), statementMap: { '0': { start: { line: 1 }, end: { line: 1 } } }, s: { '0': 1 } },
+    }), 'utf-8')
+    expect(coveredLinesByFile(p, cwd)!.size).toBe(0)
+  })
+})
+```
+
+> ⚠️ 위 첫 테스트의 `cwd0()` 호이스팅 회피가 지저분하므로 구현 단계에서 아래처럼 정리한다(객체 키를 변수로):
+> ```ts
+> it('s[k]>0 ...', () => {
+>   const cwd = mkdtempSync(join(tmpdir(), 'covtest-')); dirs.push(cwd)
+>   const abs = join(cwd, 'src/lib/foo.ts')
+>   const jsonPath = join(cwd, 'coverage-final.json')
+>   writeFileSync(jsonPath, JSON.stringify({ [abs]: { path: abs, statementMap: { '0': { start: { line: 1 }, end: { line: 1 } }, '1': { start: { line: 5 }, end: { line: 6 } } }, s: { '0': 3, '1': 0 } } }), 'utf-8')
+>   const m = coveredLinesByFile(jsonPath, cwd)
+>   expect([...(m!.get('src/lib/foo.ts') ?? [])]).toEqual([1])
+> })
+> ```
+> 실제 작성 시 이 정리본을 쓸 것(첫 블록의 `tmpJson`/`cwd0` 버전 폐기).
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `pnpm test:run -- tests/coverage-parse.test.ts`
+Expected: FAIL — 모듈 없음.
+
+- [ ] **Step 3: 구현**
+
+`src/lib/coverage-parse.ts` 생성:
+
+```ts
+import { existsSync, readFileSync } from 'node:fs'
+import { relative } from 'node:path'
+import { isFeatureSource, toPosix } from './test-mapping.js'
+
+interface V8FileCov {
+  path?: string
+  statementMap?: Record<string, { start: { line: number }; end: { line: number } }>
+  s?: Record<string, number>
+}
+
+/**
+ * v8 coverage-final.json → 기능소스(src/commands·src/lib)별 "실행된(커버된)" 라인 집합.
+ * - 리포트 파일 부재/손상 → null (측정 불가 — diff-coverage 가 "먼저 --coverage" 안내).
+ * - 리포트 존재 but 특정 파일 부재 → 그 파일은 맵에 없음(= 테스트가 import 안 함 → 전 라인 미커버로 처리됨).
+ * 경로: 절대경로 키 → cwd 상대 posix 정규화(git rel posix 와 매칭).
+ */
+export function coveredLinesByFile(jsonPath: string, cwd: string = process.cwd()): Map<string, Set<number>> | null {
+  if (!existsSync(jsonPath)) return null
+  let data: Record<string, V8FileCov>
+  try {
+    data = JSON.parse(readFileSync(jsonPath, 'utf-8')) as Record<string, V8FileCov>
+  } catch {
+    return null
+  }
+  const out = new Map<string, Set<number>>()
+  for (const [absKey, cov] of Object.entries(data)) {
+    const rel = toPosix(relative(cwd, cov.path ?? absKey))
+    if (!isFeatureSource(rel)) continue
+    const set = new Set<number>()
+    const sMap = cov.statementMap ?? {}
+    const counts = cov.s ?? {}
+    for (const [k, stmt] of Object.entries(sMap)) {
+      if ((counts[k] ?? 0) > 0) {
+        for (let l = stmt.start.line; l <= stmt.end.line; l++) set.add(l)
+      }
+    }
+    out.set(rel, set)
+  }
+  return out
+}
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `pnpm test:run -- tests/coverage-parse.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/coverage-parse.ts tests/coverage-parse.test.ts
+git commit -m "feat(goal-50): coverage-parse.coveredLinesByFile — v8 json 파싱(부재≠빈맵)"
+```
+
+---
+
+## Task 5: diff-coverage.diffCoverage (순수 교차)
+
+**Files:**
+- Create: `src/lib/diff-coverage.ts`
+- Test: `tests/diff-coverage.test.ts`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/diff-coverage.test.ts` 생성:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { diffCoverage } from '../src/lib/diff-coverage.js'
+
+const set = (...n: number[]) => new Set(n)
+
+describe('diffCoverage — 추가라인 ∩ 커버라인 교차', () => {
+  it('커버된/미커버 추가라인을 분리하고 비율 계산', () => {
+    const added = new Map([['src/lib/a.ts', set(1, 2, 3, 4)]])
+    const covered = new Map([['src/lib/a.ts', set(1, 2)]])
+    const r = diffCoverage(added, covered)
+    const f = r.files[0]
+    expect(f).toMatchObject({ file: 'src/lib/a.ts', added: 4, covered: 2, uncoveredNew: [3, 4], inCoverage: true })
+    expect(f.ratio).toBeCloseTo(0.5)
+    expect(r).toMatchObject({ totalAdded: 4, totalCovered: 2, totalUncovered: 2 })
+  })
+
+  it('커버리지에 부재한 파일 = 전 라인 미검증 + inCoverage:false', () => {
+    const added = new Map([['src/lib/new.ts', set(10, 11)]])
+    const covered = new Map<string, Set<number>>() // 리포트엔 있으나 이 파일 없음
+    const f = diffCoverage(added, covered).files[0]
+    expect(f).toMatchObject({ added: 2, covered: 0, uncoveredNew: [10, 11], inCoverage: false, ratio: 0 })
+  })
+
+  it('covered=null(리포트 자체 없음)도 안전 — 전 라인 미검증', () => {
+    const r = diffCoverage(new Map([['src/lib/a.ts', set(1)]]), null)
+    expect(r.files[0]).toMatchObject({ covered: 0, uncoveredNew: [1], inCoverage: false })
+  })
+
+  it('변경 없음 → 빈 결과, 총비율 1', () => {
+    const r = diffCoverage(new Map(), new Map())
+    expect(r).toMatchObject({ files: [], totalAdded: 0, totalUncovered: 0, ratio: 1 })
+  })
+
+  it('파일은 이름순, 라인은 오름차순 정렬(결정성)', () => {
+    const added = new Map([['src/lib/z.ts', set(2, 1)], ['src/commands/a.ts', set(5)]])
+    const r = diffCoverage(added, new Map())
+    expect(r.files.map((f) => f.file)).toEqual(['src/commands/a.ts', 'src/lib/z.ts'])
+    expect(r.files[1].uncoveredNew).toEqual([1, 2])
+  })
+})
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `pnpm test:run -- tests/diff-coverage.test.ts`
+Expected: FAIL — 모듈 없음.
+
+- [ ] **Step 3: 구현**
+
+`src/lib/diff-coverage.ts` 생성:
+
+```ts
+export interface FileDiffCoverage {
+  file: string
+  added: number
+  covered: number
+  uncoveredNew: number[]
+  ratio: number // added===0 ? 1 : covered/added
+  inCoverage: boolean // 커버리지 리포트에 이 파일이 존재했나(false = 테스트가 import 안 함)
+}
+
+export interface DiffCoverageResult {
+  files: FileDiffCoverage[]
+  totalAdded: number
+  totalCovered: number
+  totalUncovered: number
+  ratio: number
+}
+
+/**
+ * 추가라인 맵 ∩ 커버라인 맵 → 파일별 미검증 변경분(순수). fs/시간 부수효과 0.
+ * @param covered 커버라인 맵 또는 null(리포트 자체 부재 — 전 라인 미검증으로 처리, 호출부가 별도 안내).
+ */
+export function diffCoverage(
+  added: Map<string, Set<number>>,
+  covered: Map<string, Set<number>> | null
+): DiffCoverageResult {
+  const files: FileDiffCoverage[] = []
+  let totalAdded = 0
+  let totalCovered = 0
+  const sortedFiles = [...added.entries()].sort((a, b) => a[0].localeCompare(b[0]))
+  for (const [file, addedLines] of sortedFiles) {
+    const cov = covered?.get(file) ?? null
+    const inCoverage = cov !== null
+    const uncoveredNew: number[] = []
+    let cnt = 0
+    for (const ln of [...addedLines].sort((a, b) => a - b)) {
+      if (cov && cov.has(ln)) cnt++
+      else uncoveredNew.push(ln)
+    }
+    const addedN = addedLines.size
+    files.push({ file, added: addedN, covered: cnt, uncoveredNew, ratio: addedN === 0 ? 1 : cnt / addedN, inCoverage })
+    totalAdded += addedN
+    totalCovered += cnt
+  }
+  return {
+    files,
+    totalAdded,
+    totalCovered,
+    totalUncovered: totalAdded - totalCovered,
+    ratio: totalAdded === 0 ? 1 : totalCovered / totalAdded,
+  }
+}
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `pnpm test:run -- tests/diff-coverage.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/diff-coverage.ts tests/diff-coverage.test.ts
+git commit -m "feat(goal-50): diff-coverage.diffCoverage — 미검증 변경분 교차(순수)"
+```
+
+---
+
+## Task 6: diff-cover 명령 + 등록
+
+**Files:**
+- Create: `src/commands/diff-cover.ts`
+- Modify: `src/index.ts`
+- Test: `tests/diff-cover.test.ts`
+
+- [ ] **Step 1: formatReport 실패 테스트 작성**
+
+`tests/diff-cover.test.ts` 생성 (출력은 순수 `formatReport`로 테스트, IO는 스모크로):
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { formatReport } from '../src/commands/diff-cover.js'
+import type { DiffCoverageResult } from '../src/lib/diff-coverage.js'
+
+describe('formatReport — diff-coverage 결과 → 표시 라인(순수)', () => {
+  it('미검증 변경분 있으면 파일별 미커버 라인 표시', () => {
+    const r: DiffCoverageResult = {
+      files: [{ file: 'src/lib/a.ts', added: 4, covered: 2, uncoveredNew: [3, 4], ratio: 0.5, inCoverage: true }],
+      totalAdded: 4, totalCovered: 2, totalUncovered: 2, ratio: 0.5,
+    }
+    const out = formatReport(r).join('\n')
+    expect(out).toContain('src/lib/a.ts')
+    expect(out).toContain('3, 4') // 미커버 라인번호
+    expect(out).toContain('2/4') // 또는 50%
+  })
+
+  it('전부 커버되면 축하 라인', () => {
+    const r: DiffCoverageResult = {
+      files: [{ file: 'src/lib/a.ts', added: 2, covered: 2, uncoveredNew: [], ratio: 1, inCoverage: true }],
+      totalAdded: 2, totalCovered: 2, totalUncovered: 0, ratio: 1,
+    }
+    expect(formatReport(r).join('\n')).toMatch(/모두|✅|100/)
+  })
+
+  it('inCoverage:false 파일은 "테스트 미import" 힌트', () => {
+    const r: DiffCoverageResult = {
+      files: [{ file: 'src/lib/new.ts', added: 2, covered: 0, uncoveredNew: [1, 2], ratio: 0, inCoverage: false }],
+      totalAdded: 2, totalCovered: 0, totalUncovered: 2, ratio: 0,
+    }
+    expect(formatReport(r).join('\n')).toMatch(/import|테스트 안|미import/)
+  })
+})
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `pnpm test:run -- tests/diff-cover.test.ts`
+Expected: FAIL — 모듈/`formatReport` 없음.
+
+- [ ] **Step 3: 명령 구현**
+
+`src/commands/diff-cover.ts` 생성:
+
+```ts
+import { join } from 'node:path'
+import chalk from 'chalk'
+import { safeExecFile } from '../lib/exec.js'
+import { diffUnified0 } from '../lib/git-session.js'
+import { addedLinesByFile } from '../lib/diff-hunks.js'
+import { coveredLinesByFile } from '../lib/coverage-parse.js'
+import { diffCoverage, type DiffCoverageResult } from '../lib/diff-coverage.js'
+import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
+
+const COVERAGE_JSON_REL = 'coverage/coverage-final.json'
+
+/** diff-coverage 결과 → 표시 라인(순수, chalk 없음 — 테스트 용이). */
+export function formatReport(r: DiffCoverageResult): string[] {
+  const lines: string[] = []
+  if (r.totalUncovered === 0) {
+    lines.push('✅ 이번 변경의 모든 추가 라인이 테스트로 커버됨 (미검증 변경분 0).')
+    return lines
+  }
+  const pct = Math.round(r.ratio * 100)
+  lines.push(`미검증 변경분 ${r.totalUncovered}라인 / 추가 ${r.totalAdded}라인 (커버 ${pct}%)`)
+  for (const f of r.files) {
+    if (f.uncoveredNew.length === 0) continue
+    const hint = f.inCoverage ? '' : '  ← 테스트가 이 파일을 import 안 함(전부 미검증)'
+    lines.push(`  ${f.file}: 미커버 ${f.uncoveredNew.length}/${f.added} → 라인 ${f.uncoveredNew.join(', ')}${hint}`)
+  }
+  return lines
+}
+
+/**
+ * vhk diff-cover — HEAD 대비 변경된 기능소스가 테스트로 실행됐나 측정(자문형·차단 0).
+ * 측정 결과(미검증 변경분 존재)로는 exit 1 안 함. 운영 전제 실패(저장소 아님/리포트 없음)만 exit 1.
+ */
+export async function diffCover(): Promise<void> {
+  if (!ensureNotHardStopped('diff-cover')) return
+  const cwd = process.cwd()
+
+  console.log(chalk.bold('\n🔬 diff-coverage — 이번 변경이 테스트로 닿았나'))
+  console.log(chalk.gray('─'.repeat(44)))
+
+  if (!safeExecFile('git', ['rev-parse', '--is-inside-work-tree'], { cwd }).ok) {
+    console.error(chalk.red('  ❌ git 저장소가 아닙니다.'))
+    process.exitCode = 1
+    return
+  }
+
+  const diffRes = diffUnified0(cwd)
+  const added = addedLinesByFile(diffRes.ok ? diffRes.out : '')
+  if (added.size === 0) {
+    console.log(chalk.green('\n  ✅ HEAD 대비 변경된 기능소스(src/commands·src/lib) 없음 — 측정 대상 없음.'))
+    return
+  }
+
+  const covPath = join(cwd, COVERAGE_JSON_REL)
+  const covered = coveredLinesByFile(covPath, cwd)
+  if (covered === null) {
+    console.error(chalk.yellow(`\n  ⚠️  커버리지 리포트 없음(${COVERAGE_JSON_REL}). 먼저 생성하세요:`))
+    console.error(chalk.cyan('     pnpm test:run --coverage'))
+    process.exitCode = 1
+    return
+  }
+
+  const result = diffCoverage(added, covered)
+  const out = formatReport(result)
+  const color = result.totalUncovered === 0 ? chalk.green : chalk.yellow
+  console.log('\n' + out.map((l) => color(l)).join('\n'))
+  console.log(chalk.dim('\n  ℹ️  자문형(advisory) — 차단하지 않습니다. 미검증 변경분은 테스트 보강을 권장하는 신호입니다.'))
+  // 측정 결과로는 exit 0 유지(advisory).
+}
+```
+
+- [ ] **Step 4: formatReport 통과 확인**
+
+Run: `pnpm test:run -- tests/diff-cover.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: index.ts 등록 (import)**
+
+`src/index.ts` 상단 import 블록(약 line 20, `import { diff } from './commands/diff.js'` 근처)에 추가:
+
+```ts
+import { diffCover } from './commands/diff-cover.js'
+```
+
+- [ ] **Step 6: index.ts 등록 (별칭 맵)**
+
+별칭 맵(약 line 135, `diff: '변경',` 줄 아래)에 추가:
+
+```ts
+  'diff-cover': '커버리지',
+```
+
+- [ ] **Step 7: index.ts 등록 (명령 정의)**
+
+`.command('diff')...action(diff)` 블록(약 line 343) 바로 뒤에 추가:
+
+```ts
+program
+  .command('diff-cover')
+  .alias('커버리지')
+  .description('이번 변경(HEAD 대비)이 테스트로 커버됐는지 측정 (자문형·차단 없음)')
+  .action(async () => { await diffCover() })
+```
+
+- [ ] **Step 8: 빌드 + 전체 게이트**
+
+Run: `pnpm build; pnpm typecheck; pnpm lint; pnpm test:run`
+Expected: 전부 통과, 회귀 0.
+
+- [ ] **Step 9: 실제 CLI 스모크**
+
+Run: `node dist/index.js diff-cover`
+Expected: coverage 리포트 있으면 "변경 없음" 또는 미검증 변경분 보고. 리포트 없으면 "먼저 --coverage" 안내. (정상 동작 = exit 0/1 적절.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/commands/diff-cover.ts src/index.ts tests/diff-cover.test.ts
+git commit -m "feat(goal-50): vhk diff-cover 자문 명령 — 미검증 변경분 보고(차단 0)"
+```
+
+---
+
+## Task 7: 도그푸딩 실측 + Goal 50 카드 정합 + dev log
+
+**Files:**
+- Modify: `goals/50-coverage-diff-gate.md`
+- Create: `docs/log/2026-06-XX-diff-coverage.md` (실제 날짜)
+
+- [ ] **Step 1: 도그푸딩 측정 (코드 diff에)**
+
+이 PR1의 src 변경 자체에 대해 `pnpm test:run --coverage; node dist/index.js diff-cover` 실행.
+기록: 미검증 변경분 라인 수 / 추가 라인 수 / 비율. (RFC §5 PR2 결정 입력 — 단일 표본임을 명시, 며칠 누적 필요.)
+
+- [ ] **Step 2: Goal 50 카드 정합 갱신**
+
+`goals/50-coverage-diff-gate.md` Completion Check에서 `diff-coverage(신규분 차단) 도입` 항목 옆에 표기 추가:
+
+```md
+- [ ] diff-coverage(신규분 차단) 도입 — **PR1=측정(vhk diff-cover, 차단 0)**, 차단은 PR2(RFC 0050 §5 승격 시)
+```
+
+`status`는 PR1 머지 후 별도 판단(전 항목 충족 아니므로 IN_PROGRESS 유지).
+
+- [ ] **Step 3: dev log 작성 (append-only)**
+
+`docs/log/<날짜>-diff-coverage.md` 생성 — 한 일(PR1 모듈·명령), 실측치, RFC 0050 링크, PR2 결정 보류(표본 부족).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add goals/50-coverage-diff-gate.md docs/log/*-diff-coverage.md
+git commit -m "docs(goal-50): diff-cover 도그푸딩 실측 + 카드 정합 + dev log"
+```
+
+- [ ] **Step 5: PR 생성**
+
+```bash
+git push -u origin feat/diff-coverage
+```
+PR 본문은 Write로 임시 .md 작성 후 `gh pr create --body-file`(PS5.1 here-string 회피). CI green 확인 후 squash 머지.
+
+---
+
+## Self-Review (작성자 점검 — 완료)
+
+**1. Spec coverage:** RFC §4 PR1 스코프 5항목 전부 매핑 — coverage 인프라(T1) · 순수 3모듈+git-session(T2~5) · diff-cover 자문(T6) · 도그푸딩(T7). §8 수용기준 5개 전부 태스크 존재(coverage 생성 T1S3 · 정확보고 T3~6 · 매칭0 경고 = coverage-parse null/diffCoverage inCoverage · 게이트 T6S8 · 실측 T7).
+**2. Placeholder scan:** 모든 코드 스텝에 실제 코드. coverage-parse 첫 테스트의 호이스팅 지저분함은 정리본 명시.
+**3. Type consistency:** `addedLinesByFile`/`coveredLinesByFile`/`diffCoverage`/`formatReport` 시그니처가 다이어그램·모듈·테스트·command에서 일관. `DiffCoverageResult`/`FileDiffCoverage` 필드(added/covered/uncoveredNew/ratio/inCoverage)가 T5 정의 ↔ T6 사용 일치.
+**4. 경로 정규화 리스크:** RFC §7대로 `relative(cwd, abs)+toPosix`. 매칭 0건이면 `inCoverage:false`로 드러남(조용한 100% 아님). 윈도우 realpath 강화는 스모크(T6S9)에서 매칭 실패 관측 시 적용.

--- a/goals/50-coverage-diff-gate.md
+++ b/goals/50-coverage-diff-gate.md
@@ -3,7 +3,7 @@ vhk_format: 1
 type: goal
 id: 50
 title: 커버리지 측정 + diff-coverage 게이트 — 미검증 경로 가시화 — P1
-status: NOT_STARTED
+status: IN_PROGRESS
 priority: P1
 created: 2026-06-08
 leads_to: 테스트 4→5 · 1162 pass에 분모 부여
@@ -27,11 +27,13 @@ leads_to: 테스트 4→5 · 1162 pass에 분모 부여
 - `pnpm test:run --coverage`로 커버리지 리포트 생성, CI에 노출. 신규분 게이트 동작(임계 강제 아님).
 
 ## Completion Check
-- [ ] @vitest/coverage-v8 추가 + vitest.config coverage 블록
-- [ ] 커버리지 리포트 CI Summary 노출
-- [ ] diff-coverage(신규분 차단) 도입
-- [ ] 공통 게이트 통과, 회귀 0
-- [ ] check-goal-50.mjs 통과
+- [x] @vitest/coverage-v8 추가 + vitest.config coverage 블록 (PR1)
+- [ ] 커버리지 리포트 CI Summary 노출 — **PR2/CI**
+- [x] diff-coverage **측정** 도입 (`vhk diff-cover`, 자문형·차단 0, PR1) — **차단은 PR2**(RFC 0050 §5 승격 시)
+- [x] 공통 게이트 통과, 회귀 0 (PR1)
+- [ ] check-goal-50.mjs 통과 — **PR2**(게이트 스크립트는 차단 도입과 함께)
+
+> **PR 분할(RFC 0050)**: PR1 = 측정(coverage 인프라 + 순수 3모듈 + `vhk diff-cover` 자문). 차단/review 통합/CI는 PR1 도그푸딩 실측이 정당화하면 PR2(measure-first). 카드의 "신규분 차단" 원문은 PR2로 미룸.
 
 ## Mandatory Reading
 - vitest.config.ts · package.json(devDeps) · .github/workflows/ci.yml

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   "devDependencies": {
     "@types/inquirer": "^9.0.9",
     "@types/node": "^25.9.1",
+    "@vitest/coverage-v8": "^4.1.7",
     "eslint": "^10.4.1",
     "fast-check": "^4.8.0",
     "ignore": "^7.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
+      '@vitest/coverage-v8':
+        specifier: ^4.1.7
+        version: 4.1.7(vitest@4.1.7)
       eslint:
         specifier: ^10.4.1
         version: 10.4.1
@@ -267,9 +270,30 @@ importers:
         version: 8.60.1(eslint@10.4.1)(typescript@6.0.3)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
 
 packages:
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -1037,6 +1061,15 @@ packages:
     resolution: {integrity: sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/coverage-v8@4.1.7':
+    resolution: {integrity: sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==}
+    peerDependencies:
+      '@vitest/browser': 4.1.7
+      vitest: 4.1.7
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.7':
     resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
 
@@ -1116,6 +1149,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.3:
+    resolution: {integrity: sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -1500,6 +1536,9 @@ packages:
     resolution: {integrity: sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==}
     engines: {node: '>=16.9.0'}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -1572,12 +1611,27 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -1700,6 +1754,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2304,6 +2365,21 @@ packages:
 
 snapshots:
 
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -2848,6 +2924,20 @@ snapshots:
       '@typescript-eslint/types': 8.60.1
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/coverage-v8@4.1.7(vitest@4.1.7)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.7
+      ast-v8-to-istanbul: 1.0.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+
   '@vitest/expect@4.1.7':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2933,6 +3023,12 @@ snapshots:
   any-promise@1.3.0: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.3:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   balanced-match@4.0.4: {}
 
@@ -3371,6 +3467,8 @@ snapshots:
 
   hono@4.12.22: {}
 
+  html-escaper@2.0.2: {}
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -3434,9 +3532,24 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jose@6.2.3: {}
 
   joycon@3.1.1: {}
+
+  js-tokens@10.0.0: {}
 
   json-buffer@3.0.1: {}
 
@@ -3529,6 +3642,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.2
 
   math-intrinsics@1.1.0: {}
 
@@ -4046,7 +4169,7 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.22.3
 
-  vitest@4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)):
+  vitest@4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
@@ -4070,6 +4193,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
+      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
     transitivePeerDependencies:
       - msw
 

--- a/src/commands/diff-cover.ts
+++ b/src/commands/diff-cover.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 import { safeExecFile } from '../lib/exec.js'
 import { diffUnified0 } from '../lib/git-session.js'
 import { addedLinesByFile } from '../lib/diff-hunks.js'
-import { coveredLinesByFile } from '../lib/coverage-parse.js'
+import { fileCoverageByFile } from '../lib/coverage-parse.js'
 import { diffCoverage, type DiffCoverageResult } from '../lib/diff-coverage.js'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
 
@@ -51,7 +51,7 @@ export async function diffCover(): Promise<void> {
   }
 
   const covPath = join(cwd, COVERAGE_JSON_REL)
-  const covered = coveredLinesByFile(covPath, cwd)
+  const covered = fileCoverageByFile(covPath, cwd)
   if (covered === null) {
     console.error(chalk.yellow(`\n  ⚠️  커버리지 리포트 없음(${COVERAGE_JSON_REL}). 먼저 생성하세요:`))
     console.error(chalk.cyan('     pnpm test:run --coverage'))

--- a/src/commands/diff-cover.ts
+++ b/src/commands/diff-cover.ts
@@ -1,0 +1,70 @@
+import { join } from 'node:path'
+import chalk from 'chalk'
+import { safeExecFile } from '../lib/exec.js'
+import { diffUnified0 } from '../lib/git-session.js'
+import { addedLinesByFile } from '../lib/diff-hunks.js'
+import { coveredLinesByFile } from '../lib/coverage-parse.js'
+import { diffCoverage, type DiffCoverageResult } from '../lib/diff-coverage.js'
+import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
+
+const COVERAGE_JSON_REL = 'coverage/coverage-final.json'
+
+/** diff-coverage 결과 → 표시 라인(순수, chalk 없음 — 테스트 용이). */
+export function formatReport(r: DiffCoverageResult): string[] {
+  const lines: string[] = []
+  if (r.totalUncovered === 0) {
+    lines.push('✅ 이번 변경의 모든 추가 라인이 테스트로 커버됨 (미검증 변경분 0).')
+    return lines
+  }
+  const pct = Math.round(r.ratio * 100)
+  lines.push(`미검증 변경분 ${r.totalUncovered}라인 / 추가 ${r.totalAdded}라인 (커버 ${pct}%)`)
+  for (const f of r.files) {
+    if (f.uncoveredNew.length === 0) continue
+    const hint = f.inCoverage ? '' : '  ← 테스트가 이 파일을 import 안 함(전부 미검증)'
+    lines.push(`  ${f.file}: 미커버 ${f.uncoveredNew.length}/${f.added} → 라인 ${f.uncoveredNew.join(', ')}${hint}`)
+  }
+  return lines
+}
+
+/**
+ * vhk diff-cover — HEAD 대비 변경된 기능소스가 테스트로 실행됐나 측정(자문형·차단 0).
+ * 측정 결과(미검증 변경분 존재)로는 exit 1 안 함. 운영 전제 실패(저장소 아님/리포트 없음)만 exit 1.
+ */
+export async function diffCover(): Promise<void> {
+  if (!ensureNotHardStopped('diff-cover')) return
+  const cwd = process.cwd()
+
+  console.log(chalk.bold('\n🔬 diff-coverage — 이번 변경이 테스트로 닿았나'))
+  console.log(chalk.gray('─'.repeat(44)))
+
+  if (!safeExecFile('git', ['rev-parse', '--is-inside-work-tree'], { cwd }).ok) {
+    console.error(chalk.red('  ❌ git 저장소가 아닙니다.'))
+    process.exitCode = 1
+    return
+  }
+
+  const diffRes = diffUnified0(cwd)
+  const added = addedLinesByFile(diffRes.ok ? diffRes.out : '')
+  if (added.size === 0) {
+    console.log(chalk.green('\n  ✅ HEAD 대비 변경된 기능소스(src/commands·src/lib) 없음 — 측정 대상 없음.'))
+    return
+  }
+
+  const covPath = join(cwd, COVERAGE_JSON_REL)
+  const covered = coveredLinesByFile(covPath, cwd)
+  if (covered === null) {
+    console.error(chalk.yellow(`\n  ⚠️  커버리지 리포트 없음(${COVERAGE_JSON_REL}). 먼저 생성하세요:`))
+    console.error(chalk.cyan('     pnpm test:run --coverage'))
+    process.exitCode = 1
+    return
+  }
+
+  const result = diffCoverage(added, covered)
+  const out = formatReport(result)
+  const color = result.totalUncovered === 0 ? chalk.green : chalk.yellow
+  console.log('\n' + out.map((l) => color(l)).join('\n'))
+  console.log(
+    chalk.dim('\n  ℹ️  자문형(advisory) — 차단하지 않습니다. 미검증 변경분은 테스트 보강을 권장하는 신호입니다.')
+  )
+  // 측정 결과로는 exit 0 유지(advisory).
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { save } from './commands/save.js'
 import { undo } from './commands/undo.js'
 import { restore } from './commands/restore.js'
 import { diff } from './commands/diff.js'
+import { diffCover } from './commands/diff-cover.js'
 import { status } from './commands/status.js'
 import { startMcpServer } from './mcp/server.js'
 import { mcpInit } from './commands/mcp-init.js'
@@ -133,6 +134,7 @@ const KO_ALIASES: Record<string, string> = {
   restore: '복원',
   status: '상태',
   diff: '변경',
+  'diff-cover': '커버리지',
   deploy: '배포',
   env: '환경변수',
   'env-check': '환경변수점검',
@@ -341,6 +343,12 @@ program
   .alias('차이')
   .description('Git 변경사항 한국어 요약 (staged / unstaged / 새 파일)')
   .action(diff)
+
+program
+  .command('diff-cover')
+  .alias('커버리지')
+  .description('이번 변경(HEAD 대비)이 테스트로 커버됐는지 측정 (자문형·차단 없음)')
+  .action(async () => { await diffCover() })
 
 program
   .command('mcp')

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -17,6 +17,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'restore', '복원',
   'status', '상태', '현황',
   'diff', '변경', '차이',
+  'diff-cover', '커버리지',
   'mcp',
   'mcp-init', 'mcp설정',
   'deploy', '배포',

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -67,6 +67,7 @@ export const TOP_LEVEL_COMMANDS: ReadonlyArray<{ name: string; desc: string }> =
   { name: 'restore', desc: 'sync 백업 복원' },
   { name: 'status', desc: '프로젝트 상태 대시보드' },
   { name: 'diff', desc: 'Git 변경사항 한국어 요약' },
+  { name: 'diff-cover', desc: '이번 변경이 테스트로 커버됐는지 측정 (자문형)' },
   { name: 'mcp', desc: 'MCP 서버 시작 (stdio)' },
   { name: 'mcp-init', desc: 'Cursor·Claude Desktop MCP 설정 생성' },
   { name: 'deploy', desc: '프로덕션 배포 (자동 감지)' },

--- a/src/lib/coverage-parse.ts
+++ b/src/lib/coverage-parse.ts
@@ -1,0 +1,45 @@
+import { existsSync } from 'node:fs'
+import { relative } from 'node:path'
+import { isFeatureSource, toPosix } from './test-mapping.js'
+import { readJsonFile } from './read-json.js'
+
+interface V8FileCov {
+  path?: string
+  statementMap?: Record<string, { start: { line: number }; end: { line: number } }>
+  s?: Record<string, number>
+}
+
+/**
+ * v8 coverage-final.json → 기능소스(src/commands·src/lib)별 "실행된(커버된)" 라인 집합.
+ * - 리포트 파일 부재/손상 → null (측정 불가 — diff-cover 가 "먼저 --coverage" 안내).
+ * - 리포트 존재 but 특정 파일 부재 → 그 파일은 맵에 없음(= 테스트가 import 안 함 → 전 라인 미커버로 처리됨).
+ * 경로: 절대경로 키 → cwd 상대 posix 정규화(git rel posix 와 매칭).
+ */
+export function coveredLinesByFile(
+  jsonPath: string,
+  cwd: string = process.cwd()
+): Map<string, Set<number>> | null {
+  if (!existsSync(jsonPath)) return null
+  let data: Record<string, V8FileCov>
+  try {
+    // 프로젝트 단일 JSON 통로(BOM 처리 + raw JSON.parse 가드 회피).
+    data = readJsonFile<Record<string, V8FileCov>>(jsonPath)
+  } catch {
+    return null
+  }
+  const out = new Map<string, Set<number>>()
+  for (const [absKey, cov] of Object.entries(data)) {
+    const rel = toPosix(relative(cwd, cov.path ?? absKey))
+    if (!isFeatureSource(rel)) continue
+    const set = new Set<number>()
+    const sMap = cov.statementMap ?? {}
+    const counts = cov.s ?? {}
+    for (const [k, stmt] of Object.entries(sMap)) {
+      if ((counts[k] ?? 0) > 0) {
+        for (let l = stmt.start.line; l <= stmt.end.line; l++) set.add(l)
+      }
+    }
+    out.set(rel, set)
+  }
+  return out
+}

--- a/src/lib/coverage-parse.ts
+++ b/src/lib/coverage-parse.ts
@@ -9,16 +9,25 @@ interface V8FileCov {
   s?: Record<string, number>
 }
 
+export interface FileCoverage {
+  /** s[k]>0 인 statement 의 라인 — 실제 실행된 라인. */
+  covered: Set<number>
+  /** statementMap 의 모든 라인 — 실행가능(코드) 라인. import/주석/타입/빈줄/중괄호는 제외(노이즈 차단). */
+  executable: Set<number>
+}
+
 /**
- * v8 coverage-final.json → 기능소스(src/commands·src/lib)별 "실행된(커버된)" 라인 집합.
+ * v8 coverage-final.json → 기능소스(src/commands·src/lib)별 {커버된 라인, 실행가능 라인}.
  * - 리포트 파일 부재/손상 → null (측정 불가 — diff-cover 가 "먼저 --coverage" 안내).
- * - 리포트 존재 but 특정 파일 부재 → 그 파일은 맵에 없음(= 테스트가 import 안 함 → 전 라인 미커버로 처리됨).
+ * - 리포트 존재 but 특정 파일 부재 → 맵에 없음(= 테스트가 import 안 함 → diff-coverage 가 coarse 처리).
+ * executable 을 따로 노출하는 이유: "미검증 변경분"은 *실행가능* 추가라인 중 미커버만 세야 한다.
+ * 비실행 라인(import·주석·타입·중괄호)까지 세면 false-completion 신호가 노이즈에 묻힘(도그푸딩이 잡은 결함).
  * 경로: 절대경로 키 → cwd 상대 posix 정규화(git rel posix 와 매칭).
  */
-export function coveredLinesByFile(
+export function fileCoverageByFile(
   jsonPath: string,
   cwd: string = process.cwd()
-): Map<string, Set<number>> | null {
+): Map<string, FileCoverage> | null {
   if (!existsSync(jsonPath)) return null
   let data: Record<string, V8FileCov>
   try {
@@ -27,19 +36,22 @@ export function coveredLinesByFile(
   } catch {
     return null
   }
-  const out = new Map<string, Set<number>>()
+  const out = new Map<string, FileCoverage>()
   for (const [absKey, cov] of Object.entries(data)) {
     const rel = toPosix(relative(cwd, cov.path ?? absKey))
     if (!isFeatureSource(rel)) continue
-    const set = new Set<number>()
+    const covered = new Set<number>()
+    const executable = new Set<number>()
     const sMap = cov.statementMap ?? {}
     const counts = cov.s ?? {}
     for (const [k, stmt] of Object.entries(sMap)) {
-      if ((counts[k] ?? 0) > 0) {
-        for (let l = stmt.start.line; l <= stmt.end.line; l++) set.add(l)
+      const hit = (counts[k] ?? 0) > 0
+      for (let l = stmt.start.line; l <= stmt.end.line; l++) {
+        executable.add(l)
+        if (hit) covered.add(l)
       }
     }
-    out.set(rel, set)
+    out.set(rel, { covered, executable })
   }
   return out
 }

--- a/src/lib/diff-coverage.ts
+++ b/src/lib/diff-coverage.ts
@@ -1,10 +1,13 @@
+import type { FileCoverage } from './coverage-parse.js'
+
 export interface FileDiffCoverage {
   file: string
+  /** 분모 — *실행가능* 추가라인 수(inCoverage 시). 비실행(주석·import·타입)은 제외. 부재 파일은 전 추가라인. */
   added: number
   covered: number
   uncoveredNew: number[]
   ratio: number // added===0 ? 1 : covered/added
-  inCoverage: boolean // 커버리지 리포트에 이 파일이 존재했나(false = 테스트가 import 안 함)
+  inCoverage: boolean // 커버리지 리포트에 이 파일이 존재했나(false = 테스트가 import 안 함 → coarse)
 }
 
 export interface DiffCoverageResult {
@@ -16,27 +19,34 @@ export interface DiffCoverageResult {
 }
 
 /**
- * 추가라인 맵 ∩ 커버라인 맵 → 파일별 미검증 변경분(순수). fs/시간 부수효과 0.
- * @param covered 커버라인 맵 또는 null(리포트 자체 부재 — 전 라인 미검증으로 처리, 호출부가 별도 안내).
+ * 추가라인 맵 ∩ 커버리지 → 파일별 미검증 변경분(순수). fs/시간 부수효과 0.
+ * "미검증 변경분"은 **실행가능 추가라인 중 미커버**만 센다(비실행 라인은 분모에서 제외 — 도그푸딩이 잡은 노이즈 결함).
+ * @param coverage 파일별 {covered, executable} 맵, 또는 null(리포트 자체 부재).
+ *   - 파일이 맵에 있으면(inCoverage): 분모 = 추가라인 ∩ executable, 미커버 = 그중 covered 아님.
+ *   - 파일이 맵에 없거나 coverage=null(inCoverage:false): 실행가능 판별 불가 → 전 추가라인을 coarse 미검증으로(플래그로 구분).
  */
 export function diffCoverage(
   added: Map<string, Set<number>>,
-  covered: Map<string, Set<number>> | null
+  coverage: Map<string, FileCoverage> | null
 ): DiffCoverageResult {
   const files: FileDiffCoverage[] = []
   let totalAdded = 0
   let totalCovered = 0
   const sortedFiles = [...added.entries()].sort((a, b) => a[0].localeCompare(b[0]))
-  for (const [file, addedLines] of sortedFiles) {
-    const cov = covered?.get(file) ?? null
-    const inCoverage = cov !== null
+  for (const [file, addedLinesRaw] of sortedFiles) {
+    const fc = coverage?.get(file) ?? null
+    const inCoverage = fc !== null
+    const addedSorted = [...addedLinesRaw].sort((a, b) => a - b)
+
+    // 실행가능 필터: 커버리지 있으면 executable 인 추가라인만, 없으면(coarse) 전 추가라인.
+    const considered = fc ? addedSorted.filter((ln) => fc.executable.has(ln)) : addedSorted
     const uncoveredNew: number[] = []
     let cnt = 0
-    for (const ln of [...addedLines].sort((a, b) => a - b)) {
-      if (cov && cov.has(ln)) cnt++
+    for (const ln of considered) {
+      if (fc && fc.covered.has(ln)) cnt++
       else uncoveredNew.push(ln)
     }
-    const addedN = addedLines.size
+    const addedN = considered.length
     files.push({
       file,
       added: addedN,

--- a/src/lib/diff-coverage.ts
+++ b/src/lib/diff-coverage.ts
@@ -1,0 +1,58 @@
+export interface FileDiffCoverage {
+  file: string
+  added: number
+  covered: number
+  uncoveredNew: number[]
+  ratio: number // added===0 ? 1 : covered/added
+  inCoverage: boolean // 커버리지 리포트에 이 파일이 존재했나(false = 테스트가 import 안 함)
+}
+
+export interface DiffCoverageResult {
+  files: FileDiffCoverage[]
+  totalAdded: number
+  totalCovered: number
+  totalUncovered: number
+  ratio: number
+}
+
+/**
+ * 추가라인 맵 ∩ 커버라인 맵 → 파일별 미검증 변경분(순수). fs/시간 부수효과 0.
+ * @param covered 커버라인 맵 또는 null(리포트 자체 부재 — 전 라인 미검증으로 처리, 호출부가 별도 안내).
+ */
+export function diffCoverage(
+  added: Map<string, Set<number>>,
+  covered: Map<string, Set<number>> | null
+): DiffCoverageResult {
+  const files: FileDiffCoverage[] = []
+  let totalAdded = 0
+  let totalCovered = 0
+  const sortedFiles = [...added.entries()].sort((a, b) => a[0].localeCompare(b[0]))
+  for (const [file, addedLines] of sortedFiles) {
+    const cov = covered?.get(file) ?? null
+    const inCoverage = cov !== null
+    const uncoveredNew: number[] = []
+    let cnt = 0
+    for (const ln of [...addedLines].sort((a, b) => a - b)) {
+      if (cov && cov.has(ln)) cnt++
+      else uncoveredNew.push(ln)
+    }
+    const addedN = addedLines.size
+    files.push({
+      file,
+      added: addedN,
+      covered: cnt,
+      uncoveredNew,
+      ratio: addedN === 0 ? 1 : cnt / addedN,
+      inCoverage,
+    })
+    totalAdded += addedN
+    totalCovered += cnt
+  }
+  return {
+    files,
+    totalAdded,
+    totalCovered,
+    totalUncovered: totalAdded - totalCovered,
+    ratio: totalAdded === 0 ? 1 : totalCovered / totalAdded,
+  }
+}

--- a/src/lib/diff-hunks.ts
+++ b/src/lib/diff-hunks.ts
@@ -1,0 +1,33 @@
+import { isFeatureSource, toPosix } from './test-mapping.js'
+
+/**
+ * `git diff --unified=0 HEAD` 텍스트 → 기능소스(src/commands·src/lib)별 추가 라인번호 집합. 순수 함수.
+ * 헌트 헤더(@@ -a,b +c,d @@)만으로 추가 라인 계산(컨텍스트 0이라 본문 +라인 셀 필요 없음).
+ * 파일 경계는 `diff --git` 에서 리셋, 대상은 `+++ b/<path>` 에서 확정(삭제=+++ /dev/null → 제외).
+ */
+export function addedLinesByFile(diffText: string): Map<string, Set<number>> {
+  const out = new Map<string, Set<number>>()
+  let curFile: string | null = null
+  for (const raw of diffText.split(/\r?\n/)) {
+    if (raw.startsWith('diff --git ')) {
+      curFile = null // 파일 경계 — binary/rename은 +++ 없음 → null 유지.
+      continue
+    }
+    const plus = raw.match(/^\+\+\+ (?:b\/)?(.+)$/)
+    if (plus) {
+      const path = plus[1].trim()
+      curFile = path !== '/dev/null' && isFeatureSource(path) ? toPosix(path) : null
+      continue
+    }
+    if (!curFile) continue
+    const hunk = raw.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/)
+    if (!hunk) continue
+    const start = Number(hunk[1])
+    const count = hunk[2] === undefined ? 1 : Number(hunk[2])
+    if (count <= 0) continue // 순수 삭제 헌트(+c,0).
+    const set = out.get(curFile) ?? new Set<number>()
+    for (let i = 0; i < count; i++) set.add(start + i)
+    out.set(curFile, set)
+  }
+  return out
+}

--- a/src/lib/git-session.ts
+++ b/src/lib/git-session.ts
@@ -66,6 +66,11 @@ export function numstatHead(cwd: string = process.cwd()): ExecResult {
   return safeExecFile('git', ['diff', '--numstat', 'HEAD'], { cwd })
 }
 
+/** git diff --unified=0 HEAD — 헌트 헤더(@@ -a,b +c,d @@)로 추가 라인번호 추출용. raw 보존. */
+export function diffUnified0(cwd: string = process.cwd()): ExecResult {
+  return safeExecFile('git', ['diff', '--unified=0', 'HEAD'], { cwd, trimOutput: false })
+}
+
 /** git log --format=%h %ad %s --date=short -n — recap 용 날짜 포함 히스토리. */
 export function recapLog(n: number, cwd: string = process.cwd()): ExecResult {
   return safeExecFile('git', ['log', '--format=%h %ad %s', '--date=short', `-${n}`], { cwd })

--- a/tests/coverage-parse.test.ts
+++ b/tests/coverage-parse.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest'
 import { writeFileSync, rmSync, mkdtempSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { coveredLinesByFile } from '../src/lib/coverage-parse.js'
+import { fileCoverageByFile } from '../src/lib/coverage-parse.js'
 
 const dirs: string[] = []
 function tmpDir(): string {
@@ -14,8 +14,8 @@ afterEach(() => {
   while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true })
 })
 
-describe('coveredLinesByFile — v8 coverage-final.json → 커버 라인', () => {
-  it('s[k]>0 인 statement 의 start..end 라인만 커버로 펼친다', () => {
+describe('fileCoverageByFile — v8 coverage-final.json → {covered, executable}', () => {
+  it('executable = 모든 statement 라인, covered = s[k]>0 라인만', () => {
     const cwd = tmpDir()
     const abs = join(cwd, 'src/lib/foo.ts')
     const jsonPath = join(cwd, 'coverage-final.json')
@@ -33,20 +33,22 @@ describe('coveredLinesByFile — v8 coverage-final.json → 커버 라인', () =
       }),
       'utf-8'
     )
-    const m = coveredLinesByFile(jsonPath, cwd)
+    const m = fileCoverageByFile(jsonPath, cwd)
     expect(m).not.toBeNull()
-    expect([...(m!.get('src/lib/foo.ts') ?? [])]).toEqual([1]) // 5,6은 s=0 → 미커버
+    const fc = m!.get('src/lib/foo.ts')!
+    expect([...fc.executable].sort((a, b) => a - b)).toEqual([1, 5, 6])
+    expect([...fc.covered]).toEqual([1]) // 5,6은 s=0 → executable 이나 미커버
   })
 
   it('리포트 파일 부재 → null (측정 불가, 빈 맵과 구분)', () => {
-    expect(coveredLinesByFile('/no/such/coverage-final.json', '/x')).toBeNull()
+    expect(fileCoverageByFile('/no/such/coverage-final.json', '/x')).toBeNull()
   })
 
   it('손상된 json → null', () => {
     const cwd = tmpDir()
     const p = join(cwd, 'coverage-final.json')
     writeFileSync(p, '{not json', 'utf-8')
-    expect(coveredLinesByFile(p, cwd)).toBeNull()
+    expect(fileCoverageByFile(p, cwd)).toBeNull()
   })
 
   it('기능소스 아닌 파일(tests/)은 제외', () => {
@@ -60,6 +62,6 @@ describe('coveredLinesByFile — v8 coverage-final.json → 커버 라인', () =
       }),
       'utf-8'
     )
-    expect(coveredLinesByFile(p, cwd)!.size).toBe(0)
+    expect(fileCoverageByFile(p, cwd)!.size).toBe(0)
   })
 })

--- a/tests/coverage-parse.test.ts
+++ b/tests/coverage-parse.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { writeFileSync, rmSync, mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { coveredLinesByFile } from '../src/lib/coverage-parse.js'
+
+const dirs: string[] = []
+function tmpDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'covtest-'))
+  dirs.push(d)
+  return d
+}
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true })
+})
+
+describe('coveredLinesByFile — v8 coverage-final.json → 커버 라인', () => {
+  it('s[k]>0 인 statement 의 start..end 라인만 커버로 펼친다', () => {
+    const cwd = tmpDir()
+    const abs = join(cwd, 'src/lib/foo.ts')
+    const jsonPath = join(cwd, 'coverage-final.json')
+    writeFileSync(
+      jsonPath,
+      JSON.stringify({
+        [abs]: {
+          path: abs,
+          statementMap: {
+            '0': { start: { line: 1 }, end: { line: 1 } },
+            '1': { start: { line: 5 }, end: { line: 6 } },
+          },
+          s: { '0': 3, '1': 0 },
+        },
+      }),
+      'utf-8'
+    )
+    const m = coveredLinesByFile(jsonPath, cwd)
+    expect(m).not.toBeNull()
+    expect([...(m!.get('src/lib/foo.ts') ?? [])]).toEqual([1]) // 5,6은 s=0 → 미커버
+  })
+
+  it('리포트 파일 부재 → null (측정 불가, 빈 맵과 구분)', () => {
+    expect(coveredLinesByFile('/no/such/coverage-final.json', '/x')).toBeNull()
+  })
+
+  it('손상된 json → null', () => {
+    const cwd = tmpDir()
+    const p = join(cwd, 'coverage-final.json')
+    writeFileSync(p, '{not json', 'utf-8')
+    expect(coveredLinesByFile(p, cwd)).toBeNull()
+  })
+
+  it('기능소스 아닌 파일(tests/)은 제외', () => {
+    const cwd = tmpDir()
+    const abs = join(cwd, 'tests/a.test.ts')
+    const p = join(cwd, 'coverage-final.json')
+    writeFileSync(
+      p,
+      JSON.stringify({
+        [abs]: { path: abs, statementMap: { '0': { start: { line: 1 }, end: { line: 1 } } }, s: { '0': 1 } },
+      }),
+      'utf-8'
+    )
+    expect(coveredLinesByFile(p, cwd)!.size).toBe(0)
+  })
+})

--- a/tests/diff-cover.test.ts
+++ b/tests/diff-cover.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { formatReport } from '../src/commands/diff-cover.js'
+import type { DiffCoverageResult } from '../src/lib/diff-coverage.js'
+
+describe('formatReport — diff-coverage 결과 → 표시 라인(순수)', () => {
+  it('미검증 변경분 있으면 파일별 미커버 라인 표시', () => {
+    const r: DiffCoverageResult = {
+      files: [{ file: 'src/lib/a.ts', added: 4, covered: 2, uncoveredNew: [3, 4], ratio: 0.5, inCoverage: true }],
+      totalAdded: 4,
+      totalCovered: 2,
+      totalUncovered: 2,
+      ratio: 0.5,
+    }
+    const out = formatReport(r).join('\n')
+    expect(out).toContain('src/lib/a.ts')
+    expect(out).toContain('3, 4') // 미커버 라인번호
+    expect(out).toContain('2/4')
+  })
+
+  it('전부 커버되면 축하 라인', () => {
+    const r: DiffCoverageResult = {
+      files: [{ file: 'src/lib/a.ts', added: 2, covered: 2, uncoveredNew: [], ratio: 1, inCoverage: true }],
+      totalAdded: 2,
+      totalCovered: 2,
+      totalUncovered: 0,
+      ratio: 1,
+    }
+    expect(formatReport(r).join('\n')).toMatch(/모두|✅|100/)
+  })
+
+  it('inCoverage:false 파일은 "테스트 미import" 힌트', () => {
+    const r: DiffCoverageResult = {
+      files: [{ file: 'src/lib/new.ts', added: 2, covered: 0, uncoveredNew: [1, 2], ratio: 0, inCoverage: false }],
+      totalAdded: 2,
+      totalCovered: 0,
+      totalUncovered: 2,
+      ratio: 0,
+    }
+    expect(formatReport(r).join('\n')).toMatch(/import|테스트 안|미import/)
+  })
+})

--- a/tests/diff-cover.test.ts
+++ b/tests/diff-cover.test.ts
@@ -1,6 +1,20 @@
-import { describe, it, expect } from 'vitest'
-import { formatReport } from '../src/commands/diff-cover.js'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// diffCover() 오케스트레이션 분기 테스트용 — 저수준 IO/순수 의존을 mock.
+// (diff-coverage 는 실제 순수함수 사용 — 교차 로직은 그대로 검증.)
+vi.mock('../src/lib/exec.js', () => ({ safeExecFile: vi.fn() }))
+vi.mock('../src/lib/git-session.js', () => ({ diffUnified0: vi.fn() }))
+vi.mock('../src/lib/diff-hunks.js', () => ({ addedLinesByFile: vi.fn() }))
+vi.mock('../src/lib/coverage-parse.js', () => ({ fileCoverageByFile: vi.fn() }))
+vi.mock('../src/lib/hard-stop-guard.js', () => ({ ensureNotHardStopped: vi.fn(() => true) }))
+
+import { formatReport, diffCover } from '../src/commands/diff-cover.js'
+import { safeExecFile } from '../src/lib/exec.js'
+import { diffUnified0 } from '../src/lib/git-session.js'
+import { addedLinesByFile } from '../src/lib/diff-hunks.js'
+import { fileCoverageByFile } from '../src/lib/coverage-parse.js'
 import type { DiffCoverageResult } from '../src/lib/diff-coverage.js'
+import type { FileCoverage } from '../src/lib/coverage-parse.js'
 
 describe('formatReport — diff-coverage 결과 → 표시 라인(순수)', () => {
   it('미검증 변경분 있으면 파일별 미커버 라인 표시', () => {
@@ -13,7 +27,7 @@ describe('formatReport — diff-coverage 결과 → 표시 라인(순수)', () =
     }
     const out = formatReport(r).join('\n')
     expect(out).toContain('src/lib/a.ts')
-    expect(out).toContain('3, 4') // 미커버 라인번호
+    expect(out).toContain('3, 4')
     expect(out).toContain('2/4')
   })
 
@@ -37,5 +51,63 @@ describe('formatReport — diff-coverage 결과 → 표시 라인(순수)', () =
       ratio: 0,
     }
     expect(formatReport(r).join('\n')).toMatch(/import|테스트 안|미import/)
+  })
+})
+
+describe('diffCover — 오케스트레이션 분기(자문형·차단 0)', () => {
+  let logs: string[]
+  let errs: string[]
+  const mockExec = vi.mocked(safeExecFile)
+  const mockDiff = vi.mocked(diffUnified0)
+  const mockAdded = vi.mocked(addedLinesByFile)
+  const mockCov = vi.mocked(fileCoverageByFile)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    logs = []
+    errs = []
+    vi.spyOn(console, 'log').mockImplementation((m?: unknown) => { logs.push(String(m)) })
+    vi.spyOn(console, 'error').mockImplementation((m?: unknown) => { errs.push(String(m)) })
+    process.exitCode = undefined
+    // 기본값: 저장소 O, diff 있음, 변경 1파일.
+    mockExec.mockReturnValue({ ok: true, out: 'true' })
+    mockDiff.mockReturnValue({ ok: true, out: 'irrelevant(mocked)' })
+    mockAdded.mockReturnValue(new Map([['src/lib/a.ts', new Set([10, 11])]]))
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    process.exitCode = undefined
+  })
+
+  it('git 저장소 아님 → exit 1 + 에러', async () => {
+    mockExec.mockReturnValue({ ok: false, err: 'not a repo', out: '' })
+    await diffCover()
+    expect(process.exitCode).toBe(1)
+    expect(errs.join('\n')).toContain('git 저장소')
+  })
+
+  it('변경된 기능소스 없음 → 측정 대상 없음(exit 0)', async () => {
+    mockAdded.mockReturnValue(new Map())
+    await diffCover()
+    expect(process.exitCode).not.toBe(1)
+    expect(logs.join('\n')).toContain('측정 대상 없음')
+  })
+
+  it('커버리지 리포트 없음 → exit 1 + 안내', async () => {
+    mockCov.mockReturnValue(null)
+    await diffCover()
+    expect(process.exitCode).toBe(1)
+    expect(errs.join('\n')).toContain('커버리지 리포트 없음')
+  })
+
+  it('정상 — 미검증 변경분 있어도 advisory(exit 0) + 보고', async () => {
+    const fc: FileCoverage = { covered: new Set([10]), executable: new Set([10, 11]) }
+    mockCov.mockReturnValue(new Map([['src/lib/a.ts', fc]]))
+    await diffCover()
+    expect(process.exitCode).not.toBe(1) // 측정 결과로는 차단 안 함
+    const out = logs.join('\n')
+    expect(out).toContain('미검증 변경분')
+    expect(out).toContain('11') // 미커버 라인
+    expect(out).toContain('자문형')
   })
 })

--- a/tests/diff-coverage.test.ts
+++ b/tests/diff-coverage.test.ts
@@ -1,27 +1,40 @@
 import { describe, it, expect } from 'vitest'
 import { diffCoverage } from '../src/lib/diff-coverage.js'
+import type { FileCoverage } from '../src/lib/coverage-parse.js'
 
 const set = (...n: number[]) => new Set(n)
+const cov = (covered: number[], executable: number[]): FileCoverage => ({
+  covered: new Set(covered),
+  executable: new Set(executable),
+})
 
-describe('diffCoverage — 추가라인 ∩ 커버라인 교차', () => {
-  it('커버된/미커버 추가라인을 분리하고 비율 계산', () => {
-    const added = new Map([['src/lib/a.ts', set(1, 2, 3, 4)]])
-    const covered = new Map([['src/lib/a.ts', set(1, 2)]])
-    const r = diffCoverage(added, covered)
+describe('diffCoverage — 실행가능 추가라인 ∩ 커버라인 교차', () => {
+  it('실행가능 추가라인만 분모, 그중 미커버를 분리', () => {
+    // 추가 1~6 중 실행가능은 1~4 (5,6은 비실행=주석/import). 커버는 1,2.
+    const added = new Map([['src/lib/a.ts', set(1, 2, 3, 4, 5, 6)]])
+    const coverage = new Map([['src/lib/a.ts', cov([1, 2], [1, 2, 3, 4])]])
+    const r = diffCoverage(added, coverage)
     const f = r.files[0]
     expect(f).toMatchObject({ file: 'src/lib/a.ts', added: 4, covered: 2, uncoveredNew: [3, 4], inCoverage: true })
     expect(f.ratio).toBeCloseTo(0.5)
     expect(r).toMatchObject({ totalAdded: 4, totalCovered: 2, totalUncovered: 2 })
   })
 
-  it('커버리지에 부재한 파일 = 전 라인 미검증 + inCoverage:false', () => {
+  it('비실행 라인(주석·import·중괄호)만 추가됐으면 미검증 0 (노이즈 제외)', () => {
+    const added = new Map([['src/lib/a.ts', set(1, 2, 3)]]) // 전부 비실행
+    const coverage = new Map([['src/lib/a.ts', cov([10], [10, 11])]]) // 실행가능은 다른 라인
+    const f = diffCoverage(added, coverage).files[0]
+    expect(f).toMatchObject({ added: 0, covered: 0, uncoveredNew: [], ratio: 1 })
+  })
+
+  it('커버리지에 부재한 파일 = 전 추가라인 미검증(coarse) + inCoverage:false', () => {
     const added = new Map([['src/lib/new.ts', set(10, 11)]])
-    const covered = new Map<string, Set<number>>() // 리포트엔 있으나 이 파일 없음
-    const f = diffCoverage(added, covered).files[0]
+    const coverage = new Map<string, FileCoverage>() // 리포트엔 있으나 이 파일 없음
+    const f = diffCoverage(added, coverage).files[0]
     expect(f).toMatchObject({ added: 2, covered: 0, uncoveredNew: [10, 11], inCoverage: false, ratio: 0 })
   })
 
-  it('covered=null(리포트 자체 없음)도 안전 — 전 라인 미검증', () => {
+  it('coverage=null(리포트 자체 없음)도 안전 — 전 라인 미검증', () => {
     const r = diffCoverage(new Map([['src/lib/a.ts', set(1)]]), null)
     expect(r.files[0]).toMatchObject({ covered: 0, uncoveredNew: [1], inCoverage: false })
   })

--- a/tests/diff-coverage.test.ts
+++ b/tests/diff-coverage.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { diffCoverage } from '../src/lib/diff-coverage.js'
+
+const set = (...n: number[]) => new Set(n)
+
+describe('diffCoverage — 추가라인 ∩ 커버라인 교차', () => {
+  it('커버된/미커버 추가라인을 분리하고 비율 계산', () => {
+    const added = new Map([['src/lib/a.ts', set(1, 2, 3, 4)]])
+    const covered = new Map([['src/lib/a.ts', set(1, 2)]])
+    const r = diffCoverage(added, covered)
+    const f = r.files[0]
+    expect(f).toMatchObject({ file: 'src/lib/a.ts', added: 4, covered: 2, uncoveredNew: [3, 4], inCoverage: true })
+    expect(f.ratio).toBeCloseTo(0.5)
+    expect(r).toMatchObject({ totalAdded: 4, totalCovered: 2, totalUncovered: 2 })
+  })
+
+  it('커버리지에 부재한 파일 = 전 라인 미검증 + inCoverage:false', () => {
+    const added = new Map([['src/lib/new.ts', set(10, 11)]])
+    const covered = new Map<string, Set<number>>() // 리포트엔 있으나 이 파일 없음
+    const f = diffCoverage(added, covered).files[0]
+    expect(f).toMatchObject({ added: 2, covered: 0, uncoveredNew: [10, 11], inCoverage: false, ratio: 0 })
+  })
+
+  it('covered=null(리포트 자체 없음)도 안전 — 전 라인 미검증', () => {
+    const r = diffCoverage(new Map([['src/lib/a.ts', set(1)]]), null)
+    expect(r.files[0]).toMatchObject({ covered: 0, uncoveredNew: [1], inCoverage: false })
+  })
+
+  it('변경 없음 → 빈 결과, 총비율 1', () => {
+    const r = diffCoverage(new Map(), new Map())
+    expect(r).toMatchObject({ files: [], totalAdded: 0, totalUncovered: 0, ratio: 1 })
+  })
+
+  it('파일은 이름순, 라인은 오름차순 정렬(결정성)', () => {
+    const added = new Map([['src/lib/z.ts', set(2, 1)], ['src/commands/a.ts', set(5)]])
+    const r = diffCoverage(added, new Map())
+    expect(r.files.map((f) => f.file)).toEqual(['src/commands/a.ts', 'src/lib/z.ts'])
+    expect(r.files[1].uncoveredNew).toEqual([1, 2])
+  })
+})

--- a/tests/diff-hunks.test.ts
+++ b/tests/diff-hunks.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { addedLinesByFile } from '../src/lib/diff-hunks.js'
+
+describe('addedLinesByFile — unified=0 diff → 기능소스별 추가 라인', () => {
+  it('단일 헌트(+c,d) 추가 라인을 c..c+d-1로 펼친다', () => {
+    const diff = [
+      'diff --git a/src/lib/foo.ts b/src/lib/foo.ts',
+      '--- a/src/lib/foo.ts',
+      '+++ b/src/lib/foo.ts',
+      '@@ -10,0 +11,3 @@',
+      '+a',
+      '+b',
+      '+c',
+    ].join('\n')
+    const m = addedLinesByFile(diff)
+    expect([...(m.get('src/lib/foo.ts') ?? [])]).toEqual([11, 12, 13])
+  })
+
+  it('count 생략형 @@ +c @@ = 1줄', () => {
+    const diff = 'diff --git a/src/lib/x.ts b/src/lib/x.ts\n+++ b/src/lib/x.ts\n@@ -5 +5 @@\n+one'
+    expect([...(addedLinesByFile(diff).get('src/lib/x.ts') ?? [])]).toEqual([5])
+  })
+
+  it('순수 삭제 헌트(+c,0)는 추가 0', () => {
+    const diff = 'diff --git a/src/lib/x.ts b/src/lib/x.ts\n+++ b/src/lib/x.ts\n@@ -5,3 +4,0 @@'
+    expect(addedLinesByFile(diff).has('src/lib/x.ts')).toBe(false)
+  })
+
+  it('한 파일 멀티헌트는 누적된다', () => {
+    const diff = [
+      'diff --git a/src/commands/c.ts b/src/commands/c.ts',
+      '+++ b/src/commands/c.ts',
+      '@@ -1,0 +1,1 @@',
+      '+x',
+      '@@ -10,0 +20,2 @@',
+      '+y',
+      '+z',
+    ].join('\n')
+    expect([...(addedLinesByFile(diff).get('src/commands/c.ts') ?? [])]).toEqual([1, 20, 21])
+  })
+
+  it('기능소스 아닌 파일(문서·테스트)은 무시', () => {
+    const diff = [
+      'diff --git a/docs/x.md b/docs/x.md\n+++ b/docs/x.md\n@@ -1,0 +1,1 @@\n+m',
+      'diff --git a/src/lib/x.test.ts b/src/lib/x.test.ts\n+++ b/src/lib/x.test.ts\n@@ -1,0 +1,1 @@\n+t',
+    ].join('\n')
+    expect(addedLinesByFile(diff).size).toBe(0)
+  })
+
+  it('삭제 파일(+++ /dev/null)은 무시', () => {
+    const diff = 'diff --git a/src/lib/g.ts b/src/lib/g.ts\n--- a/src/lib/g.ts\n+++ /dev/null\n@@ -1,2 +0,0 @@'
+    expect(addedLinesByFile(diff).size).toBe(0)
+  })
+
+  it('빈 diff → 빈 맵', () => {
+    expect(addedLinesByFile('').size).toBe(0)
+  })
+})

--- a/tests/git-session.test.ts
+++ b/tests/git-session.test.ts
@@ -86,6 +86,14 @@ describe('git-session — git argv SoT (같은 질문 = 함수 하나)', () => {
     expect(lastArgv()).toEqual(['diff', '--numstat', 'HEAD'])
   })
 
+  it('diffUnified0 → git diff --unified=0 HEAD (raw 보존)', () => {
+    session.diffUnified0('/repo')
+    expect(lastBin()).toBe('git')
+    expect(lastArgv()).toEqual(['diff', '--unified=0', 'HEAD'])
+    // 헌트 헤더(@@ -a,b +c,d @@) 라인번호 보존 위해 trimOutput:false.
+    expect(lastOpts()).toMatchObject({ cwd: '/repo', trimOutput: false })
+  })
+
   it('recapLog(n) → git log --format=%h %ad %s --date=short -n', () => {
     session.recapLog(10, '/repo')
     expect(lastArgv()).toEqual(['log', '--format=%h %ad %s', '--date=short', '-10'])

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,5 +11,13 @@ export default defineConfig({
       '**/dist/**',
       '**/.claude/**',
     ],
+    // Goal 50 / RFC 0050: coverage 측정(차단 아님 — 리포트 + vhk diff-cover 입력용).
+    coverage: {
+      provider: 'v8',
+      reporter: ['text-summary', 'json'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['dist/**', '.claude/**', 'tests/**', '**/*.config.*', 'src/**/*.d.ts', 'src/index.ts'],
+    },
   },
 })


### PR DESCRIPTION
## 무엇

`vhk diff-cover` — "이번 변경(HEAD 대비)이 실제로 테스트에 실행됐나" 측정하는 **자문형** 명령 + coverage 인프라. (RFC 0050 PR1, Goal 50)

review.ts:40이 자백한 구멍("git diff 미사용 — 기존 테스트가 green이어도 이번 변경을 커버 못 했을 수 있음")을 **측정**으로 메우는 첫 단계. **차단 0**(measure-first — 게이트는 실측이 정당화한 뒤 PR2).

## 변경

- **coverage 인프라**: `@vitest/coverage-v8@4.1.7` + vitest.config v8 블록(json reporter). `coverage/` gitignore.
- **순수 3모듈 + git-session 확장** (전부 TDD):
  - `git-session.diffUnified0` — 라인단위 diff(단일 SoT)
  - `diff-hunks.addedLinesByFile` — diff → 기능소스별 추가라인
  - `coverage-parse.fileCoverageByFile` — v8 json → `{covered, executable}`
  - `diff-coverage.diffCoverage` — 교차 → 미검증 변경분(**실행가능 라인만** 분모)
- **`vhk diff-cover`** 자문 명령 + 5지점 등록(한글별칭 '커버리지').

## 도그푸딩 (measure-first 루프가 결함 잡음)

PR1 코드 자체에 도구를 돌림:
1. 1차: 미검증 118/213 — 미커버 목록이 import·주석·중괄호 투성이 → **지표가 노이즈에 묻힘**.
2. 수정: 실행가능(statementMap) 추가라인만 분모로. 재측정 → 미검증 30(전부 `diffCover()` 미테스트 오케스트레이션).
3. 자기 dogfood 먹기: 통합 테스트 4분기 추가 → **미검증 0 / 132 = 100% diff-coverage**.

## 비목표 (PR2 — 실측 정당화 후)

review 통합(line-40 제거)·CI Summary·신규분 차단. RFC 0050 §5 관찰 프로토콜(실제 코드 diff ≥5건)이 "구멍 실재" 증명하면 승격, ≈0이면 중단(YAGNI).

## 검증

- TDD red→green 전부. 테스트 1356→1381. build·typecheck·lint·전체 green. 실제 CLI 스모크 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
