### PR TITLE
fix(goals): goal71·72 게이트 백필 + core-rules lint 픽스

### DIFF
--- a/docs/log/2026-06-16-goal-71-72-gate-backfill.md
+++ b/docs/log/2026-06-16-goal-71-72-gate-backfill.md
@@ -1,0 +1,54 @@
+# 2026-06-16 — goal71·72 게이트 백필 + lint 픽스 (Fable5 직접 push 수습)
+
+## 배경
+
+전날(카페 노트북) Fable5 시스템 프롬프트 흡수 스프린트에서 goal71(core-ruleset 상속)·
+goal72(secure LLM 가드레일)을 **main 직접 push**(9106ec1·2d302ce·2aa4f08, PR 없음).
+집 컴퓨터(stale)에서 `git fetch` + main fast-forward 동기화 후 게이트 돌리니 깨짐 발견.
+
+## 발견 (게이트 우회의 실제 피해)
+
+1. **`findCompletedStubGates` 회귀 가드 실패** (`tests/meta-gate.test.ts:142`)
+   — goal71·72 가 `status: DONE` 인데 `scripts/check-goal-71.mjs`·`check-goal-72.mjs`
+   가 **아예 없음**(미싱). `vhk goal sync` 미실행 → 헛통과 DONE.
+2. **lint 에러 2건** — `src/lib/core-rules.ts:150·155` 불필요한 타입 단언
+   (`@typescript-eslint/no-unnecessary-type-assertion`). `pnpm lint` 미실행 흔적.
+3. **로컬 의존성 미설치** — pull 이 `yaml@2.9.0` 추가 → `pnpm install`(CI=true) 필요했음.
+
+## 한 일
+
+- `scripts/check-goal-71.mjs` 신규 — 기본 게이트 + goal71 고유 검증(core-rules.ts export
+  4종·CORE-RULES:START 마커·번들 스냅샷·init 의 .agents/CORE-RULES.md 생성)
+- `scripts/check-goal-72.mjs` 신규 — 기본 게이트 + goal72 고유 검증(scanLlmGuardrails
+  export·PAT-001/002/004·secure 호출+섹션)
+- `src/lib/core-rules.ts` — 150·155 행 `as Record<string, string>` 단언 제거(불필요)
+
+## 근본원인 (gate 우회 구멍)
+
+main 브랜치 보호 = `required_status_checks: ["gate"]` 는 있으나 **`enforce_admins: false`**.
+소유자(admin)는 보호규칙 면제 → `gate` CI 체크 건너뛰고 main 직접 push 가능.
+`required_pull_request_reviews` 없음(PR 비강제) + 로컬 pre-push 훅 없음(.husky 는 sample 뿐).
+→ "분류기가 직접 push 차단"은 부정확. admin 직접 push 엔 무력.
+
+## 검증
+
+- `pnpm lint` → exit 0
+- `pnpm test` → 1690 pass (163 files), meta-gate green
+- `node scripts/check-goal-71.mjs` → ✅ goal 71 gate passes (typecheck/lint/test/build + 고유 9)
+- `node scripts/check-goal-72.mjs` → ✅ goal 72 gate passes (typecheck/lint/test/build + 고유 7)
+
+## 교훈
+
+- 게이트 우회 푸시는 "헛통과 DONE"을 만든다 — goal 파일 status=DONE 인데 게이트 스크립트
+  미싱/스텁이면 `findCompletedStubGates` 가 잡지만, **그건 PR CI(`gate` job)가 돌 때만**.
+  admin 직접 push 는 그 job 을 건너뛰므로 회귀 가드가 작동할 기회조차 없음.
+- 브랜치 보호의 `enforce_admins: false` = 1인 admin 레포에선 사실상 무방비. 정책 결정 필요
+  (true 로 올리면 소유자도 PR+게이트 강제 — 워크플로 변경이라 사람 판단).
+- 멀티머신 작업 후 동기화 시: `git fetch` → ff → **`pnpm install`(lockfile 변경분)** → 게이트.
+
+## 남은 작업
+
+- 이슈 #274(goal71)·#275(goal72) close (작업 완료·게이트 백필됨)
+- (정책) `enforce_admins: true` 전환 여부 — 사람 결정
+- news-automation PAT-002 3건 실제 위반 픽스(별도 레포)
+- goal73(check --evals LLM-judge, goal66 선행)

