### PR TITLE
docs: 세션 기록 2026-06-11 저녁 — claude-assist·auto-merge dev log + Notion 적재 + LIVE 갱신

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,8 +151,8 @@ tags: [process, constitution]
 **마지막 갱신:** 2026-06-11
 - **버전:** v2.5.1 (발행 완료) — 사실 확인은 package.json·CHANGELOG
 - **테스트:** 1536 pass(main) · **MCP tools:** 29 — 사실값은 package.json·CHANGELOG
-- **Phase:** measure-first 2종(diff-coverage RFC 0050·recall RFC 0049) 측정·기록 완료, 승격/ML 보류(실사용 대기). 추가: 도그푸딩 버그 8건 일괄 픽스(#254, 2026-06-11 dev log) — 트리아지 워크플로 8병렬.
+- **Phase:** measure-first 2종(diff-coverage RFC 0050·recall RFC 0049) 측정·기록 완료, 승격/ML 보류(실사용 대기). 추가: 도그푸딩 버그 8건 일괄 픽스(#254, 2026-06-11 dev log) — 트리아지 워크플로 8병렬. 저녁: 전수 코드 리뷰 137건+Top10 즉시수정(#260) · governance T1~T5 기록 집행 hook(#261) · @claude 리뷰반영 워크플로(#259) · auto-merge 무인 머지 스킬(#262) · CodeRabbit 도입(#255, App 설치 대기). 오늘 작업 5건 Notion Dev Log DB 적재 완료.
 - **블로커:** 없음
-- **진행 중(미발행):** main 누적 미발행분 — measure-first 2종(#251) + RFC 0051 docs 배선(#253) + 도그푸딩 8건(#254). 다음 릴리즈 시 일괄 발행 판단.
+- **진행 중(미발행):** main 누적 미발행분 — measure-first 2종(#251) + RFC 0051 docs 배선(#253) + 도그푸딩 8건(#254) + 전수리뷰 Top10(#260) + governance T1~T5(#261, CodeRabbit 후속픽스 #263). 다음 릴리즈 시 일괄 발행 판단.
 - **다음 할 일:** measure-first 잔여 = **사람 게이트**: `vhk recall` 며칠 실사용 → `vhk memory eval --init` 실쿼리 라벨 → 진짜 Recall@5(<70 반복이면 2차 ML bge-m3). 병행: 미완 goal(린트 25/27·#128, SEO 21~26). **열린 이슈 = 0개**(2026-06-11 확인, #243~250 일괄 close).
 - **주의:** publish는 main에서만(#119)·사용자 직접(2FA) / 직접 main push 차단 → PR 경유

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ tags: [process, constitution]
 **마지막 갱신:** 2026-06-11
 - **버전:** v2.5.1 (발행 완료) — 사실 확인은 package.json·CHANGELOG
 - **테스트:** 1536 pass(main) · **MCP tools:** 29 — 사실값은 package.json·CHANGELOG
-- **Phase:** measure-first 2종(diff-coverage RFC 0050·recall RFC 0049) 측정·기록 완료, 승격/ML 보류(실사용 대기). 추가: 도그푸딩 버그 8건 일괄 픽스(#254, 2026-06-11 dev log) — 트리아지 워크플로 8병렬. 저녁: 전수 코드 리뷰 137건+Top10 즉시수정(#260) · governance T1~T5 기록 집행 hook(#261) · @claude 리뷰반영 워크플로(#259) · auto-merge 무인 머지 스킬(#262) · CodeRabbit 도입(#255, App 설치 대기). 오늘 작업 5건 Notion Dev Log DB 적재 완료.
+- **Phase:** measure-first 2종(diff-coverage RFC 0050·recall RFC 0049) 측정·기록 완료, 승격/ML 보류(실사용 대기). 추가: 도그푸딩 버그 8건 일괄 픽스(#254, 2026-06-11 dev log) — 트리아지 워크플로 8병렬. 저녁: 전수 코드 리뷰 137건+Top10 즉시수정(#260) · governance T1~T5 기록 집행 hook(#261) · @claude 리뷰반영 워크플로(#259) · auto-merge 무인 머지 스킬(#262) · CodeRabbit 도입(#255, App 설치 대기). 오늘 PR 8개를 Notion Dev Log DB 5개 항목으로 적재 완료.
 - **블로커:** 없음
 - **진행 중(미발행):** main 누적 미발행분 — measure-first 2종(#251) + RFC 0051 docs 배선(#253) + 도그푸딩 8건(#254) + 전수리뷰 Top10(#260) + governance T1~T5(#261, CodeRabbit 후속픽스 #263). 다음 릴리즈 시 일괄 발행 판단.
 - **다음 할 일:** measure-first 잔여 = **사람 게이트**: `vhk recall` 며칠 실사용 → `vhk memory eval --init` 실쿼리 라벨 → 진짜 Recall@5(<70 반복이면 2차 ML bge-m3). 병행: 미완 goal(린트 25/27·#128, SEO 21~26). **열린 이슈 = 0개**(2026-06-11 확인, #243~250 일괄 close).

--- a/docs/log/2026-06-11-claude-assist-automerge.md
+++ b/docs/log/2026-06-11-claude-assist-automerge.md
@@ -1,0 +1,45 @@
+# 2026-06-11 — @claude 리뷰 반영 워크플로 + auto-merge 무인 머지 스킬
+
+> 저녁 세션 산출물 2건(#259, #262)의 dev log. 하네스 사례 연구(#257)에서 "풀자동 머지는 따라가지 않는다"고
+> 결정한 뒤, 헌법과 충돌하지 않는 **반자동 구간**만 골라 자동화한 후속 작업.
+
+## 1. @claude 멘션 리뷰 반영 워크플로 — PR #259
+
+- `.github/workflows/claude-assist.yml` 신설. PR 코멘트에 `@claude` 멘션하면
+  `anthropics/claude-code-action@v1`이 리뷰 반영(커밋 푸시 + 답글)까지 무인 수행.
+- **머지는 항상 사람** — 헌법(사람 게이트, publish main+2FA, 가드 #119)과 충돌하지 않는 구간만 자동화.
+- 보안 게이트(public 레포): `@claude` 멘션 + `author_association == 'OWNER'` 일 때만 실행.
+  외부인의 크레딧 소모·프롬프트 주입을 트리거 단계에서 차단(action 자체 write 권한 검증과 이중).
+- 폭주 방지: `--max-turns 30` + `timeout-minutes: 30`. `persist-credentials: false`
+  (action이 git 인증 자체 구성).
+- 비용 인지: 2026-06-15부터 Agent SDK 월간 크레딧 차감(API 요율), 소진 시 종량제 — 워크플로 주석에 명시.
+
+## 2. auto-merge 무인 머지 에이전트 스킬 — PR #262
+
+- `.claude/skills/auto-merge/SKILL.md` 신설. `auto-merge` **라벨 붙은** 열린 PR만 대상으로
+  4중 게이트 통과 시 무인 `gh pr merge --squash`. 가동은 전용 세션 `/loop 15m /auto-merge`
+  (노트북 종료 = 의도된 kill switch).
+- 4중 게이트: G1 CI 전부 pass(pending=대기) → G2 diff ≤500줄(초과=사람 호출) →
+  G3 CodeRabbit 미해결 스레드 0(GraphQL) → G4 적대적 최종 리뷰(서브에이전트가 "머지하면
+  안 되는 이유"를 적극 탐색, 불확실=치명).
+- 안전 설계: 매 주기 HARD_STOP 선확인 / 주기당 최대 3개(AI 독주 방지) / 라벨은 사람만 부착 /
+  publish·main 직접 push·resume 절대 금지 명문화.
+
+## 3. 기록 정리 (이 세션)
+
+- 오늘(2026-06-11) 커밋 8건(#254·#256·#255·#257·#259·#260·#261·#262) 중 dev log 미커버 2건
+  (#259·#262)을 본 파일로 백필. 나머지는 기존 로그가 커버:
+  도그푸딩 8건 → `2026-06-11-dogfood-bug-batch-243-250.md` / 하네스 사례 연구 →
+  `2026-06-11-harness-case-study.md` / 전수 코드 리뷰 → `2026-06-11-full-code-review.md` /
+  거버넌스 T1~T5 → `2026-06-10-governance.md` (+ 회고 백필 5편 `2026-06-11-retro-*.md`).
+- 오늘 작업 전체를 Notion Dev Log DB(바이브코딩 Dev Log)에 적재 — 노뚝이 후속 처리용.
+
+## 교훈
+
+- **PowerShell 중첩 따옴표로 gh GraphQL 호출 깨짐** — `gh api graphql -f query='...'` 를
+  PowerShell에서 실행하면 따옴표 파싱이 깨져 `Expected type 'number', malformed "-cpu"` 오류(실측).
+  GraphQL 같은 중첩 따옴표 명령은 반드시 Bash 도구로. 스킬 본문에 강제 명시.
+- **적대적 리뷰 서브에이전트에 구조화 스키마 금지** — schema 강제 시 StructuredOutput 미호출로
+  발견사항 전부 유실된 전적(2026-06-10 적대검증) → auto-merge G4는 일반 텍스트 출력으로 고정.
+- 외부 사례(풀자동 머지)를 그대로 복제하지 않고 **헌법과의 충돌 지점을 먼저 그어** 반자동
+  구간(리뷰 반영·라벨 기반 머지)만 떼어내는 방식이 안전했다 — "차이는 결함 아닌 선택"(#257)의 실행편.

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -12,7 +12,7 @@
 - **recall 실측** → 며칠 `vhk recall` 실사용 → `vhk memory eval --init` 실쿼리 라벨 → 진짜 Recall@5. <70 반복이면 2차 ML(bge-m3, RFC 0049 §2 결정 잠금됨). **실사용 시나리오 추가(2026-06-11): "리뷰 기준 추출"** — PR 리뷰 전 diff 요약을 쿼리로 `vhk recall` 실행 → 관련 ADR·패턴만 뽑아 리뷰 기준으로 주입(외부 사례 gen-criteria 패턴: 메타데이터 1차 필터 + 의미 2차 판단 + "이 작업에 어떻게 적용되는지" 서술 강제). 실쿼리 라벨 축적과 직결.
 - **🎯 업계최상위(~4.7) 품질 로드맵** → [docs/rfc/0048](../rfc/0048-top-tier-quality-roadmap.md) + **Goals 47~54**. 13-에이전트 감사(3.5/5) 도출. 순서: **P0 먼저** — Goal 47(win32+Node20 CI 매트릭스) · Goal 48(MCP↔CLI 단일 진실원) → P1 49(린트 확대)·50(커버리지) → P2 51~54. 각 goal `vhk goal next`로 꺼내 개별 PR(AI 독주 방지). ※ 작업2.2(fast-check #213)·2.3(tsc/eslint #216) 머지로 Goal 49는 "도입→확대", Goal 52 property 옵션은 선점됨 — 재조정 필요.
 - **미완 goal** (goals/ 동적 계산 — `vhk goal next`): silent-fallback 린트(Goal 25/27 영역·#128) · SEO 묶음(Goal 21~26) 등.
-- **하네스 사례 연구 후속(2026-06-11)**: CodeRabbit 자동 PR 리뷰 설정 PR #255 — **사용자 GitHub App 설치 대기**(coderabbit.ai에서 vhk 레포 승인, ~2분, public=Pro 무료). Goal 62(docs-first+docs-diff, P2) 기안됨. 파이썬 headless 러너는 보류(6/15 Agent SDK 종량제 전환 + 현행 worktree 패턴으로 충분).
+- **하네스 사례 연구 후속(2026-06-11)**: CodeRabbit 자동 PR 리뷰 설정 PR #255 — **사용자 GitHub App 설치 대기**(coderabbit.ai에서 vhk 레포 승인, ~2분, public=Pro 무료). Goal 62(docs-first+docs-diff, P2) 기안됨. 파이썬 headless 러너는 보류(6/15 Agent SDK 종량제 전환 + 현행 worktree 패턴으로 충분). 후속 구현 완료(저녁): @claude 리뷰반영 워크플로(#259) + auto-merge 무인 머지 스킬(#262 — 가동은 전용 세션 `/loop 15m /auto-merge`, 라벨은 사람만 부착).
 - **열린 이슈 = #38 1개** (RFC 0001 .vhk 규격 의견수렴 — 코딩 아닌 결정 토론, 4개 미해결 질문). 나머지(#157·#155·#171·#148·#160·#159·#158·#151) close 완료. #38은 close/유지 product 결정.
 
 ## 백로그 (예약 — 선행조건 충족 후)


### PR DESCRIPTION
## 요약

2026-06-11 작업 전체의 기록 정리 (docs-only).

- **dev log 신규**: `docs/log/2026-06-11-claude-assist-automerge.md` — 오늘 커밋 8건 중 dev log 미커버였던 #259(@claude 리뷰반영 워크플로)·#262(auto-merge 무인 머지 스킬) 백필. 교훈 포함(PowerShell 중첩따옴표 GraphQL 깨짐 → Bash 강제 / 적대 리뷰 서브에이전트 구조화 스키마 금지).
- **CLAUDE.md LIVE**: 저녁 작업(#259·#260·#261·#262 + 후속 #263) Phase·미발행분 반영.
- **next-task.md**: 하네스 사례 연구 후속 구현 완료(#259·#262) 표기.
- **Notion Dev Log DB 적재 5건**(레포 외 작업): 도그푸딩 8건(#254) / 하네스+CodeRabbit(#255·#257) / 전수 코드 리뷰(#260) / 거버넌스 T1~T5(#261) / claude-assist+auto-merge(#259·#262) — 오늘 PR 8개 전체 커버, 자동화 도우미 후속 처리용(역전파 상태=미처리).

## 비고

- 작업트리에 본 세션이 만들지 않은 `docs/log/2026-06-11-full-code-review.md` 1글자 수정 잔재 있음(동시세션 추정) — 이 PR에서 제외.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 프로젝트 진행 상태의 `Phase` 항목이 상세화되었습니다: 승격/ML 보류 유지, 도그푸딩 버그 픽스 병렬 트리아지, 전수 코드리뷰 및 Top10 즉시수정, 거버넌스 기록 집행 훅, 리뷰 반영 워크플로, 자동 병합 역량 준비, CodeRabbit 도입 대기 등 추가·확장.
  * 블로커는 없음 유지, 진행 중 항목이 거버넌스 T1~T5 및 후속 픽스 포함으로 확장되었으며 오늘 PR 8건의 로그 반영이 명시되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->