### PR TITLE
feat(goal-80): 증거 신선도 review 연결 — SHA≠HEAD/dirty 시 낡음 강등

### DIFF
--- a/docs/log/2026-06-22-goal-80-evidence-freshness.md
+++ b/docs/log/2026-06-22-goal-80-evidence-freshness.md
@@ -1,0 +1,38 @@
+# 2026-06-22 — Goal 80: 증거 신선도 review 연결 (SHA≠HEAD/dirty → 낡음 강등)
+
+> append-only. 추가만, 수정·삭제 금지.
+
+## 한 일
+- **Goal 80 DONE** — `vhk review` 의 증거 신선도 판정을 **커밋 SHA 기반**으로 승격(RFC 0053 §4 D3, Goal 44 의 소비 측 완결).
+  - 기록은 됐는데 소비를 안 하던 갭 해소: Goal 44 가 `latest.json` 에 HEAD SHA·dirty 를 **기록**까지 했으나, review 출력은 여전히 *"신선도는 생성시각으로만 추정"* 이었다 → 이제 review 가 그 SHA 를 읽어 현재 HEAD 와 비교.
+
+## 변경 (산출물 포인터)
+- `src/commands/review.ts`
+  - `assessFreshness(report, current, nowMs)` — 증거에 `commit`(SHA) 있으면 verify 의 `checkEvidenceFreshness` 재사용해 SHA≠HEAD/dirty 판정(`basis: 'sha'`). SHA 없는 구(舊)증거는 생성시각 폴백(`basis: 'time'`, 하위호환).
+  - `EvidenceFreshness` 에 `basis`('sha'|'time') + `reasons`(낡음 사유) 추가.
+  - `crossCheck(..., current = null)` — current(HEAD) 옵셔널 주입(순수성 유지: IO 는 review() 에서).
+  - `review()` 가 `getCommitInfo(cwd)` 로 현재 HEAD 읽어 전달. disclaimer 문구 "생성시각으로만 추정" → "SHA로 판정(구버전은 시각 폴백)".
+- `tests/review.test.ts` — SHA 신선도 7케이스(일치=신선/불일치=강등/dirty=강등/구증거=시각폴백/현재미상=낡음/disclaimer) + 통합 end-to-end 강등 1케이스.
+- `scripts/check-goal-80.mjs` — 고유 게이트(배선·시그니처·문구·테스트·Forbidden 불변).
+- `goals/80-evidence-freshness-review.md` — status DONE + 완료체크 전부 체크.
+- `goals/README.md` — 자동 재생성(gen-goals-index).
+
+## 검증
+- `npx vitest run tests/review.test.ts` → 33 pass (신규 8 포함).
+- `pnpm build` OK · 전체 테스트 1768 pass(드리프트 1건은 goal 80 status 갱신·index 재생성으로 해소).
+- `node scripts/check-goal-80.mjs` (SKIP_DEEP) → 고유검증 전부 ✓.
+- 외부 영향 0: `crossCheck`/`EvidenceFreshness` 소비자는 review.ts 단독(grep 확인). verify/verify-report 시그니처 불변(GA).
+
+## 교훈
+- SHA 비교 로직은 **이미 verify.ts 에 존재**(`checkEvidenceFreshness`+`getCommitInfo`) — Goal 80 은 신규 구현이 아니라 *기존 순수함수를 review 로 배선*하는 일이었다. "기록 있는데 소비 안 함" 갭은 대개 새 코드가 아니라 연결선이 빠진 것.
+- 순수성 유지: 신선도 판정 함수는 `current`(HEAD)·`nowMs` 를 **주입** 받게 유지 → IO 는 핸들러(review())에만. crossCheck 가 순수라 테스트가 SHA 매트릭스를 격리 검증 가능(git 레포 없이).
+- 강등은 confidence 캡까지만(advisory exit 0 유지) — review 는 권고 신호라 fail 격상 안 함(goal 80 Forbidden). 활성 작업 중 tree dirty 면 medium 으로 떨어지는 게 정상(정직 신호).
+
+## 적대 리뷰 반영 (7-에이전트 워크플로, 3렌즈+반증)
+- blocker/major **0**. confirmed 2건 모두 nit, dropped 2건(반증 기각 — confirmed:true no-op·SHA가 시각무시는 의도된 docstring 기존문서화).
+- **nit#1(테스트 공백)** 반영: `generatedAt 파싱불가 + commit 있음` 조합 회귀 가드 추가 — SHA 분기가 ageMs 안 쓰고 note 는 shortSha 만 써 NaN/null 누출·크래시 0 임을 고정.
+- **nit#2(문구)** 반영: 비개발자 사용자가 "advisory 통과인데 왜 항상 medium?" 오해 방지 — disclaimer 에 "미커밋(dirty)이면 신뢰도 상한 medium(커밋 후 verify 시 high 가능)" 1줄. 코드 동작 변경 0.
+- 결과: review 테스트 33→35 pass, 전 게이트(typecheck/lint/test/build) + 고유검증 16 전부 ✓.
+
+## 다음
+- Goal 81(제품 설명 단일 SoT, P1) — brief↔package.json.description 불일치 제거. 개별 PR.

