### PR TITLE
feat(goal-81): 제품 설명 단일 SoT — index.ts .description 런타임 주입

### DIFF
--- a/docs/log/2026-06-22-goal-81-product-desc-sot.md
+++ b/docs/log/2026-06-22-goal-81-product-desc-sot.md
@@ -1,0 +1,32 @@
+# 2026-06-22 — Goal 81: 제품 설명 단일 SoT (index.ts → package.json.description 주입)
+
+> append-only. 추가만, 수정·삭제 금지.
+
+## 선조사 → 범위 재조정 (goal 79 선례 "확실한 것만")
+- **카드 전제가 코드와 어긋남**: 카드는 "brief 가 제품 설명을 하드코딩 → package.json 주입"이라 했으나, `brief.ts` 는 하드코딩 안 함 — `readProjectIdentity()` 로 RULES.md "한 줄 설명" → `package.json.description` 폴백 순으로 읽는다(VHK-004 의도, 유저 프로젝트 문서-우선 SoT). brief 를 package.json 으로 강제하면 VHK-004 가 깨짐 → **건드리지 않음**.
+- **전수 grep 결과 진짜 SoT 위반 1곳**: `index.ts:181 .description('VHK — AI 코딩 세션을…')` = `package.json.description` 첫 문장의 하드코딩 복제(드리프트 위험). → 이것만 수정.
+- 나머지 "설명" 문자열 = 브랜드 태그라인(다른 층위, 유지): 메뉴 헤더 "바이브코딩 프로젝트 코치" · RULES.md "한 줄 설명" · core-ruleset role · gate.ts hint.
+
+## 한 일
+- **Goal 81 DONE** — 제품 설명을 `package.json.description` **단일 SoT**로 고정. `index.ts` 의 하드코딩 복제를 런타임 주입으로 구조적 제거(드리프트 원천 차단).
+
+## 변경 (산출물 포인터)
+- `src/lib/version.ts` — `getVhkDescription()` 추가(`getVhkVersion` 동형: 같은 폴백 경로 + BOM 안전, description 부재 시 빈 문자열).
+- `src/index.ts` — `.description(getVhkDescription())` 런타임 주입(하드코딩 리터럴 제거). 메뉴 헤더(962)에 "브랜드 태그라인 ≠ npm 제품 설명" 의도 주석.
+- `tests/version-sync.test.ts` — Goal 81 describe: getVhkDescription == package.json.description + index.ts 하드코딩 복제 금지 가드.
+- `scripts/check-goal-81.mjs` — 고유 게이트.
+- `goals/81-product-desc-sot.md` — 선조사 재조정 노트 + status DONE.
+- `goals/README.md` — 자동 재생성.
+
+## 검증
+- `npx vitest run tests/version-sync.test.ts` → 5 pass(신규 2).
+- `vhk --help` → package.json.description **전체** 노출(주입 작동 확인).
+- `pnpm build` OK · 전체 테스트 **1772 pass** · check-goal-81 고유검증 전부 ✓.
+
+## 교훈
+- **카드 전제는 검증 대상**: 도그푸딩 감사가 본 "drift"(brief vs package)는 실제론 *RULES.md 태그라인 vs package 설명* = VHK-004 의도된 층위차였다. 선조사 없이 카드대로 "brief→package 강제"했으면 유저 프로젝트 SoT를 깰 뻔. → goal 79식 "선조사 후 확실한 것만".
+- **태그라인 ≠ 제품 설명**: 둘을 한 SoT로 합치려 하지 말 것. 브랜드 별칭(짧은 후크)과 npm 제품 설명(검색·--help)은 목적이 달라 의도적으로 분리 유지가 옳음 — 합치면 둘 다 어색.
+- 런타임 주입(getVhkVersion 동형) > 빌드주입/가드테스트: 복제 자체를 없애면 드리프트가 구조적으로 불가능(가드가 잡을 드리프트가 안 생김).
+
+## 다음
+- 다음 P2 도그푸딩: goal 82(.vhk gitignore 정합) · 83(보안 scan false positive allowlist) · 84(doctor/status next-step 맥락). 또는 우선순위 2 measure-first 누적 대기.

--- a/goals/81-product-desc-sot.md
+++ b/goals/81-product-desc-sot.md
@@ -3,7 +3,7 @@ vhk_format: 1
 type: goal
 id: 81
 title: 제품 설명 단일 SoT — package.json.description 주입 — P1
