### PR TITLE
docs: 하네스 사례 연구 — Goal 62 기안 + recall 시나리오 + dev log

### DIFF
--- a/docs/log/2026-06-11-harness-case-study.md
+++ b/docs/log/2026-06-11-harness-case-study.md
@@ -1,0 +1,27 @@
+# 2026-06-11 — 하네스 엔지니어링 사례 연구 (영상 + mafia-codereview-harness 분석)
+
+> 출처: 빌더조쉬 팟캐스트(바이브마피아 최수민) + `github.com/vibemafiaclub/mafia-codereview-harness` (v0.1.0, MIT) 전수 분석.
+
+## 핵심 발견 (플러그인 구조)
+
+- **코드 0줄, 100% 마크다운 프롬프트 하네스** — 플러그인 매니페스트 + 커맨드 프롬프트 7개(auto/write-intent/gen-criteria/create-pr-body/review/reflect-review/update-docs) + 샘플 YAML 2개, 총 643줄.
+- **"fork"의 실체 = git worktree 지시 프롬프트** (세션 포크 API 아님). 격리 대상 구분이 진짜 설계 원칙:
+  - **파일 격리** = worktree (산출물 생성 단계, 소스 수정 금지)
+  - **컨텍스트 격리** = sub-agent (review만 — 구현 편향 차단, 사용자 확인 없이 자동)
+  - **컨텍스트 보존** = reflect-review는 구현 세션에서 실행 (sub-agent 금지 명시)
+- **gen-criteria 2단 필터**: ① `stacks` 메타데이터 매칭(기계적 1차) ② context/decision 의미 판단(LLM 2차) ③ "이 작업에 구체적으로 어떻게 적용되는지" 서술 강제(환각성 매칭 방지). ADR 전문은 sub-agent만 읽음 — 메인 컨텍스트 오염 차단.
+- **리뷰 규율**: 모든 코멘트는 평가기준(code-quality-guide.md) 근거 인용 필수 — 취향 리뷰 구조적 차단. 설계의도 문서의 의도적 결정에 "왜 이렇게 했나요?" 금지, 의도-구현 불일치만 지적. `[p1~p4]` 우선순위 + side effect 명시 + ACCEPT/REJECT 판정 append.
+- **update-docs 환류**: 신규 결정 vs 기존 문서의 충돌·연쇄수정·폐기 탐지 → MUST/RECOMMENDED 등급 제안. ADR context는 "고통의 서사" 수준으로 구체적으로(누가/어디서 고통받았는지).
+
+## 결정 사항
+
+1. **CodeRabbit 자동 PR 리뷰 도입** — PR #255 (`.coderabbit.yaml`, ko-KR, append-only 경로 제외, src/** 규칙 주입). public 레포 = Pro 무료. 사용자 GitHub App 설치 대기.
+2. **Goal 62 기안** — docs-first 작업 의례 + docs-diff 산출물 (자문형, P2). RFC 0051 사후 감지의 사전 보완.
+3. **recall 실사용 시나리오 추가** — "리뷰 기준 추출"(diff 요약 쿼리 → 관련 ADR·패턴 주입). next-task.md 반영.
+4. **파이썬 headless 러너 보류** — 2026-06-15부터 `claude -p`/Agent SDK가 구독에서 분리되어 별도 크레딧·종량제(API 요율) 전환. 현행 대화형+worktree 패턴이 컨텍스트 보존 목적 달성, measure-first상 인프라 선행 금지.
+5. **풀자동 머지는 따라가지 않음** — vhk 헌법(사람 게이트, publish main+2FA, #119)과 의도적 충돌. 차이는 결함 아닌 선택.
+
+## 교훈
+
+- 하네스 가치의 대부분은 코드가 아니라 **프롬프트로 명문화된 운영 원칙**(격리 대상 구분, 근거 기반 리뷰, 문서 환류)에 있다 — vhk가 이미 가진 자산(worktree, recall, review, RFC 0051)에 원칙만 이식하면 되고, 새 인프라는 거의 불필요.
+- 외부 기법 도입 전 **과금 정책 변동 확인 필수** — 영상 시점(구독 무료)과 현재(6/15 종량제)의 경제성이 다름. 날짜도 소문(6/23)과 실제(6/15)가 달랐음.

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -2,14 +2,15 @@
 
 > "지금 무엇부터"의 상태 SoT. 버전·테스트 등 사실값은 package.json·CHANGELOG가 SoT.
 
-**갱신:** 2026-06-10
+**갱신:** 2026-06-11
 **Phase:** measure-first 2종 진행. recall(RFC 0049) MVP+eval 머지(#232·#233). diff-coverage(RFC 0050·Goal 50) PR1 머지(#236)+파서픽스(#239) — `vhk diff-cover` 측정 도구(차단 0). 둘 다 **실측 누적 대기**(게이트/ML은 숫자가 정당화한 뒤). 추가: 콜드스타트 −37%(#240, inquirer lazy). 사실값(버전·테스트수)은 package.json·CHANGELOG.
 
 ## 다음 할 일 (measure-first 최우선)
 - **diff-coverage 실측 누적** → `vhk diff-cover`를 실제 코드 작업 **diff ≥5건(며칠)** 돌려 미검증 변경분 분포 수집(RFC 0050 §5 관찰 프로토콜). 유의미>0 → PR2(review line-40 제거 + verify 증거 + CI). ≈0 → "이론적 구멍" 문서화 후 중단(YAGNI). ※ diff-hunks `+++` 파서 엣지는 #239에서 이미 강화 완료(상태머신).
-- **recall 실측** → 며칠 `vhk recall` 실사용 → `vhk memory eval --init` 실쿼리 라벨 → 진짜 Recall@5. <70 반복이면 2차 ML(bge-m3, RFC 0049 §2 결정 잠금됨).
+- **recall 실측** → 며칠 `vhk recall` 실사용 → `vhk memory eval --init` 실쿼리 라벨 → 진짜 Recall@5. <70 반복이면 2차 ML(bge-m3, RFC 0049 §2 결정 잠금됨). **실사용 시나리오 추가(2026-06-11): "리뷰 기준 추출"** — PR 리뷰 전 diff 요약을 쿼리로 `vhk recall` 실행 → 관련 ADR·패턴만 뽑아 리뷰 기준으로 주입(외부 사례 gen-criteria 패턴: 메타데이터 1차 필터 + 의미 2차 판단 + "이 작업에 어떻게 적용되는지" 서술 강제). 실쿼리 라벨 축적과 직결.
 - **🎯 업계최상위(~4.7) 품질 로드맵** → [docs/rfc/0048](../rfc/0048-top-tier-quality-roadmap.md) + **Goals 47~54**. 13-에이전트 감사(3.5/5) 도출. 순서: **P0 먼저** — Goal 47(win32+Node20 CI 매트릭스) · Goal 48(MCP↔CLI 단일 진실원) → P1 49(린트 확대)·50(커버리지) → P2 51~54. 각 goal `vhk goal next`로 꺼내 개별 PR(AI 독주 방지). ※ 작업2.2(fast-check #213)·2.3(tsc/eslint #216) 머지로 Goal 49는 "도입→확대", Goal 52 property 옵션은 선점됨 — 재조정 필요.
 - **미완 goal** (goals/ 동적 계산 — `vhk goal next`): silent-fallback 린트(Goal 25/27 영역·#128) · SEO 묶음(Goal 21~26) 등.
+- **하네스 사례 연구 후속(2026-06-11)**: CodeRabbit 자동 PR 리뷰 설정 PR #255 — **사용자 GitHub App 설치 대기**(coderabbit.ai에서 vhk 레포 승인, ~2분, public=Pro 무료). Goal 62(docs-first+docs-diff, P2) 기안됨. 파이썬 headless 러너는 보류(6/15 Agent SDK 종량제 전환 + 현행 worktree 패턴으로 충분).
 - **열린 이슈 = #38 1개** (RFC 0001 .vhk 규격 의견수렴 — 코딩 아닌 결정 토론, 4개 미해결 질문). 나머지(#157·#155·#171·#148·#160·#159·#158·#151) close 완료. #38은 close/유지 product 결정.
 
 ## 백로그 (예약 — 선행조건 충족 후)

--- a/goals/62-docs-diff.md
+++ b/goals/62-docs-diff.md
@@ -1,0 +1,37 @@
+---
+vhk_format: 1
+type: goal
+id: 62
+title: docs-first 작업 의례 — 문서 선행 갱신 + docs-diff 산출물 (자문형) — P2
+status: NOT_STARTED
+priority: P2
+created: 2026-06-11
+leads_to: 스펙-코드 드리프트 사전 차단 · RFC 0051(사후 감지)의 사전 보완
+---
+
+# Goal 62: docs-first + docs-diff
+
+> 출처: 하네스 엔지니어링 사례 연구(2026-06-11) — mafia-codereview-harness 구조 분석 + 바이브마피아 영상. "모든 작업의 1단계 = 문서 갱신, 변경된 줄만 발췌한 docs-diff 산출물을 후속 단계가 참조."
+
+## 근거
+- vhk의 문서 환류는 전부 **사후형**: RFC 0051(doc-capture-wiring)은 handoff 시 미기록 ADR/TS 후보를 감지(작업이 끝난 뒤), dev log도 세션 종료 시 기록 — 작업 **도중** 스펙 앵커가 없음.
+- 스펙(goals/RFC/README)이 안 바뀐 채 코드부터 변경되면 에이전트가 계획을 제멋대로 해석해 스펙과 어긋나게 구현할 위험 — 외부 사례는 이를 "1단계 문서 강제 + 변경 줄 발췌 참조"로 차단.
+- 발췌(docs-diff)의 효용: 문서가 커질수록 "이 문서들 바뀌었어" 수준 언급은 불충분 — 추가/삭제된 줄만 강조해야 후속 구현·리뷰가 정확히 참조함.
+
+## 동작 (기안 — 구현 착수 시 ADR로 포맷·트리거 확정)
+- 작업 시작 의례(`vhk mission set` 또는 `vhk work`)에 "이 작업으로 바뀌어야 할 문서" 질문 단계 추가 — **자문형, 차단 0** (measure-first).
+- 문서 변경분을 `.vhk/docs-diff/{branch}.md`로 발췌 기록(파일·줄 번호·추가/삭제 내용) → 이후 구현·리뷰 단계가 이 파일을 참조.
+- RFC 0051 사후 감지와 짝: 사전(docs-diff 작성 여부) + 사후(미기록 ADR/TS 후보) 양방향 대조.
+
+## 수용 기준
+- 실제 작업 1건에서 docs-diff 산출물이 생성되고, 후속 리뷰가 이를 근거로 인용 (도그푸딩 1회 필수).
+- 차단 게이트 아님(자문형) — 강제 전환은 실측 누적이 정당화한 뒤 별도 결정.
+
+## Completion Check
+- [ ] 동작 설계 ADR 작성 (.vhk/docs-diff 포맷 · 트리거 시점 · RFC 0051 연계)
+- [ ] 구현 (커맨드 신설 시 한국어 별칭 + ko.ts + nlp-router 키워드 필수)
+- [ ] 도그푸딩 1회 — 실제 작업에서 산출물 생성·참조 확인
+- [ ] 공통 게이트 통과 (goals/_meta.md)
+
+## Mandatory Reading
+- docs/rfc/0051-doc-capture-wiring.md · src/commands/work.ts · src/commands/mission.ts · goals/_meta.md


### PR DESCRIPTION
## 요약
하네스 엔지니어링 사례 연구(영상 + mafia-codereview-harness 전수 분석) 후속 — 문서 3건.

## 변경
- **goals/62-docs-diff.md 신설**: docs-first 작업 의례 + docs-diff 산출물 기안 (P2, NOT_STARTED, 자문형·차단 0). RFC 0051(사후 감지)의 사전 보완. 구현은 별도 iteration — 착수 시 ADR로 포맷 확정.
- **docs/state/next-task.md**: recall 실사용 시나리오에 "리뷰 기준 추출" 추가(diff 요약 쿼리 → 관련 ADR·패턴 주입, gen-criteria 패턴). 하네스 사례 연구 후속 상태 1줄 추가. 갱신일 2026-06-11.
- **docs/log/2026-06-11-harness-case-study.md 신설** (append-only dev log): 플러그인 분석 핵심 발견(100% 마크다운 하네스, fork=worktree, 파일 격리 vs 컨텍스트 격리 구분, gen-criteria 2단 필터) + 결정 5건 + 교훈.

## 게이트
docs 전용 변경(goal 기안·상태 SoT·dev log) — 소스 코드 무변경, CI로 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
