### PR TITLE
feat(goal-82): .vhk 증거 원장 추적 정합 — ledger.jsonl 추적 + 정책 가드

### DIFF
--- a/.vhk/README.md
+++ b/.vhk/README.md
@@ -15,6 +15,12 @@
 | `events/ai-actions.jsonl` · `ledger.jsonl` | ✅ | 행동 원장(Goal 55)·증거 원장(Goal 45) — 레포 영속 설계 |
 | `HARD_STOP` | ❌ (로컬 only) | 존재하면 모든 자동화 즉시 중단. `vhk resume --confirm` 으로만 해제. |
 
+> **증거 원장 추적 주의 (Goal 82):** `ledger.jsonl`·`events/ai-actions.jsonl` 은 ✅ 추적이 **정답**이다
+> (untracked 면 매번 `?? ` 로 떠 `git status` 가 더 지저분 + 증거가 레포에 안 남아 Goal 45 무결성 훼손).
+> 이 둘은 **증거 이벤트에만 append** 된다 — `ledger.jsonl` 은 `vhk verify` 시, `ai-actions.jsonl` 은 가드를
+> 지난 mutate 시. 일반 명령(status·goal·recall·brief 등)은 안 건드리므로 `git status` 는 깨끗하다.
+> verify 후 ` M ledger.jsonl` 은 노이즈가 아니라 **그 작업의 증거** — 작업과 함께 커밋하면 된다.
+
 ## HARD_STOP 규칙
 
 - 다음 조건에서 자동 생성:

--- a/.vhk/ledger.jsonl
+++ b/.vhk/ledger.jsonl
@@ -1,0 +1,1 @@
+{"version":"2.6.0","date":"2026-06-22","status":"PASS","sha":"827c56f7a015b730b7d132ea86e179f8bd59f320","shortSha":"827c56f","dirty":true}