--- a/scripts/check-goal-71.mjs
+++ b/scripts/check-goal-71.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// scripts/check-goal-71.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 71 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 71] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 71 고유 검증 (직접 추가) ───────────────────────────────
+const read = (p) => (existsSync(p) ? readFileSync(p, 'utf-8') : null)
+const coreRules = read('src/lib/core-rules.ts') ?? ''
+must(existsSync('src/lib/core-rules.ts'), 'core-rules.ts 존재')
+must(/export function loadCoreRuleset/.test(coreRules), 'loadCoreRuleset export')
+must(/export function renderCoreRuleset/.test(coreRules), 'renderCoreRuleset export')
+must(/export function applyMarkerBlock/.test(coreRules), 'applyMarkerBlock export (멱등 마커)')
+must(/export function generateCoreRulesContent/.test(coreRules), 'generateCoreRulesContent export')
+must(/CORE-RULES:START/.test(coreRules), 'CORE-RULES:START 마커 정의')
+must(existsSync('src/templates/core-ruleset-snapshot.ts'), '번들 폴백 스냅샷 존재')
+must(existsSync('src/lib/core-rules.test.ts'), 'core-rules.test.ts(vitest) 존재')
+must(/\.agents\/CORE-RULES\.md/.test(read('src/commands/init.ts') ?? ''), 'init 이 .agents/CORE-RULES.md 생성')
+
+if (pass) { console.log('✅ goal 71 gate passes'); process.exit(0) }
+console.log('❌ goal 71 gate failed'); process.exit(1)

--- a/scripts/check-goal-72.mjs
+++ b/scripts/check-goal-72.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// scripts/check-goal-72.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 72 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 72] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 72 고유 검증 (직접 추가) ───────────────────────────────
+const read = (p) => (existsSync(p) ? readFileSync(p, 'utf-8') : null)
+const scan = read('src/lib/scan-llm-guardrails.ts') ?? ''
+must(existsSync('src/lib/scan-llm-guardrails.ts'), 'scan-llm-guardrails.ts 존재')
+must(/export function scanLlmGuardrails/.test(scan), 'scanLlmGuardrails export')
+must(/PAT-001/.test(scan), 'PAT-001 닫힌어휘 allowlist 검출')
+must(/PAT-002/.test(scan), 'PAT-002 JSON 직접 파싱 검출')
+must(/PAT-004/.test(scan), 'PAT-004 입력 클램프 누락 검출')
+const secure = read('src/commands/secure.ts') ?? ''
+must(/scanLlmGuardrails/.test(secure), 'secure 가 LLM 가드레일 스캔 호출')
+must(/LLM 가드레일/.test(secure), 'secure 에 LLM 가드레일 섹션 출력')
+
+if (pass) { console.log('✅ goal 72 gate passes'); process.exit(0) }
+console.log('❌ goal 72 gate failed'); process.exit(1)

--- a/src/lib/core-rules.ts
+++ b/src/lib/core-rules.ts
@@ -147,12 +147,12 @@ export function renderCoreRuleset(loaded: LoadedCoreRuleset): string {
 
   // 4. 판단·라우팅
   if (data.judgment_routing) {
-    sections.push(`## 4. 판단·라우팅\n\n${kvItems(data.judgment_routing as Record<string, string>)}`)
+    sections.push(`## 4. 판단·라우팅\n\n${kvItems(data.judgment_routing)}`)
   }
 
   // 5. 안전
   if (data.safety) {
-    sections.push(`## 5. 안전\n\n${kvItems(data.safety as Record<string, string>)}`)
+    sections.push(`## 5. 안전\n\n${kvItems(data.safety)}`)
   }
 
   // 6. 비용·효율


### PR DESCRIPTION
## 배경
전날 Fable5 흡수 스프린트에서 goal71·72 가 **main 직접 push**(9106ec1·2d302ce·2aa4f08, PR 없음)되며 게이트를 건너뜀. 집 컴퓨터 동기화 후 게이트가 깨짐을 발견.

## 발견 (게이트 우회의 실제 피해)
- `tests/meta-gate.test.ts` **실패** — goal71·72 가 `status: DONE` 인데 `scripts/check-goal-71/72.mjs` 미싱 → `findCompletedStubGates` 회귀 가드 발동(헛통과 DONE).
- **lint 에러 2건** — `src/lib/core-rules.ts:150·155` 불필요 타입 단언.

## 수정
- `scripts/check-goal-71.mjs`·`check-goal-72.mjs` 신규 — 기본 게이트 + goal 고유 검증(export·마커·PAT 스캔).
- `src/lib/core-rules.ts` — `as Record<string, string>` 단언 2건 제거.

## 근본원인 (gate 우회 구멍)
main 브랜치 보호 `required_status_checks: [gate]` 는 있으나 **`enforce_admins: false`** → 소유자(admin)가 `gate` CI 를 건너뛰고 직접 push 가능. PR 비강제 + 로컬 pre-push 훅 없음. → 정책 결정 필요(`enforce_admins: true` 전환 여부, 별도).

## 검증
- `pnpm lint` → exit 0
- `pnpm test` → **1690 pass** (163 files), meta-gate green
- `node scripts/check-goal-71.mjs` → ✅ goal 71 gate passes
- `node scripts/check-goal-72.mjs` → ✅ goal 72 gate passes

Closes #274, Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 자동화된 품질 검증 게이트 추가로 타입 체크, 린트, 테스트, 빌드 단계 자동 실행
  * 추가 보안 및 코어 규칙 검증 메커니즘 구현

* **Bug Fixes**
  * 타입 안정성 개선으로 컴파일 시간에 타입 오류 감지 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->