### PR TITLE
fix(goal-50): diff-hunks 파서 +++/--- 본문 오인 차단 (적대검증 발견)

### DIFF
--- a/src/lib/diff-hunks.ts
+++ b/src/lib/diff-hunks.ts
@@ -8,20 +8,28 @@ import { isFeatureSource, toPosix } from './test-mapping.js'
 export function addedLinesByFile(diffText: string): Map<string, Set<number>> {
   const out = new Map<string, Set<number>>()
   let curFile: string | null = null
+  // 상태: false=헤더 영역(+++ b/ 가 파일 경로), true=헌트 본문(+++/--- 은 *내용*이므로 무시).
+  // 첫 @@ 이후 본문으로 전환 → 추가된 소스 라인 "++ x"(diff 에선 "+++ x")를 헤더로 오인하지 않음.
+  // (적대 검증 2026-06-10: 본문 +++/--- 오인이 같은 파일 후속 헌트를 누락시키던 버그 차단.)
+  let inHunks = false
   for (const raw of diffText.split(/\r?\n/)) {
     if (raw.startsWith('diff --git ')) {
       curFile = null // 파일 경계 — binary/rename은 +++ 없음 → null 유지.
+      inHunks = false
       continue
     }
-    const plus = raw.match(/^\+\+\+ (?:b\/)?(.+)$/)
-    if (plus) {
-      const path = plus[1].trim()
-      curFile = path !== '/dev/null' && isFeatureSource(path) ? toPosix(path) : null
-      continue
+    if (!inHunks) {
+      const plus = raw.match(/^\+\+\+ (?:b\/)?(.+)$/)
+      if (plus) {
+        const path = plus[1].trim()
+        curFile = path !== '/dev/null' && isFeatureSource(path) ? toPosix(path) : null
+        continue
+      }
     }
-    if (!curFile) continue
     const hunk = raw.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/)
     if (!hunk) continue
+    inHunks = true // 이 파일은 헌트 본문 진입 — 이후 +++/--- 은 내용.
+    if (!curFile) continue
     const start = Number(hunk[1])
     const count = hunk[2] === undefined ? 1 : Number(hunk[2])
     if (count <= 0) continue // 순수 삭제 헌트(+c,0).

--- a/tests/diff-hunks.test.ts
+++ b/tests/diff-hunks.test.ts
@@ -55,4 +55,34 @@ describe('addedLinesByFile — unified=0 diff → 기능소스별 추가 라인'
   it('빈 diff → 빈 맵', () => {
     expect(addedLinesByFile('').size).toBe(0)
   })
+
+  // 적대 검증 발견(2026-06-10): 헌트 본문의 +++/--- 내용라인을 파일 헤더로 오인 →
+  // 같은 파일 후속 헌트 누락. 상태머신(첫 @@ 이후 본문)으로 차단.
+  it('헌트 본문 +++ 내용라인(소스 "++ x") 뒤 후속 헌트 유지', () => {
+    const diff = [
+      'diff --git a/src/lib/a.ts b/src/lib/a.ts',
+      '--- a/src/lib/a.ts',
+      '+++ b/src/lib/a.ts',
+      '@@ -5,0 +6,1 @@',
+      '+++ x', // 소스 "++ x" 추가 → diff 본문(헤더 아님)
+      '@@ -20,0 +30,2 @@', // 같은 파일 두 번째 헌트
+      '+y',
+      '+z',
+    ].join('\n')
+    expect([...(addedLinesByFile(diff).get('src/lib/a.ts') ?? [])]).toEqual([6, 30, 31])
+  })
+
+  it('헌트 본문 --- 내용라인(소스 "-- y")도 헤더 오인 안 함', () => {
+    const diff = [
+      'diff --git a/src/lib/a.ts b/src/lib/a.ts',
+      '--- a/src/lib/a.ts',
+      '+++ b/src/lib/a.ts',
+      '@@ -5,1 +6,1 @@',
+      '--- y',
+      '+++ x',
+      '@@ -20,0 +30,1 @@',
+      '+z',
+    ].join('\n')
+    expect([...(addedLinesByFile(diff).get('src/lib/a.ts') ?? [])]).toEqual([6, 30])
+  })
 })


### PR DESCRIPTION
## 무엇

`diff-hunks.addedLinesByFile` 파서 버그 수정 — 적대적 스트레스 테스트(실행 증거)로 발견.

## 버그

헌트 본문의 추가라인 `++ x`(diff에선 `+++ x`)·제거라인 `-- y`(`--- y`)를 **파일 헤더로 오인** → `curFile=null` → **같은 파일 후속 헌트의 추가라인 누락**(undercount). 측정값을 실제보다 낮게 보고.

- 저빈도(TS서 `++ ` 콜0 드묾)지만 실재. PR1 TDD 테스트·도그푸딩 둘 다 못 침.
- 교차오염은 기존 `diff --git` 리셋이 막아 무영향 — 같은 파일 내 후속 헌트만 누락.

## 수정

헤더/본문 **상태머신**: 첫 `@@` 이후 본문 진입 → `+++`/`---` 라인은 내용으로 간주(헤더 파싱 안 함). 회귀 테스트 2건.

## 검증

적대 스트레스 8케이스(새파일·섹션제목·CRLF·파일격리·diff-coverage 엣지 포함) ALL PASS. 전체 1383 green. build·typecheck·lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)