--- a/goals/80-evidence-freshness-review.md
+++ b/goals/80-evidence-freshness-review.md
@@ -3,7 +3,7 @@ vhk_format: 1
 type: goal
 id: 80
 title: 증거 신선도 review 연결 — SHA≠HEAD 시 강등 — P1
-status: NOT_STARTED
+status: DONE
 priority: P1
 created: 2026-06-20
 leads_to: 낡은 PASS 증거로 거짓완료 차단(기록→소비 완결)
@@ -28,13 +28,13 @@ leads_to: 낡은 PASS 증거로 거짓완료 차단(기록→소비 완결)
 - 코드 변경(HEAD 이동) 후 낡은 증거로 review하면 "증거 낡음"으로 신선도가 강등된다.
 
 ## Completion Check (작은 단위)
-- [ ] review가 latest.json HEAD SHA·dirty 필드 읽음(Goal 44 스키마)
-- [ ] `SHA≠HEAD` or dirty → 신선도 "낡음" 강등 + 신뢰도 반영
-- [ ] review 출력 메시지 "생성시각 추정" → "SHA 기반"으로 정정
-- [ ] SHA 필드 없는 구증거 graceful 폴백(크래시 0)
-- [ ] 회귀 테스트 `tests/review.test.ts`: SHA 일치=신선 / 불일치=강등 / 필드없음=폴백
-- [ ] check-goal-80.mjs
-- [ ] 공통 게이트 통과, 회귀 0
+- [x] review가 latest.json HEAD SHA·dirty 필드 읽음(Goal 44 스키마 — checkEvidenceFreshness 재사용)
+- [x] `SHA≠HEAD` or dirty → 신선도 "낡음" 강등 + 신뢰도 반영(basis=sha, stale→confidence medium 캡)
+- [x] review 출력 메시지 "생성시각 추정" → "SHA 기반"으로 정정(disclaimer + freshness.note)
+- [x] SHA 필드 없는 구증거 graceful 폴백(basis=time, 크래시 0)
+- [x] 회귀 테스트 `tests/review.test.ts`: SHA 일치=신선 / 불일치=강등 / 필드없음=폴백
+- [x] check-goal-80.mjs
+- [x] 공통 게이트 통과, 회귀 0
 
 ## Forbidden Actions (OUT)
 - verify/verify-report 시그니처 변경 0 (읽기 측만 추가 — GA 안정성)

--- a/goals/README.md
+++ b/goals/README.md
@@ -2,7 +2,7 @@
 
 # goals/ 인덱스
 
-> 총 84 goal — DONE 75 · IN_PROGRESS 2 · NOT_STARTED 7
+> 총 84 goal — DONE 76 · IN_PROGRESS 2 · NOT_STARTED 6
 > 공통 게이트 = [_meta.md](_meta.md) · 카드 형식/상태 의미는 각 파일 frontmatter 참조.
 
 | # | 제목 | 상태 | 우선순위 | 다음 연결 |
