### PR TITLE
feat(autopilot): vhk-auto 1단계 MVP — 자율 검증·리뷰 루프 스킬

### DIFF
--- a/.claude/skills/vhk-auto/SKILL.md
+++ b/.claude/skills/vhk-auto/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: vhk-auto
+description: VHK 프로젝트에서 active goal 1개를 사람 개입 없이 한 바퀴 자율 구동(앵커→개발→검증→적대리뷰→commit)하고 멈춰 핵심 보고. 외부 발송·이슈 등록·코드 집행 0(1단계 MVP). 트리거 - "오토파일럿", "자동으로 돌려", "혼자 한 바퀴", "vhk auto", "goal 자동 진행".
+---
+
+# VHK Autopilot (1단계 MVP)
+
+VHK로 개발 중인 프로젝트에서 **active goal 카드 1개**를 사람 개입 없이 한 바퀴 돌리고,
+끝나면 **멈춰서 핵심만 보고**한다. 위험한 건 하지 않는다 — 외부 발송·이슈 등록·코드 집행은
+2단계 `vhk auto` 명령 영역이다.
+
+## 🔒 불변조건 (절대 어기지 마라)
+- **INV-1** 진행 허가 = `vhk verify` green(결정론)에만. 적대리뷰(LLM)는 "중단 트리거"로만 —
+  "진행해도 된다"는 긍정 판정 금지.
+- **INV-2** 외부 발송 0. `gh issue create` 호출 금지. 문제는 채팅 보고 + 이슈 초안 텍스트까지만.
+- **INV-3** 집행 코드 0. dedupe·rate-limit·이슈 jsonl 영속 금지. (dev log append 는 허용·필수 — INV-5)
+- **INV-4** 자동 합·불 입력 = `vhk verify` 의 `.vhk/reports/latest.json` + 각 명령 exit code 만.
+  `vhk review`·`vhk mission check` 는 exit code 만 신뢰하고 stdout 텍스트는 파싱하지 말 것
+  (텍스트는 적대 판단의 신호로만 읽는다).
+- **INV-5** commit 전 `docs/log/<오늘날짜>-autopilot.md` 에 1줄 append + `git add` 필수.
+  안 하면 check-records 훅(exit 2)이 막는다. src 실코드 커밋에 `[skip-record]` 우회 금지.
+- **INV-6** critical 결함 발견 또는 `vhk verify` 연속 2회 red 시 `.vhk/HARD_STOP` 파일 생성하고 종료.
+  매 시작(0번)에 `.vhk/HARD_STOP` 존재를 먼저 확인한다.
+- **INV-7** commit 만 자동. push·PR·머지·publish 는 절대 자동 금지.
+- **INV-8** 적대리뷰는 `/code-review` 스킬만 사용. cavecrew·Workflow 다중에이전트 쓰지 마라
+  (이 환경에 없을 수 있음).
+
+## 루프 (1회 호출 = active goal 카드 1개)
+0. **안전 확인**: `.vhk/HARD_STOP` 존재? → 있으면 즉시 중단, 사유 보고하고 종료. (INV-6)
+1. **앵커 재주입**: `vhk loop-brief` 와 `vhk remind` 실행 → 산출 파일
+   (`.vhk/loop-brief.md`·`.vhk/remind.md`) 를 Read 해서 의도·치명규칙을 컨텍스트에 넣는다.
+2. **상태 파악**: `vhk work`(또는 `vhk goal next`) 실행 → 지금의 active goal 카드 1개를 식별한다.
+3. **개발**: 그 카드의 미션을 구현한다. test-first(실패 테스트 먼저 → 통과 구현) + 기존 코딩 규칙 준수.
+4. **결정론 게이트**: `vhk verify` 실행 → `.vhk/reports/latest.json` 을 읽는다.
+   green(typecheck/test/build/secure 통과) = 진행 허가 / red = 게이트 실패 카운트 +1. (INV-1·INV-4)
+5. **적대 검증**: `/code-review` 1패스(자유텍스트). 추가로 `vhk review`·`vhk mission check` 실행 —
+   exit code 는 결정론 중단신호, stdout 텍스트는 적대판단 신호로만(파싱 X, INV-4).
+   판단 규칙: "치명(critical) 결함이 1개라도 있나? 불확실하면 치명으로 간주" → 있으면 중단. (보수적)
+6. **종결 분기**:
+   - **합격**(verify green AND 적대 치명 0):
+     1) `docs/log/<오늘날짜>-autopilot.md` 에 "무엇을 했고 검증 결과" 1줄 append + `git add`. (INV-5)
+     2) 작은 commit 1개. **commit 만** — push/PR 금지. (INV-7)
+     3) goal 완주 → 정지 + 핵심 보고 → 종료.
+   - **critical 발견 또는 verify 연속 2회 red**:
+     1) `.vhk/HARD_STOP` 파일을 사유와 함께 생성. (INV-6)
+     2) 핵심 보고 → 종료(사람이 `vhk resume --confirm` 하기 전엔 재진입 금지).
+   - **3사이클 진전 없음**:
+     1) `vhk blocker "<증상>"` (독푸딩 중이면 `[dogfood]` 태그로 HARD_STOP 임계 우회 가능) → 종료.
+7. **보고**(두괄식, 핵심 먼저):
+   `[결과 1줄] → [한 일] → [문제 있으면 핵심 + 이슈 초안 텍스트]`.
+   이슈는 **초안 텍스트만** 제시한다 — 등록은 사람이 2단계 `vhk auto` 로 결정한다. (INV-2)
+
+## 판정 모델
+- **진행 허가**(commit 해도 되나?) = `vhk verify latest.json` 이 green 인가 (결정론, LLM 무관).
+- **중단**(멈춰야 하나?) = verify red OR 적대 치명 OR `.vhk/HARD_STOP`.
+- 적대리뷰는 "멈출 이유"만 찾는다. 불확실하면 치명으로 본다.
+
+## 보고 규약
+- 문제·정리는 **핵심 먼저(두괄식)**. 설계·이론·플랜 설명은 자세히 해도 됨.
+- 비개발자 대상 — 전문용어는 쉬운 말로 풀이.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,20 @@ vhk evolve list
 
 `pattern`은 반복되는 실패/성공 신호를 찾고, `evolve`는 사람이 승인할 수 있는 RULES.md 후보를 만듭니다. 자동 적용이 아니라 diff와 확인을 거치는 구조입니다.
 
