### PR TITLE
feat(goal-83): secure 테스트 픽스처 false positive — MEDIUM→INFO 강등

### DIFF
--- a/docs/log/2026-06-22-goal-83-secure-fixture-allowlist.md
+++ b/docs/log/2026-06-22-goal-83-secure-fixture-allowlist.md
@@ -1,0 +1,35 @@
+# 2026-06-22 — Goal 83: 보안 scan 테스트 픽스처 false positive (MEDIUM→INFO 강등)
+
+> append-only. 추가만, 수정·삭제 금지.
+
+## 한 일
+- **Goal 83 DONE** — `vhk secure` 가 테스트 픽스처(가짜 토큰)의 MEDIUM 발견을 **INFO 로 강등**해 false positive 노이즈 제거(RFC 0053 §4 D7). 비개발자가 "유출됐나?" 놀라던 거짓 경보 해소.
+
+## 변경 (산출물 포인터)
+- `src/lib/secret-patterns.ts` — `SecretSeverity` 에 `'info'` 추가(컨텍스트 강등 신호).
+- `src/lib/scan-secrets.ts`
+  - `isTestFixturePath(file)` — tests?/·__tests__·__mocks__·fixtures?/·__fixtures__·*.test.*·*.spec.* 식별(Windows 역슬래시 정규화, 'latest' 부분문자열 오탐 방지 경계).
+  - `downgradeTestFixtureFindings(findings)` — 순수함수. 픽스처 경로 + `medium` 만 → `info`. critical/high 위치 무관 유지(약화 금지). **제거가 아닌 강등**(INFO 로 노출 = 신호 보존).
+- `src/commands/secure.ts` — 강등 적용 + INFO 그룹 렌더("테스트 픽스처/예시 토큰 — 유출 아님") + 요약 INFO 카운트.
+- `tests/scan-secrets.test.ts` — Goal 83 6케이스(경로식별/MEDIUM→info/소스 MEDIUM 유지/CRITICAL 유지/제거안함/filterSevere 불변).
+- `scripts/check-goal-83.mjs` · `goals/83` DONE · `goals/README.md` 재생성.
+
+## 검증
+- `vhk secure` 라이브: 원래 false positive(`tests/property-parsers.test.ts:31 JWT`)가 `· INFO — 1건 (테스트 픽스처 — 유출 아님)`, CRITICAL/HIGH/MEDIUM 0.
+- `pnpm build` OK · 전체 **1782 pass**(신규 6) · check-goal-83 고유검증 13 ✓.
+- **게이팅 불변 확인**: verify·save·mcp 는 `filterSevereFindings`(critical/high)만 사용 → medium/info 무시. preflight·check 는 자체 severity 타입(무관). 즉 `info` 추가가 exit/차단 로직에 영향 0.
+
+## 교훈
+- **false positive 강등은 "제거" 아니라 "INFO 노출"**: 숨기면(allowlist 제거) 진짜 유출을 가릴 위험(Forbidden). INFO 로 라벨링해 노출하면 신호는 보존하되 경보는 끈다 — 비개발자에게 "유출 아님"을 분명히.
+- **컨텍스트 강등은 medium 한정**: critical/high(AWS·private key·gh token)는 픽스처여도 약화 안 함 — 그런 포맷은 테스트에도 두면 안 되니까. 강등 범위를 medium 으로 좁혀 Forbidden(약화 0) 충족.
+- **새 enum 값 추가 전 게이팅 소비처 전수 확인**: `filterSevereFindings`(critical/high)가 단일 게이팅 통로라 `info` 추가가 안전했음 — 추가 전 grep 으로 medium 을 직접 보는 소비처 0 확인.
+
+## 적대 리뷰 반영 (10-에이전트, 3렌즈+반증, 에이전트 read-only 명시)
+- **보안 약화 0**(security 렌즈 findings 전부 반증 기각 — 강등 medium 한정·게이팅(filterSevereFindings) 무관·강등=제거 아님). confirmed 3 = 문서 2 + UX 1.
+- **minor(핵심 UX) 반영**: 전부 INFO여도 요약 "총 N건 감지"가 빨강 + "유출 키 즉시 폐기" 조치안내가 떠 카드가 없애려던 *놀람*이 잔존 → 진짜 신호(critical/high/medium) 0이고 info만이면 **회색 총계 + "✅ 실제 유출 신호 없음 — INFO는 테스트 픽스처" + 조치안내 생략**. 라이브 확인됨.
+- **nit 반영**: JSDoc "JWT·generic 등" 오기(generic-api-key 는 high라 강등 안 됨) → "현재 medium 패턴은 JWT 단 하나" 정정. + 카드에 픽스처 실범위(fixtures/·__mocks__가 tests/**보다 넓음, 의도적) 명시.
+- 결과: 전체 1782 pass · check-goal-83 ✓ · `vhk secure` 픽스처 결과가 회색·안심 톤.
+- 운영 노트: 이번 리뷰 워크플로는 에이전트에 **READ-ONLY 명시**(git/vhk save 금지) — goal 82 때 리뷰 에이전트가 `vhk save` 정크 커밋 만든 사고 재발 방지.
+
+## 다음
+- P2 마지막: goal 84(doctor/status next-step 맥락 인지 — 신규 vs 기존 레포 분기).

--- a/goals/83-secure-fixture-allowlist.md
+++ b/goals/83-secure-fixture-allowlist.md
@@ -3,7 +3,7 @@ vhk_format: 1
 type: goal
 id: 83
 title: 보안 scan 테스트 픽스처 false positive allowlist — P2
-status: NOT_STARTED
+status: DONE
 priority: P2
 created: 2026-06-20
 leads_to: secure scan 노이즈 ↓ (진짜 시크릿 신호 보존)
@@ -25,12 +25,18 @@ leads_to: secure scan 노이즈 ↓ (진짜 시크릿 신호 보존)
 - 알려진 테스트 픽스처는 경보에서 빠지거나 INFO로 강등되고, 실제 시크릿(소스/.env)은 여전히 잡힌다.
 
 ## Completion Check (작은 단위)
-- [ ] `tests/**` 내 알려진 가짜 토큰/픽스처 패턴 식별(property-parsers 등)
-- [ ] allowlist 메커니즘 or `tests/` 픽스처 컨텍스트 MEDIUM→INFO 강등 구현
-- [ ] CRITICAL/HIGH는 위치 무관 유지 — 회귀 테스트로 보장
-- [ ] 진짜 시크릿(소스/.env mock) 여전히 탐지 단언 테스트
-- [ ] check-goal-83.mjs
-- [ ] 공통 게이트 통과, 회귀 0
+- [x] `tests/**` 픽스처 컨텍스트 식별 — `isTestFixturePath`(tests?/·__tests__·__mocks__·fixtures?/·*.test.*·*.spec.*, Windows 정규화, 'latest' 부분문자열 오탐 방지)
+- [x] 컨텍스트 기반 MEDIUM→INFO 강등 — `downgradeTestFixtureFindings`(순수함수, 제거 아님=신호 보존) + secure.ts INFO 그룹("유출 아님")
+- [x] CRITICAL/HIGH는 위치 무관 유지 — 강등 조건 medium 한정 + 회귀 테스트(tests/** AWS=critical 유지)
+- [x] 진짜 시크릿(소스 .ts MEDIUM·src AWS) 여전히 탐지/유지 단언 테스트
+- [x] check-goal-83.mjs
+- [x] 공통 게이트 통과, 회귀 0 (게이팅 소비처 verify·save·mcp 는 filterSevereFindings=critical/high 만 → info 영향 0)
+
+## 구현 노트 (선조사)
+- 카드 premise 정확(재조정 불필요). secure.ts 는 이미 MEDIUM 을 exit 1 안 시킴(ℹ 정보성) — 문제는 *표시 문구*가 "MEDIUM 1건"으로 떠 비개발자가 "유출?" 놀람.
+- **픽스처 실범위(카드 문구 "tests/**"보다 넓음, 의도적):** `isTestFixturePath` 는 `tests?/`·`__tests__`·`__mocks__`·`fixtures?/`·`__fixtures__` 디렉터리 + `*.test.*`·`*.spec.*` 파일 모두 픽스처로 본다(가짜 토큰이 정상적으로 들어가는 관례 경로). 경계는 보수적 — `latest.ts`·`contest/`·`tests-data/` 는 미매칭. 강등은 medium 한정이라 이 경로들의 critical/high 는 그대로 잡힌다.
+- `info` severity 추가가 안전한 이유: 게이팅 소비처(verify:206·save:64·mcp:127)가 전부 `filterSevereFindings`(critical/high)만 사용 → medium/info 무시. preflight·check 는 자체 severity 타입(무관).
+- 라이브: `vhk secure` → 원래 false positive(property-parsers.test.ts:31 JWT)가 `INFO — 1건 (테스트 픽스처 — 유출 아님)`, CRITICAL/HIGH/MEDIUM 0.
 
 ## Forbidden Actions (OUT)
 - CRITICAL/HIGH 탐지 약화 0

--- a/goals/README.md
+++ b/goals/README.md
@@ -2,7 +2,7 @@
 
 # goals/ 인덱스
 
-> 총 84 goal — DONE 78 · IN_PROGRESS 2 · NOT_STARTED 4
+> 총 84 goal — DONE 79 · IN_PROGRESS 2 · NOT_STARTED 3
 > 공통 게이트 = [_meta.md](_meta.md) · 카드 형식/상태 의미는 각 파일 frontmatter 참조.
 
 | # | 제목 | 상태 | 우선순위 | 다음 연결 |
@@ -89,5 +89,5 @@
 | 80 | 증거 신선도 review 연결 — SHA≠HEAD 시 강등 — P1 | ✅ DONE | P1 | 낡은 PASS 증거로 거짓완료 차단(기록→소비 완결) |
 | 81 | 제품 설명 단일 SoT — package.json.description 주입 — P1 | ✅ DONE | P1 | 제품 설명 드리프트 0 (G54 버전 SoT의 설명판 보완) |
 | 82 | .vhk 런타임 산출물 gitignore 정합 — git status 청결 — P2 | ✅ DONE | P2 | vhk 명령 사용 후 git status 노이즈 0 |
-| 83 | 보안 scan 테스트 픽스처 false positive allowlist — P2 | ⬜ NOT_STARTED | P2 | secure scan 노이즈 ↓ (진짜 시크릿 신호 보존) |
+| 83 | 보안 scan 테스트 픽스처 false positive allowlist — P2 | ✅ DONE | P2 | secure scan 노이즈 ↓ (진짜 시크릿 신호 보존) |
 | 84 | doctor/status next-step 맥락 인지 — 신규 vs 기존 레포 분기 — P2 | ⬜ NOT_STARTED | P2 | "다음에 이것만 하세요"가 현재 상태에 맞음 |

--- a/scripts/check-goal-83.mjs
+++ b/scripts/check-goal-83.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// scripts/check-goal-83.mjs — goal 83: 보안 scan 테스트 픽스처 false positive (tests/** MEDIUM→INFO 강등).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역.
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 83 gate.')
+  process.exit(1)
+}
+
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 83] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 83 고유 검증 ───────────────────────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+const pat = read('src/lib/secret-patterns.ts') ?? ''
+must(/SecretSeverity = 'critical' \| 'high' \| 'medium' \| 'info'/.test(pat), "SecretSeverity 에 'info' 추가(강등 대상)")
+
+const scan = read('src/lib/scan-secrets.ts') ?? ''
+must(/export function isTestFixturePath/.test(scan), 'isTestFixturePath() export(픽스처 경로 식별)')
+must(/export function downgradeTestFixtureFindings/.test(scan), 'downgradeTestFixtureFindings() export(MEDIUM→INFO 강등)')
+// 강등은 medium 한정 — critical/high 약화 금지(Forbidden).
+must(/f\.severity === 'medium' && isTestFixturePath/.test(scan), '강등 조건 = medium + 픽스처 경로만(critical/high 위치무관 유지)')
+must(/filterSevereFindings[\s\S]*'critical' \|\| f\.severity === 'high'/.test(scan), 'filterSevereFindings 불변(critical/high — 게이팅 영향 0)')
+
+const sec = read('src/commands/secure.ts') ?? ''
+must(/downgradeTestFixtureFindings\(scan\.findings\)/.test(sec), 'secure.ts 가 강등 적용')
+must(/severity === 'info'/.test(sec) && /테스트 픽스처/.test(sec), 'secure.ts INFO 그룹 렌더("테스트 픽스처 — 유출 아님")')
+
+const t = read('tests/scan-secrets.test.ts') ?? ''
+must(/Goal 83 — 테스트 픽스처 false positive 강등/.test(t), '회귀 테스트 describe(Goal 83)')
+must(/severity\)\.toBe\('info'\)/.test(t), '테스트: tests/** MEDIUM → info')
+must(/aws-access-key'\)\?\.severity\)\.toBe\('critical'\)/.test(t), '테스트: tests/** CRITICAL 유지(약화 금지)')
+
+const goal = read('goals/83-secure-fixture-allowlist.md') ?? ''
+must(/status:\s*DONE/.test(goal), 'goals/83 status DONE')
+
+if (pass) { console.log('✅ goal 83 gate passes'); process.exit(0) }
+console.log('❌ goal 83 gate failed'); process.exit(1)

--- a/src/commands/secure.ts
+++ b/src/commands/secure.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import {
   scanProjectForSecrets,
+  downgradeTestFixtureFindings,
   MAX_SECRET_FINDINGS,
 } from '../lib/scan-secrets.js'
 import { MAX_SCAN_FILE_BYTES } from '../lib/scan-files.js'
@@ -31,7 +32,10 @@ export async function secure() {
   console.log(chalk.dim(`  ${ko.secure.scanning}\n`))
 
   // 두 스캔 모두 실행 후 각 섹션 출력 (early return 제거 → LLM 스캔 항상 실행)
-  const { findings, scannedFiles, truncated, truncationReasons } = scanProjectForSecrets(cwd)
+  const scan = scanProjectForSecrets(cwd)
+  const { scannedFiles, truncated, truncationReasons } = scan
+  // Goal 83: 테스트 픽스처(가짜 토큰)의 MEDIUM 을 INFO 로 강등 — false positive 노이즈↓(critical/high 불변).
+  const findings = downgradeTestFixtureFindings(scan.findings)
   const llmScan = scanLlmGuardrails(cwd)
 
   // --- 시크릿 스캔 결과 ---
@@ -60,6 +64,7 @@ export async function secure() {
     const critical = findings.filter(f => f.severity === 'critical')
     const high = findings.filter(f => f.severity === 'high')
     const medium = findings.filter(f => f.severity === 'medium')
+    const info = findings.filter(f => f.severity === 'info') // Goal 83: 테스트 픽스처 강등분
 
     if (critical.length > 0) {
       console.log(chalk.red.bold(`  🚨 CRITICAL — ${critical.length}건`))
@@ -88,13 +93,32 @@ export async function secure() {
       console.log('')
     }
 
+    // Goal 83: 테스트 픽스처(가짜 토큰)로 강등된 INFO — 표시는 하되 "유출 아님"을 분명히(false positive 안심).
+    if (info.length > 0) {
+      console.log(chalk.gray.bold(`  · INFO — ${info.length}건 (테스트 픽스처/예시 토큰 — 유출 아님)`))
+      info.forEach(f => {
+        console.log(chalk.gray(`    · ${f.patternName} (테스트 픽스처)`))
+        console.log(chalk.dim(`      ${f.file}:${f.line} → ${f.match}`))
+      })
+      console.log('')
+    }
+
+    // Goal 83: 진짜 신호(강등 안 된 critical/high/medium) 개수. 전부 INFO(픽스처)면 빨간 총계·유출 조치
+    //          안내를 띄우지 않는다 — 카드가 없애려던 "유출됐나?" 놀람이 색·문구로 잔존하던 것 제거.
+    const realCount = critical.length + high.length + medium.length
+    const totalColor = realCount > 0 ? chalk.red : chalk.gray
     console.log(chalk.bold(`  ${ko.secure.summary}`))
-    console.log(`  총 ${chalk.red(String(findings.length))}건 감지 | CRITICAL: ${critical.length} | HIGH: ${high.length} | MEDIUM: ${medium.length}`)
+    console.log(`  총 ${totalColor(String(findings.length))}건 감지 | CRITICAL: ${critical.length} | HIGH: ${high.length} | MEDIUM: ${medium.length} | INFO: ${info.length}`)
     console.log('')
-    console.log(chalk.dim('  💡 조치 방법:'))
-    console.log(chalk.dim('    1. 해당 파일에서 시크릿을 제거하고 환경변수로 이동'))
-    console.log(chalk.dim('    2. git history에서도 제거: git filter-branch 또는 BFG Repo-Cleaner'))
-    console.log(chalk.dim('    3. 유출된 키는 즉시 폐기하고 재발급\n'))
+    if (realCount > 0) {
+      console.log(chalk.dim('  💡 조치 방법:'))
+      console.log(chalk.dim('    1. 해당 파일에서 시크릿을 제거하고 환경변수로 이동'))
+      console.log(chalk.dim('    2. git history에서도 제거: git filter-branch 또는 BFG Repo-Cleaner'))
+      console.log(chalk.dim('    3. 유출된 키는 즉시 폐기하고 재발급\n'))
+    } else {
+      // info 만 — 실제 유출 신호 없음(테스트 픽스처). 조치 불필요.
+      console.log(chalk.green('  ✅ 실제 유출 신호 없음 — 위 INFO 는 테스트 픽스처(가짜 토큰)입니다.\n'))
+    }
 
     if (critical.length > 0 || high.length > 0) {
       process.exitCode = 1

--- a/src/lib/scan-secrets.ts
+++ b/src/lib/scan-secrets.ts
@@ -122,3 +122,26 @@ export function scanProjectForSecrets(cwd: string): ProjectSecretScan {
 export function filterSevereFindings(findings: SecretFinding[]): SecretFinding[] {
   return findings.filter(f => f.severity === 'critical' || f.severity === 'high')
 }
+
+// Goal 83: 테스트 픽스처/예시 토큰이 정상적으로 들어가는 경로(가짜 토큰 = 유출 아님).
+//   tests/·test/·__tests__/·__mocks__/·fixtures?/·__fixtures__/ 디렉터리 또는 *.test.*·*.spec.* 파일.
+//   보수적으로 좁힌다 — 'latest.ts' 처럼 'test' 부분문자열만 있는 경로는 제외(경계 필수).
+const TEST_FIXTURE_PATH =
+  /(?:^|\/)(?:tests?|__tests__|__mocks__|fixtures?|__fixtures__)\/|\.(?:test|spec)\.[cm]?[jt]sx?$/i
+
+/** 경로가 테스트 픽스처 컨텍스트인가(Windows 역슬래시 정규화). */
+export function isTestFixturePath(file: string): boolean {
+  return TEST_FIXTURE_PATH.test(file.replace(/\\/g, '/'))
+}
+
+/**
+ * Goal 83: 테스트 픽스처(가짜 토큰)의 MEDIUM 발견을 INFO 로 강등 — secure 리포트 false positive 노이즈↓.
+ *   - 픽스처 경로 + severity 'medium' 만 강등(현재 medium 패턴은 JWT 단 하나 — generic-api-key 등은 high 라 미강등).
+ *   - CRITICAL/HIGH 는 위치 무관 유지(약화 금지 — 실제 자격증명 포맷은 픽스처여도 두면 안 됨, Forbidden).
+ *   - 강등은 제거가 아니다(INFO 로 여전히 노출) → 신호 보존, filterSevereFindings(critical/high)도 불변.
+ */
+export function downgradeTestFixtureFindings(findings: SecretFinding[]): SecretFinding[] {
+  return findings.map((f) =>
+    f.severity === 'medium' && isTestFixturePath(f.file) ? { ...f, severity: 'info' as const } : f
+  )
+}

--- a/src/lib/secret-patterns.ts
+++ b/src/lib/secret-patterns.ts
@@ -1,4 +1,5 @@
-export type SecretSeverity = 'critical' | 'high' | 'medium'
+// 'info': Goal 83 — 테스트 픽스처(가짜 토큰) 등 컨텍스트로 강등된 신호. 표시는 하되 경보 아님.
+export type SecretSeverity = 'critical' | 'high' | 'medium' | 'info'
 
 export interface SecretPattern {
   id: string

--- a/tests/scan-secrets.test.ts
+++ b/tests/scan-secrets.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { findSecretsInLine, scanProjectForSecrets, filterSevereFindings } from '../src/lib/scan-secrets.js'
+import {
+  findSecretsInLine,
+  scanProjectForSecrets,
+  filterSevereFindings,
+  downgradeTestFixtureFindings,
+  isTestFixturePath,
+} from '../src/lib/scan-secrets.js'
 import { MAX_SCAN_FILE_BYTES } from '../src/lib/scan-files.js'
 
 // fake AWS key — 자기 레포 secure 스캔에 걸리지 않게 조각 합성.
@@ -198,5 +204,65 @@ describe('scan-secrets', () => {
         fs.rmSync(d, { recursive: true, force: true })
       }
     })
+  })
+})
+
+// Goal 83: 테스트 픽스처(가짜 토큰) false positive — tests/** 의 MEDIUM 만 INFO 로 강등.
+//   critical/high 는 위치 무관 유지(Forbidden — 약화 금지). 강등은 제거가 아님(INFO 로 여전히 노출 = 신호 보존).
+describe('Goal 83 — 테스트 픽스처 false positive 강등', () => {
+  // split 합성 — 자기 레포 secure 스캔이 이 테스트 파일을 자기탐지하지 않도록(런타임엔 합쳐짐).
+  const FAKE_JWT = 'eyJ' + 'h'.repeat(8) + '.eyJ' + 's'.repeat(8) + '.' + 'x'.repeat(8)
+
+  it('isTestFixturePath: tests/·*.test.·*.spec.·fixtures/·__mocks__ 식별, 소스/.env 는 아님', () => {
+    expect(isTestFixturePath('tests/property-parsers.test.ts')).toBe(true)
+    expect(isTestFixturePath('src/foo.test.ts')).toBe(true)
+    expect(isTestFixturePath('src/bar.spec.tsx')).toBe(true)
+    expect(isTestFixturePath('src/__mocks__/x.ts')).toBe(true)
+    expect(isTestFixturePath('test/fixtures/token.json')).toBe(true)
+    expect(isTestFixturePath('app/__fixtures__/a.ts')).toBe(true)
+    // Windows 역슬래시도 정규화.
+    expect(isTestFixturePath('tests\\a.test.ts')).toBe(true)
+    expect(isTestFixturePath('src/commands/secure.ts')).toBe(false)
+    expect(isTestFixturePath('.env')).toBe(false)
+    expect(isTestFixturePath('src/lib/latest.ts')).toBe(false) // 'test' 부분문자열 오탐 방지
+  })
+
+  it('tests/** 의 MEDIUM(JWT 픽스처) → INFO 강등', () => {
+    const findings = findSecretsInLine(`const t = "${FAKE_JWT}"`, 'tests/property-parsers.test.ts', 31)
+    const jwt = findings.filter((f) => f.patternId === 'jwt')
+    expect(jwt).toHaveLength(1)
+    expect(jwt[0].severity).toBe('medium') // 원시 탐지는 medium
+    const downgraded = downgradeTestFixtureFindings(findings)
+    expect(downgraded.find((f) => f.patternId === 'jwt')?.severity).toBe('info')
+  })
+
+  it('소스(.ts)의 MEDIUM 은 강등 안 됨(유지)', () => {
+    const findings = findSecretsInLine(`const t = "${FAKE_JWT}"`, 'src/auth.ts', 10)
+    const downgraded = downgradeTestFixtureFindings(findings)
+    expect(downgraded.find((f) => f.patternId === 'jwt')?.severity).toBe('medium')
+  })
+
+  it('tests/** 의 CRITICAL 은 위치 무관 유지(약화 금지 — Forbidden)', () => {
+    const realAws = 'AKIA' + '1234567890ABCDEF'
+    const findings = findSecretsInLine(`const k = "${realAws}"`, 'tests/leak.test.ts', 5)
+    const downgraded = downgradeTestFixtureFindings(findings)
+    expect(downgraded.find((f) => f.patternId === 'aws-access-key')?.severity).toBe('critical')
+  })
+
+  it('강등은 finding 을 제거하지 않음(INFO 로 여전히 노출 — 신호 보존, 숨김 0)', () => {
+    const findings = findSecretsInLine(`const t = "${FAKE_JWT}"`, 'tests/x.test.ts', 1)
+    const downgraded = downgradeTestFixtureFindings(findings)
+    expect(downgraded).toHaveLength(findings.length)
+  })
+
+  it('filterSevereFindings 는 강등 후에도 critical/high 만(info 미포함 — 게이팅 불변)', () => {
+    const realAws = 'AKIA' + '1234567890ABCDEF'
+    const findings = [
+      ...findSecretsInLine(`const t = "${FAKE_JWT}"`, 'tests/x.test.ts', 1),
+      ...findSecretsInLine(`const k = "${realAws}"`, 'src/real.ts', 2),
+    ]
+    const severe = filterSevereFindings(downgradeTestFixtureFindings(findings))
+    expect(severe.every((f) => f.severity === 'critical' || f.severity === 'high')).toBe(true)
+    expect(severe.some((f) => f.patternId === 'aws-access-key')).toBe(true)
   })
 })