@@ -86,7 +86,7 @@
 | 77 | vhk sell — 풀사이클 뒷단 판매 트랙 (RFC 0052 넷째·마지막 구현) | ✅ DONE | P2 |  |
 | 78 | goal next 비파괴화 + vhk goal peek — 조회/변경 분리 — P0 | ✅ DONE | P0 | 읽기 안전성 — 조회 의도가 상태파일을 파괴하지 않음 |
 | 79 | verify 로컬 환경의존 테스트 분리 — 선조사 후 범위 재조정(확실한 것만) — P0 | 🔄 IN_PROGRESS | P0 | 로컬 verify 신뢰 — 선조사로 회귀 0 확인, 확실한 조치만 적용 |
-| 80 | 증거 신선도 review 연결 — SHA≠HEAD 시 강등 — P1 | ⬜ NOT_STARTED | P1 | 낡은 PASS 증거로 거짓완료 차단(기록→소비 완결) |
+| 80 | 증거 신선도 review 연결 — SHA≠HEAD 시 강등 — P1 | ✅ DONE | P1 | 낡은 PASS 증거로 거짓완료 차단(기록→소비 완결) |
 | 81 | 제품 설명 단일 SoT — package.json.description 주입 — P1 | ⬜ NOT_STARTED | P1 | 제품 설명 드리프트 0 (G54 버전 SoT의 설명판 보완) |
 | 82 | .vhk 런타임 산출물 gitignore 정합 — git status 청결 — P2 | ⬜ NOT_STARTED | P2 | vhk 명령 사용 후 git status 노이즈 0 |
 | 83 | 보안 scan 테스트 픽스처 false positive allowlist — P2 | ⬜ NOT_STARTED | P2 | secure scan 노이즈 ↓ (진짜 시크릿 신호 보존) |

--- a/scripts/check-goal-80.mjs
+++ b/scripts/check-goal-80.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// scripts/check-goal-80.mjs — goal 80: 증거 신선도 review 연결 (SHA≠HEAD/dirty → 낡음 강등).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역.
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 80 gate.')
+  process.exit(1)
+}
+
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 80] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 80 고유 검증 ───────────────────────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+const r = read('src/commands/review.ts') ?? ''
+must(/import \{ getCommitInfo, type CommitInfo \} from '\.\.\/lib\/git-repo\.js'/.test(r), 'review.ts getCommitInfo·CommitInfo import (git-repo 단일통로)')
+must(/checkEvidenceFreshness/.test(r), 'review.ts 가 verify 의 checkEvidenceFreshness(SHA 비교) 재사용')
+must(/basis: 'sha' \| 'time'/.test(r), 'EvidenceFreshness.basis(sha|time) 필드')
+must(/reasons: string\[\]/.test(r), 'EvidenceFreshness.reasons 필드(낡음 사유)')
+must(/function assessFreshness\([\s\S]*?current: CommitInfo \| null/.test(r), 'assessFreshness 가 current(HEAD) 주입 받음(순수성 유지)')
+must(/const current = getCommitInfo\(cwd\)/.test(r), 'review() 가 현재 HEAD 를 읽어 비교에 전달')
+must(/crossCheck\(checks, goalStatus, report, Date\.now\(\), current\)/.test(r), 'crossCheck 호출에 current 전달(배선)')
+must(/current: CommitInfo \| null = null/.test(r), 'crossCheck 시그니처 current 옵셔널(구증거 graceful)')
+// 출력 문구 정정: "생성시각으로만 추정" 제거 + SHA 명시
+must(/SHA≠HEAD\/dirty.*낡음/.test(r) || /SHA로 판정/.test(r), 'disclaimer 가 SHA 기반 신선도 명시')
+must(!/신선도는 생성시각으로만 추정/.test(r), 'disclaimer 에서 "생성시각으로만 추정"(구문구) 제거')
+
+const t = read('tests/review.test.ts') ?? ''
+must(/crossCheck SHA 신선도 \(Goal 80\)/.test(t), '회귀 테스트 describe(crossCheck SHA 신선도)')
+must(/basis\)\.toBe\('sha'\)/.test(t), '테스트: SHA 일치/불일치 → basis sha')
+must(/basis\)\.toBe\('time'\)/.test(t), '테스트: 구증거(commit 없음) → 생성시각 폴백')
+must(/freshness\.stale\)\.toBe\(true\)/.test(t), '테스트: SHA≠HEAD/dirty → stale 강등')
+
+const goal = read('goals/80-evidence-freshness-review.md') ?? ''
+must(/status:\s*DONE/.test(goal), 'goals/80 status DONE')
+
+// Forbidden(OUT) — verify/verify-report 시그니처 변경 0 (읽기 측만 추가)
+must(/export function checkEvidenceFreshness\(\s*report: VerifyReport,\s*current: CommitInfo \| null\s*\)/.test(read('src/commands/verify.ts') ?? ''), 'verify.checkEvidenceFreshness 시그니처 불변(GA 안정성)')
+
+if (pass) { console.log('✅ goal 80 gate passes'); process.exit(0) }
+console.log('❌ goal 80 gate failed'); process.exit(1)

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -9,10 +9,12 @@ import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
 import { printNextStep } from '../lib/next-step.js'
 import {
   REPORT_PATH_REL,
+  checkEvidenceFreshness,
   type GateResult,
   type ReportStatus,
   type VerifyReport,
 } from './verify.js'
