### PR TITLE
fix: harden secret scanning placeholders and Python files

### DIFF
--- a/docs/log/2026-06-12-secure-scan-placeholder-python.md
+++ b/docs/log/2026-06-12-secure-scan-placeholder-python.md
@@ -1,0 +1,25 @@
+# 2026-06-12 secure scan placeholder/Python 회귀 수정
+
+## 증상
+
+- `.env.example`의 `your_*_api_key_*` 예시 값이 HIGH 시크릿으로 오탐됐다.
+- `missing_api_key` 같은 상태 객체 키가 Generic API Key로 오탐됐다.
+- Python 파일의 실제 `api_key` 리터럴은 검사 확장자에서 빠져 미탐됐다.
+
+## 수정
+
+- `.py`를 프로젝트 시크릿 스캔 대상에 추가했다.
+- Generic API Key 패턴에 식별자 경계를 추가했다.
+- Generic 패턴에 한해 대입값의 명시적 placeholder와 상태 키 접두사를 제외했다.
+- placeholder 단어가 변수명에만 있는 실제 키는 계속 탐지하도록 했다.
+- 예시 env, 상태 객체, 실제 generic key, Python 파일 스캔 회귀 테스트를 추가했다.
+
+## 검증
+
+- `npm run test:run -- tests/scan-files.test.ts -t "Python" --maxWorkers=1 --no-file-parallelism`
+- `node node_modules/vitest/vitest.mjs run tests/scan-secrets.test.ts -t "generic|Python" --maxWorkers=1 --no-file-parallelism`
+- `npm run test:run -- tests/secure.test.ts --maxWorkers=1 --no-file-parallelism`
+- `npm run typecheck`
+- `npm run lint`
+- `npm run build`
+- `node dist/index.js secure scan`

