### PR TITLE
perf(rfc-0047): inquirer 지연 로딩 — 콜드스타트 512→323ms (-37%)

### DIFF
--- a/docs/rfc/0047-cli-coldstart-lazy-load.md
+++ b/docs/rfc/0047-cli-coldstart-lazy-load.md
@@ -1,11 +1,13 @@
 ---
 rfc: 47
 title: "CLI 콜드스타트 단축 — 명령 지연 로딩(dynamic import) + 번들 코드 분할"
-status: Deferred
+status: In Progress
 author: VHK
 created: 2026-06-08
 depends_on: "index.ts 를 건드리는 모든 선행 작업(예: goal 21 seo-init 등록, 명령 추가 이슈) 머지 완료"
 ---
+
+> **구현 진행(2026-06-10):** 측정으로 단일 최대 레버 = **inquirer(~212ms net = 콜드스타트 절반)** 확정 → `lib/prompt.ts` lazy 래퍼로 먼저 처리. **vhk --version 512→323ms (−37%)**. 22파일 코드모드 + 회귀 가드(`tests/check-inquirer-lazy.test.ts`). 나머지(명령 60+ lazy + tsup splitting)는 잔여 dep 가 12~33ms로 ROI 낮아 보류 — §9 참조.
 
 # RFC 0047 — CLI 콜드스타트 지연 로딩
 
@@ -75,3 +77,21 @@ VHK(얇은 git/파일 래퍼, 유저가 이미 Node 보유)에는 그 4대 이�
 - 측정에 Windows 오버헤드(Defender의 node spawn 스캔, `.ps1` 래퍼) 섞임. 절대 수치는 OS별 상이하나 **비율(VHK로드 ≫ Node바닥)은 OS 불문 유지** → 결론 불변.
 - splitting 활성 시 dist 산출물이 단일파일→다중청크. `bin` 진입점(dist/index.js·dist/mcp/index.js)과 청크 경로 해석이 깨지지 않는지 확인 필요.
 - `--help` 전체 출력은 모든 명령 메타가 필요 → help 경로는 지연 이득이 작을 수 있음(명령 *실행*은 이득 큼).
