### PR TITLE
docs(goals): goal 68·69·70 번호 구멍 백필 — Fable5 배치 3 복원

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,9 +150,9 @@ tags: [process, constitution]
 
 **마지막 갱신:** 2026-06-16
 - **버전:** v2.6.0 (npm 발행 대기 — 사용자 직접 publish 필요) — 사실 확인은 package.json·CHANGELOG
-- **테스트:** 1691 pass(feat/goal-66-67) · **MCP tools:** 30 — 사실값은 package.json·CHANGELOG
-- **Phase:** 루프 엔지니어링 스프린트 완료(goal66+67). goal71·72(core-ruleset+LLM가드) 노트북→집컴 동기화·백필 완료. enforce_admins=true 브랜치 보호 강화.
+- **테스트:** 1708 pass(main) · **MCP tools:** 30 — 사실값은 package.json·CHANGELOG
+- **Phase:** goal66+67(루프 엔지니어링) 머지 완료(#273) — 적대 리뷰 14건 수정 동반. goal71·72 머지(#277). PR #280(PRD 풀사이클 하네스) 머지됨.
 - **블로커:** 없음
-- **진행 중(미완):** PR #273(goal66+67) CI 확인 후 squash merge 필요 — 사용자 직접. PR #278(goal68~70 번호 구멍 백필) 병행 확인.
-- **다음 할 일:** PR #273 머지 → v2.6.0 main 발행(사용자 직접 npm publish 2FA). measure-first 사람 게이트: `vhk recall` 며칠 실사용 → recall@5 측정. 미완 goal: 린트 25/27(#128)·SEO 21~26. goal 73(#276, check --evals LLM-judge) 다음 세션.
+- **진행 중(미완):** PR #278(goal68~70 번호 구멍 백필) CI 확인 후 머지 — rebase+README 재생성 완료, CI 대기.
+- **다음 할 일:** v2.6.0 main 발행(사용자 직접 npm publish 2FA). measure-first 사람 게이트: `vhk recall` 며칠 실사용 → recall@5 측정. 미완 goal: 68~70 착수 대기·린트 25/27(#128)·SEO 21~26·goal 73(#276, check --evals LLM-judge).
 - **주의:** publish는 main에서만(#119)·사용자 직접(2FA) / 직접 main push 차단 → PR 경유

--- a/goals/68-remind.md
+++ b/goals/68-remind.md
@@ -1,0 +1,53 @@
+---
+vhk_format: 1
+type: goal
+id: 68
+title: vhk remind — 긴 세션 치명 규칙 재주입 (Fable 5 리마인더 시스템)
+status: NOT_STARTED
+priority: P2
+created: 2026-06-16
+---
+
+# Goal 68: vhk remind — 치명 규칙 재주입
+
+> 출처: Fable 5 `long_conversation_reminder` 패턴. 긴 자율 루프·세션에서 컴팩션이 일어나면
+> 치명 규칙이 증발한다. 매 N 턴마다 RULES.md에서 NON-NEGOTIABLE 섹션만 골라 재주입하면
+> 1번째 턴과 100번째 턴이 같은 가중치를 가진다.
+> ⚠️ **기안 단계(NOT_STARTED)** — 카드만.
+
+## The Goal
+
+`vhk remind`가 `.vhk/remind.md`를 생성 — RULES.md의 치명 규칙(NON-NEGOTIABLE) 섹션만
+골라 최소 포맷으로 압축 출력. 루프가 매 N 턴에 이 파일을 컨텍스트에 재주입.
+
+## 차별점 (loop-brief·context --compact와 다른 축)
+
+| | `vhk remind` | `vhk loop-brief` | `vhk context --compact` |
+|---|---|---|---|
+| 목적 | **치명 규칙 가중치 유지** | 1틱 의도 고정 | 환경 파악 |
+| 내용 | NON-NEGOTIABLE만 | 의도+goal1+교훈+STOP | 스택+메모리+goal+참조 |
+| 시점 | 매 N 턴 삽입 | 매 틱 시작 | 세션 시작 |
+| 비유 | Fable 5 리마인더 | Ralph PROMPT.md | 온보딩 문서 |
+
+## 동작 (착수 시)
+
+1. RULES.md에서 `## NON-NEGOTIABLE` 또는 `## 절대 규칙` 헤더 아래 항목만 추출
+2. `치명: ` 접두 + 불릿 목록으로 압축 (원문 보존 아닌 핵심만)
+3. `.vhk/remind.md` 파일로 저장 (loop-brief 사이드카)
+4. `printNextStep`: `/loop N/remind` 패턴 안내
+
+재사용: RULES.md 파싱은 `sync.ts`의 파싱 헬퍼 활용.
+
+## Completion Check (착수 후)
+
+- [ ] `_meta` 모든 게이트 통과
+- [ ] RULES.md NON-NEGOTIABLE 섹션 추출 + `.vhk/remind.md` 생성
+- [ ] RULES.md 없을 때 graceful (빈 섹션, 크래시 0)
+- [ ] 4지점 등록(index.ts + command-registry + nlp-router + COMMANDS.md)
+- [ ] MCP 등록 (읽기 전용, `runVhkCli`)
+
+## Forbidden Actions (OUT)
+
+- RULES.md 자체 수정 금지 (읽기 전용)
+- loop-brief 포맷 변경 금지 (독립 명령)
+- 기존 tool API 시그니처 변경 0

--- a/goals/69-evolve-negative-examples.md
+++ b/goals/69-evolve-negative-examples.md
@@ -1,0 +1,42 @@
+---
+vhk_format: 1
+type: goal
+id: 69
+title: vhk evolve — 부정 예시 자동 수집 (실패 패턴 → RULES.md ❌ 후보)
+status: NOT_STARTED
+priority: P2
+created: 2026-06-16
+---
+
+# Goal 69: evolve 부정 예시 자동 수집
+
+> 출처: Fable 5 "부정 예시 설계" 패턴 — 실패 사례가 자산이다. ✅/❌ 예시 쌍은
+> 긍정 예시만큼 부정 예시가 중요하다(충돌 회피, 잘못된 행동 억제).
+> 현재 `vhk evolve`는 학습·패턴만 수집. 실패 패턴 → RULES.md ❌ 예시 자동 제안이 빠짐.
+> ⚠️ **기안 단계(NOT_STARTED)** — 카드만.
+
+## The Goal
+
+`vhk evolve --collect-negatives`(or `vhk evolve failures`) 가 memory/learnings에서
+실패·오류 패턴을 추출 → RULES.md에 ❌ 예시 후보로 제안(사람 확인 후 추가).
+
+## 핵심 설계
+
+1. **수집원**: `vhk memory` 4버킷 중 `failures` + docs/troubleshooting/ `TS-NNN` 파일
+2. **추출**: 실패 패턴 → "❌ 하지 마라: <행동> — 이유: <원인>" 형식으로 압축
+3. **출력**: `.vhk/negative-candidates.md` (사람이 검토 후 RULES.md에 추가)
+4. **강제 추가 금지**: RULES.md 자동 편집 금지, 후보 제안만
+
+## Completion Check (착수 후)
+
+- [ ] `_meta` 모든 게이트 통과
+- [ ] `vhk evolve` 기존 동작 무손상
+- [ ] failures 버킷 + troubleshooting/ 추출 → `.vhk/negative-candidates.md` 생성
+- [ ] RULES.md 자동 편집 0 (후보만, 사람 확인)
+- [ ] 빈 failures 버킷 시 graceful
+
+## Forbidden Actions (OUT)
+
+- RULES.md 자동 수정 금지
+- memory 4버킷 스키마 변경 금지 (RFC 0049 Kill-gate)
+- 기존 evolve 동작·API 변경 0

--- a/goals/70-mcp-optin-policy.md
+++ b/goals/70-mcp-optin-policy.md
@@ -1,0 +1,50 @@
+---
+vhk_format: 1
+type: goal
+id: 70
+title: MCP high-risk 도구 옵트인 정책 명문화 (deploy·publish류 명시 선택 강제)
+status: NOT_STARTED
+priority: P2
+created: 2026-06-16
+---
+
+# Goal 70: MCP high-risk 도구 옵트인 정책
+
+> 출처: Fable 5 MCP 옵트인 패턴 — 위험 도구는 명시 선택 전 호출 금지.
+> 현재 vhk MCP(`src/mcp/server.ts`) 는 모든 도구를 동등하게 노출.
+> deploy·publish·delete류 고위험 도구에 별도 게이트 없음.
+> PAT-003(되돌릴 수 없는 작업 4중 안전장치)과 연결.
+> ⚠️ **기안 단계(NOT_STARTED)** — 카드만.
+
+## The Goal
+
+MCP 도구에 `risk_level: 'high'` 메타데이터 + 호출 전 옵트인 확인 레이어.
+`confirm: true` capability gate 패턴(goal71 MCP1 `inject_core_rules` 와 동일 사상).
+
+## 고위험 도구 후보
+
+- publish류 (npm 발행, git push to main)
+- delete류 (파일 삭제, DB 삭제)
+- deploy류 (서버 배포, 클라우드 리소스)
+- external API write (외부 서비스 쓰기)
+
+## 핵심 설계
+
+1. `src/mcp/server.ts` 도구 등록에 `risk_level` 필드 추가
+2. `high` 도구: 호출 파라미터에 `confirm: true` 없으면 dry-run 결과만 반환
+3. RULES.md init 템플릿에 MCP 옵트인 정책 섹션 추가
+4. docs/adr/ ADR로 정책 결정 기록
+
+## Completion Check (착수 후)
+
+- [ ] `_meta` 모든 게이트 통과
+- [ ] `risk_level` 필드 도구 등록 + `confirm: true` gate 패턴
+- [ ] 기존 low-risk 도구 동작 무손상 (GA 안정성)
+- [ ] ADR 작성
+- [ ] init RULES.md 템플릿 MCP 옵트인 섹션
+
+## Forbidden Actions (OUT)
+
+- 기존 tool API 시그니처 변경 0 (GA 안정성)
+- MCP 모드에서 inquirer 프롬프트 호출 금지 (TTY 없음)
+- PAT-003 4중 안전장치 우회 금지

--- a/goals/README.md
+++ b/goals/README.md
@@ -2,7 +2,7 @@
 
 # goals/ 인덱스
 
-> 총 70 goal — DONE 62 · IN_PROGRESS 6 · NOT_STARTED 2
+> 총 73 goal — DONE 62 · IN_PROGRESS 6 · NOT_STARTED 5
 > 공통 게이트 = [_meta.md](_meta.md) · 카드 형식/상태 의미는 각 파일 frontmatter 참조.
 
 | # | 제목 | 상태 | 우선순위 | 다음 연결 |
@@ -75,5 +75,8 @@
 | 65 | pre-commit L2 기록 집행 — 조건부(우회 실측 시에만 착수) — P2 | ⬜ NOT_STARTED | P2 | 기록 집행 우회 경로 0 (ADR-001 L2 트리거 이행) |
 | 66 | VISION.md 북극성 앵커 — 루프 매-틱 의도 고정 (init 템플릿 + 도그푸딩) -P1 | ✅ DONE | P1 | 67 |
 | 67 | vhk loop-brief — 토큰-부족 루프 1틱 최소 앵커 (의도+1goal+recall+STOP) -P1 | ✅ DONE | P1 |  |
+| 68 | vhk remind — 긴 세션 치명 규칙 재주입 (Fable 5 리마인더 시스템) | ⬜ NOT_STARTED | P2 |  |
+| 69 | vhk evolve — 부정 예시 자동 수집 (실패 패턴 → RULES.md ❌ 후보) | ⬜ NOT_STARTED | P2 |  |
+| 70 | MCP high-risk 도구 옵트인 정책 명문화 (deploy·publish류 명시 선택 강제) | ⬜ NOT_STARTED | P2 |  |
 | 71 | vhk init — core-ruleset.yaml 마커블록 상속 (goal71) | ✅ DONE | P1 |  |
 | 72 | vhk secure — PAT-001/002/004 LLM 가드레일 검출 (goal72) | ✅ DONE | P1 |  |

--- a/scripts/check-goal-68.mjs
+++ b/scripts/check-goal-68.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// scripts/check-goal-68.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 68 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 68] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 68 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 68 gate passes'); process.exit(0) }
+console.log('❌ goal 68 gate failed'); process.exit(1)

--- a/scripts/check-goal-69.mjs
+++ b/scripts/check-goal-69.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// scripts/check-goal-69.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 69 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 69] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 69 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 69 gate passes'); process.exit(0) }
+console.log('❌ goal 69 gate failed'); process.exit(1)

--- a/scripts/check-goal-70.mjs
+++ b/scripts/check-goal-70.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// scripts/check-goal-70.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 70 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 70] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 70 고유 검증 (직접 추가) ───────────────────────────────
+// const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+// must(read('src/foo.ts')?.includes('bar'), 'foo.ts 에 bar 존재')
+
+if (pass) { console.log('✅ goal 70 gate passes'); process.exit(0) }
+console.log('❌ goal 70 gate failed'); process.exit(1)


### PR DESCRIPTION
## 배경
2026-06-12 Fable5 이식 핸드오프에서 goal 67~70을 백로그로 정의했으나:
- 2026-06-13: goal 67이 `loop-brief`로 재정의되며 원래 67(remind) 번호 공백
- 2026-06-16: Fable5가 68(OWASP)을 goal **72**로 직접 구현 → 68~70 번호 구멍 확정

이번 PR은 원래 핸드오프 정의대로 파일 복원 (코드 0줄, 기안 카드만).

## 등록 내용
| Goal | 제목 |
|---|---|
| **68** | `vhk remind` — 긴 세션 치명 규칙 재주입 (Fable 5 리마인더 시스템) |
| **69** | `evolve` 부정 예시 자동 수집 (실패 패턴 → RULES.md ❌ 후보) |
| **70** | MCP high-risk 도구 옵트인 정책 명문화 |

모두 `status: NOT_STARTED` — 게이트 스텁은 빈 스캐폴드(NOT_STARTED 정상).

## 검증
- `meta-gate.test` 18 pass (NOT_STARTED 스텁 오탐 0)
- `check-goal-frontmatter` 이상 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * `vhk remind`의 긴 세션 치명 규칙 재주입 워크플로우 문서 추가
  * `vhk evolve` 실패 패턴을 후보로 수집·검토하는 절차 문서화
  * MCP 고위험 도구에 대한 옵트인(사전 확인) 정책 및 안전 가이드라인 추가

* **Chores**
  * Goal 68, 69, 70 준수 여부를 자동 점검하는 검증 스크립트 추가
  * LIVE 진행 정보 및 목표 목록(총 73개) 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->