### PR TITLE
ci: @claude 멘션 리뷰 반영 워크플로 (머지는 사람)

### DIFF
--- a/.github/workflows/claude-assist.yml
+++ b/.github/workflows/claude-assist.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # PR 브랜치 전환·diff 계산에 전체 이력 필요
+          # action이 git 인증을 자체 구성(configureGitAuth)하므로 checkout 인증정보 잔류 불필요
+          persist-credentials: false
 
       - uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/claude-assist.yml
+++ b/.github/workflows/claude-assist.yml
@@ -1,0 +1,35 @@
+name: Claude 리뷰 반영
+
+# PR 코멘트에 @claude 멘션하면 Claude Code가 리뷰 반영(커밋 푸시 + 답글)까지 무인 수행.
+# 머지는 항상 사람 — 헌법(사람 게이트, publish main+2FA)과 충돌하지 않는 반자동 구간만 자동화.
+# 비용: 2026-06-15부터 구독의 Agent SDK 월간 크레딧에서 차감(API 요율), 소진 시 종량제.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    # 보안 게이트(public 레포): @claude 멘션 + 작성자가 OWNER 본인일 때만 실행.
+    # 외부인의 크레딧 소모·프롬프트 주입을 트리거 단계에서 차단 (action 자체의 write 권한 검증과 이중).
+    if: |
+      contains(github.event.comment.body, '@claude') &&
+      github.event.comment.author_association == 'OWNER'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write # 리뷰 반영 커밋을 PR 브랜치에 푸시
+      pull-requests: write # 리뷰 코멘트에 반영/거부 답글
+      issues: write
+      actions: read # CI 결과 참조
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # PR 브랜치 전환·diff 계산에 전체 이력 필요
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # 폭주 방지(크레딧 보호) — 리뷰 반영은 30턴이면 충분, 초과는 비정상
+          claude_args: "--max-turns 30"


### PR DESCRIPTION
## 요약
PR 코멘트에 `@claude` 멘션하면 Claude Code가 **리뷰 반영(커밋 푸시 + 코멘트 답글)을 무인 수행**하는 GitHub Action 추가. **머지는 계속 사람** — 헌법(사람 게이트)과 충돌 없는 반자동 구간만 자동화.

## 동작 흐름
1. PR에 CodeRabbit(또는 사람) 리뷰가 달림
2. 오너가 코멘트: `@claude 코드래빗 리뷰 중 타당한 것만 반영하고 각 코멘트에 한국어로 반영/거부 근거 답글 달아줘`
3. Action이 Claude Code 실행 → 반영 커밋을 PR 브랜치에 푸시 + 답글
4. 머지는 사람이 확인 후 직접

## 보안 (public 레포 핵심)
- **OWNER 게이트**: `author_association == 'OWNER'` — 외부인 멘션은 트리거 자체가 안 됨 (크레딧 소모·프롬프트 주입 차단)
- `created` 이벤트만 (edited 재트리거 배제)
- `--max-turns 30` + `timeout-minutes: 30` — 폭주 시 크레딧 보호
- action 자체의 write 권한 검증과 이중 게이트

## 활성화 절차 (사용자, 1회)
1. 로컬 터미널에서 `claude setup-token` 실행 → OAuth 토큰 발급 (구독 연동)
2. GitHub → vhk 레포 → Settings → Secrets and variables → Actions → New repository secret
   - Name: `CLAUDE_CODE_OAUTH_TOKEN`, Value: 발급받은 토큰
3. 아무 PR에 `@claude` 멘션으로 테스트

secret 등록 전에는 워크플로가 실행돼도 인증 실패로 멈출 뿐 — 머지해도 무해.

## 비용
2026-06-15부터 이 무인 실행은 구독의 **Agent SDK 월간 크레딧**(Pro $20/월~)에서 API 요율로 차감, 소진 시 종량제. 대화형 세션은 영향 없음.

## 게이트
워크플로 yaml 단독 추가 — 소스 코드 무변경, CI로 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이슈 및 풀 리퀘스트 댓글에서 특정 호출로 자동 코드 리뷰 반영이 가능해졌습니다.
  * 권한 있는 작성자(OWNER)의 요청만 처리되며, 처리 횟수와 실행 시간이 제한되어 안정성을 제공합니다.
  * 요청 실행 시 리뷰 반영 커밋을 PR에 푸시하고, 반영 또는 거부 여부를 댓글로 회신합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->