### PR TITLE
docs(state): measure-first 상태 갱신 (recall+diff-coverage PR1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,11 +86,11 @@ tags: [process, constitution]
 > 세션 종료: 마지막 갱신·버전·Phase·다음 할 일 갱신. (위 🔒 구역은 절대 건드리지 마.)
 > ⚠️ 아래 `**버전:**` 줄은 CI(version-sync.test.ts)가 강제 — 형식 `**버전:** vX.Y.Z` 유지, 릴리즈마다 package.json 따라 갱신.
 
-**마지막 갱신:** 2026-06-08
+**마지막 갱신:** 2026-06-10
 - **버전:** v2.5.1 (발행 완료) — 사실 확인은 package.json·CHANGELOG
-- **테스트:** 1162 pass · **MCP tools:** 29
-- **Phase:** v2.5.1 발행 완료 (npm latest=2.5.1) — 생산성 5종(Phase 2~3) + 증거 체인(goal 44 SHA·45 ledger) + self-gate(goal 28 testmap·43 drift·46 git-access 단일화) + README/npm 갱신.
+- **테스트:** 1381 pass(main) · **MCP tools:** 29 — 사실값은 package.json·CHANGELOG
+- **Phase:** measure-first 2종. recall(RFC 0049) #232·#233 머지. diff-coverage(RFC 0050·Goal 50) PR1 #236 머지 — `vhk diff-cover` 측정 도구(자문·차단 0). 둘 다 실측 누적 후 게이트/ML 결정.
 - **블로커:** 없음
-- **진행 중(미발행):** 없음
-- **다음 할 일:** 미완 goal(silent-fallback 린트 Goal 25/27·#128, SEO 묶음 21~26) + 열린 이슈 10개 트리아지(불확실 4: #157·#155·#171·#148 해결확인 후 close).
+- **진행 중(미발행):** diff-coverage PR1 main 머지(미발행). PR2(review/CI 통합)는 도그푸딩 ≥5 diff 실측 대기.
+- **다음 할 일:** measure-first 실측 누적 — `vhk diff-cover` ≥5 실제 diff(RFC 0050 §5) + `vhk recall` 실사용→eval(RFC 0049 §5). 그 후 PR2/2차ML 결정. 병행: 미완 goal(린트 25/27·#128, SEO 21~26) + 열린 이슈 트리아지(#157·#155·#171·#148). ※ PR2 시 diff-hunks 파서 `diff --git`줄 기반으로 강화(코드리뷰 발견 엣지).
 - **주의:** publish는 main에서만(#119)·사용자 직접(2FA) / 직접 main push 차단 → PR 경유

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -2,10 +2,13 @@
 
 > "지금 무엇부터"의 상태 SoT. 버전·테스트 등 사실값은 package.json·CHANGELOG가 SoT.
 
-**갱신:** 2026-06-08
-**Phase:** v2.5.1 발행 완료 (npm latest=2.5.1). 생산성 5종(preflight·worktree·doctor·standup·today Phase 2~3) + 증거 체인(goal 44 SHA·45 ledger) + self-gate(goal 28 testmap·43 drift·46 git-access 단일화) 완료. 테스트 1162 pass.
+**갱신:** 2026-06-10
+**Phase:** measure-first 2종 진행. recall(RFC 0049) MVP+eval 머지(#232·#233). diff-coverage(RFC 0050·Goal 50) PR1 머지(#236) — `vhk diff-cover` 측정 도구(차단 0). 둘 다 **실측 누적 대기**(게이트/ML은 숫자가 정당화한 뒤). 사실값(버전·테스트수)은 package.json·CHANGELOG.
 
-## 다음 할 일
+## 다음 할 일 (measure-first 최우선)
+- **diff-coverage 실측 누적** → `vhk diff-cover`를 실제 코드 작업 **diff ≥5건(며칠)** 돌려 미검증 변경분 분포 수집(RFC 0050 §5 관찰 프로토콜). 유의미>0 → PR2(review line-40 제거 + verify 증거 + CI). ≈0 → "이론적 구멍" 문서화 후 중단(YAGNI).
+  - **PR2 파서 강화 같이**: diff-hunks 파일명을 `+++` 대신 `diff --git a/X b/X` 줄에서 추출(코드리뷰 발견 — 추가라인 `++ x` 콜0이 `+++` 헤더로 오인되는 엣지).
+- **recall 실측** → 며칠 `vhk recall` 실사용 → `vhk memory eval --init` 실쿼리 라벨 → 진짜 Recall@5. <70 반복이면 2차 ML(bge-m3, RFC 0049 §2 결정 잠금됨).
 - **🎯 업계최상위(~4.7) 품질 로드맵** → [docs/rfc/0048](../rfc/0048-top-tier-quality-roadmap.md) + **Goals 47~54**. 13-에이전트 감사(3.5/5) 도출. 순서: **P0 먼저** — Goal 47(win32+Node20 CI 매트릭스) · Goal 48(MCP↔CLI 단일 진실원) → P1 49(린트 확대)·50(커버리지) → P2 51~54. 각 goal `vhk goal next`로 꺼내 개별 PR(AI 독주 방지). ※ 작업2.2(fast-check #213)·2.3(tsc/eslint #216) 머지로 Goal 49는 "도입→확대", Goal 52 property 옵션은 선점됨 — 재조정 필요.
 - **미완 goal** (goals/ 동적 계산 — `vhk goal next`): silent-fallback 린트(Goal 25/27 영역·#128) · SEO 묶음(Goal 21~26) 등.
 - **열린 이슈 10개 트리아지** — 불확실 해결분 4개(#157 verify UX·#155 goal check mission drift·#171 nested pkg audit·#148 memory add `--`) 재현/해결확인 후 close. 백로그: #160·#159·#158·#151·#38.


### PR DESCRIPTION
next-task.md·CLAUDE.md LIVE를 현재 상태로 갱신.

- recall(#232·#233)·diff-coverage PR1(#236) 머지 반영
- 다음 = measure-first 실측 누적(vhk diff-cover ≥5 diff·recall eval)
- 코드리뷰 발견(diff-hunks +++ 파서가 추가라인 `++ x` 콜0을 헤더로 오인하는 엣지) → PR2 강화 메모

문서 전용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)