-status: NOT_STARTED
+status: DONE
 priority: P1
 created: 2026-06-20
 leads_to: 제품 설명 드리프트 0 (G54 버전 SoT의 설명판 보완)
@@ -18,21 +18,27 @@ leads_to: 제품 설명 드리프트 0 (G54 버전 SoT의 설명판 보완)
 - `package.json.description` = "VHK — AI 코딩 세션을 목표·증거·기억·규칙으로 묶는 한국어 CLI…".
 - 둘이 다름 = 설명이 두 곳에 하드코딩. Goal 54는 *버전* 드리프트만 SoT화했고 *설명*은 가드 밖.
 
-## 동작
-- 제품 설명을 `package.json.description` **단일 SoT**에서 주입(brief 등 하드코딩 제거).
-- 다른 설명 하드코딩 지점(index.ts 메뉴 헤더 "바이브코딩 프로젝트 코치" 등) grep·정리 또는 의도 구분(브랜드 태그라인 vs 제품 설명).
-- version-sync 패턴 확장(설명 드리프트 가드) 또는 런타임 주입으로 드리프트 구조적 차단.
+## 선조사 범위 재조정 (2026-06-22, goal 79 선례 "확실한 것만")
+> 카드 전제("brief 가 설명 하드코딩")가 코드와 어긋나 재조정.
+- **brief.ts 는 설명 하드코딩 안 함** — `readProjectIdentity()` 로 RULES.md "한 줄 설명" → `package.json.description` 폴백 순으로 읽는다(VHK-004 의도). brief 를 package.json 으로 **강제하면 유저 프로젝트의 문서-우선 SoT(VHK-004)가 깨짐** → 건드리지 않음.
+- 전수 grep 결과 **진짜 SoT 위반 1곳**: `index.ts` `.description('VHK — AI 코딩 세션을…')` = `package.json.description` 의 하드코딩 복제(드리프트 위험). → 이것만 고친다.
+- 나머지 "설명" 문자열은 **브랜드 태그라인**(다른 층위, 유지): `index.ts` 메뉴 헤더 "바이브코딩 프로젝트 코치" · RULES.md "한 줄 설명" · core-ruleset role · gate.ts hint 예시.
+
+## 동작 (재조정 후)
+- `getVhkDescription()`(version.ts, `getVhkVersion` 동형) 추가 → `index.ts .description(getVhkDescription())` 런타임 주입 = 하드코딩 복제 **구조적** 제거(드리프트 원천 차단).
+- 태그라인(메뉴 헤더)은 "브랜드 태그라인 ≠ npm 제품 설명" 의도 주석으로 명문화.
 
 ## 수용 기준
-- 제품 설명이 단일 출처에서 온다. brief↔package 설명 불일치 0. 회귀 0.
+- 제품 설명이 단일 출처(`package.json.description`)에서 온다. index.ts ↔ package 설명 복제 0. 회귀 0.
 
 ## Completion Check (작은 단위)
-- [ ] brief.ts(또는 brief 생성기) 제품 설명 하드코딩 → `package.json.description` 주입
-- [ ] 설명 하드코딩 전수 grep(src 전역) → 정리 or "태그라인 ≠ 제품설명" 의도 명문화
-- [ ] (택1) version-sync.test 설명 케이스 추가 / 런타임 주입으로 가드 불필요화 — 선택 근거 기록
-- [ ] 회귀 테스트(brief 설명 = package.description 단언)
-- [ ] check-goal-81.mjs
-- [ ] 공통 게이트 통과, 회귀 0
+- [x] index.ts `.description` 하드코딩 복제 → `getVhkDescription()` 런타임 주입(package.json.description SoT)
+- [x] 설명 하드코딩 전수 grep(src 전역) → 제품설명 1곳 정리 + 태그라인은 "≠ 제품설명" 의도 명문화
+- [x] (택1 선택) **런타임 주입**으로 드리프트 구조적 차단 — version.ts getVhkVersion 동형(근거: 빌드주입보다 단순·dist/src 양쪽 동작)
+- [x] 회귀 테스트(getVhkDescription = package.description 단언 + index.ts 하드코딩 복제 금지 가드)
+- [x] check-goal-81.mjs
+- [x] 공통 게이트 통과, 회귀 0
+- [~] brief↔package "불일치"는 RULES.md 태그라인 vs package 설명 = VHK-004 의도된 층위차 → 변경 안 함(문서화로 종결)
 
 ## Forbidden Actions (OUT)
 - `package.json.description` 자체 임의 변경 0 (그것이 SoT — 바꾸려면 별도 product 결정)

