### PR TITLE
docs(state): stale 정리 — 콜드스타트·파서픽스 반영, 이슈 #38만

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,9 +88,9 @@ tags: [process, constitution]
 
 **마지막 갱신:** 2026-06-10
 - **버전:** v2.5.1 (발행 완료) — 사실 확인은 package.json·CHANGELOG
-- **테스트:** 1381 pass(main) · **MCP tools:** 29 — 사실값은 package.json·CHANGELOG
-- **Phase:** measure-first 2종. recall(RFC 0049) #232·#233 머지. diff-coverage(RFC 0050·Goal 50) PR1 #236 머지 — `vhk diff-cover` 측정 도구(자문·차단 0). 둘 다 실측 누적 후 게이트/ML 결정.
+- **테스트:** 1385 pass(main) · **MCP tools:** 29 — 사실값은 package.json·CHANGELOG
+- **Phase:** measure-first 2종. recall(RFC 0049) #232·#233. diff-coverage(RFC 0050·Goal 50) PR1 #236+파서픽스 #239 — `vhk diff-cover` 측정(자문·차단 0). 둘 다 실측 누적 후 게이트/ML 결정. 추가: 콜드스타트 −37%(#240 inquirer lazy).
 - **블로커:** 없음
-- **진행 중(미발행):** diff-coverage PR1 main 머지(미발행). PR2(review/CI 통합)는 도그푸딩 ≥5 diff 실측 대기.
-- **다음 할 일:** measure-first 실측 누적 — `vhk diff-cover` ≥5 실제 diff(RFC 0050 §5) + `vhk recall` 실사용→eval(RFC 0049 §5). 그 후 PR2/2차ML 결정. 병행: 미완 goal(린트 25/27·#128, SEO 21~26) + 열린 이슈 트리아지(#157·#155·#171·#148). ※ PR2 시 diff-hunks 파서 `diff --git`줄 기반으로 강화(코드리뷰 발견 엣지).
+- **진행 중(미발행):** diff-coverage PR1 + 콜드스타트(#240) main 머지(미발행). PR2(review/CI 통합)는 ≥5 diff 실측 대기.
+- **다음 할 일:** measure-first 실측 누적 — `vhk diff-cover` ≥5 실제 diff(RFC 0050 §5) + `vhk recall` 실사용→eval(RFC 0049 §5). 그 후 PR2/2차ML 결정. 병행: 미완 goal(린트 25/27·#128, SEO 21~26). 열린 이슈 = #38 1개(.vhk 규격 의견수렴, 코딩 아님).
 - **주의:** publish는 main에서만(#119)·사용자 직접(2FA) / 직접 main push 차단 → PR 경유

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -3,18 +3,17 @@
 > "지금 무엇부터"의 상태 SoT. 버전·테스트 등 사실값은 package.json·CHANGELOG가 SoT.
 
 **갱신:** 2026-06-10
-**Phase:** measure-first 2종 진행. recall(RFC 0049) MVP+eval 머지(#232·#233). diff-coverage(RFC 0050·Goal 50) PR1 머지(#236) — `vhk diff-cover` 측정 도구(차단 0). 둘 다 **실측 누적 대기**(게이트/ML은 숫자가 정당화한 뒤). 사실값(버전·테스트수)은 package.json·CHANGELOG.
+**Phase:** measure-first 2종 진행. recall(RFC 0049) MVP+eval 머지(#232·#233). diff-coverage(RFC 0050·Goal 50) PR1 머지(#236)+파서픽스(#239) — `vhk diff-cover` 측정 도구(차단 0). 둘 다 **실측 누적 대기**(게이트/ML은 숫자가 정당화한 뒤). 추가: 콜드스타트 −37%(#240, inquirer lazy). 사실값(버전·테스트수)은 package.json·CHANGELOG.
 
 ## 다음 할 일 (measure-first 최우선)
-- **diff-coverage 실측 누적** → `vhk diff-cover`를 실제 코드 작업 **diff ≥5건(며칠)** 돌려 미검증 변경분 분포 수집(RFC 0050 §5 관찰 프로토콜). 유의미>0 → PR2(review line-40 제거 + verify 증거 + CI). ≈0 → "이론적 구멍" 문서화 후 중단(YAGNI).
-  - **PR2 파서 강화 같이**: diff-hunks 파일명을 `+++` 대신 `diff --git a/X b/X` 줄에서 추출(코드리뷰 발견 — 추가라인 `++ x` 콜0이 `+++` 헤더로 오인되는 엣지).
+- **diff-coverage 실측 누적** → `vhk diff-cover`를 실제 코드 작업 **diff ≥5건(며칠)** 돌려 미검증 변경분 분포 수집(RFC 0050 §5 관찰 프로토콜). 유의미>0 → PR2(review line-40 제거 + verify 증거 + CI). ≈0 → "이론적 구멍" 문서화 후 중단(YAGNI). ※ diff-hunks `+++` 파서 엣지는 #239에서 이미 강화 완료(상태머신).
 - **recall 실측** → 며칠 `vhk recall` 실사용 → `vhk memory eval --init` 실쿼리 라벨 → 진짜 Recall@5. <70 반복이면 2차 ML(bge-m3, RFC 0049 §2 결정 잠금됨).
 - **🎯 업계최상위(~4.7) 품질 로드맵** → [docs/rfc/0048](../rfc/0048-top-tier-quality-roadmap.md) + **Goals 47~54**. 13-에이전트 감사(3.5/5) 도출. 순서: **P0 먼저** — Goal 47(win32+Node20 CI 매트릭스) · Goal 48(MCP↔CLI 단일 진실원) → P1 49(린트 확대)·50(커버리지) → P2 51~54. 각 goal `vhk goal next`로 꺼내 개별 PR(AI 독주 방지). ※ 작업2.2(fast-check #213)·2.3(tsc/eslint #216) 머지로 Goal 49는 "도입→확대", Goal 52 property 옵션은 선점됨 — 재조정 필요.
 - **미완 goal** (goals/ 동적 계산 — `vhk goal next`): silent-fallback 린트(Goal 25/27 영역·#128) · SEO 묶음(Goal 21~26) 등.
-- **열린 이슈 10개 트리아지** — 불확실 해결분 4개(#157 verify UX·#155 goal check mission drift·#171 nested pkg audit·#148 memory add `--`) 재현/해결확인 후 close. 백로그: #160·#159·#158·#151·#38.
+- **열린 이슈 = #38 1개** (RFC 0001 .vhk 규격 의견수렴 — 코딩 아닌 결정 토론, 4개 미해결 질문). 나머지(#157·#155·#171·#148·#160·#159·#158·#151) close 완료. #38은 close/유지 product 결정.
 
 ## 백로그 (예약 — 선행조건 충족 후)
-- **CLI 콜드스타트 지연 로딩** → [docs/rfc/0047](../rfc/0047-cli-coldstart-lazy-load.md). 실측 콜드스타트 489ms 중 94%가 index.ts eager import(런타임 무관). dynamic import + tsup splitting 으로 해결. **선행조건: index.ts 닿는 작업(SEO goal-21 등록·명령 추가 이슈) 전부 머지 후 → 단독 PR 마지막에** (index.ts 중앙성 → 동시 진행 시 충돌). Bun/Rust 전환은 RFC §4에서 기각.
+- **CLI 콜드스타트 — inquirer lazy 머지 완료(#240, 512→323ms −37%)**. dep별 실측 결과 inquirer가 단일 최대(212ms=절반) → `lib/prompt.ts` lazy 래퍼로 80/20 처리(RFC 0047 §9). 잔여 명령 lazy+splitting(잔여 ~297ms, dep 12~33ms 단위)는 ROI↓·index.ts 고위험이라 보류.
 
 ## 블로커
 - 없음


### PR DESCRIPTION
next-task.md·CLAUDE.md LIVE 현행화.

- 콜드스타트 inquirer lazy 머지(#240, −37%) 반영
- diff-hunks 파서 강화 #239 완료 — "PR2 시 강화" 줄 제거
- '열린 이슈 10개 트리아지' → #38 1개(나머지 close). #38=.vhk 규격 의견수렴(코딩 아닌 결정 토론)
- 테스트 카운트 1385

문서 전용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)