+## 🤖 오토파일럿 스킬 `/vhk-auto` (1단계 MVP)
+
+VHK 프로젝트에서 **active goal 1개를 혼자 한 바퀴 돌리고 멈춰 보고**하는 클로드 코드 스킬입니다.
+
+- 호출: 클로드 코드에서 `/vhk-auto` (또는 "오토파일럿으로 한 바퀴 돌려").
+- 하는 일: 앵커 재주입(`loop-brief`+`remind`) → 개발(TDD) → `vhk verify` 결정론 게이트
+  → `/code-review` 적대검증 → 합격 시 작은 commit → 끝나면 핵심 보고.
+- **안전(1단계 한계)**: 외부 발송·이슈 등록·`gh` 호출을 **하지 않습니다.** commit만 자동(push·PR·publish 금지).
+  문제는 "이슈 초안 텍스트"로만 보고하고, 실제 GitHub 등록은 2단계 `vhk auto` 명령(예정)이 맡습니다.
+- 설치: 다른 프로젝트에서 쓰려면 글로벌 `~/.claude/skills/vhk-auto/`에 이 스킬이 복제돼 있어야 합니다.
+
+> 2단계 로드맵: CLI `vhk auto` + MCP `vhk_auto`로 승격 시 이슈 자동등록(safeExecFile gh·dedupe·
+> undo 승인 패턴·secure 강제)이 결정론 코드로 추가됩니다.
+
 ## MCP 30 tools
 
 `vhk mcp-init`으로 MCP 설정을 만들고, MCP 클라이언트는 `vhk mcp` stdio 서버를 통해 아래 도구를 호출합니다.

--- a/docs/log/2026-06-16-autopilot-mvp.md
+++ b/docs/log/2026-06-16-autopilot-mvp.md
@@ -32,3 +32,12 @@
 
 **참고 SoT:** 스펙 `docs/superpowers/specs/2026-06-16-vhk-autopilot-mvp-design.md` · 플랜 `docs/superpowers/plans/2026-06-16-vhk-autopilot-mvp.md` · 프로젝트 기억 `vhk-autopilot-dogfooding`(매 세션 자동 로드).
 **미커밋 작업 없음. 블로커 없음.**
+
+### 갱신 (2026-06-17) — 재개 1순위 = 2단계 스펙 작성
+- PR **#291** 생성됨(`feat/autopilot-mvp` → main, docs/skill only). CI 통과 시 머지.
+- **재개하면 가장 먼저 = 2단계 스펙 작성**(`autopilot-issue-pipeline`). 사용자 지시로 독푸딩보다 우선.
+  - 입력 SoT(이미 결정된 것): MVP 스펙 `§11 로드맵 표` + 적대검증 mustFixBeforeSpec —
+    gh safeExecFile·dedupe·rate-limit·undo 승인 패턴·secure 본문 강제·public app-bug 등록 금지·
+    CLI `vhk auto`(등록 7항+MCP 30→31)·MCP `vhk_auto`·`vhk review`/`mission check --json` 신규.
+  - 흐름: brainstorming 가볍게(결정 대부분 끝남) → 스펙 작성 → writing-plans.
+- 그 다음 순서: 독푸딩(Task 4 검증) → 2단계 구현.

--- a/docs/log/2026-06-16-autopilot-mvp.md
+++ b/docs/log/2026-06-16-autopilot-mvp.md
@@ -18,3 +18,17 @@
 ## 다음
 - 독푸딩: POS 프로젝트에서 `/vhk-auto` 1회 호출 → 수용기준(스펙 §10) 검증.
 - 검증되면 2단계 스펙(`...-issue-pipeline-design.md`) 착수.
+
+## 핸드오프 (2026-06-17 — 독푸딩 보류, 나중에 재개)
+**상태:** 1단계 MVP 구현·커밋 완료. 브랜치 `feat/autopilot-mvp` (main +5, 미푸시·미머지, 작업트리 클린).
+독푸딩은 사용자가 나중에 하기로 → 이번엔 미실행.
+
+**재개 순서 (다음 세션):**
+1. `git checkout feat/autopilot-mvp` → `/vhk-auto` 가 글로벌(`~/.claude/skills/vhk-auto/`)에 설치돼 있음(확인: `Test-Path $env:USERPROFILE\.claude\skills\vhk-auto\SKILL.md`).
+2. **Task 4 독푸딩** — POS 프로젝트에서 `/vhk-auto` 1회 호출 → INV 준수 4개 관찰(플랜 Task 4 Step 3):
+   ① verify red인데 commit 0  ② `gh issue create` 호출 0  ③ critical 시 `.vhk/HARD_STOP` 생성  ④ commit이 check-records에 안 막힘.
+3. 검증 OK → `feat/autopilot-mvp` PR 머지(PR 경유, 사람 승인). 위반 발견 → SKILL.md 수정 후 재검증.
+4. 그 다음 → 2단계 스펙 착수.
+
+**참고 SoT:** 스펙 `docs/superpowers/specs/2026-06-16-vhk-autopilot-mvp-design.md` · 플랜 `docs/superpowers/plans/2026-06-16-vhk-autopilot-mvp.md` · 프로젝트 기억 `vhk-autopilot-dogfooding`(매 세션 자동 로드).
+**미커밋 작업 없음. 블로커 없음.**

--- a/docs/log/2026-06-16-autopilot-mvp.md
+++ b/docs/log/2026-06-16-autopilot-mvp.md
@@ -1,0 +1,20 @@
+# 2026-06-16 — VHK Autopilot 1단계 MVP
+
+## 한 일
+- 오토파일럿(지휘자) 설계 → 적대 검증(5렌즈, blocker 9·high 16) → 교정 → 스펙·플랜·스킬 작성.
+- 1단계 산출물 = `.claude/skills/vhk-auto/SKILL.md` (코드 0, 외부발송·집행 0).
+
+## 결정 (교정안)
+- "1단계=순수 지침 스킬"에 외부발송·집행·자동판정을 얹으면 헌법 5곳과 충돌(검증 결론) →
+  위험·집행은 2단계 `vhk auto` 코드로 이연, 1단계는 "혼자 한 바퀴 돌고 멈춰 보고"만.
+- 불변조건 INV-1..8 로 못박음(진행허가=verify green만 / 발송0 / 집행0 / 판정입력=latest.json+exit /
+  commit 전 dev log stage / 멈춤=HARD_STOP 영속 / commit만 자동 / cavecrew·Workflow 제외).
+
+## 교훈
+- 자율 설계는 저자 자평 금지 — 독립 적대 검증이 코드까지 까서 "review/mission --json 부재",
+  "check-records 훅이 무인 commit 차단", "MCP TTY 없어 승인 프롬프트 불가" 등 실측 결함 7건을 잡음.
+- 바깥행동(gh issue)·집행(dedupe)은 LLM 결정경로에서 빼고 결정론 코드로(PAT-003 재확인).
+
+## 다음
+- 독푸딩: POS 프로젝트에서 `/vhk-auto` 1회 호출 → 수용기준(스펙 §10) 검증.
+- 검증되면 2단계 스펙(`...-issue-pipeline-design.md`) 착수.