### PR DESCRIPTION
## Goal 83 — secure 테스트 픽스처 false positive (P2, RFC 0053 §4 D7)

**한 줄:** `vhk secure` 가 테스트 픽스처(가짜 토큰)의 MEDIUM 발견을 **INFO 로 강등** — 비개발자가 "유출됐나?" 놀라던 거짓 경보 제거, 진짜 시크릿 신호는 보존.

### 근거
- `vhk secure` → `MEDIUM — 1건: JWT Token · tests/property-parsers.test.ts:31` = 테스트 픽스처(가짜)인데 경보처럼 떠 거짓 놀람 → 신호 신뢰 저하.

### 무엇
- `SecretSeverity` 에 `'info'` 추가.
- `isTestFixturePath` — `tests?/`·`__tests__`·`__mocks__`·`fixtures?/`·`__fixtures__`·`*.test.*`·`*.spec.*` 식별(Windows 정규화, `latest` 부분문자열 오탐 방지 경계).
- `downgradeTestFixtureFindings`(순수함수) — 픽스처 경로 + `medium` 만 → `info`. **제거가 아닌 강등**(INFO 로 여전히 노출 = 신호 보존). CRITICAL/HIGH 위치 무관 유지(약화 금지).
- `secure.ts` — 강등 적용 + INFO 그룹("테스트 픽스처 — 유출 아님"). 전부 INFO 면 **회색 총계 + "✅ 실제 유출 신호 없음" + 조치안내 생략**.

