### PR TITLE
chore: release v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-06-12
+
 > v2.5.1 이후 main 누적분 백필(2026-06-11 전수 리뷰 G-01에서 공백 발견) + 전수 리뷰 Top 10 즉시수정.
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,11 +148,11 @@ tags: [process, constitution]
 > 세션 종료: 마지막 갱신·버전·Phase·다음 할 일 갱신. (위 🔒 구역은 절대 건드리지 마.)
 > ⚠️ 아래 `**버전:**` 줄은 CI(version-sync.test.ts)가 강제 — 형식 `**버전:** vX.Y.Z` 유지, 릴리즈마다 package.json 따라 갱신.
 
-**마지막 갱신:** 2026-06-11
-- **버전:** v2.5.1 (발행 완료) — 사실 확인은 package.json·CHANGELOG
+**마지막 갱신:** 2026-06-12
+- **버전:** v2.6.0 (npm 발행 대기 — 사용자 직접 publish 필요) — 사실 확인은 package.json·CHANGELOG
 - **테스트:** 1536 pass(main) · **MCP tools:** 29 — 사실값은 package.json·CHANGELOG
 - **Phase:** measure-first 2종(diff-coverage RFC 0050·recall RFC 0049) 측정·기록 완료, 승격/ML 보류(실사용 대기). 추가: 도그푸딩 버그 8건 일괄 픽스(#254, 2026-06-11 dev log) — 트리아지 워크플로 8병렬. 저녁: 전수 코드 리뷰 137건+Top10 즉시수정(#260) · governance T1~T5 기록 집행 hook(#261) · @claude 리뷰반영 워크플로(#259) · auto-merge 무인 머지 스킬(#262) · CodeRabbit 도입(#255, App 설치 대기). 오늘 PR 8개를 Notion Dev Log DB 5개 항목으로 적재 완료.
 - **블로커:** 없음
-- **진행 중(미발행):** main 누적 미발행분 — measure-first 2종(#251) + RFC 0051 docs 배선(#253) + 도그푸딩 8건(#254) + 전수리뷰 Top10(#260) + governance T1~T5(#261, CodeRabbit 후속픽스 #263). 다음 릴리즈 시 일괄 발행 판단.
+- **진행 중(미발행):** v2.6.0 릴리즈 준비 완료(버전 범프 + CHANGELOG 승격, 누적분 #251·#253·#254·#260·#261 일괄 포함) — main 머지 후 사용자 `npm publish`(2FA)만 남음.
 - **다음 할 일:** measure-first 잔여 = **사람 게이트**: `vhk recall` 며칠 실사용 → `vhk memory eval --init` 실쿼리 라벨 → 진짜 Recall@5(<70 반복이면 2차 ML bge-m3). 병행: 미완 goal(린트 25/27·#128, SEO 21~26). **열린 이슈 = 0개**(2026-06-11 확인, #243~250 일괄 close).
 - **주의:** publish는 main에서만(#119)·사용자 직접(2FA) / 직접 main push 차단 → PR 경유

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ---
 id: vhk-readme
 date: 2026-06-08
-tags: [vhk, cli, readme, v2.5.1, mcp, proof, ai-coding]
+tags: [vhk, cli, readme, v2.6.0, mcp, proof, ai-coding]
 ---
 
 # VHK - Vibe Harness Kit
 
-> **v2.5.1** - AI 코딩 세션을 **목표, 증거, 기억, 규칙**으로 묶는 한국어 CLI.
+> **v2.6.0** - AI 코딩 세션을 **목표, 증거, 기억, 규칙**으로 묶는 한국어 CLI.
 >
 > Cursor, Claude Code, Claude Desktop, Windsurf, Copilot, Antigravity, Gemini, Cline 사이를 옮겨도 같은 규칙과 맥락, 같은 검증 루프를 유지합니다.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "packageManager": "pnpm@11.2.2",
   "description": "VHK — AI 코딩 세션을 목표·증거·기억·규칙으로 묶는 한국어 CLI. 규칙 동기화, MCP 29 tools, verify/review/preflight 게이트.",
   "bin": {


### PR DESCRIPTION
## 요약

v2.6.0은 발행된 적이 없었습니다 — #268은 '발행 전 백필(준비)' PR이었고, 실제 버전 범프·CHANGELOG 승격·publish 단계가 빠져 있었습니다. 이 PR이 그 빠진 릴리즈 준비 단계입니다.

## 변경

- `package.json` 2.5.1 → **2.6.0**
- `CHANGELOG.md` — [Unreleased] 누적분 전체를 **[2.6.0] - 2026-06-12** 로 승격
- `README.md` — frontmatter tags + 제목 blockquote 버전 갱신 (version-sync 가드 2지점)
- `CLAUDE.md` LIVE — 버전 줄(v2.6.0, npm 발행 대기) + 진행 중(미발행) 정리

## 게이트

- 빌드: 로컬 통과 (tsup ESM+DTS success)
- 테스트: 로컬 환경에서 Node 24 worker fork 크래시(0xC0000409)로 풀 실행 불가 — **이 PR의 CI 매트릭스(ubuntu·windows × node 22·24)를 게이트로 사용**. 코드 변경 0줄(버전 문자열·문서만)이라 회귀 위험 없음.

## 머지 후 절차 (사람)

1. main 에서 `git pull`
2. `npm publish` (2FA — 가드 #119, 사용자 직접)
3. `git tag v2.6.0` 후 `git push origin v2.6.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## �리스 노트

* **Chores**
  * 버전을 v2.6.0으로 업데이트했습니다.
  * 문서 및 메타데이터를 새 버전에 맞게 갱신했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->