+
+## 9. 구현 결과 (2026-06-10)
+
+**측정이 전략을 바꿈(measure-first).** dep별 import 비용 실측:
+
+| dep | net import |
+|---|---|
+| **inquirer** | **212ms** ← 단일 최대(전체 434ms의 절반) |
+| handlebars | 33ms |
+| simple-git | 31ms |
+| @notionhq/client | 20ms |
+| chalk / commander | 14 / 12ms |
+
+→ "명령 60+ 전부 lazy" 대신 **inquirer 하나만 lazy** 가 80/20. `lib/prompt.ts`(`await import('inquirer')`) 래퍼 + 22파일 `inquirer.prompt`→`prompt` 코드모드. 모든 호출이 async라 무위험. splitting 불필요(ESM dynamic import 자체가 모듈 init 지연).
+
+**결과:** `vhk --version` 512→**323ms (−37%)** · `vhk status` 739→610ms · 전체 1383 테스트 green(inquirer mock 정상, 테스트 import도 23s→12s). 회귀 가드 `tests/check-inquirer-lazy.test.ts`.
+
+**보류(다음 레버는 작음):** 명령 모듈 60+ lazy + tsup splitting 으로 잔여 ~297ms 추가 공략 가능하나, 다음 dep 가 12~33ms 단위라 inquirer 만큼 극적이지 않고 index.ts 통째 재작성(고위험)이 필요 → 실수요/추가 실측이 정당화할 때.

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import ora from 'ora'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
@@ -144,7 +144,7 @@ export async function audit(autoFix = false): Promise<void> {
     ? true
     : aggregate.critical > 0 || aggregate.high > 0
       ? (
-          await inquirer.prompt<{ shouldFix: boolean }>([
+          await prompt<{ shouldFix: boolean }>([
             {
               type: 'confirm',
               name: 'shouldFix',

--- a/src/commands/cost.ts
+++ b/src/commands/cost.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import { readConfig, writeConfig } from '../lib/config.js'
 import { readCostEntries, appendCostEntry, sumUsd, type CostEntry } from '../lib/cost-ledger.js'
 import { evaluateBudget, costToGuard, usdOf, type BudgetEval } from '../lib/cost-policy.js'
@@ -156,7 +156,7 @@ export async function cost(action?: string, value?: string, opts: CostOptions = 
   // runGuarded 와 동일 기준(stdin TTY)으로 대화형 가능 여부 판단 — stdout/stdin 비대칭 제거.
   const isTTY = !!process.stdin.isTTY
   if (isTTY) {
-    const { ok } = await inquirer.prompt<{ ok: boolean }>([
+    const { ok } = await prompt<{ ok: boolean }>([
       { type: 'confirm', name: 'ok', message: '예산을 초과했습니다. 그래도 계속할까요?', default: false },
     ])
     if (ok) return

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs'
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import { safeExecFile, safeExecFileStream } from '../lib/exec.js'
 import { readJsonFile } from '../lib/read-json.js'
 import { t } from '../i18n/ko.js'
@@ -132,7 +132,7 @@ export async function deploy(): Promise<void> {
     config = target.config
     console.log(chalk.cyan(`\n🔍 감지된 플랫폼: ${config.name}`))
   } else {
-    const { selected } = await inquirer.prompt<{ selected: Platform }>([
+    const { selected } = await prompt<{ selected: Platform }>([
       {
         type: 'list',
         name: 'selected',
@@ -157,7 +157,7 @@ export async function deploy(): Promise<void> {
     return
   }
 
-  const { confirm } = await inquirer.prompt<{ confirm: boolean }>([
+  const { confirm } = await prompt<{ confirm: boolean }>([
     {
       type: 'confirm',
       name: 'confirm',

--- a/src/commands/design.ts
+++ b/src/commands/design.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { ensureInteractive } from '../lib/interactive.js'
@@ -128,7 +128,7 @@ export async function design(): Promise<void> {
   // VHK-014: 비-TTY 면 inquirer 크래시(ERR_USE_AFTER_CLOSE) 대신 friendly 안내 + exit 1.
   if (!ensureInteractive('컬러 팔레트 선택은 대화형으로만 가능합니다.')) return
 
-  const { paletteIndex } = await inquirer.prompt<{ paletteIndex: number }>([
+  const { paletteIndex } = await prompt<{ paletteIndex: number }>([
     {
       type: 'list',
       name: 'paletteIndex',
@@ -156,7 +156,7 @@ export async function design(): Promise<void> {
       : generateCSSTokens(palette)
 
   if (existsSync(targetPath)) {
-    const { overwrite } = await inquirer.prompt<{ overwrite: boolean }>([{
+    const { overwrite } = await prompt<{ overwrite: boolean }>([{
       type: 'confirm',
       name: 'overwrite',
       message: `${targetPath} 이미 있어요. 덮어쓸까요?`,

--- a/src/commands/evolve.ts
+++ b/src/commands/evolve.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, writeFileSync, readFileSync, copyFileSync, renameSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { ensureInteractive } from '../lib/interactive.js'
@@ -346,14 +346,14 @@ export async function evolveApply(idStr: string): Promise<void> {
   console.log(chalk.cyan('\n추가될 룰 초안:'))
   console.log(chalk.white(`  ${item.draft}`))
 
-  const { editedDraft } = await inquirer.prompt<{ editedDraft: string }>([{
+  const { editedDraft } = await prompt<{ editedDraft: string }>([{
     type: 'input',
     name: 'editedDraft',
     message: '룰 문구 수정 (Enter = 그대로):',
     default: item.draft,
   }])
 
-  const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([{
+  const { confirmed } = await prompt<{ confirmed: boolean }>([{
     type: 'confirm',
     name: 'confirmed',
     message: `RULES.md에 이 룰을 추가할까요?\n  ${editedDraft}`,
@@ -478,7 +478,7 @@ export async function evolveUndo(): Promise<void> {
   console.log(chalk.dim(`  되돌릴 항목: [${last.id}] ${last.draft}`))
 
   // 4. 확인 프롬프트
-  const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([{
+  const { confirmed } = await prompt<{ confirmed: boolean }>([{
     type: 'confirm',
     name: 'confirmed',
     message: 'RULES.md를 .bak으로 복원하고 vhk sync를 재실행할까요?',

--- a/src/commands/gate.ts
+++ b/src/commands/gate.ts
@@ -1,4 +1,4 @@
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import chalk from 'chalk'
 import { ko } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
@@ -44,7 +44,7 @@ export async function gate() {
 
   console.log(chalk.bold(`\n${ko.gate.title}\n`))
 
-  const { mode } = await inquirer.prompt<{ mode: GateMode }>([{
+  const { mode } = await prompt<{ mode: GateMode }>([{
     type: 'list',
     name: 'mode',
     message: ko.gate.modePrompt,
@@ -56,7 +56,7 @@ export async function gate() {
   }])
 
   if (mode === 'skip') {
-    const { source } = await inquirer.prompt<{ source: string }>([{
+    const { source } = await prompt<{ source: string }>([{
       type: 'input',
       name: 'source',
       message: ko.gate.skipSourcePrompt,
@@ -77,17 +77,17 @@ export async function gate() {
   console.log(chalk.dim(`\n${ko.gate.welcome}\n`))
 
   console.log(chalk.dim(`  ${ko.gate.ideaHint}`))
-  const { idea } = await inquirer.prompt<{ idea: string }>([
+  const { idea } = await prompt<{ idea: string }>([
     { type: 'input', name: 'idea', message: ko.gate.idea },
   ])
 
   console.log(chalk.dim(`  ${ko.gate.painPointHint}`))
-  const { painPoint } = await inquirer.prompt<{ painPoint: string }>([
+  const { painPoint } = await prompt<{ painPoint: string }>([
     { type: 'input', name: 'painPoint', message: ko.gate.painPoint },
   ])
 
   console.log(chalk.dim(`  ${ko.gate.edgeHint}`))
-  const { edge } = await inquirer.prompt<{ edge: string }>([
+  const { edge } = await prompt<{ edge: string }>([
     { type: 'input', name: 'edge', message: ko.gate.edge },
   ])
 
@@ -101,13 +101,13 @@ export async function gate() {
     const q = questions[i]
     if (q.hint) console.log(chalk.dim(`${ko.gate.hintPrefix} ${q.hint}`))
 
-    const { answer } = await inquirer.prompt<{ answer: string }>([{
+    const { answer } = await prompt<{ answer: string }>([{
       type: 'input',
       name: 'answer',
       message: `[${i + 1}/${total}] ${q.stage}: ${q.question}`,
     }])
 
-    const { status } = await inquirer.prompt<{ status: GateStatus }>([{
+    const { status } = await prompt<{ status: GateStatus }>([{
       type: 'list',
       name: 'status',
       message: ko.gate.verdictPrompt(q.failIf),

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,4 @@
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import type { DistinctQuestion } from 'inquirer'
 import chalk from 'chalk'
 import fs from 'node:fs'
@@ -90,7 +90,7 @@ async function collectAnswers(
     }
   }
 
-  const prompted = prompts.length ? await inquirer.prompt(prompts) : {}
+  const prompted = prompts.length ? await prompt(prompts) : {}
 
   // 폴백(비대화형에서만 실제 발동 — 대화형이면 prompted 값이 채워져 있음):
   //   name → 현재 디렉토리명, description → name 기반, type → 기본 타입(webapp)
@@ -149,7 +149,7 @@ export async function init(options: InitOptions = {}) {
   // 비대화형(yes/비-TTY)이면 confirmStack 프롬프트 skip — default(진행)로 자동 진행.
   // (이전엔 !options.yes 만 봐서 비-TTY+무-yes 에서 EOF 멈춤 — Goal 8 비대화형 계약 위반.)
   if (isInteractive(options)) {
-    const { confirmStack } = await inquirer.prompt([{
+    const { confirmStack } = await prompt([{
       type: 'confirm', name: 'confirmStack',
       message: ko.init.confirmStack, default: true,
     }])
@@ -168,7 +168,7 @@ export async function init(options: InitOptions = {}) {
     const existingRules = detectExistingRuleFiles(cwd)
     if (existingRules.length > 0) {
       if (isInteractive(options)) {
-        const { adopt } = await inquirer.prompt([{
+        const { adopt } = await prompt([{
           type: 'confirm',
           name: 'adopt',
           message: ko.init.adoptPrompt(
@@ -206,7 +206,7 @@ export async function init(options: InitOptions = {}) {
       // 비대화형이면 프롬프트 default(=false, 보존) 자동 적용 — 기존 파일 클로버 금지.
       const overwrite = !isInteractive(options)
         ? false
-        : (await inquirer.prompt([{
+        : (await prompt([{
             type: 'confirm', name: 'overwrite',
             message: ko.init.overwrite(filePath),
             default: false,
@@ -352,7 +352,7 @@ async function writeInitExtras(projectDir: string, noninteractive = false) {
     // 비대화형이면 프롬프트 default(=false, 보존) 자동 적용.
     const overwrite = noninteractive
       ? false
-      : (await inquirer.prompt([{
+      : (await prompt([{
           type: 'confirm',
           name: 'overwrite',
           message: ko.init.overwrite('COMMANDS.md'),

--- a/src/commands/memory-eval.ts
+++ b/src/commands/memory-eval.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import { readMemory, recallMemories, type FailEntry } from './memory.js'
 import { scoreEval, RECALL_EVAL_THRESHOLD, type EvalLabel } from '../lib/recall-eval.js'
 import { readRecallLog } from '../lib/recall-log.js'
@@ -90,7 +90,7 @@ async function memoryEvalInit(): Promise<void> {
       continue
     }
     hits.forEach((h, i) => console.log(`   [${i + 1}] ${entryText(h.entry)}`))
-    const { ans } = await inquirer.prompt<{ ans: string }>([
+    const { ans } = await prompt<{ ans: string }>([
       { type: 'input', name: 'ans', message: '정답 기억 번호 (쉼표 구분, 없으면 엔터로 skip):' },
     ])
     const ids = String(ans || '')

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,6 +1,6 @@
 import { existsSync, unlinkSync, rmSync } from 'node:fs'
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import ora from 'ora'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
@@ -40,7 +40,7 @@ export async function migrate(target?: string): Promise<void> {
     const choices = (['npm', 'yarn', 'pnpm'] as PackageManager[])
       .filter((pm) => pm !== current)
       .map((pm) => ({ name: pm, value: pm }))
-    const { selected } = await inquirer.prompt<{ selected: PackageManager }>([
+    const { selected } = await prompt<{ selected: PackageManager }>([
       {
         type: 'list',
         name: 'selected',
@@ -62,7 +62,7 @@ export async function migrate(target?: string): Promise<void> {
     return
   }
 
-  const { confirm } = await inquirer.prompt<{ confirm: boolean }>([
+  const { confirm } = await prompt<{ confirm: boolean }>([
     {
       type: 'confirm',
       name: 'confirm',

--- a/src/commands/mission.ts
+++ b/src/commands/mission.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, rmSync } from 'node:fs'
 import { atomicWriteFile } from '../lib/atomic-write.js'
 import { join } from 'node:path'
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import { simpleGit } from 'simple-git'
 import { readJsonFile } from '../lib/read-json.js'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
@@ -134,7 +134,7 @@ export async function missionSet(opts: {
   let objective = opts.objective ?? existing?.objective ?? ''
   if (!objective) {
     if (isInteractive(opts)) {
-      const ans = await inquirer.prompt<{ obj: string }>([
+      const ans = await prompt<{ obj: string }>([
         { type: 'input', name: 'obj', message: '미션 목표(objective)는?' },
       ])
       objective = ans.obj.trim()

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import ora from 'ora'
 import { safeExecFile, safeExecFileStream } from '../lib/exec.js'
 import { t } from '../i18n/ko.js'
@@ -205,7 +205,7 @@ export async function publish(): Promise<void> {
     }
   }
 
-  const { bumpType } = await inquirer.prompt<{ bumpType: BumpType }>([
+  const { bumpType } = await prompt<{ bumpType: BumpType }>([
     {
       type: 'list',
       name: 'bumpType',
@@ -266,7 +266,7 @@ export async function publish(): Promise<void> {
   testSpinner.succeed(t('publish.testSuccess'))
 
   // 최종 확인
-  const { confirm } = await inquirer.prompt<{ confirm: boolean }>([
+  const { confirm } = await prompt<{ confirm: boolean }>([
     {
       type: 'confirm',
       name: 'confirm',

--- a/src/commands/recap.ts
+++ b/src/commands/recap.ts
@@ -1,4 +1,4 @@
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import chalk from 'chalk'
 import fs from 'node:fs'
 import path from 'node:path'
@@ -70,7 +70,7 @@ export async function recap(options: RecapOptions = {}) {
   // VHK-014: 비-TTY 면 프롬프트 크래시 대신 friendly 안내 + exit 1 (위 git 분석은 보여준 뒤).
   if (!ensureInteractive('회고 입력은 대화형으로만 가능합니다.')) return
 
-  const answers = await inquirer.prompt([
+  const answers = await prompt([
     {
       type: 'input',
       name: 'summary',
@@ -153,7 +153,7 @@ export async function recap(options: RecapOptions = {}) {
       candidate.files.forEach(f => console.log(chalk.dim(`    ${f}`)))
     }
 
-    const { createAdr } = await inquirer.prompt([{
+    const { createAdr } = await prompt([{
       type: 'confirm',
       name: 'createAdr',
       message: ko.recap.createAdr,
@@ -162,7 +162,7 @@ export async function recap(options: RecapOptions = {}) {
 
     if (createAdr) {
       for (const candidate of adrCandidates) {
-        const adrAnswers = await inquirer.prompt([
+        const adrAnswers = await prompt([
           {
             type: 'input',
             name: 'decision',
@@ -197,7 +197,7 @@ export async function recap(options: RecapOptions = {}) {
       console.log(chalk.dim(`  • ${c.message}`))
     })
 
-    const { createTroubleshoot } = await inquirer.prompt([{
+    const { createTroubleshoot } = await prompt([{
       type: 'confirm',
       name: 'createTroubleshoot',
       message: ko.recap.createTroubleshoot,
@@ -208,7 +208,7 @@ export async function recap(options: RecapOptions = {}) {
       const tsDir = path.join(process.cwd(), 'docs', 'troubleshooting')
       if (!fs.existsSync(tsDir)) fs.mkdirSync(tsDir, { recursive: true })
 
-      const tsAnswers = await inquirer.prompt([
+      const tsAnswers = await prompt([
         {
           type: 'input',
           name: 'problem',
@@ -260,7 +260,7 @@ export async function recap(options: RecapOptions = {}) {
 
   const claudeMdPath = path.join(process.cwd(), 'CLAUDE.md')
   if (fs.existsSync(claudeMdPath)) {
-    const { updateClaude } = await inquirer.prompt([{
+    const { updateClaude } = await prompt([{
       type: 'confirm',
       name: 'updateClaude',
       message: ko.recap.updateClaude,

--- a/src/commands/restore.ts
+++ b/src/commands/restore.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import { ko } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { listBackups, restoreBackup } from '../lib/backup.js'
@@ -30,7 +30,7 @@ export async function restore(id?: string): Promise<void> {
       console.log(chalk.yellow(`\n${ko.restore.nonTtyHint}`))
       return
     }
-    const { picked } = await inquirer.prompt<{ picked: string }>([
+    const { picked } = await prompt<{ picked: string }>([
       {
         type: 'list',
         name: 'picked',

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process'
 import chalk from 'chalk'
 import ora from 'ora'
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import { printSecurityWarnings } from '../lib/check-secure.js'
 import { parsePorcelainLines } from '../lib/git-porcelain.js'
 import {
@@ -71,7 +71,7 @@ export async function save(opts: SaveOptions = {}): Promise<void> {
       console.log(chalk.dim(`   ... 외 ${severe.length - 5}건 (vhk 보안 scan)`))
     }
     const proceed = await promptOrDefault(
-      async () => (await inquirer.prompt<{ proceed: boolean }>([{
+      async () => (await prompt<{ proceed: boolean }>([{
         type: 'confirm',
         name: 'proceed',
         message: t('save.secretsConfirm'),
@@ -103,7 +103,7 @@ export async function save(opts: SaveOptions = {}): Promise<void> {
   const message = opts.message?.trim()
     ? opts.message.trim()
     : await promptOrDefault(
-        async () => (await inquirer.prompt<{ message: string }>([{
+        async () => (await prompt<{ message: string }>([{
           type: 'input',
           name: 'message',
           message: t('save.commitMessage'),

--- a/src/commands/seo/init.ts
+++ b/src/commands/seo/init.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+import { prompt } from '../../lib/prompt.js'
 import { ko } from '../../i18n/ko.js'
 import { isInteractive, TTY_REQUIRED_EXIT_CODE } from '../../lib/interactive.js'
 import {
@@ -42,7 +42,7 @@ export async function seoInit(opts: SeoInitOptions = {}, root: string = process.
       process.exitCode = TTY_REQUIRED_EXIT_CODE
       return
     }
-    const ans = await inquirer.prompt<{ domain: string }>([
+    const ans = await prompt<{ domain: string }>([
       { type: 'input', name: 'domain', message: ko.seo.init.domainPrompt },
     ])
     domain = ans.domain?.trim()

--- a/src/commands/ship.ts
+++ b/src/commands/ship.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import fs from 'node:fs'
 import path from 'node:path'
 import { ko } from '../i18n/ko.js'
@@ -74,7 +74,7 @@ export async function ship() {
 
   console.log(chalk.cyan.bold(`  ${ko.ship.checklist}\n`))
 
-  const { passed } = await inquirer.prompt<{ passed: string[] }>([{
+  const { passed } = await prompt<{ passed: string[] }>([{
     type: 'checkbox',
     name: 'passed',
     message: ko.ship.checkboxPrompt,
@@ -94,7 +94,7 @@ export async function ship() {
       console.log(chalk.dim(`      → ${ko.ship[s.hintKey]}`))
     })
 
-    const { proceed } = await inquirer.prompt<{ proceed: boolean }>([{
+    const { proceed } = await prompt<{ proceed: boolean }>([{
       type: 'confirm',
       name: 'proceed',
       message: ko.ship.proceedConfirm,
@@ -116,7 +116,7 @@ export async function ship() {
   console.log(chalk.cyan.bold(`  ${ko.ship.retro}\n`))
 
   console.log(chalk.dim(`  ${ko.ship.versionHint}`))
-  const retro = await inquirer.prompt<{
+  const retro = await prompt<{
     version: string
     whatWentWell: string
     whatWentWrong: string

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import { simpleGit } from 'simple-git'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
@@ -76,7 +76,7 @@ export async function start(options: StartOptions = {}): Promise<void> {
     console.log(chalk.yellow('⚠️  이미 VHK 설치 흔적이 감지됐어요:'))
     for (const f of footprint) console.log(chalk.dim(`   - ${f}`))
     console.log(chalk.dim('   계속 진행하면 일부 파일(`.cursor/mcp.json`, `.vhk/context.md`)은 갱신·덮어쓰기됩니다.'))
-    const { proceedExisting } = await inquirer.prompt<{ proceedExisting: boolean }>([{
+    const { proceedExisting } = await prompt<{ proceedExisting: boolean }>([{
       type: 'confirm',
       name: 'proceedExisting',
       message: '그래도 다시 마법사를 진행할까요?',
@@ -87,7 +87,7 @@ export async function start(options: StartOptions = {}): Promise<void> {
       return
     }
   } else if (!options.yes) {
-    const { proceed } = await inquirer.prompt<{ proceed: boolean }>([{
+    const { proceed } = await prompt<{ proceed: boolean }>([{
       type: 'confirm',
       name: 'proceed',
       message: ko.start.confirmStart,

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
 import fs from 'node:fs'
 import path from 'node:path'
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import { localDate } from '../lib/date.js'
 import { ko } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
@@ -605,7 +605,7 @@ export async function sync(opts: SyncOptions = {}): Promise<void> {
     promptOrDefault(
       async () => {
         for (const d of drifted) console.log(chalk.yellow(`  ${ko.sync.driftWarn(d.path)}`))
-        const { confirm } = await inquirer.prompt<{ confirm: boolean }>([
+        const { confirm } = await prompt<{ confirm: boolean }>([
           {
             type: 'confirm',
             name: 'confirm',

--- a/src/commands/theme.ts
+++ b/src/commands/theme.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { promptOrDefault } from '../lib/interactive.js'
@@ -89,7 +89,7 @@ export async function theme(options?: { yes?: boolean }): Promise<void> {
     const overwrite = options?.yes === true
       ? true
       : await promptOrDefault(
-          async () => (await inquirer.prompt<{ overwrite: boolean }>([{
+          async () => (await prompt<{ overwrite: boolean }>([{
             type: 'confirm',
             name: 'overwrite',
             message: `다음 파일이 이미 있어요. 덮어쓸까요?\n   ${conflicts.join('\n   ')}`,

--- a/src/commands/undo.ts
+++ b/src/commands/undo.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process'
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+import { prompt } from '../lib/prompt.js'
 import {
   countLocalCommits,
   getGitRoot,
@@ -75,7 +75,7 @@ export async function undo(): Promise<void> {
   })
 
   const maxUndo = commits.length
-  const { count } = await inquirer.prompt<{ count: number }>([{
+  const { count } = await prompt<{ count: number }>([{
     type: 'number',
     name: 'count',
     message: t('undo.howMany'),
@@ -104,7 +104,7 @@ export async function undo(): Promise<void> {
     }
   }
 
-  const { confirm } = await inquirer.prompt<{ confirm: boolean }>([{
+  const { confirm } = await prompt<{ confirm: boolean }>([{
     type: 'confirm',
     name: 'confirm',
     message: risky ? t('undo.confirmRisky', undoCount) : t('undo.confirmMessage'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Command, Help } from 'commander'
 import { fileURLToPath } from 'node:url'
 import fs from 'node:fs'
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+import { prompt } from './lib/prompt.js'
 import { detectNaturalLanguageInput } from './lib/cli-args.js'
 import { runNaturalLanguageRoute } from './lib/nlp-run.js'
 import { getVhkVersion } from './lib/version.js'
@@ -72,7 +72,7 @@ async function guardCli(
       channel: 'cli',
       approved,
       confirm: async () => {
-        const { ok } = await inquirer.prompt<{ ok: boolean }>([{
+        const { ok } = await prompt<{ ok: boolean }>([{
           type: 'confirm',
           name: 'ok',
           message: `⚠️ 위험 작업(${action})을 실행할까요?`,
@@ -898,7 +898,7 @@ program.action(async () => {
     { name: '⏸️  작업 중단 정리 (handoff)', value: 'work-handoff' },
   ]
 
-  const { choice } = await inquirer.prompt<{ choice: string }>([{
+  const { choice } = await prompt<{ choice: string }>([{
     type: 'list',
     name: 'choice',
     message: '뭘 도와드릴까요?',

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+import { prompt } from './prompt.js'
 import { routeNaturalLanguage, extractNotionUrl, type NlpRoute, type NlpCommand } from './nlp-router.js'
 import { ko } from '../i18n/ko.js'
 import { gate } from '../commands/gate.js'
@@ -179,7 +179,7 @@ export async function runNaturalLanguageRoute(input: string): Promise<void> {
   console.log(chalk.cyan(`  → ${route.explanation}`))
 
   if (requiresConfirmation(route)) {
-    const { confirm } = await inquirer.prompt<{ confirm: boolean }>([{
+    const { confirm } = await prompt<{ confirm: boolean }>([{
       type: 'confirm',
       name: 'confirm',
       message: `${route.explanation} — ${ko.nlp.matched}`,

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -1,0 +1,12 @@
+import type { Answers, QuestionCollection } from 'inquirer'
+
+/**
+ * inquirer 지연 로딩 래퍼 (RFC 0047 — 콜드스타트).
+ * inquirer 는 단일 최대 무게(실측 ~212ms net = 콜드스타트 절반). top-level import 면
+ * `vhk --version` 같은 비대화형 핫패스도 매번 로드 → 여기서 `await import()` 로 *프롬프트 실제 호출 시점*까지 미룬다.
+ * 모든 호출부가 async(await prompt(...)) 라 안전. inquirer.prompt 외 API(Separator 등)는 미사용이라 이 래퍼로 충분.
+ */
+export async function prompt<T extends Answers = Answers>(questions: QuestionCollection): Promise<T> {
+  const inquirer = (await import('inquirer')).default
+  return inquirer.prompt<T>(questions)
+}

--- a/tests/check-inquirer-lazy.test.ts
+++ b/tests/check-inquirer-lazy.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, statSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// RFC 0047: inquirer(~212ms net = 콜드스타트 절반)는 top-level value import 금지.
+// 반드시 lib/prompt.ts 의 lazy `await import('inquirer')` 경유 — 비대화형 핫패스(--version 등)서 미로드.
+// import type 은 허용(런타임 무관, 빌드서 소거). 이 가드가 회귀(누가 다시 top-level import) 차단.
+
+const FORBID = /^\s*import\s+inquirer\s+from\s+['"]inquirer['"]/m
+
+function scan(dir: string): string[] {
+  const offenders: string[] = []
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name)
+    if (statSync(p).isDirectory()) {
+      offenders.push(...scan(p))
+    } else if (p.endsWith('.ts')) {
+      if (FORBID.test(readFileSync(p, 'utf-8'))) offenders.push(p)
+    }
+  }
+  return offenders
+}
+
+describe('inquirer lazy 가드 (RFC 0047 콜드스타트)', () => {
+  it('src/ 어디에도 top-level `import inquirer from` 없음 (lib/prompt.ts lazy 경유)', () => {
+    expect(scan('src')).toEqual([])
+  })
+
+  it('FORBID 정규식이 default value import 만 잡고 import type 은 통과', () => {
+    expect(FORBID.test("import inquirer from 'inquirer'")).toBe(true)
+    expect(FORBID.test('import type { Answers } from \'inquirer\'')).toBe(false)
+    expect(FORBID.test("const x = await import('inquirer')")).toBe(false)
+  })
+})


### PR DESCRIPTION
## 무엇

CLI 콜드스타트 **512→323ms (−37%)** — inquirer 지연 로딩 (RFC 0047).

## measure-first

dep별 import 비용 실측 → 전략 결정:

| dep | net import |
|---|---|
| **inquirer** | **212ms** ← 단일 최대(전체 434ms의 절반) |
| handlebars | 33ms · simple-git 31 · notion 20 · chalk 14 · commander 12 |

→ "명령 60+ 전부 lazy"(index.ts 통째 재작성·고위험) 대신 **inquirer 하나만 lazy** 가 80/20.

## 변경

- `src/lib/prompt.ts` — `await import('inquirer')` lazy 래퍼. inquirer 는 *프롬프트 실호출* 시점까지 미로드.
- 22파일 `import inquirer` → `import { prompt }`, `inquirer.prompt`(49곳) → `prompt` 코드모드. 모든 호출이 async라 무위험.
- `tests/check-inquirer-lazy.test.ts` — top-level `import inquirer from` 재등장 차단(회귀=콜드스타트 +212ms 복귀).
- splitting 불필요 — ESM dynamic import 자체가 모듈 init 지연.

## 결과

- `vhk --version` 512→**323ms (−37%)** · `vhk status` 739→610ms · node 바닥 26ms.
- 전체 **1385 테스트 green**(inquirer mock 정상). 부수 이득: 테스트 import 23s→12s.
- build·typecheck·lint green.

## 보류

명령 lazy + tsup splitting 으로 잔여 ~297ms 추가 공략 가능하나 다음 dep 가 12~33ms로 ROI↓·index.ts 고위험 → 실수요/추가 실측 정당화 시 (RFC 0047 §9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