### 제약 준수 (Forbidden)
- **게이팅 불변**: verify·save·mcp 는 `filterSevereFindings`(critical/high)만 사용 → `info` 추가가 exit/차단 로직에 영향 **0**.
- CRITICAL/HIGH 약화 0(강등 medium 한정) · 실 시크릿 false negative 0(소스 .ts·src AWS 여전히 탐지) · 광범위 allowlist 아님(경계 보수적).

### 검증
- `vhk secure` 라이브: 원래 false positive(`property-parsers.test.ts:31 JWT`) → `· INFO — 1건 (테스트 픽스처 — 유출 아님)`, CRITICAL/HIGH/MEDIUM 0, 회색 총계.
- 테스트 **1782 pass**(신규 6) · `check-goal-83.mjs` 13 ✓.
- **적대 리뷰**(10-에이전트, 3렌즈+반증, 에이전트 read-only 명시): **보안 약화 0**, confirmed 3(문서 2 + UX 1) 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 보안 스캔이 테스트 코드의 테스트 픽스처(예시 토큰)를 감지하여 자동으로 낮은 우선순위로 분류합니다.
  * 실제 보안 위협(CRITICAL/HIGH)과 테스트용 데이터를 명확히 구분한 결과 보고입니다.

* **Bug Fixes**
  * 테스트 경로의 거짓 양성 알림 감소로 더 정확한 보안 스캔 결과 제공입니다.

* **Tests**
  * 테스트 픽스처 우선순위 조정 기능에 대한 테스트 추가입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->