### PR TITLE
fix: 도그푸딩 버그 8건 일괄 수정 (#243-#250)

### DIFF
--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import chalk from 'chalk'
 import { prompt } from '../lib/prompt.js'
+import { promptOrDefault } from '../lib/interactive.js'
 import ora from 'ora'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
@@ -140,19 +141,25 @@ export async function audit(autoFix = false): Promise<void> {
     console.log(chalk.bold(`\n  총 ${aggregate.total}개의 취약점`))
   }
 
+  // #244: 비-TTY(CI/agent)면 프롬프트에 hang → promptOrDefault 로 report-only(false) 폴백.
+  //       대화형이면 기존대로 확인. --fix(autoFix) 는 비-TTY 에서도 강제 수정 경로.
   const shouldRunFix = autoFix
     ? true
     : aggregate.critical > 0 || aggregate.high > 0
-      ? (
-          await prompt<{ shouldFix: boolean }>([
-            {
-              type: 'confirm',
-              name: 'shouldFix',
-              message: '자동 수정을 시도할까요? (npm audit fix)',
-              default: true,
-            },
-          ])
-        ).shouldFix
+      ? await promptOrDefault(
+          async () =>
+            (
+              await prompt<{ shouldFix: boolean }>([
+                {
+                  type: 'confirm',
+                  name: 'shouldFix',
+                  message: '자동 수정을 시도할까요? (npm audit fix)',
+                  default: true,
+                },
+              ])
+            ).shouldFix,
+          false,
+        )
       : false
 
   if (shouldRunFix) {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -134,7 +134,7 @@ export async function doctor(opts: DoctorOptions = {}) {
       }
     } else if (file.name === '.env' && fs.existsSync(path.join(cwd, '.env.local'))) {
       // VHK-009: .env 없어도 .env.local 있으면 정상(Vite 관례) — 모호한 부재 안내 대신 인식.
-      console.log(chalk.green('    ✅ .env.local') + chalk.dim(' — 로컴 env 사용 중 (.env 없어도 정상)'))
+      console.log(chalk.green('    ✅ .env.local') + chalk.dim(' — 로컬 env 사용 중 (.env 없어도 정상)'))
     } else {
       console.log(chalk.dim(`    ⚫ ${file.name}`) + chalk.dim(` — ${file.hint}`))
     }

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -39,17 +39,18 @@ export function loadDefinedEnvKeys(dir = '.'): string[] {
   return [...keys]
 }
 
-function ensureGitignore(): void {
+// #247: 사용한 env 파일(.env 또는 .env.local)을 gitignore 에 보장 — 둘 다 시크릿 보유.
+function ensureGitignore(envFile = '.env'): void {
   const gitignorePath = '.gitignore'
   if (existsSync(gitignorePath)) {
     const content = readFileSync(gitignorePath, 'utf-8')
-    if (!content.split('\n').some((l) => l.trim() === '.env')) {
-      appendFileSync(gitignorePath, '\n.env\n')
-      console.log(chalk.green('\n🔒 .gitignore에 .env 추가됨'))
+    if (!content.split('\n').some((l) => l.trim() === envFile)) {
+      appendFileSync(gitignorePath, `\n${envFile}\n`)
+      console.log(chalk.green(`\n🔒 .gitignore에 ${envFile} 추가됨`))
     }
   } else {
-    writeFileSync(gitignorePath, '.env\nnode_modules/\ndist/\n')
-    console.log(chalk.green('\n🔒 .gitignore 생성 (.env 포함)'))
+    writeFileSync(gitignorePath, `${envFile}\nnode_modules/\ndist/\n`)
+    console.log(chalk.green(`\n🔒 .gitignore 생성 (${envFile} 포함)`))
   }
 }
 
@@ -58,13 +59,15 @@ export async function env(): Promise<void> {
   console.log(chalk.bold('\n🔐 ' + t('env.title')))
   console.log(chalk.gray('─'.repeat(40)))
 
-  if (!existsSync('.env')) {
-    console.log(chalk.yellow('\n⚠️  .env 파일이 없습니다.'))
-    console.log(chalk.gray('   .env 파일을 먼저 만들어주세요.'))
+  // #247: .env 없으면 .env.local 폴백(Vercel/Vite 관례) — doctor 와 일관.
+  const envFile = existsSync('.env') ? '.env' : existsSync('.env.local') ? '.env.local' : null
+  if (!envFile) {
+    console.log(chalk.yellow('\n⚠️  .env / .env.local 파일이 없습니다.'))
+    console.log(chalk.gray('   .env 또는 .env.local 파일을 먼저 만들어주세요.'))
     return
   }
 
-  const envContent = readFileSync('.env', 'utf-8')
+  const envContent = readFileSync(envFile, 'utf-8')
   const keys = parseEnvKeys(envContent)
 
   if (keys.length === 0) {
@@ -77,7 +80,7 @@ export async function env(): Promise<void> {
   console.log(chalk.green(`\n✅ .env.example 생성 (${keys.length}개 키)`))
   keys.forEach((k) => console.log(chalk.gray(`   ${k}`)))
 
-  ensureGitignore()
+  ensureGitignore(envFile)
 
   printNextStep({
     message: '.env.example 생성 완료!',

--- a/src/commands/preflight.ts
+++ b/src/commands/preflight.ts
@@ -85,6 +85,7 @@ export async function preflight(opts: PreflightCliOptions = {}): Promise<void> {
       pm,
       scripts,
       hasVitest,
+      hasTsconfig: existsSync(join(cwd, 'tsconfig.json')), // #245: 없으면 typecheck skip(바닐라 JS)
     }
   )
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -623,10 +623,12 @@ export async function sync(opts: SyncOptions = {}): Promise<void> {
 
   // ③ 누락 발생 지점(syncCore)이 집계한 미매칭 섹션을 호출자가 경고 — 조용히 사라지지 않게.
   if (result.unmapped.length) {
+    // #249: 비표준 섹션은 AGENTS.md 「기타 규칙」에 전파됨(#130) — 손실 아님.
+    //       단 .cursorrules 등 코딩 규칙 파일은 표준 제목만(설계상 코딩/디자인 전용).
     console.error(
       chalk.yellow(
-        `  ⚠️  ${result.unmapped.length}개 섹션이 어느 타깃에도 매핑 안 돼 산출물에서 제외됨: ${result.unmapped.join(', ')}` +
-          `\n     (코딩 규칙/기술 스택/커밋/기록 등 표준 제목을 쓰거나, 이 섹션은 RULES.md 에만 보존됩니다.)`
+        `  ⚠️  ${result.unmapped.length}개 비표준 섹션은 .cursorrules 등 코딩 규칙 파일엔 미포함(표준 제목만): ${result.unmapped.join(', ')}` +
+          `\n     (단 AGENTS.md 「기타 규칙」에는 전파됨 — 손실 아님. 코딩 파일에도 넣으려면 표준 제목 사용, 수정은 RULES.md 에서.)`
       )
     )
   }

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -2,7 +2,9 @@ import { execFileSync } from 'node:child_process'
 
 // Windows에서 pnpm/npm/npx/yarn/vhk는 .cmd shim. execFileSync는 native 바이너리만 찾으므로 .cmd 확장자 부여.
 // #150: 'vhk' 추가 — 전역 설치 시 vhk.cmd 만 노출돼 MCP 가 bare 'vhk' spawn 시 ENOENT 였음.
-const SHIM_BINARIES = new Set(['pnpm', 'npm', 'npx', 'yarn', 'vhk'])
+// #246: 배포 CLI(vercel/netlify/wrangler) 추가 — npm 전역 설치 시 .cmd shim 만 노출돼
+//       deploy 의 isCLIAvailable 가 Windows 에서 설치돼 있어도 ENOENT 로 "미설치" 오판.
+const SHIM_BINARIES = new Set(['pnpm', 'npm', 'npx', 'yarn', 'vhk', 'vercel', 'netlify', 'wrangler'])
 
 export function platformCmd(cmd: string): string {
   if (process.platform === 'win32' && SHIM_BINARIES.has(cmd)) {

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -26,6 +26,7 @@ export interface PreflightDeps {
   pm?: string // 'pnpm' | 'yarn' | 'npm'
   scripts?: Record<string, string> // package.json scripts
   hasVitest?: boolean // vitest 설치/설정 여부 (없으면 테스트 하드코딩 강제 안 함)
+  hasTsconfig?: boolean // #245: tsconfig.json 존재 여부 (typecheck 스크립트도 없으면 skip)
 }
 
 /** 명령 실행 spec — 스크립트 우선 해석 결과. */
@@ -89,10 +90,16 @@ export function checkLint(run: Runner, hasLinter: boolean, lintCmd?: CmdSpec): P
     : check('lint', 'fail', `eslint 오류 — ${evidence(r)}`, 'critical')
 }
 
-export function checkTypecheck(run: Runner): PreflightCheck {
-  const r = run('npx', ['tsc', '--noEmit'])
+// #245: typecheckCmd 우선 — {bin,args}=그 스크립트, null=수단 없음(tsconfig·스크립트 둘 다 없음)→skip,
+//       undefined=npx tsc 폴백(하위호환). verify 게이트 로직(스크립트/tsconfig 없으면 skip) 미러.
+export function checkTypecheck(run: Runner, typecheckCmd?: CmdSpec | null): PreflightCheck {
+  if (typecheckCmd === null) {
+    return check('typecheck', 'skip', 'tsconfig.json/typecheck 스크립트 없음 — 스킵', 'critical')
+  }
+  const spec: CmdSpec = typecheckCmd ?? { bin: 'npx', args: ['tsc', '--noEmit'] }
+  const r = run(spec.bin, spec.args)
   return r.ok
-    ? check('typecheck', 'pass', 'tsc --noEmit pass', 'critical')
+    ? check('typecheck', 'pass', typecheckCmd ? '통과' : 'tsc --noEmit pass', 'critical')
     : check('typecheck', 'fail', `tsc 타입 오류 — ${evidence(r)}`, 'critical')
 }
 
@@ -177,6 +184,13 @@ export function runPreflight(opts: PreflightOptions, deps: PreflightDeps): Prefl
 
   const lintCmd = scripts.lint ? mkCmd('lint') : undefined
 
+  // #245: typecheck 스크립트 우선 → tsconfig 있으면 npx tsc 폴백 → 둘 다 없으면 skip(바닐라 JS 차단 방지).
+  const typecheckCmd: CmdSpec | null | undefined = scripts.typecheck
+    ? mkCmd('typecheck')
+    : deps.hasTsconfig
+      ? undefined
+      : null
+
   // 테스트: 일회성(run) 스크립트 우선 → vitest 폴백 → 비-vitest test 스크립트 → 없으면 skip.
   // bare `test` 를 vitest 폴백보다 뒤에 두는 건 의도적 — `test:"vitest"`(watch) 가 preflight 를
   // 멈추게 하는 회귀 방지. (test:run/test:ci 는 관례상 일회성.)
@@ -194,7 +208,7 @@ export function runPreflight(opts: PreflightOptions, deps: PreflightDeps): Prefl
     checkShim(deps.nodeVersion),
     deps.worktreeEnv(),
     checkLint(deps.run, deps.hasLinter, lintCmd),
-    checkTypecheck(deps.run),
+    checkTypecheck(deps.run, typecheckCmd),
     checkTests(deps.run, { full: opts.full }, testCmd),
     checkGitClean(deps.run),
     checkBranch(deps.run),

--- a/src/lib/scan-secrets.ts
+++ b/src/lib/scan-secrets.ts
@@ -21,12 +21,20 @@ export function findSecretsInLine(
   if (line.length > MAX_LINE_CHARS) return found
   // #218: 주석줄이라고 줄 전체를 스킵하면('example' 포함 시) 주석에 섞인 진짜 시크릿을 놓친다
   //       (보안 false-negative). 매칭된 '값' 자체가 placeholder(…EXAMPLE 등)일 때만 그 매치를 무시한다.
-  const isComment = trimmed.startsWith('//') || trimmed.startsWith('#')
+  // #250: 블록주석(/** */·* 연속줄·/*)도 주석으로 인식 + placeholder 표식 확대(YOUR_·xxxx 등).
+  //       단 isComment 게이트 안에서만 동작 → 진짜 토큰은 주석/코드 어디서든 여전히 탐지(false-negative 0).
+  const isComment =
+    trimmed.startsWith('//') ||
+    trimmed.startsWith('#') ||
+    trimmed.startsWith('*') ||
+    trimmed.startsWith('/*')
 
   for (const pattern of SECRET_PATTERNS) {
     const regex = globalPattern(pattern.pattern)
     for (const match of line.matchAll(regex)) {
-      if (isComment && /example/i.test(match[0])) continue // placeholder 시크릿만 무시
+      // placeholder 표식이 매칭값에 있으면(주석 한정) 무시 — your_·fake_·dummy·redacted·changeme·xxxx·<...>
+      if (isComment && /(?:example|placeholder|your[_-]|fake[_-]|dummy|redacted|changeme|x{4,}|<[^>]+>)/i.test(match[0]))
+        continue // placeholder 시크릿만 무시
       found.push({
         patternId: pattern.id,
         patternName: pattern.name,

--- a/src/lib/vhk-cloud.ts
+++ b/src/lib/vhk-cloud.ts
@@ -15,6 +15,7 @@ export const DEFAULT_CLOUD_EXCLUDES = [
   'HARD_STOP',     // 로컬 안전 신호
   'cloud.json',    // gist 포인터 (백업 대상 아님)
   '.gitignore',    // .vhk/ 내부 gitignore
+  '*.bak',         // #248: 백업본(memory.json.bak·.v1.bak 등) — 원본과 동일 개인정보, 누출 차단
 ]
 
 export const VHK_DIR = '.vhk'

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 const mockSafeExecFile = vi.fn()
 const mockExistsSync = vi.fn()
@@ -34,6 +34,10 @@ describe('audit', () => {
     mockExistsSync.mockReturnValue(false) // npm 기본
   })
 
+  afterEach(() => {
+    delete process.env.VHK_FORCE_INTERACTIVE // #244: 테스트 간 TTY 시뮬레이션 누수 방지
+  })
+
   it('모듈을 import 할 수 있다', async () => {
     const mod = await import('../src/commands/audit.js')
     expect(mod.audit).toBeDefined()
@@ -65,7 +69,8 @@ describe('audit', () => {
     expect(fixCall![0]).toBe('npm')
   })
 
-  it('critical/high가 있고 autoFix=false면 사용자에게 fix 여부를 묻는다', async () => {
+  it('critical/high가 있고 autoFix=false면 (TTY) 사용자에게 fix 여부를 묻는다', async () => {
+    process.env.VHK_FORCE_INTERACTIVE = '1' // #244: TTY 시뮬레이션 — 프롬프트 경로 검증
     mockSafeExecFile.mockReturnValue({
       ok: true,
       out: JSON.stringify({
@@ -78,7 +83,25 @@ describe('audit', () => {
     expect(mockPrompt).toHaveBeenCalled()
   })
 
+  it('#244: 비-TTY(CI/agent) + critical/high + autoFix=false면 프롬프트 없이 report-only(fix 호출 안 함)', async () => {
+    // VHK_FORCE_INTERACTIVE 미설정 = 비-TTY → promptOrDefault 가 prompt 호출 없이 false 폴백.
+    mockSafeExecFile.mockReturnValue({
+      ok: true,
+      out: JSON.stringify({
+        metadata: { vulnerabilities: { critical: 2, high: 1, moderate: 0, low: 0, total: 3 } },
+      }),
+    })
+    const { audit } = await import('../src/commands/audit.js')
+    await audit(false)
+    expect(mockPrompt).not.toHaveBeenCalled() // hang 안 함
+    const fixCall = mockSafeExecFile.mock.calls.find(
+      (c) => Array.isArray(c[1]) && (c[1] as string[]).includes('fix')
+    )
+    expect(fixCall).toBeUndefined() // report-only — 자동 수정 안 함
+  })
+
   it('exit code !=0지만 stdout에 JSON이 담겨도 파싱한다 (safeExecFile err 경로)', async () => {
+    process.env.VHK_FORCE_INTERACTIVE = '1' // TTY 시뮬레이션 — 파싱 성공 시 프롬프트 도달 확인
     mockSafeExecFile.mockReturnValue({
       ok: false,
       err: 'audit exit 1',

--- a/tests/cloud.test.ts
+++ b/tests/cloud.test.ts
@@ -42,6 +42,10 @@ describe('vhk-cloud — 기본 제외', () => {
     expect(DEFAULT_CLOUD_EXCLUDES).toContain('HARD_STOP')
     expect(DEFAULT_CLOUD_EXCLUDES).toContain('cloud.json')
   })
+
+  it('#248: *.bak 백업본도 기본 제외 (memory.json.bak 누출 차단)', () => {
+    expect(DEFAULT_CLOUD_EXCLUDES).toContain('*.bak')
+  })
 })
 
 describe('vhk-cloud — collectVhkFiles', () => {
@@ -68,6 +72,14 @@ describe('vhk-cloud — collectVhkFiles', () => {
     const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-empty-'))
     expect(collectVhkFiles(empty)).toEqual([])
     fs.rmSync(empty, { recursive: true, force: true })
+  })
+
+  it('#248: memory.json.bak 등 *.bak 백업본을 수집서 제외(개인정보 누출 차단)', () => {
+    fs.writeFileSync(path.join(repo, '.vhk', 'memory.json.bak'), '[]\n')
+    fs.writeFileSync(path.join(repo, '.vhk', 'memory.json.v1.bak'), '[]\n')
+    const files = collectVhkFiles(repo)
+    expect(files).not.toContain('memory.json.bak')
+    expect(files).not.toContain('memory.json.v1.bak')
   })
 })
 

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -67,6 +67,19 @@ describe('env', () => {
     expect(String(exampleCall![1])).not.toContain('postgres')
   })
 
+  it('#247: .env 없고 .env.local 있으면 .env.local 로 폴백 (.env.example 생성)', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p) === '.env.local')
+    mockReadFileSync.mockReturnValue('API_KEY=secret\nDB_URL=postgres')
+    const { env } = await import('../src/commands/env.js')
+    await env()
+    // .env.local 을 읽어야 함 (.env 폴백)
+    const readCall = mockReadFileSync.mock.calls.find((c) => String(c[0]) === '.env.local')
+    expect(readCall).toBeDefined()
+    const exampleCall = mockWriteFileSync.mock.calls.find((c) => String(c[0]) === '.env.example')
+    expect(exampleCall).toBeDefined()
+    expect(String(exampleCall![1])).toContain('API_KEY=')
+  })
+
   it('envCheck: .env.example 없으면 경고', async () => {
     mockExistsSync.mockReturnValue(false)
     const { envCheck } = await import('../src/commands/env.js')

--- a/tests/exec.test.ts
+++ b/tests/exec.test.ts
@@ -11,6 +11,10 @@ describe('lib/exec', () => {
       expect(platformCmd('npm')).toBe('npm.cmd')
       expect(platformCmd('npx')).toBe('npx.cmd')
       expect(platformCmd('yarn')).toBe('yarn.cmd')
+      // #246: 배포 CLI도 .cmd shim — Windows 에서 deploy isCLIAvailable 탐지 위해.
+      expect(platformCmd('vercel')).toBe('vercel.cmd')
+      expect(platformCmd('netlify')).toBe('netlify.cmd')
+      expect(platformCmd('wrangler')).toBe('wrangler.cmd')
       expect(platformCmd('git')).toBe('git')
       expect(platformCmd('node')).toBe('node')
     } finally {

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -103,6 +103,16 @@ describe('checkTypecheck', () => {
     const { run } = mockRunner({ 'npx tsc --noEmit': { ok: false, out: 'TS2322', err: '' } })
     expect(checkTypecheck(run).status).toBe('fail')
   })
+  it('#245: typecheckCmd=null(tsconfig·스크립트 없음)이면 skip — 바닐라 JS 차단 안 함', () => {
+    const { run } = mockRunner({})
+    const r = checkTypecheck(run, null)
+    expect(r.status).toBe('skip')
+  })
+  it('#245: typecheck 스크립트(CmdSpec) 주면 그걸 실행', () => {
+    const { run } = mockRunner({ 'pnpm run typecheck': { ok: true, out: '' } })
+    const r = checkTypecheck(run, { bin: 'pnpm', args: ['run', 'typecheck'] })
+    expect(r.status).toBe('pass')
+  })
 })
 
 describe('checkTests', () => {
@@ -275,5 +285,16 @@ describe('runPreflight', () => {
       worktreeEnv: (): PreflightCheck => ({ name: 'worktree env', status: 'fail', detail: '누락', severity: 'critical' }),
     })
     expect(summarizePreflight(checks).blocked).toBe(true)
+  })
+  it('#245: tsconfig 없고 typecheck 스크립트도 없으면 typecheck skip(차단 아님)', () => {
+    const checks = runPreflight({}, { ...deps, hasTsconfig: false })
+    const tc = checks.find((c) => c.name === 'typecheck')
+    expect(tc?.status).toBe('skip')
+    expect(summarizePreflight(checks).blocked).toBe(false)
+  })
+  it('#245: tsconfig 있으면 typecheck 실행(npx tsc 폴백)', () => {
+    const checks = runPreflight({}, { ...deps, hasTsconfig: true })
+    const tc = checks.find((c) => c.name === 'typecheck')
+    expect(tc?.status).toBe('pass')
   })
 })

--- a/tests/scan-secrets.test.ts
+++ b/tests/scan-secrets.test.ts
@@ -47,6 +47,26 @@ describe('scan-secrets', () => {
     expect(findings.filter(f => f.patternId === 'authorization-bearer')).toHaveLength(0)
   })
 
+  // #250: 블록주석(* 연속줄·/**·/*)의 placeholder 토큰(YOUR_*·xxxx)은 오탐 → 스킵.
+  it('#250: 블록주석(* 줄)의 placeholder Bearer(YOUR_*)는 스킵', () => {
+    const line = ' *   Header: Authorization: Bearer' + ' YOUR_TRIGGER_SYNC_SECRET'
+    const findings = findSecretsInLine(line, 'api/trigger-sync.js', 11)
+    expect(findings.filter(f => f.patternId === 'authorization-bearer')).toHaveLength(0)
+  })
+
+  it('#250: /* 시작 주석의 placeholder(xxxx)도 스킵', () => {
+    const line = '/* Authorization: Bearer' + ' xxxxxxxx */'
+    const findings = findSecretsInLine(line, 'a.ts', 1)
+    expect(findings.filter(f => f.patternId === 'authorization-bearer')).toHaveLength(0)
+  })
+
+  // SECURITY 회귀: 블록주석이라도 진짜 토큰은 여전히 탐지 — placeholder 확대가 false-negative 만들면 안 됨.
+  it('#250: 블록주석에 진짜 토큰이 있으면 여전히 탐지(false-negative 0)', () => {
+    const line = ' * Authorization: Bearer' + ' tok_RealAbCd123456'
+    const findings = findSecretsInLine(line, 'api/x.js', 1)
+    expect(findings.filter(f => f.patternId === 'authorization-bearer')).toHaveLength(1)
+  })
+
   // #170 회귀 픽스처: tracked .cursor/mcp.json 의 Bearer 자격증명을 프로젝트 스캔이 탐지.
   it('회귀: .cursor/mcp.json 의 Bearer 자격증명을 scanProjectForSecrets 가 탐지', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-scan-cursor-'))


### PR DESCRIPTION
## 요약

Haruchi-game 도그푸딩에서 발견된 **8개 버그 일괄 수정**. 각 이슈를 RFC 0050 트리아지(8-에이전트 병렬 워크플로)로 **현재 코드(cbe80c9) 대비 검증** → surgical 픽스 + TDD. 전부 valid·미수정 확인.

build·test·lint green. 테스트 **1525 → 1536 (+11)**.

## 수정 내역

| 이슈 | 근본원인 | 픽스 |
|------|---------|------|
| #243 | `doctor.ts:137` UI 오타 '로컴 env' | '로컬 env' (1자) |
| #244 | `audit.ts` 비-TTY서 fix 프롬프트 hang | `promptOrDefault` 래핑 → 비-TTY report-only 폴백(--fix 는 여전히 강제) |
| #245 | `preflight.ts` tsconfig 없어도 tsc 강행 차단 | typecheck 스크립트·tsconfig 둘 다 없으면 skip (verify 게이트 미러) |
| #246 | `exec.ts` SHIM_BINARIES 에 배포 CLI 누락 → Windows .cmd 미탐지 | vercel/netlify/wrangler 추가 |
| #247 | `env.ts` `.env` 만 확인, `.env.local` 무시 | `.env` 없으면 `.env.local` 폴백(Vercel 관례) + gitignore 보장 |
| #248 | `vhk-cloud.ts` DEFAULT_CLOUD_EXCLUDES 에 `*.bak` 없음 → gist 누출 | `*.bak` 추가(memory.json.bak 등 개인정보 차단) |
| #249 | `sync.ts` 미매핑 경고가 "제외됨"이라 오해(실제 AGENTS.md 「기타 규칙」 전파됨) | 경고 메시지 정정(손실 아님 명시) |
| #250 | `scan-secrets.ts` 블록주석(`*`)의 placeholder(YOUR_*) Bearer 오탐 | 블록주석 인식 + placeholder 표식 확대. **진짜 토큰 탐지는 유지**(false-negative 0 회귀 테스트 포함) |

## 보안 노트 (#250)

placeholder 필터는 **주석 안에서만** 동작 — 진짜 토큰은 주석/코드 어디서든 여전히 HIGH 탐지. 회귀 테스트로 "블록주석 진짜 토큰 → 탐지" 보장.

## 검증

- `pnpm build` · `pnpm test:run`(1536 pass) · `pnpm lint` 전부 green.
- 신규 테스트 11건: audit 비-TTY report-only, scan-secrets placeholder/진짜토큰, cloud *.bak, preflight skip, env .env.local, exec SHIM.

Fixes #243
Fixes #244
Fixes #245
Fixes #246
Fixes #247
Fixes #248
Fixes #249
Fixes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)