--- a/docs/log/2026-06-22-goal-82-vhk-artifact-tracking.md
+++ b/docs/log/2026-06-22-goal-82-vhk-artifact-tracking.md
@@ -1,0 +1,41 @@
+# 2026-06-22 — Goal 82: .vhk 증거 원장 추적 정합 (ledger.jsonl 추적)
+
+> append-only. 추가만, 수정·삭제 금지.
+
+## 선조사 → 범위 재조정 (goal 79/81 선례 "확실한 것만")
+- **카드 premise 가 정책과 정반대**: 카드는 "`ledger.jsonl` 을 .gitignore 에 추가"라 했으나, `.vhk/README` **spec 1.1 트래킹 정책이 이미 `ledger.jsonl`·`events/ai-actions.jsonl` 둘 다 ✅ 추적("레포 영속", Goal 45/55)으로 결정**했다.
+- 실측: `ai-actions.jsonl` 은 추적 정합. `ledger.jsonl` 만 **untracked**(한 번도 `git add` 안 됨). `git check-ignore .vhk/ledger.jsonl` = 비어 있음(어떤 .gitignore 로도 제외 안 됨) → 단지 미추가.
+- 따라서 `?? .vhk/ledger.jsonl` 노이즈의 올바른 해소 = **gitignore 가 아니라 추적**. gitignore 하면 Goal 45 증거 영속 설계가 깨짐(Forbidden "증거 원장 무결성 훼손 0" 정면 위반).
+
+## 한 일
+- **Goal 82 DONE** — `.vhk/ledger.jsonl` 을 git 추적시켜 spec 1.1·Goal 45 와 일치(untracked `??` 노이즈 해소). 정책을 테스트·게이트로 락.
+
+## 변경 (산출물 포인터)
+- `.vhk/ledger.jsonl` — `git add`(추적). 기존 1줄 PASS 증거 보존(원장 무결성 — 재작성 안 함).
+- `.vhk/README.md` — 트래킹 정책표 아래 명확화: 증거 원장은 **증거 이벤트에만 append**(`ledger`=verify 시, `ai-actions`=가드 mutate 시) → **일반 명령(status·goal·recall·brief)은 안 건드림** → git status 깨끗. verify 후 ` M ledger.jsonl` 은 노이즈가 아니라 그 작업의 증거.
+- `tests/vhk-artifact-tracking.test.ts` — 정책 가드: gitignore(root·.vhk)가 두 증거 원장을 제외 안 함 + README 가 추적으로 명문화(미래 드리프트=증거 휘발 차단).
+- `scripts/check-goal-82.mjs` — `git ls-files`/`git check-ignore` 로 두 원장 추적·비제외 검증.
+- `goals/82-vhk-artifact-gitignore.md` — 재조정 노트 + status DONE.
+
+## 검증
+- check-goal-82 고유검증 7항목 전부 ✓(ledger 추적 RED→git add→GREEN).
+- `pnpm build` OK · 전체 테스트 **1775 pass**(신규 가드 3).
+- ai-actions.jsonl 미변경(Forbidden — `git rm --cached` 안 함).
+
+## 교훈
+- **카드 premise 는 검증 대상, 특히 "정합"류 goal**: 도그푸딩 감사가 `??`(untracked)를 보고 "gitignore 하자"로 적었지만, 정책(spec 1.1)은 정반대(추적). untracked ≠ should-ignore — `git check-ignore` 로 "제외됐나 vs 안 더해졌나"를 먼저 구분해야. 카드대로 gitignore 했으면 Goal 45 증거영속을 깰 뻔.
+- **증거 원장의 git status 등장은 버그 아님**: append-only 증거 로그는 증거 이벤트(verify·mutate)에만 변경 → 그건 "그 작업의 증거"라 작업과 함께 커밋이 정상. 일반 명령이 안 건드리면 정합. "git status 청결"과 "증거 영속"은 양립한다(변경 주체를 증거 이벤트로 한정하면).
+
+## 별도(범위 밖) 관찰
+- `docs/state/research-backlog.md` 가 untracked 로 status 에 뜸 — .vhk 산출물 아님(goal 82 범위 밖). 별도 처리(커밋 or 정리) 필요 — 추정 RFC 0054(#307) 잔여.
+
+## 적대 리뷰 반영 (12-에이전트, 3렌즈+반증)
+- 재조정(추적 vs gitignore) **타당 확정**(반증 실패). confirmed 5건 = 전부 **가드 견고성**(코어 변경 아님).
+- **major 반영**: `git check-ignore` 는 **이미 추적된 파일엔 ignore 패턴을 안 잡는다**(데드 가드) → "ledger 를 gitignore 에 추가" 회귀를 못 봄. `--no-index` 로 수정(추적 무관 패턴 평가). check-goal-82 + vitest 둘 다 적용.
+- **가드 이전**: vitest(=CI 집행)에 git 권위 검사(`ls-files` 추적 + `check-ignore --no-index` 비제외) 이전 — 기존엔 텍스트 휴리스틱만이고 실제 추적/제외 판정은 CI 미연결 check-goal-82 에만 있어 회귀를 CI 가 못 잡던 갭 해소.
+- **양성 대조 추가**: 실제 ignore 경로(`.vhk/memory.json`)를 가드가 검출함을 단언(함수가 깨져 항상 통과하는 거짓 green 방지).
+- **nit**: 카드에 verify-dirty trade-off(머지 충돌 표면 작음·sameAsLast dedup) 1줄 명시.
+- 결과: 가드 테스트 4 pass(git 권위+양성대조) · 전체 1776 pass · check-goal-82 8항목 ✓.
+
+## 다음
+- P2 계속: goal 83(보안 scan 픽스처 false positive allowlist) → goal 84(doctor/status next-step 맥락).

--- a/goals/82-vhk-artifact-gitignore.md
+++ b/goals/82-vhk-artifact-gitignore.md
@@ -3,7 +3,7 @@ vhk_format: 1
 type: goal
 id: 82
 title: .vhk 런타임 산출물 gitignore 정합 — git status 청결 — P2
-status: NOT_STARTED
+status: DONE
 priority: P2
 created: 2026-06-20
 leads_to: vhk 명령 사용 후 git status 노이즈 0
@@ -19,22 +19,31 @@ leads_to: vhk 명령 사용 후 git status 노이즈 0
   - ` M .vhk/events/ai-actions.jsonl` — **추적되어** 명령마다 변경 → 매번 diff에 잡힘.
 - 추적/비추적 경계가 일관되지 않아 작업 중 git status가 지저분 → 진짜 변경이 묻힌다.
 
-## 동작
-- 런타임 생성물(`ledger.jsonl` 등) `.gitignore`에 추가.
-- `ai-actions.jsonl` 추적 의도 확정 — Goal 45(원장) 정책과 대조해 "추적 유지(이벤트 사료)" vs "제외" 결정 후 일관 적용.
-- `.vhk` 추적/비추적 경계를 RFC 0001(.vhk 규격) 또는 `.vhk/README`에 명문화.
+## 선조사 범위 재조정 (2026-06-22, goal 79/81 선례)
+> 카드 premise("ledger.jsonl gitignore 추가")가 **정책과 정반대** — 재조정.
+- 실측: `.vhk/README` **spec 1.1 트래킹 정책이 이미 `ledger.jsonl`·`events/ai-actions.jsonl` 둘 다 ✅ 추적("레포 영속", Goal 45/55)으로 결정**. ai-actions 는 추적 정합, `ledger.jsonl`만 **untracked(한 번도 `git add` 안 됨, 오변)**.
+- `git check-ignore` 확인: ledger.jsonl 은 어떤 .gitignore 로도 제외 안 됨 → 단지 미추가.
+- 따라서 `??` 노이즈의 올바른 해소 = **gitignore 가 아니라 추적**(spec·Goal 45 일치). gitignore 하면 Goal 45 증거 영속 설계가 깨짐(Forbidden "증거 원장 무결성 훼손 0" 정면 위반).
+
+## 동작 (재조정 후)
+- `.vhk/ledger.jsonl` **git 추적**(`git add`) → spec 1.1·Goal 45 일치, `??` 노이즈 해소.
+- `ai-actions.jsonl` 추적 유지(이미 정합, Forbidden — `git rm --cached` 금지).
+- `.vhk/README` 경계표에 "증거 원장은 증거 이벤트(verify·가드 mutate)에만 append → 일반 명령은 git status 안 더럽힘" 명확화.
+- 정책 가드: gitignore 가 두 원장을 제외하지 않음 + 추적됨을 테스트/게이트로 락(미래 회귀 차단).
 
 ## 수용 기준
-- 일반 vhk 명령 실행 후 `git status`에 의도치 않은 `.vhk` 변경이 안 뜬다(또는 의도된 것만).
+- 일반 vhk 명령 실행 후 `git status`에 의도치 않은 `.vhk` 변경이 안 뜬다(증거 원장은 추적되어 verify 시에만 변경 = 의도된 것).
+
+> **Trade-off(명시):** 추적이라 `vhk verify` 후엔 ` M ledger.jsonl` dirty 가 뜬다 — 노이즈가 아니라 *그 작업의 증거*(작업과 함께 커밋). 멀티-컨트리뷰터에선 append-only JSONL 한 줄이라 머지 충돌 표면이 작고, `sameAsLast` dedup(동일 version·sha·status·dirty 면 append skip)으로 churn 최소. 일반(read-only) 명령은 원장을 안 건드려 status 청결. README 가 의도 명문화.
 
 ## Completion Check (작은 단위)
-- [ ] `.vhk` 런타임 산출물 목록화(생성 명령별) → 추적/비추적 분류
-- [ ] 비추적 대상(`ledger.jsonl` 등) `.gitignore` 추가
-- [ ] `ai-actions.jsonl` 추적 의도 확정(Goal 45 대조) + 일관 적용
-- [ ] 경계 명문화(RFC 0001 또는 .vhk/README)
-- [ ] 회귀 테스트: 대표 명령 실행 후 `git status --porcelain` 청결 단언
-- [ ] check-goal-82.mjs
-- [ ] 공통 게이트 통과, 회귀 0
+- [x] `.vhk` 런타임 산출물 목록화(생성 명령별) → 추적/비추적 분류(spec 1.1 표 = SoT, README 명확화)
+- [x] ~~비추적 대상 gitignore 추가~~ → **재조정: ledger.jsonl 추적**(카드 premise 가 정책과 반대였음)
+- [x] `ai-actions.jsonl` 추적 의도 확정(Goal 55 영속 — 추적 유지) + 일관 적용
+- [x] 경계 명문화(.vhk/README — 증거 이벤트 append vs 일반 명령 구분)
+- [x] 회귀 테스트: gitignore 가 증거 원장 제외 안 함 + 추적됨 가드(tests/vhk-artifact-tracking.test.ts + check-goal-82 git ls-files)
+- [x] check-goal-82.mjs
+- [x] 공통 게이트 통과, 회귀 0
 
 ## Forbidden Actions (OUT)
 - 기존 추적 파일을 강제 `git rm --cached`로 끊어 사용자 이력 손실 0 (의도 확정 후 신중히)

--- a/goals/README.md
+++ b/goals/README.md
@@ -2,7 +2,7 @@
 
 # goals/ 인덱스
 
-> 총 84 goal — DONE 77 · IN_PROGRESS 2 · NOT_STARTED 5
+> 총 84 goal — DONE 78 · IN_PROGRESS 2 · NOT_STARTED 4
 > 공통 게이트 = [_meta.md](_meta.md) · 카드 형식/상태 의미는 각 파일 frontmatter 참조.
 
 | # | 제목 | 상태 | 우선순위 | 다음 연결 |
@@ -88,6 +88,6 @@
 | 79 | verify 로컬 환경의존 테스트 분리 — 선조사 후 범위 재조정(확실한 것만) — P0 | 🔄 IN_PROGRESS | P0 | 로컬 verify 신뢰 — 선조사로 회귀 0 확인, 확실한 조치만 적용 |
 | 80 | 증거 신선도 review 연결 — SHA≠HEAD 시 강등 — P1 | ✅ DONE | P1 | 낡은 PASS 증거로 거짓완료 차단(기록→소비 완결) |
 | 81 | 제품 설명 단일 SoT — package.json.description 주입 — P1 | ✅ DONE | P1 | 제품 설명 드리프트 0 (G54 버전 SoT의 설명판 보완) |
-| 82 | .vhk 런타임 산출물 gitignore 정합 — git status 청결 — P2 | ⬜ NOT_STARTED | P2 | vhk 명령 사용 후 git status 노이즈 0 |
+| 82 | .vhk 런타임 산출물 gitignore 정합 — git status 청결 — P2 | ✅ DONE | P2 | vhk 명령 사용 후 git status 노이즈 0 |
 | 83 | 보안 scan 테스트 픽스처 false positive allowlist — P2 | ⬜ NOT_STARTED | P2 | secure scan 노이즈 ↓ (진짜 시크릿 신호 보존) |
 | 84 | doctor/status next-step 맥락 인지 — 신규 vs 기존 레포 분기 — P2 | ⬜ NOT_STARTED | P2 | "다음에 이것만 하세요"가 현재 상태에 맞음 |

--- a/scripts/check-goal-82.mjs
+++ b/scripts/check-goal-82.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// scripts/check-goal-82.mjs — goal 82: .vhk 증거 원장 추적 정합 (ledger.jsonl·ai-actions.jsonl 레포 영속).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역.
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+/** git 명령 표준출력(실패/비-git 환경 → ''). */
+function gitOut(args) {
+  try {
+    return execFileSync('git', args, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8' }).trim()
+  } catch {
+    return ''
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 82 gate.')
+  process.exit(1)
+}
+
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 82] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 82 고유 검증 ───────────────────────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+
+// 핵심: 증거 원장 2종이 git 추적된다(spec 1.1·Goal 45/55 — 레포 영속).
+must(gitOut(['ls-files', '.vhk/ledger.jsonl']) !== '', '.vhk/ledger.jsonl git 추적(Goal 45 증거 영속 — untracked 노이즈 해소)')
+must(gitOut(['ls-files', '.vhk/events/ai-actions.jsonl']) !== '', '.vhk/events/ai-actions.jsonl git 추적(Goal 55 행동 원장)')
+
+// 어떤 .gitignore 로도 제외되지 않음(추적 가능 보장). --no-index: 이미 추적된 파일에도 ignore 패턴을
+// 평가한다(--no-index 없으면 추적 파일엔 패턴이 안 잡혀 'gitignore 추가' 회귀를 놓침 — 데드 가드).
+must(gitOut(['check-ignore', '--no-index', '--', '.vhk/ledger.jsonl']) === '', 'ledger.jsonl 이 .gitignore 로 제외되지 않음(증거 휘발 방지)')
+must(gitOut(['check-ignore', '--no-index', '--', '.vhk/events/ai-actions.jsonl']) === '', 'ai-actions.jsonl 이 .gitignore 로 제외되지 않음')
+// 양성 대조: 가드가 실제 작동함을 증명(실제 ignore 된 .vhk/memory.json 을 잡아야 함).
+must(gitOut(['check-ignore', '--no-index', '--', '.vhk/memory.json']) !== '', '양성 대조 — 실제 ignore 경로(memory.json)를 가드가 검출(거짓 통과 방지)')
+
+// 경계 명문화 + 회귀 가드 존재.
+const readme = read('.vhk/README.md') ?? ''
+must(/ledger\.jsonl/.test(readme) && /(레포 영속|✅)/.test(readme), '.vhk/README 트래킹 정책에 증거 원장 추적 명문화')
+must(existsSync('tests/vhk-artifact-tracking.test.ts'), '회귀 테스트 tests/vhk-artifact-tracking.test.ts')
+
+const goal = read('goals/82-vhk-artifact-gitignore.md') ?? ''
+must(/status:\s*DONE/.test(goal), 'goals/82 status DONE')
+
+if (pass) { console.log('✅ goal 82 gate passes'); process.exit(0) }
+console.log('❌ goal 82 gate failed'); process.exit(1)

--- a/tests/vhk-artifact-tracking.test.ts
+++ b/tests/vhk-artifact-tracking.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+
+// Goal 82: .vhk 증거 원장 추적 정합.
+//   증거 원장(ledger.jsonl·events/ai-actions.jsonl)은 spec 1.1 + Goal 45/55 에서 "레포 영속(✅ 추적)" 설계.
+//   회귀: ① 누군가 .gitignore 에 넣거나 ② git rm --cached 로 untrack 하면 증거가 조용히 휘발한다(Goal 45 무결성 훼손).
+//   카드 premise("ledger gitignore 추가")는 untracked 를 should-ignore 로 오독한 것 — 실제 정답은 "추적".
+//
+//   가드는 git 권위 판정을 쓴다(텍스트 휴리스틱 X):
+//   - git ls-files: 실제 추적 여부 → ② git rm --cached 회귀 탐지.
+//   - git check-ignore --no-index: 추적 여부와 무관하게 .gitignore 패턴 평가(글롭·디렉터리 포함)
+//       → ① gitignore 추가 회귀 탐지. (--no-index 없으면 이미 추적된 파일엔 패턴이 안 잡혀 가드가 헛돈다.)
+//   이 테스트는 vitest(=CI 집행 경로)에 둔다 — check-goal-82.mjs(수동 게이트)에만 두면 CI 가 회귀를 못 잡는다.
+
+function git(args: string[]): string {
+  try {
+    return execFileSync('git', args, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()
+  } catch (e) {
+    const err = e as { stdout?: Buffer | string }
+    return (err.stdout?.toString() ?? '').trim()
+  }
+}
+
+const inGitRepo = git(['rev-parse', '--is-inside-work-tree']) === 'true'
+const gitIt = inGitRepo ? it : it.skip // 비-git 환경(드문 CI 형태)에서는 graceful skip.
+const README = existsSync('.vhk/README.md') ? readFileSync('.vhk/README.md', 'utf-8') : ''
+
+const isTracked = (rel: string): boolean => git(['ls-files', '--', rel]) !== ''
+const isIgnored = (rel: string): boolean => git(['check-ignore', '--no-index', '--', rel]) !== ''
+
+describe('Goal 82 — .vhk 증거 원장 추적 정책 가드', () => {
+  gitIt('증거 원장 2종이 git 추적된다 (레포 영속 — git rm --cached 회귀 탐지)', () => {
+    expect(isTracked('.vhk/ledger.jsonl')).toBe(true)
+    expect(isTracked('.vhk/events/ai-actions.jsonl')).toBe(true)
+  })
+
+  gitIt('증거 원장 2종은 어떤 .gitignore 로도 제외되지 않는다 (--no-index — gitignore 추가 회귀 탐지)', () => {
+    expect(isIgnored('.vhk/ledger.jsonl')).toBe(false)
+    expect(isIgnored('.vhk/events/ai-actions.jsonl')).toBe(false)
+  })
+
+  gitIt('양성 대조: 가드가 실제로 작동함을 증명(거짓 통과 방지)', () => {
+    // .vhk/memory.json 은 root .gitignore 로 제외됨(로컬 전용) → isIgnored 가 반드시 잡아야 함.
+    expect(isIgnored('.vhk/memory.json')).toBe(true)
+    // 존재하지 않는 경로는 추적되지 않음 → isTracked 가 false 를 반환해야 함.
+    expect(isTracked('.vhk/__definitely_absent__.xyz')).toBe(false)
+  })
+
+  it('.vhk/README 트래킹 정책표가 두 증거 원장을 추적(✅)으로 명문화', () => {
+    // 한 행에 두 파일이 함께 ✅ 로 기재됨(spec 1.1).
+    expect(README).toMatch(/ai-actions\.jsonl.*ledger\.jsonl|ledger\.jsonl.*ai-actions\.jsonl/)
+    expect(README).toMatch(/레포 영속|✅/)
+  })
+})


### PR DESCRIPTION
## Goal 82 — .vhk 증거 원장 추적 정합 (P2, RFC 0053 §4 D6)

**한 줄:** `.vhk/ledger.jsonl` 을 git 추적시켜 `??` 노이즈를 해소 — spec 1.1·Goal 45 와 일치. (카드의 "gitignore 추가"는 정책과 정반대였음.)

### 선조사 → 범위 재조정 (goal 79/81 선례 "확실한 것만")
- 카드 premise("ledger.jsonl gitignore 추가")가 **정책과 정반대**. `.vhk/README` spec 1.1 트래킹 정책이 이미 `ledger.jsonl`·`events/ai-actions.jsonl` 둘 다 **✅ 추적("레포 영속", Goal 45/55)** 으로 결정.
- 실측: `ai-actions.jsonl` 추적 정합. `ledger.jsonl` 만 untracked(한 번도 `git add` 안 됨). `git check-ignore .vhk/ledger.jsonl` = 비어 있음(어떤 .gitignore 도 제외 안 함).
- gitignore 하면 Goal 45 증거 영속이 깨짐(Forbidden "증거 원장 무결성 훼손 0" 위반) → **추적이 정답**.

### 무엇
- `.vhk/ledger.jsonl` git 추적(1줄 PASS 증거 보존 — 재작성 안 함).
- `.vhk/README`: 증거 원장은 **증거 이벤트(verify·가드 mutate)에만 append** → 일반(read-only) 명령은 git status 안 더럽힘. verify 후 ` M ledger.jsonl` 은 노이즈가 아니라 그 작업의 증거.
- 정책 가드(**vitest = CI 집행 경로**): `git ls-files`(추적) + `git check-ignore --no-index`(비제외) + 양성 대조. `check-goal-82.mjs` 동형.

### 적대 리뷰(12-에이전트, 3렌즈+반증) 반영
- 재조정(추적 vs gitignore) **타당 확정**. confirmed 5건 = 전부 가드 견고성:
  - **major**: `git check-ignore` 는 이미 추적된 파일엔 ignore 패턴 안 잡음(데드 가드) → `--no-index` 로 수정(추적 무관 패턴 평가 = "gitignore 추가" 회귀 탐지).
  - 가드를 CI 미연결 check-goal-82 → **CI 집행 vitest 로 이전**(실제 추적/제외 git 권위 판정).
  - **양성 대조** 추가(실제 ignore 경로 검출 단언 — 거짓 green 방지).
  - 카드에 verify-dirty trade-off 명시.

### 제약 준수 (Forbidden)
- `ai-actions.jsonl` 미변경(`git rm --cached` 금지) · ledger 내용 보존(무결성) · 테스트 1776 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * 증거 원장 추적 정책을 명확히 문서화했습니다.

* **테스트**
  * 증거 원장 추적 상태를 지속적으로 검증하는 회귀 테스트를 추가했습니다.

* **잡무**
  * 증거 원장 추적 정합성 검증 게이트를 추가했습니다.
  * 목표 진행 상황을 업데이트했습니다(완료: 78개).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->