### PR TITLE
docs(state): LIVE·next-task 정합 복구 — 품질천장 진단 + measure-first 가동

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,11 +148,11 @@ tags: [process, constitution]
 > 세션 종료: 마지막 갱신·버전·Phase·다음 할 일 갱신. (위 🔒 구역은 절대 건드리지 마.)
 > ⚠️ 아래 `**버전:**` 줄은 CI(version-sync.test.ts)가 강제 — 형식 `**버전:** vX.Y.Z` 유지, 릴리즈마다 package.json 따라 갱신.
 
-**마지막 갱신:** 2026-06-19
+**마지막 갱신:** 2026-06-20
 - **버전:** v2.6.0 (npm 발행 대기 — 사용자 직접 publish 필요) — 사실 확인은 package.json·CHANGELOG
 - **테스트:** ~1758 pass(CI) · **MCP tools:** 35 — 사실값은 package.json·CHANGELOG
-- **Phase:** 풀사이클 뒷단 4트랙(content→launch→ops→sell) **완성** — goal 74·75·76·77 전부 머지(#284·#293·#294·#295, RFC 0052 마감). 사용자 정의 업그레이드 우선순위 4(뒷단 확장) 완료.
+- **Phase:** 풀사이클 뒷단 4트랙(content→launch→ops→sell) **완성**(goal 74~77, RFC 0052 마감) + SOUL 상속 `.agents/SOUL.md` 머지(#297, 노션 배선 핸드오프 구현). 우선순위 4(뒷단) 완료. **우선순위 3 품질천장(RFC 0048 G47~54)은 G50(diff-coverage)만 잔여 — G51·53·54 기완료 확인(2026-06-20, LIVE 오기 정정).**
 - **블로커:** 없음
-- **진행 중(미완):** 없음 — 열린 PR 0. 원격 = main + 미머지 브랜치 2개(goal-sync-backfill-21-33·soul-injection, 살릴지/버릴지 판단 대기).
-- **다음 할 일:** ① [최우선] 우선순위 3 — 품질 천장 ~4.7 (RFC 0048 P2): G51 출력계층 단일화·G53 가드 behavior 이전(정규식 shape 350/381)·G54 제품 메타 SoT, 개별 PR. ② 우선순위 2 — measure-first 실측(`vhk recall`→recall@5·`vhk diff-cover`). ③ 우선순위 1 — 출시: v2.6.0 npm 발행(2FA)+topics 완료. ④ goal 73(#276 `vhk check --evals` LLM-judge). 미완 goal: 린트 25/27(#128)·SEO 21~26.
+- **진행 중(미완):** 없음 — 열린 PR 0. 원격 = main 단독(미머지 2개 정리: soul-injection→#297 머지 · backfill→폐기).
+- **다음 할 일:** ① 우선순위 3 품질천장: **G50(diff-coverage) 1개만 잔여**, 그것도 measure-first와 동일 지점(G51·53·54 이미 done). ② [현재] 우선순위 2 measure-first — 도구 3종(recall·diff-cover·memory eval) 작동 확인(2026-06-20). **Recall@5는 `vhk memory eval --init` 사용자 대화형 라벨링 선결**(실쿼리 3개 누적, 며칠 더 필요) · diff-cover는 실작업 코드 diff 누적 시 측정. ③ 우선순위 1 출시 — v2.6.0 npm 발행(2FA·사용자)+topics 완료. ④ 미완 goal: SEO 22~26(P2·외부키)·62 docs-diff·65 precommit-l2·73(#276 `vhk check --evals` 미기안).
 - **주의:** publish는 main에서만(#119)·사용자 직접(2FA) / 직접 main push 차단 → PR 경유

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -4,11 +4,11 @@
 > ⚠️ `vhk goal next`/`vhk work`가 이 파일을 스텁으로 **전체 덮어쓸 수 있음** — 수동 편집
 > 직후 해당 명령 실행 주의. 소실 시 복구: `git restore docs/state/next-task.md`.
 
-**갱신:** 2026-06-19
-**Phase:** 풀사이클 뒷단 4트랙(content→launch→ops→sell) **완성** — goal 74·75·76·77 전부 머지(#284·#293·#294·#295, RFC 0052 마감). 사용자 정의 업그레이드 우선순위 4(뒷단 확장) 완료 → 다음 3(품질 천장 RFC 0048 P2). measure-first 2종(recall·diff-coverage)은 **여전히 실측 누적 대기**. 사실값(버전·테스트수)은 package.json·CHANGELOG.
+**갱신:** 2026-06-20
+**Phase:** 뒷단 4트랙 완성(RFC 0052) + SOUL 상속 `.agents/SOUL.md` 머지(#297, 노션 배선 핸드오프 구현). **우선순위 3 품질천장(RFC 0048 G47~54)은 G50(diff-coverage)만 잔여 — G51·53·54 이미 done 확인(2026-06-20, 과거 문서의 "G51 착수"는 오기였음).** 현재 우선순위 2 measure-first 가동 중: 도구 3종 작동 확인, Recall@5는 사용자 라벨링 선결·diff-cover는 실작업 누적 대기. 사실값(버전·테스트수)은 package.json·CHANGELOG.
 
 ## 다음 할 일 (measure-first 최우선)
-- **풀사이클 뒷단 나머지 트랙 (RFC 0052)** → ~~`vhk launch`(goal 75)~~ 구현 완료(feat/fullcycle-launch) → **다음 `vhk ops`(76)** → `sell`(77). content(74)·launch(75)·RFC 0052 머지/구현됨. 전부 자문형(상태수집+프롬프트 생성, 발송·결제·삭제 0 — 헌법). `src/commands/launch.ts`(또는 content.ts) + `src/lib/emit-prompt.ts` 패턴 복제, 개별 goal·개별 PR(동시 착수 금지). 핸드오프: `C:\Users\user\.claude\plans\handoff-fullcycle-2026-06-16.md`.
+- **[현재] measure-first 가동 (2026-06-20 착수)** → 도구 3종 작동 확인(`vhk recall`·`vhk diff-cover`·`vhk memory eval`, 로컬 dist v2.6.0). **Recall@5 측정 = 평가셋 필요 → `vhk memory eval --init` 대화형 라벨링(사용자가 실쿼리에 정답 표시)이 선결** — 내가 비대화형으로 못 함. 실쿼리는 `.vhk/recall-log.jsonl`에 3개 누적(리뷰 기준·커버리지 게이트), 며칠 더 다양한 쿼리 쌓여야 의미. diff-cover는 실작업 기능소스(src/commands·src/lib) diff가 쌓일 때 자동 측정 — 현재 작업트리 변경 0이라 "측정 대상 없음". ※ 풀사이클 뒷단 4트랙(RFC 0052)·SOUL 상속(#297)은 **완료**.
 - **goal 73 (#276 `vhk check --evals` LLM-judge)** → Fable5 프롬프트 위생 golden-set. L1(결정적 검사) 먼저, L2(LLM-judge) 나중.
 - **diff-coverage 실측 누적** → `vhk diff-cover`를 실제 코드 작업 **diff ≥5건(며칠)** 돌려 미검증 변경분 분포 수집(RFC 0050 §5 관찰 프로토콜). 유의미>0 → PR2(review line-40 제거 + verify 증거 + CI). ≈0 → "이론적 구멍" 문서화 후 중단(YAGNI). ※ diff-hunks `+++` 파서 엣지는 #239에서 이미 강화 완료(상태머신).
 - **recall 실측** → 며칠 `vhk recall` 실사용 → `vhk memory eval --init` 실쿼리 라벨 → 진짜 Recall@5. <70 반복이면 2차 ML(bge-m3, RFC 0049 §2 결정 잠금됨). **실사용 시나리오 추가(2026-06-11): "리뷰 기준 추출"** — PR 리뷰 전 diff 요약을 쿼리로 `vhk recall` 실행 → 관련 ADR·패턴만 뽑아 리뷰 기준으로 주입(외부 사례 gen-criteria 패턴: 메타데이터 1차 필터 + 의미 2차 판단 + "이 작업에 어떻게 적용되는지" 서술 강제). 실쿼리 라벨 축적과 직결.


### PR DESCRIPTION
## 무엇
세션 상태 문서(CLAUDE.md LIVE·next-task.md)를 실측 상태로 정합 복구.

## 왜
LIVE/next-task가 "우선순위 3 = G51 출력계층 단일화 착수"로 적혀 있었으나, goals/ SoT 실측 결과 **G51·G53·G54는 이미 DONE**(G51은 2026-06-10 완료). 품질천장(RFC 0048 G47~54)은 **G50(diff-coverage) 하나만 잔여**이고 그것도 measure-first와 동일 지점. stale 정보가 main에 남으면 다음 세션이 또 "G51부터"로 헷갈림.

## 내용
- **CLAUDE.md LIVE**: 마지막 갱신 6-20 · Phase에 SOUL 상속(#297) 머지 + 품질천장 정정 · 다음 할 일 = measure-first 가동 결과
- **next-task.md**: measure-first 가동 — 도구 3종(recall·diff-cover·memory eval) 작동 확인, Recall@5는 `vhk memory eval --init` 대화형 라벨링 선결, diff-cover는 실작업 누적 대기
- soul-injection(#297) 머지·backfill 폐기 반영 → 원격 main 단독

`[skip-record]` 상태 문서 정합이라 dev log 면제. 버전 줄 불변(v2.6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 프로젝트 진행 현황이 최신 기준으로 업데이트되었습니다.
  * 완료된 단계별 상태, 우선순위별 진행 상황, 미해결 항목이 재정리되었습니다.
  * 향후 작업 계획 및 필수 선행 조건이 명확히 정의되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->