### PR TITLE
docs(state): LIVE + next-task 갱신 (Fable5 배치3·뒷단 머지 반영)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,9 +150,9 @@ tags: [process, constitution]
 
 **마지막 갱신:** 2026-06-16
 - **버전:** v2.6.0 (npm 발행 대기 — 사용자 직접 publish 필요) — 사실 확인은 package.json·CHANGELOG
-- **테스트:** 1708 pass(main) · **MCP tools:** 30 — 사실값은 package.json·CHANGELOG
-- **Phase:** goal66+67(루프 엔지니어링) 머지 완료(#273) — 적대 리뷰 14건 수정 동반. goal71·72 머지(#277). PR #280(PRD 풀사이클 하네스) 머지됨.
+- **테스트:** 1737 pass(main) · **MCP tools:** 32 — 사실값은 package.json·CHANGELOG
+- **Phase:** Fable5 배치3 완료 — goal68(remind)·69(evolve negatives)·70(MCP 옵트인) 머지(#282·#283·#285, 각 적대 리뷰 동반). 풀사이클 뒷단 첫 트랙 goal74(vhk content)+RFC 0052(뒷단 4트랙 설계) 머지(#284).
 - **블로커:** 없음
-- **진행 중(미완):** PR #278(goal68~70 번호 구멍 백필) CI 확인 후 머지 — rebase+README 재생성 완료, CI 대기.
-- **다음 할 일:** v2.6.0 main 발행(사용자 직접 npm publish 2FA). measure-first 사람 게이트: `vhk recall` 며칠 실사용 → recall@5 측정. 미완 goal: 68~70 착수 대기·린트 25/27(#128)·SEO 21~26·goal 73(#276, check --evals LLM-judge).
+- **진행 중(미완):** 없음 — 열린 PR 0. goal 75~77(뒷단 launch/ops/sell)·73은 카드/설계만, 착수 대기.
+- **다음 할 일:** ① v2.6.0 main 발행(사용자 직접 npm publish 2FA). ② 풀사이클 뒷단 나머지 트랙 — `vhk launch`(75)·`ops`(76)·`sell`(77), RFC 0052 §4·§5 예약, 자문형. ③ goal 73(#276, `vhk check --evals` LLM-judge) — Fable5 위생 golden-set. ④ measure-first: `vhk recall` 실사용→recall@5·`diff-cover` 실측. 미완 goal: 린트 25/27(#128)·SEO 21~26. 핸드오프: `C:\Users\user\.claude\plans\handoff-fullcycle-2026-06-16.md`
 - **주의:** publish는 main에서만(#119)·사용자 직접(2FA) / 직접 main push 차단 → PR 경유

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -4,10 +4,12 @@
 > ⚠️ `vhk goal next`/`vhk work`가 이 파일을 스텁으로 **전체 덮어쓸 수 있음** — 수동 편집
 > 직후 해당 명령 실행 주의. 소실 시 복구: `git restore docs/state/next-task.md`.
 
-**갱신:** 2026-06-11
-**Phase:** measure-first 2종 진행. recall(RFC 0049) MVP+eval 머지(#232·#233). diff-coverage(RFC 0050·Goal 50) PR1 머지(#236)+파서픽스(#239) — `vhk diff-cover` 측정 도구(차단 0). 둘 다 **실측 누적 대기**(게이트/ML은 숫자가 정당화한 뒤). 추가: 콜드스타트 −37%(#240, inquirer lazy). 사실값(버전·테스트수)은 package.json·CHANGELOG.
+**갱신:** 2026-06-16
+**Phase:** Fable5 배치3(goal68 remind·69 evolve negatives·70 MCP 옵트인) + 풀사이클 뒷단 첫 트랙(goal74 vhk content)+RFC 0052(뒷단 4트랙 설계) 머지(#282·#283·#284·#285). measure-first 2종(recall·diff-coverage)은 **여전히 실측 누적 대기**(게이트/ML은 숫자가 정당화한 뒤). 사실값(버전·테스트수)은 package.json·CHANGELOG.
 
 ## 다음 할 일 (measure-first 최우선)
+- **풀사이클 뒷단 나머지 트랙 (RFC 0052)** → `vhk launch`(goal 75) → `ops`(76) → `sell`(77). content(74)·RFC 0052 머지됨. 전부 자문형(상태수집+프롬프트 생성, 발송·결제·삭제 0 — 헌법). `src/commands/content.ts` + `src/lib/emit-prompt.ts` 패턴 복제, 개별 goal·개별 PR(동시 착수 금지). 핸드오프: `C:\Users\user\.claude\plans\handoff-fullcycle-2026-06-16.md`.
+- **goal 73 (#276 `vhk check --evals` LLM-judge)** → Fable5 프롬프트 위생 golden-set. L1(결정적 검사) 먼저, L2(LLM-judge) 나중.
 - **diff-coverage 실측 누적** → `vhk diff-cover`를 실제 코드 작업 **diff ≥5건(며칠)** 돌려 미검증 변경분 분포 수집(RFC 0050 §5 관찰 프로토콜). 유의미>0 → PR2(review line-40 제거 + verify 증거 + CI). ≈0 → "이론적 구멍" 문서화 후 중단(YAGNI). ※ diff-hunks `+++` 파서 엣지는 #239에서 이미 강화 완료(상태머신).
 - **recall 실측** → 며칠 `vhk recall` 실사용 → `vhk memory eval --init` 실쿼리 라벨 → 진짜 Recall@5. <70 반복이면 2차 ML(bge-m3, RFC 0049 §2 결정 잠금됨). **실사용 시나리오 추가(2026-06-11): "리뷰 기준 추출"** — PR 리뷰 전 diff 요약을 쿼리로 `vhk recall` 실행 → 관련 ADR·패턴만 뽑아 리뷰 기준으로 주입(외부 사례 gen-criteria 패턴: 메타데이터 1차 필터 + 의미 2차 판단 + "이 작업에 어떻게 적용되는지" 서술 강제). 실쿼리 라벨 축적과 직결.
 - **🎯 업계최상위(~4.7) 품질 로드맵** → [docs/rfc/0048](../rfc/0048-top-tier-quality-roadmap.md) + **Goals 47~54**. 13-에이전트 감사(3.5/5) 도출. 순서: **P0 먼저** — Goal 47(win32+Node20 CI 매트릭스) · Goal 48(MCP↔CLI 단일 진실원) → P1 49(린트 확대)·50(커버리지) → P2 51~54. 각 goal `vhk goal next`로 꺼내 개별 PR(AI 독주 방지). ※ 작업2.2(fast-check #213)·2.3(tsc/eslint #216) 머지로 Goal 49는 "도입→확대", Goal 52 property 옵션은 선점됨 — 재조정 필요.


### PR DESCRIPTION
﻿## 요약
CLAUDE.md ✏️ LIVE + docs/state/next-task.md 를 현재 main 상태로 갱신 (stale 해소). docs only, [skip-record].

## 반영
- main dba03c7 · 테스트 1737 pass · MCP tools 32.
- Fable5 배치3 완료: goal 68(remind)·69(evolve negatives)·70(MCP 옵트인) 머지(#282·#283·#285).
- 풀사이클 뒷단 첫 트랙 goal 74(vhk content) + RFC 0052 머지(#284).
- 다음 할 일: 뒷단 나머지 트랙(launch 75·ops 76·sell 77, RFC 0052) · goal 73 evals · measure-first · v2.6.0 publish(사용자 직접).
- 핸드오프 경로 명시.

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 개발 진행 상황 및 세션 정보가 최신으로 업데이트되었습니다. 테스트 성과 및 도구 관련 메트릭이 갱신되었으며, 진행 중인 작업 상태와 향후 계획이 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->