--- a/docs/log/2026-06-16-autopilot-mvp.md
+++ b/docs/log/2026-06-16-autopilot-mvp.md
@@ -41,3 +41,9 @@
     CLI `vhk auto`(등록 7항+MCP 30→31)·MCP `vhk_auto`·`vhk review`/`mission check --json` 신규.
   - 흐름: brainstorming 가볍게(결정 대부분 끝남) → 스펙 작성 → writing-plans.
 - 그 다음 순서: 독푸딩(Task 4 검증) → 2단계 구현.
+
+## 독푸딩 첫 발견 (2026-06-17) — flaky 테스트 (tool-gap)
+- PR #291 CI(windows-latest, node22)에서 `tests/goal.test.ts:533 "goal sync 자연어는 파일 쓰기 전에 confirmation 대상"` **5초 타임아웃 flaky** 발견(win-22 2회 연속, win-24·ubuntu 통과).
+- **근본원인:** 이 테스트가 파일 내 `nlp-run.js` 첫 import → 콜드 transform/import 비용(파일 import 24s)이 5초 타임아웃 테스트에 전가, 느린 win-22에서 초과. 로직 자체는 순수·즉시.
+- **fix:** 해당 테스트 타임아웃 20000ms + why-comment. 로컬 통과(1.04s). (증상패치 아님 — 원인=타임아웃 과소)
+- **분류:** VHK 본체 tool-gap(테스트 인프라). autopilot docs PR과 무관, main에도 있던 기존 결함. **독푸딩이 잡은 첫 실제 버그.**