+import { getCommitInfo, type CommitInfo } from '../lib/git-repo.js'
 
 /**
  * Goal 15: vhk review — 적대적 자기검증 v0.
@@ -36,7 +38,8 @@ export const STALE_AGE_MS = 6 * 60 * 60 * 1000 // 6시간
 export const REVIEW_DISCLAIMER = [
   '⚠️  이 판정은 보장이 아니라 신뢰도 신호입니다 — 통과해도 거짓완료 가능성은 남습니다.',
   '   · 기능 고유 완료조건은 게이트 키워드(tsc/test/build/secure)에 매핑되지 않으면 "미검증"으로 남습니다.',
-  '   · 증거(latest.json)는 commit/goal 바인딩이 없어 신선도는 생성시각으로만 추정합니다 — 코드 변경 후엔 vhk verify 재실행 필요.',
+  '   · 증거 신선도는 커밋 SHA로 판정합니다(SHA≠HEAD/dirty면 "낡음" 강등) — 구버전 리포트(SHA 없음)는 생성시각 폴백. 코드 변경 후엔 vhk verify 재실행 필요.',
+  '   · 미커밋 변경(working tree dirty)이 있으면 신뢰도 상한은 medium 입니다 — 증거가 그 변경을 아직 반영 못 하기 때문(커밋 후 vhk verify 재실행 시 high 가능).',
   '   · git diff 미사용(v0) — 기존 테스트가 green 이어도 이번 변경을 커버하지 못했을 수 있습니다.',
 ].join('\n')
 
@@ -48,10 +51,14 @@ export interface CompletionCheck {
 export interface EvidenceFreshness {
   generatedAt: string | null
   ageMs: number | null
-  /** 오래됨(>STALE_AGE_MS) 또는 생성시각 파싱 불가. */
+  /** 낡음 — SHA≠HEAD/dirty(basis=sha) 또는 생성시각 오래됨·파싱불가(basis=time). */
   stale: boolean
-  /** 신선도 판정 자체가 가능했는지(generatedAt 유효). */
+  /** 신선도 판정 자체가 가능했는지(SHA 비교 가능 또는 generatedAt 유효). */
   confirmed: boolean
+  /** 판정 근거 — 'sha'(증거에 커밋 SHA 있음, Goal 44/80) 또는 'time'(구버전 폴백). */
+  basis: 'sha' | 'time'
+  /** 낡음 사유들(없으면 신선). */
+  reasons: string[]
   note: string
 }
 
@@ -110,14 +117,48 @@ function impliedGates(text: string): GateResult['id'][] {
   return gates
 }
 