--- a/goals/README.md
+++ b/goals/README.md
@@ -2,7 +2,7 @@
 
 # goals/ 인덱스
 
-> 총 84 goal — DONE 76 · IN_PROGRESS 2 · NOT_STARTED 6
+> 총 84 goal — DONE 77 · IN_PROGRESS 2 · NOT_STARTED 5
 > 공통 게이트 = [_meta.md](_meta.md) · 카드 형식/상태 의미는 각 파일 frontmatter 참조.
 
 | # | 제목 | 상태 | 우선순위 | 다음 연결 |
@@ -87,7 +87,7 @@
 | 78 | goal next 비파괴화 + vhk goal peek — 조회/변경 분리 — P0 | ✅ DONE | P0 | 읽기 안전성 — 조회 의도가 상태파일을 파괴하지 않음 |
 | 79 | verify 로컬 환경의존 테스트 분리 — 선조사 후 범위 재조정(확실한 것만) — P0 | 🔄 IN_PROGRESS | P0 | 로컬 verify 신뢰 — 선조사로 회귀 0 확인, 확실한 조치만 적용 |
 | 80 | 증거 신선도 review 연결 — SHA≠HEAD 시 강등 — P1 | ✅ DONE | P1 | 낡은 PASS 증거로 거짓완료 차단(기록→소비 완결) |
-| 81 | 제품 설명 단일 SoT — package.json.description 주입 — P1 | ⬜ NOT_STARTED | P1 | 제품 설명 드리프트 0 (G54 버전 SoT의 설명판 보완) |
+| 81 | 제품 설명 단일 SoT — package.json.description 주입 — P1 | ✅ DONE | P1 | 제품 설명 드리프트 0 (G54 버전 SoT의 설명판 보완) |
 | 82 | .vhk 런타임 산출물 gitignore 정합 — git status 청결 — P2 | ⬜ NOT_STARTED | P2 | vhk 명령 사용 후 git status 노이즈 0 |
 | 83 | 보안 scan 테스트 픽스처 false positive allowlist — P2 | ⬜ NOT_STARTED | P2 | secure scan 노이즈 ↓ (진짜 시크릿 신호 보존) |
 | 84 | doctor/status next-step 맥락 인지 — 신규 vs 기존 레포 분기 — P2 | ⬜ NOT_STARTED | P2 | "다음에 이것만 하세요"가 현재 상태에 맞음 |