--- a/docs/superpowers/plans/2026-06-16-vhk-autopilot-mvp.md
+++ b/docs/superpowers/plans/2026-06-16-vhk-autopilot-mvp.md
@@ -1,0 +1,265 @@
+# VHK Autopilot 1단계 MVP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** VHK 프로젝트에서 active goal 1개를 사람 개입 없이 한 바퀴 자율 구동하고 멈춰 핵심 보고하는 클로드 코드 스킬 `/vhk-auto`를 만든다(코드 변경 0, 외부 발송·집행 0).
+
+**Architecture:** 단일 산출물 = `.claude/skills/vhk-auto/SKILL.md`(지침만). 새 코드·의존성 없음. 스킬은 기존 VHK 명령(`vhk loop-brief`/`remind`/`work`/`verify`/`review`/`mission check`/`blocker`)과 `/code-review` 스킬만 호출. 위험·집행(이슈 등록·dedupe·rate-limit)은 2단계 `vhk auto` 명령으로 이연.
+
+**Tech Stack:** Markdown 스킬(Claude Code skill 포맷), git. 빌드·테스트 코드 없음 — 검증은 구조 점검 + 독푸딩 수용기준.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-vhk-autopilot-mvp-design.md` (불변조건 INV-1..8 = 이 플랜의 정합 기준)
+
+---
+
+## File Structure
+
+| 파일 | 책임 | 작업 |
+|------|------|------|
+| `.claude/skills/vhk-auto/SKILL.md` | 오토파일럿 루프·불변조건·보고 규약(SoT) | Create (Task 1) |
+| `~/.claude/skills/vhk-auto/SKILL.md` | 글로벌 복제(POS 등에서 호출) | Create (Task 2) |
+| `README.md` (또는 `COMMANDS.md` 부록) | `/vhk-auto` 사용법 | Modify (Task 2) |
+| `docs/log/2026-06-16-autopilot-mvp.md` | 세션 dev log(append-only) | Create (Task 3) |
+
+> 모든 변경이 `.claude/`·`docs/`·`README` (= src/** 아님) → 커밋 메시지에 `[skip-record]`. check-records 훅 비대상.
+
+---
+
+## Task 1: 스킬 본문 작성 (SoT)
+
+**Files:**
+- Create: `.claude/skills/vhk-auto/SKILL.md`
+
+- [ ] **Step 1: 스킬 파일 생성 (전체 내용 그대로)**
+
+`.claude/skills/vhk-auto/SKILL.md` 에 아래를 **그대로** 쓴다:
+
+````markdown
+---
+name: vhk-auto
+description: VHK 프로젝트에서 active goal 1개를 사람 개입 없이 한 바퀴 자율 구동(앵커→개발→검증→적대리뷰→commit)하고 멈춰 핵심 보고. 외부 발송·이슈 등록·코드 집행 0(1단계 MVP). 트리거 - "오토파일럿", "자동으로 돌려", "혼자 한 바퀴", "vhk auto", "goal 자동 진행".
+---
+
+# VHK Autopilot (1단계 MVP)
+
+VHK로 개발 중인 프로젝트에서 **active goal 카드 1개**를 사람 개입 없이 한 바퀴 돌리고,
+끝나면 **멈춰서 핵심만 보고**한다. 위험한 건 하지 않는다 — 외부 발송·이슈 등록·코드 집행은
+2단계 `vhk auto` 명령 영역이다.
+
+## 🔒 불변조건 (절대 어기지 마라)
+- **INV-1** 진행 허가 = `vhk verify` green(결정론)에만. 적대리뷰(LLM)는 "중단 트리거"로만 —
+  "진행해도 된다"는 긍정 판정 금지.
+- **INV-2** 외부 발송 0. `gh issue create` 호출 금지. 문제는 채팅 보고 + 이슈 초안 텍스트까지만.
+- **INV-3** 집행 코드 0. dedupe·rate-limit·이슈 jsonl 영속 금지. (dev log append 는 허용·필수 — INV-5)
+- **INV-4** 자동 합·불 입력 = `vhk verify` 의 `.vhk/reports/latest.json` + 각 명령 exit code 만.
+  `vhk review`·`vhk mission check` 는 exit code 만 신뢰하고 stdout 텍스트는 파싱하지 말 것
+  (텍스트는 적대 판단의 신호로만 읽는다).
+- **INV-5** commit 전 `docs/log/<오늘날짜>-autopilot.md` 에 1줄 append + `git add` 필수.
+  안 하면 check-records 훅(exit 2)이 막는다. src 실코드 커밋에 `[skip-record]` 우회 금지.
+- **INV-6** critical 결함 발견 또는 `vhk verify` 연속 2회 red 시 `.vhk/HARD_STOP` 파일 생성하고 종료.
+  매 시작(0번)에 `.vhk/HARD_STOP` 존재를 먼저 확인한다.
+- **INV-7** commit 만 자동. push·PR·머지·publish 는 절대 자동 금지.
+- **INV-8** 적대리뷰는 `/code-review` 스킬만 사용. cavecrew·Workflow 다중에이전트 쓰지 마라
+  (이 환경에 없을 수 있음).
+
+## 루프 (1회 호출 = active goal 카드 1개)
+0. **안전 확인**: `.vhk/HARD_STOP` 존재? → 있으면 즉시 중단, 사유 보고하고 종료. (INV-6)
+1. **앵커 재주입**: `vhk loop-brief` 와 `vhk remind` 실행 → 산출 파일
+   (`.vhk/loop-brief.md`·`.vhk/remind.md`) 를 Read 해서 의도·치명규칙을 컨텍스트에 넣는다.
+2. **상태 파악**: `vhk work`(또는 `vhk goal next`) 실행 → 지금의 active goal 카드 1개를 식별한다.
+3. **개발**: 그 카드의 미션을 구현한다. test-first(실패 테스트 먼저 → 통과 구현) + 기존 코딩 규칙 준수.
+4. **결정론 게이트**: `vhk verify` 실행 → `.vhk/reports/latest.json` 을 읽는다.
+   green(typecheck/test/build/secure 통과) = 진행 허가 / red = 게이트 실패 카운트 +1. (INV-1·INV-4)
+5. **적대 검증**: `/code-review` 1패스(자유텍스트). 추가로 `vhk review`·`vhk mission check` 실행 —
+   exit code 는 결정론 중단신호, stdout 텍스트는 적대판단 신호로만(파싱 X, INV-4).
+   판단 규칙: "치명(critical) 결함이 1개라도 있나? 불확실하면 치명으로 간주" → 있으면 중단. (보수적)
+6. **종결 분기**:
+   - **합격**(verify green AND 적대 치명 0):
+     1) `docs/log/<오늘날짜>-autopilot.md` 에 "무엇을 했고 검증 결과" 1줄 append + `git add`. (INV-5)
+     2) 작은 commit 1개. **commit 만** — push/PR 금지. (INV-7)
+     3) goal 완주 → 정지 + 핵심 보고 → 종료.
+   - **critical 발견 또는 verify 연속 2회 red**:
+     1) `.vhk/HARD_STOP` 파일을 사유와 함께 생성. (INV-6)
+     2) 핵심 보고 → 종료(사람이 `vhk resume --confirm` 하기 전엔 재진입 금지).
+   - **3사이클 진전 없음**:
+     1) `vhk blocker "<증상>"` (독푸딩 중이면 `[dogfood]` 태그로 HARD_STOP 임계 우회 가능) → 종료.
+7. **보고**(두괄식, 핵심 먼저):
+   `[결과 1줄] → [한 일] → [문제 있으면 핵심 + 이슈 초안 텍스트]`.
+   이슈는 **초안 텍스트만** 제시한다 — 등록은 사람이 2단계 `vhk auto` 로 결정한다. (INV-2)
+
+## 판정 모델
+- **진행 허가**(commit 해도 되나?) = `vhk verify latest.json` 이 green 인가 (결정론, LLM 무관).
+- **중단**(멈춰야 하나?) = verify red OR 적대 치명 OR `.vhk/HARD_STOP`.
+- 적대리뷰는 "멈출 이유"만 찾는다. 불확실하면 치명으로 본다.
+
+## 보고 규약
+- 문제·정리는 **핵심 먼저(두괄식)**. 설계·이론·플랜 설명은 자세히 해도 됨.
+- 비개발자 대상 — 전문용어는 쉬운 말로 풀이.
+````
+
+- [ ] **Step 2: 구조 검증 — 불변조건 8개 + frontmatter 존재 확인**
+
+Run (PowerShell):
+```powershell
+$f = ".claude/skills/vhk-auto/SKILL.md"
+1..8 | ForEach-Object { if (-not (Select-String -Path $f -Pattern "INV-$_" -Quiet)) { Write-Host "MISSING INV-$_" } }
+if (Select-String -Path $f -Pattern '^name: vhk-auto' -Quiet) { Write-Host "frontmatter name OK" } else { Write-Host "MISSING name" }
+if (Select-String -Path $f -Pattern '^description:' -Quiet) { Write-Host "frontmatter desc OK" } else { Write-Host "MISSING desc" }
+```
+Expected: `frontmatter name OK` + `frontmatter desc OK`, **그리고 MISSING 출력 없음**(INV-1..8 모두 존재).
+
+- [ ] **Step 3: 금지 패턴 부재 확인 (INV-2·INV-8 정합)**
+
+Run (PowerShell):
+```powershell
+$f = ".claude/skills/vhk-auto/SKILL.md"
+if (Select-String -Path $f -Pattern 'gh issue create' -Quiet) { Write-Host "WARN: gh issue create 언급 — 금지 맥락인지 확인" }
+if (Select-String -Path $f -Pattern 'cavecrew|Workflow 다중' -Quiet) { Write-Host "INFO: cavecrew/Workflow 언급 — 제외 맥락인지 확인" }
+```
+Expected: 둘 다 **금지/제외 맥락으로만** 등장(허용 절차로 등장하면 안 됨). 본문 검토로 확인.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/vhk-auto/SKILL.md
+git commit -m "feat(autopilot): vhk-auto 스킬 본문 — 1단계 MVP 루프+불변조건 [skip-record]" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: 글로벌 설치 + 사용법 문서
+
+**Files:**
+- Create: `~/.claude/skills/vhk-auto/SKILL.md` (Task 1 산출물 복제)
+- Modify: `README.md` (사용법 섹션 추가)
+
+- [ ] **Step 1: 글로벌 스킬 디렉토리 생성 + 복제**
+
+Run (PowerShell):
+```powershell
+$dst = Join-Path $env:USERPROFILE ".claude/skills/vhk-auto"
+New-Item -ItemType Directory -Force -Path $dst | Out-Null
+Copy-Item ".claude/skills/vhk-auto/SKILL.md" (Join-Path $dst "SKILL.md") -Force
+Test-Path (Join-Path $dst "SKILL.md")
+```
+Expected: `True` (글로벌 경로에 SKILL.md 존재 → POS 등 다른 프로젝트에서 `/vhk-auto` 호출 가능).
+
+- [ ] **Step 2: README 사용법 섹션 추가**
+
+`README.md` 의 적절한 위치(명령/스킬 안내 근처)에 아래 섹션을 추가한다:
+
+```markdown
+## 🤖 오토파일럿 스킬 `/vhk-auto` (1단계 MVP)
+
+VHK 프로젝트에서 **active goal 1개를 혼자 한 바퀴 돌리고 멈춰 보고**하는 클로드 코드 스킬.
+
+- 호출: 클로드 코드에서 `/vhk-auto` (또는 "오토파일럿으로 한 바퀴 돌려").
+- 하는 일: 앵커 재주입(`loop-brief`+`remind`) → 개발(TDD) → `vhk verify` 결정론 게이트
+  → `/code-review` 적대검증 → 합격 시 작은 commit → 끝나면 핵심 보고.
+- **안전(1단계 한계)**: 외부 발송·이슈 등록·`gh` 호출 **안 함**. commit 만 자동(push·PR·publish 금지).
+  문제는 "이슈 초안 텍스트"로만 보고 — 실제 GitHub 등록은 2단계 `vhk auto` 명령(예정).
+- 설치(다른 프로젝트에서 쓰려면): 이 스킬은 글로벌 `~/.claude/skills/vhk-auto/` 에 복제되어 있어야 함.
+
+> 2단계 로드맵: CLI `vhk auto` + MCP `vhk_auto` 로 승격 시 이슈 자동등록(safeExecFile gh·dedupe·
+> undo 승인 패턴·secure 강제)이 결정론 코드로 추가된다.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(autopilot): /vhk-auto 사용법 + 글로벌 설치 안내 [skip-record]" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+> 참고: `~/.claude/skills/` 는 vhk 레포 밖이라 커밋되지 않음(글로벌 복제는 로컬 설치 행위).
+
+---
+
+## Task 3: dev log 기록
+
+**Files:**
+- Create: `docs/log/2026-06-16-autopilot-mvp.md`
+
+- [ ] **Step 1: dev log 작성 (append-only)**
+
+`docs/log/2026-06-16-autopilot-mvp.md` 에 아래를 쓴다:
+
+```markdown
+# 2026-06-16 — VHK Autopilot 1단계 MVP
+
+## 한 일
+- 오토파일럿(지휘자) 설계 → 적대 검증(5렌즈, blocker 9·high 16) → 교정 → 스펙·플랜·스킬 작성.
+- 1단계 산출물 = `.claude/skills/vhk-auto/SKILL.md` (코드 0, 외부발송·집행 0).
+
+## 결정 (교정안)
+- "1단계=순수 지침 스킬"에 외부발송·집행·자동판정을 얹으면 헌법 5곳과 충돌(검증 결론) →
+  위험·집행은 2단계 `vhk auto` 코드로 이연, 1단계는 "혼자 한 바퀴 돌고 멈춰 보고"만.
+- 불변조건 INV-1..8 로 못박음(진행허가=verify green만 / 발송0 / 집행0 / 판정입력=latest.json+exit /
+  commit 전 dev log stage / 멈춤=HARD_STOP 영속 / commit만 자동 / cavecrew·Workflow 제외).
+
+## 교훈
+- 자율 설계는 저자 자평 금지 — 독립 적대 검증이 코드까지 까서 "review/mission --json 부재",
+  "check-records 훅이 무인 commit 차단", "MCP TTY 없어 승인 프롬프트 불가" 등 실측 결함 7건을 잡음.
+- 바깥행동(gh issue)·집행(dedupe)은 LLM 결정경로에서 빼고 결정론 코드로(PAT-003 재확인).
+
+## 다음
+- 독푸딩: POS 프로젝트에서 `/vhk-auto` 1회 호출 → 수용기준(스펙 §10) 검증.
+- 검증되면 2단계 스펙(`...-issue-pipeline-design.md`) 착수.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/log/2026-06-16-autopilot-mvp.md
+git commit -m "docs(log): autopilot 1단계 MVP 세션 기록 [skip-record]" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: 독푸딩 수용기준 검증 (실측 게이트 — POS 프로젝트에서)
+
+> 단위테스트 없음(마크다운 스킬). 검증 = 실제 한 바퀴 돌려 불변조건 준수 관찰. **이 Task는 커밋 없음** —
+> POS 프로젝트에서 수동 실행하고 결과를 다음 세션 dev log 에 기록.
+
+- [ ] **Step 1: 글로벌 스킬 인식 확인**
+
+POS 프로젝트 디렉토리에서 클로드 코드를 열고 `/vhk-auto` 가 스킬 목록에 뜨는지 확인.
+Expected: 스킬이 보임(글로벌 설치 OK).
+
+- [ ] **Step 2: 1회 호출 → goal 1개 완주 또는 정직한 정지**
+
+`/vhk-auto` 1회 호출.
+Expected: active goal 1개를 구현→`vhk verify`→`/code-review`→(합격 시) 작은 commit 1개 후 정지+보고,
+또는 blocker/HARD_STOP 으로 정직하게 정지.
+
+- [ ] **Step 3: 불변조건 준수 관찰 (스펙 §10 수용기준)**
+
+아래를 눈으로 확인:
+1. `vhk verify` red 인데 commit 한 적 **없다** (INV-1).
+2. `gh issue create` 가 **호출되지 않았다** (INV-2). → `git log` 및 GitHub 이슈 목록에 신규 0.
+3. critical 발견 시 `.vhk/HARD_STOP` 이 생겼고 다음 호출이 0번에서 멈춘다 (INV-6).
+4. commit 이 check-records 훅에 막히지 않았다 (INV-5) — 같은 커밋에 dev log staged.
+Expected: 4개 모두 준수. 위반 1개라도 있으면 SKILL.md 수정 후 재검증.
+
+- [ ] **Step 4: 결과를 dev log 에 기록**
+
+POS 프로젝트(또는 vhk 레포) 의 다음 dev log 에 "수용기준 4개 결과 + 관찰된 문제"를 append.
+유효 결함 발견 시 → 2단계(`vhk auto` 이슈 파이프라인) 백로그로.
+
+---
+
+## Self-Review (작성자 체크)
+
+**Spec coverage:**
+- INV-1..8 → Task 1 Step 1 본문 + Step 2 구조검증 + Task 4 Step 3 관찰. ✅
+- 산출물(SKILL.md SoT + 글로벌 복제 + README + dev log) → Task 1·2·3. ✅
+- 테스트=독푸딩(§10) → Task 4 수용기준 4개로 1:1 매핑. ✅
+- 2단계 이연 항목 → 코드/플랜에 미포함(범위 밖) — README·dev log 에 로드맵으로만 언급. ✅
+
+**Placeholder scan:** TBD/TODO/"적절히"/"나중에" 없음. SKILL.md 전체 내용·검증 명령·dev log 내용 모두 실체로 제공. ✅
+
+**Type consistency:** 불변조건 명칭 INV-1..8 이 스펙·SKILL.md·검증 step·수용기준에서 동일. 경로
+`.claude/skills/vhk-auto/SKILL.md`·`.vhk/reports/latest.json`·`docs/log/<오늘>-autopilot.md` 일관. ✅
+
+**주의(실행 시):** Task 1 의 SKILL.md 는 펜스 안에 ```` ```markdown ```` 블록을 포함하므로, executor 는
+**바깥 4-backtick 펜스 안의 내용만** SKILL.md 로 저장한다(중첩 펜스 보존).