-/** report.generatedAt 으로 증거 신선도 판정 (now 는 주입 — 순수성 유지). */
-function assessFreshness(report: VerifyReport | null, nowMs: number): EvidenceFreshness {
+/**
+ * 증거 신선도 판정 (now·current 는 주입 — 순수성 유지).
+ * Goal 80: 증거에 커밋 SHA(Goal 44 기록)가 있으면 **SHA 기반**으로 판정한다 — 현재 HEAD 와 비교해
+ *   SHA≠HEAD 또는 dirty 면 "낡음"으로 강등(생성시각 추정보다 강한 신호). SHA 기록이 없는 구(舊)증거는
+ *   생성시각 폴백(하위호환). 강등은 confidence 캡까지만 — review 는 권고 신호라 fail 격상은 안 한다.
+ */
+function assessFreshness(
+  report: VerifyReport | null,
+  current: CommitInfo | null,
+  nowMs: number
+): EvidenceFreshness {
   const generatedAt = report?.generatedAt ?? null
   const parsed = generatedAt ? Date.parse(generatedAt) : NaN
-  if (!Number.isFinite(parsed)) {
-    return { generatedAt, ageMs: null, stale: true, confirmed: false, note: '생성시각 불명 — 신선도 미확인' }
+  const ageMs = Number.isFinite(parsed) ? nowMs - parsed : null
+
+  // SHA 기반 (증거에 커밋 바인딩 있음) — Goal 44 의 소비 측 완결.
+  if (report?.commit) {
+    const { reasons } = checkEvidenceFreshness(report, current)
+    const stale = reasons.length > 0
+    return {
+      generatedAt,
+      ageMs,
+      stale,
+      confirmed: true, // SHA 비교가 가능 = 신선도 판정 자체는 확정
+      basis: 'sha',
+      reasons,
+      note: stale ? `SHA 기반 신선도: ${reasons[0]}` : `SHA 일치(${report.commit.shortSha}) — 신선`,
+    }
   }
-  const ageMs = nowMs - parsed
+
+  // 폴백: 구(舊)증거(commit 필드 없음, v1) → 생성시각으로만 추정.
+  if (ageMs === null) {
+    return {
+      generatedAt,
+      ageMs: null,
+      stale: true,
+      confirmed: false,
+      basis: 'time',
+      reasons: ['생성시각 불명 — 신선도 미확인'],
+      note: '생성시각 불명 — 신선도 미확인',
+    }
+  }
   const stale = ageMs > STALE_AGE_MS || ageMs < 0
   const mins = Math.round(ageMs / 60000)
   const human = mins >= 120 ? `${Math.round(mins / 60)}시간` : `${mins}분`
@@ -126,9 +167,11 @@ function assessFreshness(report: VerifyReport | null, nowMs: number): EvidenceFr
     ageMs,
     stale,
     confirmed: true,
+    basis: 'time',
+    reasons: stale ? [`증거가 ${human} 전 생성(또는 미래시각)`] : [],
     note: stale
-      ? `증거가 ${human} 전 생성(또는 미래시각) — 코드 변경 시 무효, vhk verify 재실행 권장`
-      : `증거 ${human} 전 생성`,
+      ? `증거가 ${human} 전 생성(또는 미래시각) — 커밋 SHA 없음(구버전), vhk verify 재실행 권장`
+      : `증거 ${human} 전 생성(커밋 SHA 없음 — 생성시각 추정)`,
   }
 }
 
@@ -140,13 +183,14 @@ export function crossCheck(
   checks: CompletionCheck[],
   goalStatus: string,
   report: VerifyReport | null,
-  nowMs: number
+  nowMs: number,
+  current: CommitInfo | null = null
 ): ReviewAnalysis {
   const suspicions: ReviewAnalysis['suspicions'] = []
   const gaps: ReviewAnalysis['gaps'] = []
   const gateById = new Map<string, GateResult>()
   if (report) for (const g of report.gates) gateById.set(g.id, g)
-  const freshness = assessFreshness(report, nowMs)
+  const freshness = assessFreshness(report, current, nowMs)
 
   if (goalStatus === 'DONE' && report && report.status === 'FAIL') {
     suspicions.push({
@@ -293,7 +337,9 @@ export async function review(opts: { id?: string; strict?: boolean } = {}): Prom
     return
   }
 
-  const analysis = crossCheck(checks, goalStatus, report, Date.now())
+  // Goal 80: 현재 HEAD SHA·dirty 를 읽어 증거 SHA(Goal 44 기록)와 비교 — 낡은 증거 신선도 강등.
+  const current = getCommitInfo(cwd)
+  const analysis = crossCheck(checks, goalStatus, report, Date.now(), current)
   const result: ReviewResult = {
     ...analysis,
     reviewedAt: new Date().toISOString(),

--- a/tests/review.test.ts
+++ b/tests/review.test.ts
@@ -12,6 +12,7 @@ import {
   type CompletionCheck,
 } from '../src/commands/review.js'
 import type { GateResult, ReportStatus, VerifyReport } from '../src/commands/verify.js'
+import type { CommitInfo } from '../src/lib/git-repo.js'
 import { routeNaturalLanguage } from '../src/lib/nlp-router.js'
 import { dispatchNlpRoute } from '../src/lib/nlp-run.js'
 
@@ -32,9 +33,14 @@ function gate(id: GateResult['id'], status: GateResult['status'], exitCode: numb
   return { id, label: id, status, exitCode, skipped: status === 'skip' }
 }
 
-function report(status: ReportStatus, gates: GateResult[], generatedAt: string = GEN_AT): VerifyReport {
+function report(
+  status: ReportStatus,
+  gates: GateResult[],
+  generatedAt: string = GEN_AT,
+  commit: CommitInfo | null = null
+): VerifyReport {
   return {
-    schemaVersion: 1,
+    schemaVersion: commit ? 2 : 1,
     generatedAt,
     date: '2026-06-02',
     status,
@@ -47,10 +53,12 @@ function report(status: ReportStatus, gates: GateResult[], generatedAt: string =
     },
     gates,
     nextActions: [],
+    commit,
   }
 }
 
 const checked = (text: string): CompletionCheck => ({ text, checked: true })
+const ci = (sha: string, dirty = false): CommitInfo => ({ sha, shortSha: sha.slice(0, 7), dirty })
 
 describe('review — parseCompletionChecks', () => {
   const body = `# Goal
@@ -153,6 +161,76 @@ describe('review — crossCheck (순수)', () => {
   it('미체크 항목은 의심 대상 아님', () => {
     const r = crossCheck([{ text: '테스트 통과', checked: false }], 'IN_PROGRESS', report('FAIL', [gate('test', 'fail', 1)]), FRESH)
     expect(r.suspicions).toHaveLength(0)
+  })
+})
+
+describe('review — crossCheck SHA 신선도 (Goal 80)', () => {
+  const NOW = () => new Date().toISOString()
+
+  it('증거 SHA == 현재 HEAD + 신선 + 게이트 pass → 신선(강등 없음) + basis=sha + high', () => {
+    const rep = report('PASS', [gate('typecheck', 'pass'), gate('test', 'pass')], NOW(), ci('abc1234def'))
+    const r = crossCheck([checked('tsc 통과'), checked('테스트 통과')], 'IN_PROGRESS', rep, Date.parse(rep.generatedAt), ci('abc1234def'))
+    expect(r.freshness.basis).toBe('sha')
+    expect(r.freshness.stale).toBe(false)
+    expect(r.confidence).toBe('high')
+  })
+
+  it('증거 SHA != 현재 HEAD → 신선도 낡음 강등(high 금지, 사유에 SHA)', () => {
+    const rep = report('PASS', [gate('typecheck', 'pass'), gate('test', 'pass')], NOW(), ci('aaaaaaa1'))
+    const r = crossCheck([checked('tsc 통과'), checked('테스트 통과')], 'IN_PROGRESS', rep, Date.parse(rep.generatedAt), ci('bbbbbbb2'))
+    expect(r.freshness.basis).toBe('sha')
+    expect(r.freshness.stale).toBe(true)
+    expect(r.freshness.reasons.some((x) => /SHA/.test(x))).toBe(true)
+    // 의심 0 · 미검증 0 · coverage 1 이지만 SHA 불일치(stale) → high 금지(medium 캡)
+    expect(r.confidence).toBe('medium')
+  })
+
+  it('증거 생성 시점 dirty → 낡음 강등', () => {
+    const rep = report('PASS', [gate('typecheck', 'pass')], NOW(), ci('abc1234', true))
+    const r = crossCheck([checked('tsc 통과')], 'IN_PROGRESS', rep, Date.parse(rep.generatedAt), ci('abc1234', false))
+    expect(r.freshness.stale).toBe(true)
+  })
+
+  it('현재 working tree dirty → 낡음 강등', () => {
+    const rep = report('PASS', [gate('typecheck', 'pass')], NOW(), ci('abc1234', false))
+    const r = crossCheck([checked('tsc 통과')], 'IN_PROGRESS', rep, Date.parse(rep.generatedAt), ci('abc1234', true))
+    expect(r.freshness.stale).toBe(true)
+  })
+
+  it('구(舊)증거(commit 필드 없음) → 생성시각 폴백(graceful) + basis=time + 크래시 0', () => {
+    const rep = report('PASS', [gate('typecheck', 'pass')], NOW()) // commit null = v1
+    const r = crossCheck([checked('tsc 통과')], 'IN_PROGRESS', rep, Date.parse(rep.generatedAt), ci('abc1234'))
+    expect(r.freshness.basis).toBe('time')
+    expect(r.freshness.confirmed).toBe(true)
+    expect(r.freshness.stale).toBe(false)
+  })
+
+  it('현재 커밋 미상(current=null) + 증거 SHA 있음 → 낡음(신선도 증명 불가)', () => {
+    const rep = report('PASS', [gate('typecheck', 'pass')], NOW(), ci('abc1234'))
+    const r = crossCheck([checked('tsc 통과')], 'IN_PROGRESS', rep, Date.parse(rep.generatedAt), null)
+    expect(r.freshness.basis).toBe('sha')
+    expect(r.freshness.stale).toBe(true)
+  })
+
+  it('generatedAt 파싱불가 + commit 있음 → SHA 분기(basis=sha) 진입 + ageMs null 이 사람용 출력에 안 샘(크래시 0)', () => {
+    // SHA 분기는 시각(ageMs)을 안 쓰고 note 는 shortSha 만 쓴다 → 'not-a-date' 여도 NaN/null 누출·크래시 없음.
+    const rep = report('PASS', [gate('typecheck', 'pass')], 'not-a-date', ci('abc1234'))
+    const r = crossCheck([checked('tsc 통과')], 'IN_PROGRESS', rep, Date.parse(GEN_AT), ci('abc1234'))
+    expect(r.freshness.basis).toBe('sha')
+    expect(r.freshness.stale).toBe(false) // SHA 일치 + clean
+    expect(r.freshness.ageMs).toBeNull()
+    expect(r.freshness.note).toContain('abc1234')
+    expect(r.freshness.note).not.toMatch(/NaN|null|undefined/)
+  })
+
+  it('disclaimer 가 SHA 기반 신선도 명시(생성시각 단독 추정 문구 제거)', () => {
+    expect(REVIEW_DISCLAIMER).toMatch(/SHA/)
+    expect(REVIEW_DISCLAIMER).not.toMatch(/생성시각으로만 추정/)
+  })
+
+  it('disclaimer 가 dirty→신뢰도 상한 medium 을 설명(비개발자 "왜 항상 medium?" 오해 방지)', () => {
+    expect(REVIEW_DISCLAIMER).toMatch(/미커밋|dirty/)
+    expect(REVIEW_DISCLAIMER).toMatch(/medium/)
   })
 })
 
@@ -349,6 +427,21 @@ ${checks.map((c) => `- [x] ${c}`).join('\n')}
     await dispatchNlpRoute({ command: 'review', explanation: '', confidence: 'high' }, '거짓완료 없는지 검토해')
     const merged = JSON.parse(fs.readFileSync(path.join(d, '.vhk', 'reports', 'latest.json'), 'utf-8'))
     expect(merged.review).toBeTruthy()
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('Goal 80: 증거에 SHA 있고 현재 HEAD 미상(비-git tmpdir) → review 가 신선도 낡음 강등', async () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-review-'))
+    seedGoal(d, 9, 'IN_PROGRESS', ['tsc 통과'])
+    // 증거엔 커밋 SHA 가 박혀 있지만 tmpdir 는 git 레포가 아님 → getCommitInfo=null → 신선도 증명 불가(낡음).
+    seedReport(d, report('PASS', [gate('typecheck', 'pass')], new Date().toISOString(), ci('deadbeef0')))
+    process.chdir(d)
+    await review({ id: '9' })
+    const merged = JSON.parse(fs.readFileSync(path.join(d, '.vhk', 'reports', 'latest.json'), 'utf-8'))
+    expect(merged.review.freshness.stale).toBe(true)
+    expect(merged.review.freshness.basis).toBe('sha')
+    expect(merged.review.confidence).not.toBe('high')
     process.chdir(origCwd)
     fs.rmSync(d, { recursive: true, force: true })
   })


### PR DESCRIPTION
## Goal 80 — 증거 신선도 review 연결 (P1, RFC 0053 §4 D3)

**한 줄:** `vhk review` 의 증거 신선도 판정을 **커밋 SHA 기반**으로 승격 — Goal 44 가 기록까지 한 SHA·dirty 를 review 가 비로소 **소비**한다(기록→소비 갭 완결).

### 왜
- Goal 44 가 `latest.json` 에 HEAD SHA·dirty 를 **기록**했으나, review 출력은 여전히 *"신선도는 생성시각으로만 추정"* → 데이터는 있는데 판정이 소비 안 함.

### 무엇
- `assessFreshness(report, current, nowMs)` — 증거에 `commit`(SHA) 있으면 verify 의 `checkEvidenceFreshness` 재사용해 현재 HEAD 와 비교(`basis: 'sha'`). `SHA≠HEAD` 또는 dirty → "낡음" 강등. SHA 없는 구(舊)증거는 생성시각 폴백(`basis: 'time'`, 하위호환).
- `EvidenceFreshness` 에 `basis`('sha'|'time') + `reasons` 추가.
- `crossCheck(..., current = null)` 옵셔널 주입 — 순수성 유지(IO 는 `review()` 에서 `getCommitInfo`).
- disclaimer 정정: "생성시각으로만 추정" → "SHA로 판정(구버전은 시각 폴백) · dirty면 신뢰도 상한 medium".

### 수용 기준 충족
- 코드 변경(HEAD 이동/dirty) 후 낡은 증거로 review → 신선도 "낡음" 강등(`basis=sha`, confidence medium 캡). ✅ 라이브 도그푸딩으로 확인(`vhk review --id 80` → dirty 감지 → medium).

### 제약 준수 (Forbidden OUT)
- verify/verify-report 시그니처 변경 **0**(읽기 측만 추가, GA 안정성). · Goal 44 SHA 기록 동작 변경 **0**. · 강등을 fail 로 격상 **0**(advisory exit 0 유지).

### 검증
- 회귀 테스트 `tests/review.test.ts` SHA 매트릭스(일치=신선/불일치=강등/dirty=강등/구증거=시각폴백/현재미상=낡음/파싱불가+commit=크래시0) → **35 pass**.
- 전 게이트(typecheck/lint/test/build) + `check-goal-80.mjs` 고유검증 16 전부 ✓.
- **적대 리뷰**(7-에이전트 워크플로, 3렌즈+반증): blocker/major **0**, nit 2건 반영(SHA 분기 회귀 가드 + dirty→medium 문구), 2건 반증 기각.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 커밋 SHA 기반 증거 신선도 검토 도입으로 더 정확한 판정 제공

* **Bug Fixes**
  * 신선도 판정 로직 개선 및 신뢰도 반영 정확화
  * 이전 버전 증거에 대한 자동 폴백 처리 추가

* **Tests**
  * 신선도 검토 회귀 테스트 추가 및 자동 검증 게이트 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->