### PR TITLE
docs: 세션 기록 2026-06-11 — 도그푸딩 8건 dev log + LIVE 갱신

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,11 +124,11 @@ tags: [process, constitution]
 > 세션 종료: 마지막 갱신·버전·Phase·다음 할 일 갱신. (위 🔒 구역은 절대 건드리지 마.)
 > ⚠️ 아래 `**버전:**` 줄은 CI(version-sync.test.ts)가 강제 — 형식 `**버전:** vX.Y.Z` 유지, 릴리즈마다 package.json 따라 갱신.
 
-**마지막 갱신:** 2026-06-10
+**마지막 갱신:** 2026-06-11
 - **버전:** v2.5.1 (발행 완료) — 사실 확인은 package.json·CHANGELOG
-- **테스트:** 1385 pass(main) · **MCP tools:** 29 — 사실값은 package.json·CHANGELOG
-- **Phase:** measure-first 2종. recall(RFC 0049) #232·#233. diff-coverage(RFC 0050·Goal 50) PR1 #236+파서픽스 #239 — `vhk diff-cover` 측정(자문·차단 0). 둘 다 실측 누적 후 게이트/ML 결정. 추가: 콜드스타트 −37%(#240 inquirer lazy).
+- **테스트:** 1536 pass(main) · **MCP tools:** 29 — 사실값은 package.json·CHANGELOG
+- **Phase:** measure-first 2종(diff-coverage RFC 0050·recall RFC 0049) 측정·기록 완료, 승격/ML 보류(실사용 대기). 추가: 도그푸딩 버그 8건 일괄 픽스(#254, 2026-06-11 dev log) — 트리아지 워크플로 8병렬.
 - **블로커:** 없음
-- **진행 중(미발행):** diff-coverage PR1 + 콜드스타트(#240) main 머지(미발행). diff-cover §5 실측 **5 실제 diff 완료**(2026-06-10 dev log) → 실로직 미검증 2/5(#233·#232, 둘 다 CLI 명령부), 과반 미달=승격 임계 불충족·기각도 아님. PR2 가면 "명령부 미검증 경고"형(차단 아님)으로 좁힘.
-- **다음 할 일:** measure-first 2종 측정 완료 — diff-cover 5건(승격 보류) + recall eval **재현 56%@N34**(기억 18→34에도 불변·robust, 미스 8건 KR↔EN 어휘격차). **둘 다 임계 미달·실사용 미축적 → 승격/ML 보류**(measure-first가 조기결정 차단). 남은 건 **사람 게이트**: `vhk recall` 며칠 실사용 → `vhk memory eval --init` 실쿼리 라벨 → 진짜 Recall@5(<70 반복이면 2차 ML bge-m3). 병행: 미완 goal(린트 25/27·#128, SEO 21~26). 열린 이슈 = 0개(#38 포함 전부 closed, 2026-06-10 확인).
+- **진행 중(미발행):** main 누적 미발행분 — measure-first 2종(#251) + RFC 0051 docs 배선(#253) + 도그푸딩 8건(#254). 다음 릴리즈 시 일괄 발행 판단.
+- **다음 할 일:** measure-first 잔여 = **사람 게이트**: `vhk recall` 며칠 실사용 → `vhk memory eval --init` 실쿼리 라벨 → 진짜 Recall@5(<70 반복이면 2차 ML bge-m3). 병행: 미완 goal(린트 25/27·#128, SEO 21~26). **열린 이슈 = 0개**(2026-06-11 확인, #243~250 일괄 close).
 - **주의:** publish는 main에서만(#119)·사용자 직접(2FA) / 직접 main push 차단 → PR 경유

--- a/docs/log/2026-06-11-dogfood-bug-batch-243-250.md
+++ b/docs/log/2026-06-11-dogfood-bug-batch-243-250.md
@@ -1,0 +1,49 @@
+# 2026-06-11 — 도그푸딩 버그 8건 일괄 트리아지·픽스 (#243~#250)
+
+> append-only dev log. 추가만, 수정·삭제 금지.
+
+## 한 일 (PR #254, main 머지)
+
+Haruchi-game(외부 프로젝트) 도그푸딩에서 동시세션이 필링한 버그 8건(#243~#250)을 **트리아지 → surgical 픽스 + TDD → 일괄 PR → CI green → squash 머지**. 8개 전부 close, 열린 이슈 0 복귀.
+
+- 발견 경로: 다른 세션이 vhk 를 실제 프로젝트(바닐라 JS·Vercel 스타일)에 돌리다 8건 동시 필링(2026-06-10~11). 본 세션은 measure-first(#251) 마무리 직후 이 백로그를 받음.
+- 트리아지: **8-에이전트 병렬 워크플로**(Explore agentType)로 각 이슈를 *현재 코드(cbe80c9) 대비* 검증 — 최근 머지(#238/#252/#253)가 이미 고쳤는지 포함. 결과: 8개 전부 valid·미수정·fix-now.
+
+## 픽스 (8건 · 전부 기존 패턴 미러 또는 1줄)
+
+| 이슈 | 근본원인(file) | 픽스 | 리스크 |
+|------|---------------|------|--------|
+| #243 | `doctor.ts:137` UI 오타 '로컴 env' | '로컬 env' | trivial |
+| #244 | `audit.ts` 비-TTY서 fix 프롬프트 hang(CI/agent) | `promptOrDefault` 래핑 → 비-TTY report-only 폴백(--fix 는 강제 유지) | low |
+| #245 | `preflight.ts` tsconfig·typecheck 스크립트 없어도 tsc 강행→차단 | 둘 다 없으면 typecheck skip (verify 게이트 로직 미러, `hasTsconfig` 주입) | low |
+| #246 | `exec.ts` SHIM_BINARIES 에 배포 CLI 누락 → Windows .cmd 미탐지 | vercel/netlify/wrangler 추가 | trivial |
+| #247 | `env.ts` `.env` 만 확인, `.env.local` 무시 | `.env` 없으면 `.env.local` 폴백(Vercel 관례) + gitignore 보장 | low |
+| #248 | `vhk-cloud.ts` DEFAULT_CLOUD_EXCLUDES 에 `*.bak` 없음 → gist 백업 누출 | `*.bak` 추가(memory.json.bak 개인정보) | low |
+| #249 | `sync.ts:628` 미매핑 경고가 "제외됨"이라 오해(실제 AGENTS.md 「기타 규칙」 전파됨 #130) | 경고 메시지 정정(손실 아님 명시·동작 변경 X·설계 존중) | trivial |
+| #250 | `scan-secrets.ts:24,29` 블록주석(`*`)의 placeholder(YOUR_*) Bearer 오탐 → verify FAIL | 블록주석 인식 + placeholder 표식 확대. **진짜 토큰 탐지 유지** | low(보안) |
+
+- 테스트 **1525 → 1536 (+11)**: audit 비-TTY report-only · scan-secrets placeholder/**진짜토큰 회귀** · cloud `*.bak` · preflight skip · env `.env.local` · exec SHIM.
+- build · test(1536) · lint 전부 green. CI 9잡(windows/ubuntu 22·24 + dogfood 양쪽 + CodeQL + gate) green.
+
+## 핵심 결정
+
+- **트리아지 먼저, 픽스 나중**: 8건을 곧장 고치지 않고 병렬 조사로 "현재 코드에서 실재? 최근 머지가 고쳤나?" 먼저 검증. 헛수정·중복 방지. 0 open PR 확인으로 동시세션 충돌 회피.
+- **#250 보안 픽스는 false-negative 0 원칙**: placeholder 필터는 *주석 안에서만* 동작 — 진짜 토큰은 주석/코드 어디서든 여전히 HIGH 탐지. "블록주석 진짜 토큰 → 탐지" 회귀 테스트로 못박음(#218 의 per-match 원칙 답습).
+- **#249 는 동작 변경 안 함**: 비표준 섹션은 이미 AGENTS.md 「기타 규칙」에 전파됨(#130) — .cursorrules 는 설계상 코딩 전용. 거짓 경고 메시지만 정정(SoT 핵심 sync 의 blast radius 고려).
+
+## 교훈
+
+- **도그푸딩이 진짜 버그를 캐낸다** — 8건 전부 유닛테스트(1525 green)가 못 본 실사용 결함(Windows .cmd·비-TTY hang·바닐라 JS·Vercel .env.local·주석 오탐). 외부 프로젝트 실사용이 단위테스트의 사각을 비춤(Goal 19 SnapContext·diff-cover 도그푸딩 선례 반복).
+- **워크플로 에이전트 격리 부재 = 소스 오염 재확인** — 트리아지 Explore 에이전트가 primary 레포에 repro 스크립트(`test_bak_bug.mjs`)를 남김(worktree 격리 없음). 커밋 전 `git status` 로 발견·삭제. 읽기 전용 조사라도 scratch 파일 생성 가능 → 종료 시 잔재 점검.
+- **동시세션이 백로그를 던진다** — 작업 중 다른 세션이 이슈 8건 필링 + #252·#253 머지. main 이 계속 전진. 매 커밋 전 `git fetch` + open PR 확인으로 충돌 회피(메모리 패턴 답습).
+- **gh CLI 간헐 401** — 머지 후 이슈 상태/카운트 조회가 401 로 흔들려 "open:1" 오집계. 재시도로 0 확정. 단일 호출 결과 맹신 금지.
+
+## 정리
+
+- 트리아지 에이전트 scratch 삭제 · 로컬/리모트 feature 브랜치 삭제 · main 동기화(2b96c55).
+- 열린 이슈 0 복귀 → CLAUDE.md LIVE "0개" 드리프트 자동 해소.
+
+## 다음
+
+- measure-first 잔여(사람 게이트): `vhk recall` 며칠 실사용 → `vhk memory eval --init` 실쿼리 라벨 → 진짜 Recall@5.
+- 미완 goal(린트 #128, SEO 21~26) · 미발행분 누적 시 릴리즈 판단.


### PR DESCRIPTION
## 요약

세션 기록 — 도그푸딩 버그 8건(#243~250) 트리아지·픽스·머지(#254)의 dev log 추가 + CLAUDE.md LIVE 상태 갱신. **docs만**.

## 변경

- **dev log** `docs/log/2026-06-11-dogfood-bug-batch-243-250.md` (append-only) — 트리아지 워크플로(8병렬)·8건 픽스 표·핵심 결정·교훈(도그푸딩이 단위테스트 사각 검출·에이전트 scratch 격리·동시세션 백로그·gh 401)·정리.
- **CLAUDE.md LIVE** — 마지막 갱신 2026-06-11, 테스트 1385→1536, Phase(도그푸딩 8건 추가), 진행 중(미발행 #251·#253·#254), 다음 할 일(열린 이슈 0개).

코드 변경 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
