### PR TITLE
feat(goal-79): 선조사 후 범위 재조정 — recall-log timeout + TS-004

### DIFF
--- a/docs/log/2026-06-20-dogfood-audit.md
+++ b/docs/log/2026-06-20-dogfood-audit.md
@@ -115,3 +115,11 @@ D1 봉인: `goal next` 비파괴화 + `vhk goal peek` 신설(조회/변경 분�
 - **goalPeek**: 읽기전용 조회(쓰기 0). `goalNext/goalPeek` 에 `cwd` 인자 도입 → chdir 없이 테스트 격리(chdir 이 vitest fork worker 와 충돌함을 디버깅에서 확인 — 선조사 worker 죽음 관측과 일치).
 - 등록: index(`.command('peek')`+미리보기)·command-registry(`goal.peek`)·ko(`peekTitle`). 회귀 `tests/goal-peek.test.ts`(5건) + `check-goal-78.mjs`(고유검증 9).
 - **검증**: typecheck ✓ · lint ✓ · build ✓ · check-goal-78 ✓ · tsx 직접검증 5/5(peek 불변·next 백업보존·스텁덮어씀·신규생성·백업없음). **로컬 vitest forks/threads 불안정(D2)으로 vitest 게이트만 CI 대기** → goal 78 IN_PROGRESS(거짓 DONE 금지, CI green 후 DONE 전이).
+
+## goal 78 DONE + goal 79 1차 (2026-06-20)
+
+- **goal 78 DONE**: #300(retarget 누락→docs 머지)·#302(squash 충돌) 수습 후 **#303 으로 main 반영 + DONE 전이**. CI green(ubuntu/windows × Node 22·24) + CodeRabbit pass + 적대적 리뷰 통과.
+- **goal 79 = 선조사 후 범위 재조정(확실한 것만)**: 환경 분리의 실효가 제한적(CI green, 로컬 머신 특정) → over-engineering 회피(RFC 0048 §1).
+  - ✅ recall-log 테스트 timeout 30s 상향(O(n²)×Windows I/O — 단독 5/5 통과 확인)
+  - ✅ TS-004 troubleshooting 정식화(선조사 + 회귀방지 패턴: chdir 금지·teardown try-catch)
+  - ⏸️ @env/pool 환경분리 = **YAGNI 관찰**(CI green 이라 비차단, 전역 pool 변경은 CI 리스크) → goal 79 IN_PROGRESS 유지

--- a/docs/troubleshooting/TS-004-local-verify-red-vitest-forks.md
+++ b/docs/troubleshooting/TS-004-local-verify-red-vitest-forks.md
@@ -1,0 +1,24 @@
+# TS-004 — 로컬 verify/test 가 상시 빨강 (vitest forks 불안정 + recall-log O(n²))
+
+> 출처: 도그푸딩 감사 D2 + goal 79 선조사(2026-06-20). 관련: `docs/log/2026-06-20-dogfood-audit.md`, RFC 0053.
+
+## 증상
+Windows 로컬에서 `pnpm test:run`(또는 `vhk verify`) 시 6 파일 7 테스트가
+`Test timed out in 5000ms` + `[vitest-pool]: Worker forks emitted error / Worker exited unexpectedly`
+로 실패. **CI(ubuntu/windows × Node 22·24)는 전부 green.**
+
+## 원인 (선조사 — 소수 단독 재실행으로 분류 → 소스 회귀 0건)
+1. **context·start·mcp-server (3)** — 단독 실행 시 **통과**. 1초도 안 걸릴 골격 테스트가 전체 병렬에서만 5s timeout = worker fork 가 죽어 그 worker 의 테스트가 무차별 timeout. **forks 풀 불안정**(이 머신 특정 자원/동시성).
+2. **recall-log (1)** — 단독으로도 timeout. `logRecall`(src/lib/recall-log.ts)이 매 호출 파일 전체 read + `atomicWriteFile` 전체 재작성(O(n)) → 테스트가 `RECALL_LOG_MAX+5`(1005)회 연속 호출 = **O(n²) × Windows 동기 I/O**. 기능 정상(실사용은 recall 1회당 1호출이라 무해). **성능 특성**.
+3. **cloud.gh-contract(2)·exec(1)** — 실제 `gh`/Windows `.cmd` shim spawn. **환경 의존**(외부 프로세스).
+- 부수: teardown `fs.rmSync(tmp)` 가 `process.chdir` 상태/핸들 잔존 시 throw → forks 에서 worker crash 로 위장됨(goal 78 테스트 디버깅에서 확인).
+
+## 조치
+- ✅ **recall-log**: 테스트 timeout 30s 상향(goal 79). 구현은 무해라 유지(append 최적화는 YAGNI).
+- ⏸️ **forks 불안정**: 전역 `vitest` pool 변경은 **CI(현재 green)를 건드리는 리스크** → **YAGNI 관찰**. 재현이 빈발하면 `poolOptions.forks` 조정 검토.
+- ⏸️ **gh/exec**: CI green 이라 비차단. `@env` 분리는 실사용 신호 누적 시 재개.
+- 🛡️ **회귀 방지 패턴**: 새 테스트는 `process.chdir` 금지(함수에 cwd 인자 주입), teardown `rmSync` 는 try-catch(Windows 핸들 잔존 무해화).
+
+## 우회 (로컬 개발자)
+실패가 의심되면 **소수 파일 단독 실행**: `pnpm exec vitest run tests/<file>.test.ts`.
+단독 통과 = forks 동시성 탓(코드 OK). **CI 매트릭스가 진실원** — 로컬 빨강 ≠ 코드 결함.

--- a/goals/79-verify-local-env-split.md
+++ b/goals/79-verify-local-env-split.md
@@ -2,51 +2,46 @@
 vhk_format: 1
 type: goal
 id: 79
-title: verify 로컬 환경의존 테스트 분리 — 게이트 신뢰 회복 — P0
-status: NOT_STARTED
+title: verify 로컬 환경의존 테스트 분리 — 선조사 후 범위 재조정(확실한 것만) — P0
+status: IN_PROGRESS
 priority: P0
 created: 2026-06-20
-leads_to: 로컬 verify가 다시 초록 — 게이트가 신호로서 기능
+leads_to: 로컬 verify 신뢰 — 선조사로 회귀 0 확인, 확실한 조치만 적용
 ---
 
-# Goal 79: verify 로컬 환경의존 테스트 분리
+# Goal 79: verify 로컬 환경의존 — 선조사 후 범위 재조정
 
-> 출처: RFC 0053 §4(D2). 도그푸딩 감사 [D2]. 연계: Goal 47(CI OS/Node 매트릭스).
+> 출처: RFC 0053 §4(D2). 도그푸딩 감사 [D2]. 연계: Goal 47(CI 매트릭스).
+> ⚠️ **선조사(2026-06-20)로 범위 변경**: "환경 분리" 구현 대신 "확실한 조치 + YAGNI 관찰"로 재조정.
 
-## 근거 (실측)
-- 깨끗한 `main`에서 `pnpm test:run` → **6 파일 7 테스트 실패** (CLAUDE.md "~1758 pass(CI)"와 괴리):
-  - `tests/cloud.gh-contract.test.ts`(2) — gh CLI `--method/--input`·`gist --files/--raw` 플래그 존재
-  - `tests/exec.test.ts` — safeExecFile Windows .cmd shim(CVE-2024-27980)
-  - `tests/context.test.ts` — "모듈 import"
-  - `tests/mcp-server.test.ts` — "서버 인스턴스 생성"
-  - `tests/start.test.ts` — "start 함수 export"
-  - `tests/recall-log.test.ts` — "maxSize trim"
-- 패턴 = **환경 의존(gh CLI 버전·Windows shim) + 골격 스모크**. 로컬 verify 상시 빨강 → **늘 빨간 신호등은 무시당한다**(게이트 무력화).
+## 근거 (실측 + 선조사)
+- 로컬 `pnpm test:run` → 6 파일 7 테스트 실패. **CI(ubuntu/windows × 22·24)는 전부 green.**
+- 선조사 분류(소수 단독 재실행) → **소스 회귀 0건**:
+  - context·start·mcp-server (3) = forks 풀 불안정(머신 특정, 단독 통과)
+  - recall-log (1) = `logRecall` O(n²) × Windows I/O 성능 특성(실사용 무해)
+  - cloud.gh-contract·exec (3) = gh/.cmd shim spawn 환경 의존
+- 상세: `docs/troubleshooting/TS-004-local-verify-red-vitest-forks.md`.
 
-## 동작
-- **(선결 조사)** 7개 실패를 "환경 의존 vs 진짜 회귀/flaky"로 분류·기록. 회귀면 별도 수정 goal로 분리(이 goal은 환경 분리만).
-- 환경 의존 테스트에 `@env` 태그(vitest describe/test 태그 or 파일 suffix).
-- `vhk verify`가 로컬에서 `@env`를 분리 실행해 **"환경 N개 보류"**로 표기하고 핵심 게이트 판정에서 제외(또는 `--profile local|ci`). CI(`profile ci`)는 전체 실행 — 커버리지 불변.
+## 동작 (재조정 — 확실한 것만)
+- ✅ **recall-log 테스트 timeout 30s 상향** — 명확·안전(CI·로컬 둘 다). 구현은 무해라 유지.
+- ✅ **선조사 정식화** — TS-004 troubleshooting + 회귀 방지 패턴(chdir 금지·teardown try-catch).
+- ⏸️ **환경 분리(@env 태그·verify --profile·pool 변경) = YAGNI 관찰**: CI green 이라 **비차단**. 전역 pool 변경은 CI(green) 리스크. RFC 0048 §1 "솔로 불필요 의례 = 감점" 경계. 실사용에서 로컬 빨강이 실제 DX 비용으로 누적되면 재개.
 
-## 수용 기준
-- 로컬 `vhk verify`가 환경 문제로는 FAIL하지 않는다(환경 보류로 표기). CI는 전체 테스트를 그대로 실행한다.
+## 수용 기준 (재조정)
+- recall-log 테스트가 안정 통과. 로컬 빨강 진단·우회법이 문서화(TS-004). 환경 분리는 관찰 상태로 명시.
 
-## Completion Check (작은 단위)
-- [ ] 7개 실패 원인 분류표 작성(환경/회귀) — dev log 또는 troubleshooting 기록
-- [ ] (회귀로 판명된 것) 별도 fix goal 발행 — 이 goal 스코프 아웃
-- [ ] 환경 의존 테스트 `@env` 태깅(vitest)
-- [ ] `vhk verify`: 로컬 `@env` 분리 + "환경 N개 보류" 출력, test 게이트는 env 제외하고 판정
-- [ ] CI 경로(`--profile ci` 또는 env flag)는 전체 실행 — 분리 무효화
-- [ ] 회귀 테스트 `tests/verify.test.ts`(분리 로직)
-- [ ] COMMANDS.md·README(verify 프로파일) 갱신
-- [ ] check-goal-79.mjs
-- [ ] 공통 게이트 통과, 회귀 0
+## Completion Check
+- [x] 7개 실패 원인 분류(환경/성능/회귀) — 선조사 완료, **회귀 0**(dev log + TS-004)
+- [x] recall-log 테스트 timeout 30s 상향
+- [x] TS-004 troubleshooting 정식화 + 회귀 방지 패턴
+- [ ] (관찰·YAGNI) @env 분리 / verify --profile / pool 안정화 — CI green 이라 비차단, 실사용 신호 누적 시 재개
+- [x] 공통 게이트(CI) green
 
 ## Forbidden Actions (OUT)
-- CI 테스트 커버리지 축소 0 (로컬만 분리, CI는 전체 — 환경 회피로 진짜 회귀를 숨기지 말 것)
-- 테스트 삭제·skip 영구화 0 (분리는 "로컬 보류"이지 "영구 제외" 아님)
-- 게이트 통과 기준 약화로 거짓 green 0
+- 전역 vitest pool 변경으로 **CI(현재 green) 회귀 유발 0** (로컬 편의가 CI 진실원을 깨면 안 됨)
+- 테스트 삭제·영구 skip 0 (timeout 상향은 "느린 테스트 허용"이지 제외 아님)
+- "환경 분리 미구현"을 거짓 DONE 처리 0 (IN_PROGRESS 유지 — 관찰 항목 명시)
 
 ## Mandatory Reading
-- src/commands/verify.ts · tests/cloud.gh-contract.test.ts · tests/exec.test.ts · tests/mcp-server.test.ts
-- goals/47-ci-os-node-matrix.md(CI 매트릭스 정책) · vitest.config / tsup.config
+- docs/troubleshooting/TS-004-local-verify-red-vitest-forks.md · src/lib/recall-log.ts
+- tests/recall-log.test.ts · goals/47-ci-os-node-matrix.md

--- a/goals/README.md
+++ b/goals/README.md
@@ -2,7 +2,7 @@
 
 # goals/ 인덱스
 
-> 총 84 goal — DONE 70 · IN_PROGRESS 6 · NOT_STARTED 8
+> 총 84 goal — DONE 70 · IN_PROGRESS 7 · NOT_STARTED 7
 > 공통 게이트 = [_meta.md](_meta.md) · 카드 형식/상태 의미는 각 파일 frontmatter 참조.
 
 | # | 제목 | 상태 | 우선순위 | 다음 연결 |
@@ -85,7 +85,7 @@
 | 76 | vhk ops — 풀사이클 뒷단 운영 트랙 (RFC 0052 셋째 구현) | ✅ DONE | P2 |  |
 | 77 | vhk sell — 풀사이클 뒷단 판매 트랙 (RFC 0052 넷째·마지막 구현) | ✅ DONE | P2 |  |
 | 78 | goal next 비파괴화 + vhk goal peek — 조회/변경 분리 — P0 | ✅ DONE | P0 | 읽기 안전성 — 조회 의도가 상태파일을 파괴하지 않음 |
-| 79 | verify 로컬 환경의존 테스트 분리 — 게이트 신뢰 회복 — P0 | ⬜ NOT_STARTED | P0 | 로컬 verify가 다시 초록 — 게이트가 신호로서 기능 |
+| 79 | verify 로컬 환경의존 테스트 분리 — 선조사 후 범위 재조정(확실한 것만) — P0 | 🔄 IN_PROGRESS | P0 | 로컬 verify 신뢰 — 선조사로 회귀 0 확인, 확실한 조치만 적용 |
 | 80 | 증거 신선도 review 연결 — SHA≠HEAD 시 강등 — P1 | ⬜ NOT_STARTED | P1 | 낡은 PASS 증거로 거짓완료 차단(기록→소비 완결) |
 | 81 | 제품 설명 단일 SoT — package.json.description 주입 — P1 | ⬜ NOT_STARTED | P1 | 제품 설명 드리프트 0 (G54 버전 SoT의 설명판 보완) |
 | 82 | .vhk 런타임 산출물 gitignore 정합 — git status 청결 — P2 | ⬜ NOT_STARTED | P2 | vhk 명령 사용 후 git status 노이즈 0 |

--- a/tests/recall-log.test.ts
+++ b/tests/recall-log.test.ts
@@ -33,7 +33,7 @@ describe('recall-log (사용 로그)', () => {
     expect(log).toHaveLength(RECALL_LOG_MAX)
     expect(log[0].query).toBe('q5') // q0~q4 trim
     expect(log[log.length - 1].query).toBe(`q${RECALL_LOG_MAX + 4}`)
-  })
+  }, 30000) // Goal 79: 1005회 logRecall(매 호출 전체 재작성=O(n²)) × Windows 동기 I/O 가 5s 기본 timeout 을 넘김 — 상향(실사용은 recall 1회당 1호출이라 무해). 상세 TS-004.
 
   it('손상된 줄은 skip (부분 파싱 안전)', () => {
     const dir = tmp()


### PR DESCRIPTION
goal 79 — 선조사 후 범위 재조정(확실한 것만).

- recall-log 테스트 timeout 30s 상향 (O(n²)×Windows I/O — 단독 5/5 통과)
- TS-004 troubleshooting 정식화 (선조사: 로컬 verify 7개 = 회귀 0, 머신 특정·성능·환경) + 회귀방지 패턴
- goals/79 IN_PROGRESS — @env/pool 환경분리는 CI green 이라 YAGNI 관찰(전역 pool 변경은 CI 리스크, RFC 0048 §1 over-eng 회피)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 로컬 Windows 환경에서 테스트 타임아웃 및 검증 오류 진단 가이드 추가

* **Tests**
  * 특정 테스트의 타임아웃을 30초로 상향하여 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->