--- a/docs/superpowers/specs/2026-06-16-vhk-autopilot-mvp-design.md
+++ b/docs/superpowers/specs/2026-06-16-vhk-autopilot-mvp-design.md
@@ -1,0 +1,195 @@
+# 설계: VHK Autopilot — 1단계 MVP (autopilot-mvp)
+
+**날짜:** 2026-06-16
+**상태:** 설계 승인 대기 (brainstorming 산출 — 적대 검증 1회 통과 후 교정본)
+**범위:** 1단계만. 2단계(이슈 파이프라인)는 별도 스펙 `2026-06-16-vhk-autopilot-issue-pipeline-design.md`(후속).
+
+---
+
+## 1. 배경·목적
+
+비개발자 사용자가 VHK로 프로젝트(현재 독푸딩 대상 = 카페 미니 POS)를 개발할 때,
+**검증·리뷰 루프를 매번 손으로 프롬프트**하던 것을 자율화한다.
+
+지금 사용자가 손으로 하는 반복:
+> `vhk review`+`verify` 시킴 → 됐나 눈으로 확인 → 클로드 코드 적대검증·코드리뷰 또 돌림 → 또 확인 → 반복.
+
+이 "지휘자(orchestrator)" 역할을 스킬로 옮긴다. **1단계는 클로드 코드 전용 스킬**(빠른 독푸딩),
+바깥 발송·코드 집행·자동 등록은 전부 2단계(결정론 코드)로 이연한다.
+
+### 왜 이렇게 잘랐나 (적대 검증 결론)
+독립 5렌즈 적대 검증(거버넌스/안전/실현가능성/스코프/내부모순)이 **blocker 9·high 16**을 잡았고,
+공통 원인은 "1단계=순수 지침 스킬"에 **외부 발송(gh issue)·결정론 집행(dedupe·rate-limit)·자동 판정**을
+얹은 것이었다. 이는 VHK 헌법 5곳과 정면충돌한다(§3). 따라서 **위험·집행은 2단계 코드로 내리고,
+1단계는 "혼자 한 바퀴 돌고 멈춰 보고하는" 안전한 지침만** 남긴다.
+
+---
+
+## 2. 범위
+
+### IN (1단계 MVP)
+- 클로드 코드 스킬 `/vhk-auto` (한글 별칭 `/오토파일럿`).
+- 모드: **goal 1개 완주 후 정지+보고** (단일 모드만).
+- 루프: 앵커 재주입 → 상태 파악 → 개발(TDD) → `vhk verify` 결정론 게이트 → 적대검증(중단 트리거) → 합격 시 commit → 정체 시 blocker 이탈.
+- 멈춤 안전핀: 매 틱 HARD_STOP 확인 + 실패의 HARD_STOP 영속화.
+- 문제 발견 시: **채팅에 핵심 두괄식 보고 + 이슈 초안 텍스트 제시**(등록·파일쓰기 없음).
+
+### OUT (2단계로 이연 — 이번 스펙 아님)
+- `gh issue create` 자동 등록, dedupe, rate-limit, 라벨/레포 라우팅.
+- 이슈 초안 영속(`issues-draft.jsonl`), 14필드 템플릿, secure 본문 강제.
+- CLI `vhk auto`, MCP `vhk_auto`, yohan-brain core-ruleset 규약, sync 배포.
+- 적대검증 수단 선택형(B1 4종) · 검증도 4레벨(B2) · 무인 연속(/loop) 모드.
+- `vhk review --json` / `vhk mission check --json` 신규(2단계 선행 의존).
+
+---
+
+## 3. 불변조건 (헌법 충돌 방지 — 위반 시 설계 실패)
+
+적대 검증이 잡은 blocker를 **하드 불변조건**으로 박는다. 구현은 이 목록을 어기면 안 된다.
+
+| INV | 내용 | 근거(코드/헌법) |
+|-----|------|------|
+| INV-1 | **진행 허가는 결정론 게이트(`vhk verify` green)에만.** LLM 적대판정은 "진행 허가" 권한 없음 — **"중단 트리거"로만** 작동. | PAT-003 (LLM을 되돌리기 어려운 작업의 결정경로에서 제외) |
+| INV-2 | **1단계는 외부 발송 0.** `gh issue create` 호출 금지. 문제는 채팅 보고 + 초안 텍스트까지만. | 글로벌/PRD: 발송은 LLM 빼고 룰+하드리밋 |
+| INV-3 | **1단계는 집행 코드 0.** 이슈 버퍼 영속(`issues-draft.jsonl`)·dedupe·rate-limit 금지(스킬은 LLM 지침일 뿐 강제 불가). 영속·집행은 2단계 코드. (예외: dev log append+stage는 허용 — INV-5 필수 절차) | 검증 blocker #5 (형식 모순) |
+| INV-4 | **자동 합·불 입력 = `vhk verify`의 `latest.json` + 각 명령 exit code만.** `review`·`mission check`의 **exit code는 결정론 신호로 사용 가능**(예: `mission check` exit 1 = forbidden 위반 → 중단), 단 **stdout 텍스트 파싱 금지** — 텍스트는 적대 판단의 LLM 신호로만. | 코드확인: review/mission `--json` 부재, verify만 `latest.json` |
+| INV-5 | **commit 전 dev log append+stage 필수.** src/** 변경 commit은 `docs/log/<오늘>-autopilot.md`(append-only)를 stage하지 않으면 `check-records` 훅(exit 2)에 막힌다. src 실코드에 `[skip-record]` 우회 금지. | 코드확인: `scripts/check-records.mjs` |
+| INV-6 | **멈춤은 영속화.** critical 발견·게이트 연속 2회 실패 시 `.vhk/HARD_STOP` 생성 → 사람 `vhk resume --confirm` 전엔 재진입 불가. 매 틱 0번에 HARD_STOP 확인. | 코드확인: HARD_STOP 자동생성은 blocker≥3 단일 트리거뿐(state-files.ts:65) → 다른 멈춤은 미연동 = 무한 재시도 위험 |
+| INV-7 | **commit만 자동.** push·PR·머지·publish는 자동 절대 금지. | 헌법 #119 / governance |
+| INV-8 | **인프라 가정 금지.** 이 레포에 `.claude/agents`·cavecrew 부재 → 1단계 적대검증은 `/code-review` 스킬(가용 확인됨)만 사용. Workflow 다중에이전트·cavecrew는 1단계 제외. | Glob 확인: `.claude/agents` 없음 |
+
+---
+
+## 4. 아키텍처
+
+단일 산출물: **클로드 코드 스킬 1개**.
+
+```
+~/.claude/skills/vhk-auto/SKILL.md      ← 글로벌(POS 등 모든 프로젝트에서 호출)
+<vhk-repo>/.claude/skills/vhk-auto/SKILL.md  ← SoT 복제(레포가 진실원천)
+```
+
+스킬은 **지침(절차 + 불변조건 + 보고 규약)** 만 담는다. 새 코드·새 의존성 없음.
+스킬이 호출하는 것은 전부 **기존** VHK 명령 + 클로드 코드 내장 기능(Bash로 `vhk`/`git` 호출,
+`/code-review` 스킬, TodoWrite, Read/Edit/Write).
+
+### 단위 경계 (한 가지 책임씩)
+- **앵커 단계**: 컨텍스트 재주입만 (`vhk loop-brief`·`vhk remind` 실행 후 산출 파일 Read).
+- **개발 단계**: active goal 카드 1개 구현 (TDD).
+- **게이트 단계**: `vhk verify` 실행 → `latest.json` 읽어 결정론 합·불.
+- **적대 단계**: `/code-review` 1패스 → 자유텍스트 → "치명 발견?" 보수적 판단(중단 트리거).
+- **종결 단계**: 합격 → dev log append + commit / 정체 → blocker / critical·게이트실패 → HARD_STOP.
+- **보고 단계**: 채팅 두괄식 + 이슈 초안 텍스트(등록 X).
+
+---
+
+## 5. 루프 상세 (1 호출 = goal 카드 1개)
+
+```
+0. 안전 확인   : .vhk/HARD_STOP 존재? → 있으면 즉시 중단·보고하고 종료 (INV-6)
+1. 앵커 재주입 : vhk loop-brief; vhk remind  → 산출(.vhk/loop-brief.md·remind.md) Read
+2. 상태 파악   : vhk work (또는 vhk goal next) → active goal 카드 식별
+3. 개발        : 카드 미션 구현. TDD 기본(실패 테스트 먼저 → 통과 구현). 기존 코딩 규칙 준수.
+4. 결정론 게이트: vhk verify  → .vhk/reports/latest.json 읽기
+                  - green(typecheck/test/build/secure 통과) = 진행 허가 (INV-1)
+                  - red = 게이트 실패 카운트+1
+5. 적대 검증   : /code-review 1패스(자유텍스트) + vhk review·vhk mission check 실행
+                  → exit code = 결정론 중단신호 / stdout 텍스트 = LLM 적대판단 신호(파싱 X / INV-4)
+                  - "치명(critical) 결함 1개라도? 불확실하면 치명으로 간주" = 중단 트리거 (INV-1, 보수적)
+6. 종결 분기   :
+   - 합격(게이트 green AND 적대 치명 0):
+       a. docs/log/<오늘>-autopilot.md append (무엇을/검증결과 1줄, append-only) + git add (INV-5)
+       b. 작은 commit 1개 (commit만 — push/PR 금지, INV-7)
+       c. goal 완주 → 정지 + 핵심 보고 → 종료
+   - critical 발견 또는 게이트 연속 2회 실패:
+       a. .vhk/HARD_STOP 생성(이유 기록) (INV-6) → 핵심 보고 → 종료(사람 resume 대기)
+   - 3사이클 진전 없음:
+       a. vhk blocker "<증상>" (독푸딩 중이면 [dogfood] 태그로 HARD_STOP 임계 우회 가능) → 종료
+7. 보고        : 채팅에 두괄식 — [결과 1줄] → [무엇을 했나] → [문제 있으면 핵심+이슈 초안 텍스트]
+                  (이슈 등록·파일 영속은 1단계에서 안 함 — 2단계 vhk auto가 함, INV-2·INV-3)
+```
+
+### 게이트 실패 카운트
+- 같은 호출(goal 1개) 내 `vhk verify` red 누적 ≥2 → INV-6 HARD_STOP. (단일 goal 한 바퀴라
+  iteration 폭주 위험은 구조적으로 작다 — 무인 연속은 2단계.)
+
+---
+
+## 6. 판정 모델 (가장 중요 — INV-1 구현)
+
+```
+진행 허가 (commit 해도 되나?)  = vhk verify latest.json 이 green 인가 (결정론, LLM 무관)
+중단 트리거 (멈춰야 하나?)      = (a) verify red  OR  (b) 적대검증이 치명 결함 지목  OR  (c) HARD_STOP
+```
+
+- LLM(`/code-review`)은 **"멈출 이유를 찾는" 역할만**. "진행해도 된다"는 긍정 판정 권한 없음.
+- 적대검증 출력은 **자유텍스트**(구조화 강제 시 발견사항 유실 — auto-merge 실측). 닫힌집합 자동판정 포기.
+- 판단 규칙: **"치명 1개라도 있으면 불합격. 불확실하면 치명으로 간주"**(보수적, 사람읽기).
+
+---
+
+## 7. 보고 규약 (저장된 feedback 메모리 반영)
+
+- **문제·정리 = 핵심 먼저(두괄식).** 설계·이론 설명은 자세히 OK. (메모리 `reporting-core-first`)
+- 형식: `[결과 1줄] → [한 일] → [문제 핵심 + 이슈 초안 텍스트(있으면)]`.
+- 이슈 초안 텍스트 = 사람이 읽고 2단계 `vhk auto`로 등록 결정. 1단계는 **텍스트 제시까지만**.
+- 1단계 보고 채널 = **채팅 + dev log 1줄**(영속 로그·일자분할 파일·3채널은 2단계).
+
+---
+
+## 8. 산출물 (1단계)
+
+| 파일 | 내용 |
+|------|------|
+| `<vhk-repo>/.claude/skills/vhk-auto/SKILL.md` | 스킬 본문(frontmatter + 루프 절차 + INV 목록 + 보고 규약). SoT. |
+| `~/.claude/skills/vhk-auto/SKILL.md` | 글로벌 복제(POS 등에서 호출용). 설치 절차는 README에 수동 안내(자동 sync는 2단계). |
+| `docs/log/2026-06-16-autopilot-mvp.md` | 이 작업 dev log (append-only). |
+| README/COMMANDS 갱신 | `/vhk-auto` 사용법(스킬이라 CLI 카탈로그엔 미등록 — 명령 아님). |
+
+**코드 변경 0.** src/** 미변경 → 단, 스킬 자체 검증을 위한 독푸딩이 곧 테스트(§10).
+
+---
+
+## 9. 의존성 (코드로 확인된 사실 — 추정 아님)
+
+- `vhk verify`: `.vhk/reports/latest.json` 항상 기록(성공·실패 무관) + `--json` stdout 옵션 있음. → 판정 입력 OK.
+- `vhk review` / `vhk mission check`: `--json` 없음, exit code + chalk 텍스트뿐. → 파싱 금지(INV-4).
+- `scripts/check-records.mjs`: src/** staged commit에 당일 dev log 미스테이지면 차단. → INV-5.
+- `.vhk/HARD_STOP`: 자동생성은 blocker≥3 단일 트리거(state-files.ts:65). `writeHardStop()` 노출.
+  `[dogfood]`/`[skip-hardstop]` 태그 blocker는 임계 우회. → INV-6.
+- `/code-review` 스킬: 가용(이 세션 스킬 목록 확인). cavecrew·Workflow·`.claude/agents` = 이 레포 부재 → 1단계 제외(INV-8).
+
+---
+
+## 10. 테스트·검증
+
+- 스킬(마크다운)이라 단위테스트는 약함 → **검증 = 독푸딩 자체**.
+- 수용 기준(1단계 성공 정의):
+  1. POS 프로젝트에서 `/vhk-auto` 1회 호출 → goal 1개를 사람 개입 없이 완주(또는 정직한 blocker/HARD_STOP).
+  2. `vhk verify` red인데 commit하는 일이 **없다**(INV-1 준수).
+  3. `gh issue create`가 **호출되지 않는다**(INV-2 준수).
+  4. critical 발견 시 `.vhk/HARD_STOP` 생성되고 다음 호출이 0번에서 멈춘다(INV-6 준수).
+  5. commit이 `check-records` 훅에 막히지 않는다(INV-5 준수).
+- 2단계로 승격(코드화) 시 vitest로 결정론 부분(dedupe·rate-limit·gh 래퍼) 테스트.
+
+---
+
+## 11. 2단계 로드맵 (이연 — 별도 스펙)
+
+| 항목 | 2단계 처방 |
+|------|-----------|
+| 이슈 등록 | `gh` = safeExecFile + atomicWrite + dedupe + rate-limit (결정론 코드). 레포·라벨·등록여부 = 룰. LLM은 초안 텍스트만. |
+| 승인 | undo 패턴 — 1차 호출 초안 반환·등록 0 → `vhk auto approve`(또는 confirm 인자) 재호출로만 등록. MCP는 초안 반환까지만(TTY 없음). |
+| 유출 방지 | public 레포 app-bug 자동등록 기본 금지 → 로컬 보관. 등록 직전 issue body 전체 secure 강제, 1건이라도 걸리면 차단. |
+| 판정 강화 | `vhk review --json` · `vhk mission check --json` 신규(선행 의존). |
+| 배포 | CLI `vhk auto`(등록 7항 + MCP 30→31) · MCP `vhk_auto` · yohan-brain core-ruleset 규약(inject_core_rules) · sync 자동설치. |
+| 확장 | 적대검증 수단 선택형(B1) · 검증도 4레벨(B2) · 14필드 템플릿(D6) · 3채널 로깅(E) · 무인 연속(/loop). |
+| 승격 트리거 | 1단계 3세션 무사 가동 or 유효 이슈 5건 수집 시 재평가. |
+
+---
+
+## 12. 오픈 항목 (구현 전 확인)
+
+- 글로벌 스킬 설치를 1단계에서 수동(README 안내)으로 둘지, 최소 `vhk` 명령으로 복사할지 — **수동 권고**(자동 sync는 2단계).
+- 보고 빈도(verbose/quiet) — 첫 독푸딩 1세션 후 재결정(E2).
+- TDD 강제 수준 — 기본 경고, `VHK_TEST_FIRST=1`일 때만 HARD(검증 med 권고).

--- a/tests/goal.test.ts
+++ b/tests/goal.test.ts
@@ -530,13 +530,16 @@ describe('NL goal sync 라우팅+디스패치 (Codex #1 회귀)', () => {
     expect(r?.args).toEqual(['check'])
   })
 
+  // 이 테스트가 파일 내에서 nlp-run.js 를 첫 import → 콜드 transform/import 비용이
+  // 이 테스트의 타임아웃에 전가된다. Windows+node22 느린 러너에서 기본 5s 초과(flaky,
+  // PR #291 CI 발견). 로직 자체는 순수·즉시이므로 콜드 import 여유만 부여(원인=타임아웃 과소).
   it('goal sync 자연어는 파일 쓰기 전에 confirmation 대상', async () => {
     const { routeNaturalLanguage } = await import('../src/lib/nlp-router.js')
     const { requiresConfirmation } = await import('../src/lib/nlp-run.js')
     const r = routeNaturalLanguage('게이트 스크립트 동기화')
     expect(r).not.toBeNull()
     expect(requiresConfirmation(r!)).toBe(true)
-  })
+  }, 20000)
 
   it('dispatchNlpRoute goal/sync → goalSync 실행(스크립트 생성), goalList 아님', async () => {
     const dir = tmpProject('nl-sync')


### PR DESCRIPTION
## 요약
- VHK 오토파일럿 1단계 MVP: active goal 1개를 자율 구동하고 멈춰 핵심 보고하는 클로드 코드 스킬 `/vhk-auto`.
- **코드 0**(스킬·문서만). 외부 발송·이슈 등록·집행 0 — 위험(gh 등록·dedupe·rate-limit·LLM 진행판정)은 2단계로 이연.
- 불변조건 INV-1~8로 헌법 충돌 차단 (적대검증 5렌즈 no-go → 교정 반영).
- 산출물: `.claude/skills/vhk-auto/SKILL.md` + README 사용법 + 스펙 + 플랜 + dev log.

## 검증
- `src/**` 변경 0 → 빌드/테스트 무영향(diff 5파일 568줄, 전부 docs/skill).
- [ ] 독푸딩(런타임): POS에서 `/vhk-auto` 1회 → INV 준수 4개 관찰 — **머지와 별개, 사용자 나중에**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * VHK 오토파일럿 1단계 MVP 추가: Claude 코드에서 `/vhk-auto`(또는 오토파일럿으로 한 바퀴) 호출 시 앵커 재주입 → 개발(TDD) → `vhk verify` 게이트 → `/code-review` 적대검증 → 합격 시 작은 커밋 후 종료 흐름을 지원합니다.
* **문서화**
  * 오토파일럿 스킬 실행 규약 및 MVP 설계/계획 문서 추가
  * README에 오토파일럿 스킬 사용 안내(수행 범위, 1단계 안전 제한, 로드맵) 섹션 추가
* **테스트**
  * 목표 동기화 라우팅/확인 테스트의 타임아웃을 20초로 조정해 플래키를 완화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->