--- a/scripts/check-goal-81.mjs
+++ b/scripts/check-goal-81.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// scripts/check-goal-81.mjs — goal 81: 제품 설명 단일 SoT (index.ts .description → package.json.description 주입).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역.
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 81 gate.')
+  process.exit(1)
+}
+
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 81] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 81 고유 검증 ───────────────────────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+const v = read('src/lib/version.ts') ?? ''
+must(/export function getVhkDescription\(\): string/.test(v), 'version.ts getVhkDescription() export(런타임 주입 통로)')
+must(/pkg\.description/.test(v), 'getVhkDescription 가 package.json.description 읽음')
+
+const idx = read('src/index.ts') ?? ''
+must(/getVhkVersion, getVhkDescription/.test(idx) || /getVhkDescription/.test(idx), 'index.ts getVhkDescription import')
+must(/\.description\(getVhkDescription\(\)\)/.test(idx), 'index.ts .description 가 런타임 주입(하드코딩 복제 제거)')
+must(!/\.description\('VHK — AI 코딩 세션을/.test(idx), 'index.ts 제품 설명 하드코딩 리터럴 0(드리프트 원천 차단)')
+must(/브랜드 태그라인/.test(idx), '메뉴 헤더 태그라인 의도 명문화(태그라인 ≠ 제품 설명)')
+
+const t = read('tests/version-sync.test.ts') ?? ''
+must(/제품 설명 정합 — package\.json ↔ index\.ts \(Goal 81\)/.test(t), '회귀 테스트 describe(제품 설명 정합)')
+must(/getVhkDescription\(\)\)\.toBe\(pkg\.description\)/.test(t), '테스트: getVhkDescription == package.json.description')
+must(/\.not\.toMatch\(\/\\\.description\\\('VHK — AI 코딩 세션을/.test(t), '테스트: index.ts 하드코딩 복제 금지 가드')
+
+// 제품 설명 SoT 실제 정합(빌드 산출물 기준은 아니나, 소스 단에서 SoT 일치 확인)
+must(typeof pkg.description === 'string' && pkg.description.length > 0, 'package.json.description 존재(SoT)')
+
+const goal = read('goals/81-product-desc-sot.md') ?? ''
+must(/status:\s*DONE/.test(goal), 'goals/81 status DONE')
+
+if (pass) { console.log('✅ goal 81 gate passes'); process.exit(0) }
+console.log('❌ goal 81 gate failed'); process.exit(1)

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk'
 import { prompt } from './lib/prompt.js'
 import { detectNaturalLanguageInput } from './lib/cli-args.js'
 import { runNaturalLanguageRoute } from './lib/nlp-run.js'
-import { getVhkVersion } from './lib/version.js'
+import { getVhkVersion, getVhkDescription } from './lib/version.js'
 import { gate } from './commands/gate.js'
 import { init } from './commands/init.js'
 import { recap } from './commands/recap.js'
@@ -178,7 +178,8 @@ const KO_ALIASES: Record<string, string> = {
 
 program
   .name('vhk')
-  .description('VHK — AI 코딩 세션을 목표·증거·기억·규칙으로 묶는 한국어 CLI')
+  // Goal 81: 제품 설명 SoT = package.json.description (런타임 주입 — 하드코딩 복제·드리프트 제거).
+  .description(getVhkDescription())
   .version(getVhkVersion())
 
 program.configureHelp({
@@ -959,6 +960,8 @@ program.on('command:*', (operands: string[]) => {
 program.action(async () => {
   // 헤더: 현재 버전(즉시·네트워크 0) + 업데이트 알림(캐시 기반 "가끔 자동 확인") + 직접입력 안내.
   const info = getUpdateInfo()
+  // 메뉴 헤더는 브랜드 태그라인(짧은 별칭) — npm 제품 설명(package.json.description, --help 노출)과
+  // 의도적으로 다른 층위다(Goal 81). 태그라인은 여기 단일 표기, 제품 설명은 getVhkDescription() 주입.
   console.log('\n🎯 VHK — 바이브코딩 프로젝트 코치  ' + chalk.dim(`v${info.current}`))
   if (info.updateAvailable && info.latest) {
     console.log(chalk.yellow(`🆕 업데이트 가능: v${info.latest}`) + chalk.dim('  →  vhk update'))

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -24,3 +24,23 @@ export function getVhkVersion(): string {
   }
   return '0.0.0'
 }
+
+// Goal 81: 제품 설명 단일 SoT — package.json.description 을 런타임 주입(index.ts .description 하드코딩 복제 제거).
+//   getVhkVersion 과 동형(같은 폴백 경로 + BOM 안전). description 부재 시 빈 문자열(commander 가 무시).
+export function getVhkDescription(): string {
+  const dir = dirname(fileURLToPath(import.meta.url))
+  for (const pkgPath of [
+    join(dir, '../../package.json'),
+    join(dir, '../package.json'),
+  ]) {
+    try {
+      if (existsSync(pkgPath)) {
+        const pkg = readJsonFile<{ description?: string }>(pkgPath)
+        if (pkg.description) return pkg.description
+      }
+    } catch {
+      continue
+    }
+  }
+  return ''
+}

--- a/tests/version-sync.test.ts
+++ b/tests/version-sync.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
+import { getVhkDescription } from '../src/lib/version.js'
 
 // 버전 정합 가드 (자동화 C) — 매 릴리즈마다 손으로 맞추던 버전 표기가 어긋나면 CI 실패.
 // package.json 이 단일 진실(SoT). CLAUDE.md 의 "**버전:** vX.Y.Z" 표기가 이를 따라가야 한다.
@@ -40,5 +41,24 @@ describe('버전 정합 — package.json ↔ README.md', () => {
       m![1],
       `README blockquote 버전(v${m![1]}) ≠ package.json(${pkg.version}) — 릴리즈 시 README 도 갱신하세요`,
     ).toBe(pkg.version)
+  })
+})
+
+// Goal 81: 제품 설명 단일 SoT — package.json.description 가 SoT.
+//   과거 index.ts 가 .description('VHK — …') 로 같은 설명을 하드코딩 복제 → 드리프트 위험.
+//   getVhkDescription() 런타임 주입으로 복제를 구조적으로 제거(getVhkVersion 과 동형).
+describe('제품 설명 정합 — package.json ↔ index.ts (Goal 81)', () => {
+  const pkg = JSON.parse(readFileSync('package.json', 'utf-8')) as { description?: string }
+  const idx = readFileSync('src/index.ts', 'utf-8')
+
+  it('getVhkDescription() 이 package.json.description 을 그대로 반환', () => {
+    expect(typeof pkg.description).toBe('string')
+    expect(getVhkDescription()).toBe(pkg.description)
+  })
+
+  it('index.ts 프로그램 설명이 getVhkDescription() 주입(하드코딩 복제 제거)', () => {
+    expect(idx).toMatch(/\.name\('vhk'\)[\s\S]*?\.description\(getVhkDescription\(\)\)/)
+    // 제품 설명을 index.ts 에 통째 하드코딩 금지(드리프트 원천 차단).
+    expect(idx).not.toMatch(/\.description\('VHK — AI 코딩 세션을/)
   })
 })


### PR DESCRIPTION
## Goal 81 — 제품 설명 단일 SoT (P1, RFC 0053 §4 D8)

**한 줄:** 제품 설명을 `package.json.description` **단일 SoT**로 고정 — `index.ts` 의 하드코딩 복제를 런타임 주입으로 구조적 제거(드리프트 원천 차단).

### 선조사 → 범위 재조정 (goal 79 선례 "확실한 것만")
- 카드 전제("brief 가 설명 하드코딩")가 코드와 어긋남. **brief.ts 는 하드코딩 안 함** — `readProjectIdentity()` 로 RULES.md "한 줄 설명" → `package.json.description` 폴백 순으로 읽는다(VHK-004 문서-우선 의도). brief 를 package.json 으로 강제하면 유저 프로젝트 SoT 가 깨짐 → **미변경**.
- 전수 grep 결과 **진짜 SoT 위반 1곳**: `index.ts` `.description('VHK — AI 코딩 세션을…')` = `package.json.description` 의 하드코딩 복제. → 이것만 수정.
- 나머지는 **브랜드 태그라인**(메뉴 헤더·RULES.md 한 줄 설명) = npm 제품 설명과 다른 층위 → 유지 + 의도 주석.

### 무엇
- `getVhkDescription()`(version.ts, `getVhkVersion` 동형: 같은 폴백 경로 + BOM 안전).
- `index.ts` `.description(getVhkDescription())` 런타임 주입.
- `version-sync.test.ts` Goal 81 가드: `getVhkDescription() == package.json.description` + index.ts 하드코딩 복제 금지.

### 검증
- `vhk --help` → `package.json.description` **전체** 노출(주입 작동 확인).
- 테스트 **1772 pass**(version-sync 5/5) · `check-goal-81.mjs` 고유검증 12 ✓.
- **적대 리뷰**(9-에이전트, 3렌즈+반증): confirmed **0**(전부 nit·범위밖 기각 — 재조정 타당성 재확인).

### 제약 준수 (Forbidden)
- `package.json.description` 불변(설명 변경은 별도 product 결정) · 메뉴/CLI 출력 breaking **0**(--help 산문만 첫문장→전문으로 확장, cosmetic) · 한국어 본질 유지.

### 후속(별도, 범위 밖)
- 적대 리뷰 부수 발견: `package.json.description` 의 "MCP 30 tools" = 실제 **35 tools** 드리프트. Forbidden(설명 임의 변경 0)이라 이 PR 미포함 — 별도 product 결정으로 30→35 정정 권고.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 제품 설명 관리를 단일 출처로 통일하여 구성 불일치를 구조적으로 차단했습니다.

* **Tests**
  * 제품 설명 동기화 검증 테스트를 추가하여 일관성을 보장합니다.
  * 런타임 검증 게이트를 추가하여 제품 설명 관리 규칙 준수를 자동화합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->