### PR TITLE
chore: CodeRabbit 자동 PR 리뷰 설정 추가

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,35 @@
+# CodeRabbit 자동 PR 리뷰 설정 (public 레포 = Pro 무료)
+# 스키마 참조: https://docs.coderabbit.ai/reference/configuration
+language: "ko-KR"
+tone_instructions: "한국어로 간결하게. 실행 가능한 지적만, 칭찬·장식 생략. 위치·문제·수정안 형식으로. 오너는 비개발자 — 핵심 위주, 전문용어는 짧게 풀이."
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: false
+  path_filters:
+    # append-only 기록물·생성물은 리뷰 제외
+    - "!docs/log/**"
+    - "!docs/devlog/**"
+    - "!docs/state/**"
+    - "!CHANGELOG.md"
+    - "!dist/**"
+    - "!pnpm-lock.yaml"
+  path_instructions:
+    - path: "src/**"
+      instructions: |
+        프로젝트 규칙(RULES.md 단일소스):
+        - TypeScript strict — any 금지
+        - execSync 신규 사용 금지 → safeExecFile 사용
+        - try-catch 필수, 빈 catch 금지, console.log 프로덕션 금지
+        - 커맨드 파일: printNextStep() 패턴 + 한국어 별칭(.alias()) + src/i18n/ko.ts 메시지 필수
+        - 신규 커맨드는 src/nlp-router.ts 키워드 등록 확인
+        - MCP handler 내부 process.exit() 금지, MCP 모드에서 inquirer 호출 금지
+        - 새 이벤트 리스너는 해제 로직 짝으로, 새 캐시(Map/Set)는 TTL 또는 maxSize 필수
+chat:
+  auto_reply: true


### PR DESCRIPTION
## 요약
CodeRabbit 자동 PR 리뷰 설정 파일(`.coderabbit.yaml`) 추가. public 레포는 CodeRabbit Pro 전 기능 영구 무료.

## 설정 내용
- **언어**: `ko-KR` — 리뷰 코멘트 전부 한국어 (글로벌 규칙 준수)
- **톤**: 실행 가능한 지적만, 칭찬·장식 생략, 비개발자 오너 배려
- **리뷰 제외 경로**: `docs/log/**` · `docs/devlog/**` · `docs/state/**` (append-only 기록물), `CHANGELOG.md`, `dist/**`, `pnpm-lock.yaml`
- **`src/**` path_instructions**: RULES.md 핵심 규칙 주입 (strict/any 금지, safeExecFile, printNextStep, 한국어 별칭, nlp-router 등록, MCP 제약, 리스너·캐시 규칙)
- poem 비활성 (노이즈 제거)

## 활성화 조건
GitHub App 설치 필요 — coderabbit.ai에서 GitHub 로그인 후 vhk 레포 선택 (사용자 작업, ~2분). App 설치 전에는 이 파일은 무해하게 대기.

## 게이트
yaml 설정 파일 단독 추가 — 소스 코드 무변경, CI로 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
