### PR TITLE
chore: markdownlint MD033 off + 코드스팬 공백 픽스

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -5,5 +5,6 @@
   "MD022": false,
   "MD032": false,
   "MD060": false,
+  "MD033": false,
   "MD025": { "front_matter_title": "" }
 }

--- a/docs/log/2026-06-11-full-code-review.md
+++ b/docs/log/2026-06-11-full-code-review.md
@@ -113,7 +113,7 @@
 | A2-01(+B1-05 병합) | commands/evolve.ts:178 | 손상 queue.json → 무경고 빈 큐 (.bak 보호는 확인됨 — 복구 안내만 부재) |
 | A2-04 | commands/sync.ts:562 | CLAUDE.md 비원자 쓰기 + drift 없으면 백업 미생성 |
 | A2-05 | commands/sync.ts:212-217 | vhk:rules 마커 쌍 중복 시 스테일 블록 영구 잔존 |
-| A2-06 | commands/sync.ts:53,242,257 | 섹션 파서 코드펜스 미인지 — 펜스 내 `## `에서 오분할, 사용자 콘텐츠 제거 가능 |
+| A2-06 | commands/sync.ts:53,242,257 | 섹션 파서 코드펜스 미인지 — 펜스 내 `##` 헤더에서 오분할, 사용자 콘텐츠 제거 가능 |
 | A2-08 | commands/memory.ts:389 외 | 수동 편집으로 tags/id 누락 시 TypeError 크래시 |
 | A2-09 | commands/evolve.ts:561 | evolve undo가 apply 후 수동 편집을 무경고 소실 |
 | A3-04 | commands/publish.ts:161-162 | dirty 가드 fail-open (git 실패 시 clean 간주) |


### PR DESCRIPTION
## 요약
IDE markdownlint 노이즈 정리. **docs/config만, 코드 변경 0.**

- `.markdownlint.json`: `MD033`(no-inline-html) off — 문서 전반 `goals/<n>-<name>.md` 플레이스홀더 + `<!-- vhk:rules -->` 마커가 HTML 태그로 오인돼 경고. CLAUDE.md `<n>`·`<name>`은 🔒 영구 헌법 구역(수정 금지)이라 설정으로 무시가 유일한 클린 해법.
- `docs/log/2026-06-11-full-code-review.md:116`: 코드스팬 후행 공백 제거(MD038).

마크다운 린트는 IDE 전용(CI는 `eslint src`) → 빌드 영향 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * 마크다운 린팅 도구의 설정이 업데이트되었습니다. 개발 도구의 구성 규칙이 조정되어 개발 프로세스가 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->