--- a/src/lib/scan-files.ts
+++ b/src/lib/scan-files.ts
@@ -30,6 +30,7 @@ const SKIP_FILE_NAMES = new Set([
 
 const SCAN_EXTENSIONS = new Set([
   '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
+  '.py',
   '.json', '.yaml', '.yml', '.toml',
 ])
 

--- a/src/lib/scan-secrets.ts
+++ b/src/lib/scan-secrets.ts
@@ -4,10 +4,23 @@ import { walkProjectFiles } from './scan-files.js'
 
 export const MAX_SECRET_FINDINGS = 200
 const MAX_LINE_CHARS = 4_000
+const PLACEHOLDER_MARKER =
+  /(?:example|placeholder|your[_-]|fake[_-]|dummy|redacted|changeme|replace[_-]?me|x{4,}|<[^>]+>)/i
+const STATUS_KEY_PREFIX = /^(?:missing|invalid|status|error|has|is|needs?)[_-]/i
 
 function globalPattern(pattern: RegExp): RegExp {
   const flags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`
   return new RegExp(pattern.source, flags)
+}
+
+function isGenericApiKeyFalsePositive(matchText: string): boolean {
+  const delimiterIndex = matchText.search(/[:=]/)
+  if (delimiterIndex < 0) return false
+  const key = matchText.slice(0, delimiterIndex).trim()
+  const delimiter = matchText[delimiterIndex]
+  if (delimiter === ':' && STATUS_KEY_PREFIX.test(key)) return true
+  const value = matchText.slice(delimiterIndex + 1).trim().replace(/^['"]/, '')
+  return PLACEHOLDER_MARKER.test(value)
 }
 
 /** 한 줄에서 시크릿 패턴 검색 (global regex 중복 버그 방지) */
@@ -32,8 +45,11 @@ export function findSecretsInLine(
   for (const pattern of SECRET_PATTERNS) {
     const regex = globalPattern(pattern.pattern)
     for (const match of line.matchAll(regex)) {
+      // Generic 패턴은 실제 토큰 형식을 모르는 보조 탐지다. 예제 env 값과
+      // missing_api_key 같은 상태 식별자는 값처럼 보여도 자격증명이 아니다.
+      if (pattern.id === 'generic-api-key' && isGenericApiKeyFalsePositive(match[0])) continue
       // placeholder 표식이 매칭값에 있으면(주석 한정) 무시 — your_·fake_·dummy·redacted·changeme·xxxx·<...>
-      if (isComment && /(?:example|placeholder|your[_-]|fake[_-]|dummy|redacted|changeme|x{4,}|<[^>]+>)/i.test(match[0]))
+      if (isComment && PLACEHOLDER_MARKER.test(match[0]))
         continue // placeholder 시크릿만 무시
       found.push({
         patternId: pattern.id,

--- a/src/lib/secret-patterns.ts
+++ b/src/lib/secret-patterns.ts
@@ -103,7 +103,7 @@ export const SECRET_PATTERNS: SecretPattern[] = [
     id: 'generic-api-key',
     name: 'Generic API Key',
     severity: 'high',
-    pattern: /(?:api[_-]?key|apikey|access[_-]?token)\s*[:=]\s*['"]?[A-Za-z0-9_\-]{16,}['"]?/i,
+    pattern: /(?<![A-Za-z0-9_])(?:[A-Za-z0-9]+[_-])*(?:api[_-]?key|apikey|access[_-]?token)\s*[:=]\s*['"]?[A-Za-z0-9_\-]{16,}['"]?/i,
   },
   {
     // #170: 리터럴 Authorization: Bearer 자격증명. 토큰 문자 클래스가 '$','{' 를 제외하므로

--- a/tests/scan-files.test.ts
+++ b/tests/scan-files.test.ts
@@ -5,6 +5,10 @@ import path from 'node:path'
 import { isScannableFileName, walkProjectFiles, MAX_SCAN_FILE_BYTES } from '../src/lib/scan-files.js'
 
 describe('scan-files', () => {
+  it('Python 소스도 시크릿 스캔 대상이다', () => {
+    expect(isScannableFileName('script.py')).toBe(true)
+  })
+
   it('lock 파일은 스캔 대상에서 제외', () => {
     expect(isScannableFileName('pnpm-lock.yaml')).toBe(false)
     expect(isScannableFileName('package-lock.json')).toBe(false)

--- a/tests/scan-secrets.test.ts
+++ b/tests/scan-secrets.test.ts
@@ -33,6 +33,58 @@ describe('scan-secrets', () => {
     expect(findings).toHaveLength(0)
   })
 
+  it('generic: .env.example placeholder 값은 스킵', () => {
+    const findings = findSecretsInLine(
+      'YOUTUBE_API_KEY=your_youtube_api_key_here',
+      '.env.example',
+      1,
+    )
+    expect(findings.filter((f) => f.patternId === 'generic-api-key')).toHaveLength(0)
+  })
+
+  it('generic: missing_api_key 상태 식별자는 스킵', () => {
+    const findings = findSecretsInLine(
+      'missing_api_key: "border-amber-500/20 bg-amber-500/10"',
+      'src/status.ts',
+      1,
+    )
+    expect(findings.filter((f) => f.patternId === 'generic-api-key')).toHaveLength(0)
+  })
+
+  it('generic: 실제 긴 api_key 할당은 계속 탐지', () => {
+    const actual = 'z'.repeat(24)
+    const findings = findSecretsInLine(`api_key = "${actual}"`, 'script.py', 1)
+    expect(findings.filter((f) => f.patternId === 'generic-api-key')).toHaveLength(1)
+  })
+
+  it('generic: 상태 접두어라도 실제 값 대입은 계속 탐지', () => {
+    const actual = 'z'.repeat(24)
+    const findings = findSecretsInLine(`invalid_api_key = "${actual}"`, 'script.py', 1)
+    expect(findings.filter((f) => f.patternId === 'generic-api-key')).toHaveLength(1)
+  })
+
+  it('generic: placeholder 단어가 변수명에만 있으면 실제 값은 탐지', () => {
+    const actual = 'z'.repeat(24)
+    const findings = findSecretsInLine(`example_api_key = "${actual}"`, 'script.py', 1)
+    expect(findings.filter((f) => f.patternId === 'generic-api-key')).toHaveLength(1)
+  })
+
+  it('Python 파일의 generic API key를 프로젝트 스캔이 탐지', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-scan-python-'))
+    const fixturePath = path.join(tmp, 'script.py')
+    try {
+      const apiKey = 'z'.repeat(24)
+      fs.writeFileSync(fixturePath, `api_key = "${apiKey}"\n`, 'utf-8')
+      const { findings } = scanProjectForSecrets(tmp)
+      expect(
+        findings.some((f) => f.patternId === 'generic-api-key' && f.file === 'script.py'),
+      ).toBe(true)
+    } finally {
+      if (fs.existsSync(fixturePath)) fs.unlinkSync(fixturePath)
+      fs.rmdirSync(tmp)
+    }
+  })
+
   // #170: Authorization Bearer 리터럴 자격증명 탐지.
   // "Bearer" 경계서 concat 분리 → 자기 레포 secure 스캔 자기탐지 방지 (런타임엔 합쳐짐).
   it('Authorization Bearer 리터럴 자격증명 탐지', () => {


### PR DESCRIPTION
## Summary
- scan Python source files for secrets
- suppress generic API-key false positives for placeholder values and status object keys
- preserve detection for real assignments, including status- and placeholder-prefixed variable names
- add focused regression coverage and a dev log

## Verification
- focused scan-files test: 1 passed
- focused scan-secrets tests: 6 passed
- existing secure tests: 30 passed
- npm run typecheck
- npm run lint
- npm run build
- Focus Feed live scan: CRITICAL 0, HIGH 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Python 파일(`.py`)에 대한 비밀번호 스캔 지원 추가

* **개선 사항**
  * 일반 API 키 탐지 정확도 향상으로 위양성 감소
  * 보안 패턴 매칭 로직 강화로 더욱 정밀한 탐지 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->