### PR TITLE
feat(goal-84): doctor/status next-step 맥락 인지 — 신규 vs 기존 레포 분기

### DIFF
--- a/docs/log/2026-06-22-goal-84-contextual-next-step.md
+++ b/docs/log/2026-06-22-goal-84-contextual-next-step.md
@@ -1,0 +1,37 @@
+# 2026-06-22 — Goal 84: doctor/status next-step 맥락 인지 (신규 vs 기존 레포 분기)
+
+> append-only. 추가만, 수정·삭제 금지.
+
+## 한 일
+- **Goal 84 DONE** — `vhk doctor`/`status` 의 "다음에 이것만 하세요"가 레포 성숙도(신규 vs 기존)를 보고 맥락에 맞게 분기(RFC 0053 §4 D9). 396커밋 활성 레포에서도 "이제 프로젝트를 시작하세요" 온보딩이 뜨던 거짓 안내 해소.
+
+## 선조사 (카드 부분 정정)
+- 진짜 D9 = **doctor**: `ko.doctor.nextOkMessage`="이제 프로젝트를 시작하세요" + `vhk 시작` 이 활성 레포에도 노출.
+- **status 는 과장**: clean 시 이미 `vhk goal next`("다음 미션") — 온보딩 아님. 단 신규(초기) 레포엔 `vhk goal next`(goal 없음)보다 온보딩이 나아 그 케이스만 보강.
+
+## 변경 (산출물 포인터)
+- `src/lib/project-maturity.ts` (신규) — `classifyMaturity`(순수: .vhk/context 존재 OR 커밋수≥`ESTABLISHED_COMMIT_THRESHOLD`=5 → established) + `gatherMaturitySignals`(IO, gitOut 재사용) + `projectMaturity`(래퍼).
+- `src/commands/doctor.ts` — `selectDoctorOkNextStep(maturity)`(순수 분기). established → `vhk work`("이어서 작업"), new → `vhk 시작`(온보딩 유지). all-OK 분기가 `projectMaturity(cwd)` 로 선택.
+- `src/commands/status.ts` — `selectStatusNextStep(hasChanges, maturity='established')`. clean+new → `vhk 시작`. 호출부가 `projectMaturity(gitRoot)` 전달. (기본값 established = 하위호환).
+- `src/i18n/ko.ts` — `status.nextNewRepoMessage`·`nextNewRepoCursor`(신규 레포 온보딩).
+- `tests/project-maturity.test.ts` — 분류 3 + doctor 2 + status 4(established/new/diff/하위호환 9케이스).
+- `scripts/check-goal-84.mjs` · `goals/84` DONE · `goals/README.md` 재생성.
+
+## 검증
+- 라이브: 이 레포(396+커밋) `vhk doctor` → "환경 점검 통과 — 이어서 작업하세요 / vhk work"(구 "프로젝트를 시작하세요" 제거).
+- `pnpm build` OK · 전체 **1791 pass**(신규 9) · check-goal-84 고유검증 16 ✓.
+- 진단 항목 자체 변경 0(next-step 분기만 — Forbidden) · 신규 레포 온보딩 보존(퇴행 0).
+
+## 교훈
+- **맥락 판정은 순수함수로 분리**: `classifyMaturity`(신호→분류)를 IO(`gatherMaturitySignals`)에서 떼니 신규/기존/경계를 git 없이 단위 테스트로 고정 가능. 출력 선택도 `selectDoctorOkNextStep`/`selectStatusNextStep` 순수화 → 분기 회귀를 콘솔 캡처 없이 단언.
+- **게이트 스크립트 regex 는 주석 단어에 오탐**: `!/execSync/` 가 "신규 execSync 없음" 주석을 호출로 오인 → `execSync\(`(실제 호출)로 좁힘. 문자열 매칭 게이트는 단어 경계·구두점까지 봐야.
+- **카드 premise 검증**: status 가 D9 라던 카드는 과장(실제 `goal next`) — 선조사로 doctor 핵심·status 보강으로 정확히 범위 잡음(goal 81/82/83 선례 일관).
+
+## 적대 리뷰 반영 (12-에이전트, 3렌즈+반증, 에이전트 read-only 명시)
+- D9 핵심(396커밋 온보딩) 견고 확인 — 임계=5·parseInt 엣지·Forbidden 전부 반증 통과. confirmed 2 = 일관성.
+- **minor 반영(앵커 통일)**: doctor=`projectMaturity(cwd)`, status=`projectMaturity(gitRoot)` 였음 → 서브디렉터리(루트 context.md + 커밋<5)에서 두 명령이 신규/기존 다르게 판정. **status 도 cwd 로 통일**(context.md 가 cwd 기준 기록 + status.ts 의 기존 주석도 cwd 권장). commitCount 는 git 이 루트 해석이라 무관.
+- **nit 반영(i18n)**: doctor established 멘트가 하드코딩(status 는 t() 사용)이라 헌법 "ko.ts 메시지 필수"와 어긋남 → `ko.doctor.nextEstablishedMessage`·`nextEstablishedCursor` 키로 추출.
+- 결과: 전체 1791 pass · check-goal-84 16 ✓ · `vhk doctor` 라이브 동일("이어서 작업하세요 / vhk work").
+
+## 다음
+- P2 도그푸딩(goal 82~84) 완료. 남은 미완: goal 62(docs-diff)·65(precommit-l2)·73(check --evals). 우선순위 2 measure-first(recall@5 라벨링·diff-cover 누적) 대기. 우선순위 1 publish v2.6.0(사용자 2FA).

--- a/goals/84-contextual-next-step.md
+++ b/goals/84-contextual-next-step.md
@@ -3,7 +3,7 @@ vhk_format: 1
 type: goal
 id: 84
 title: doctor/status next-step 맥락 인지 — 신규 vs 기존 레포 분기 — P2
-status: NOT_STARTED
+status: DONE
 priority: P2
 created: 2026-06-20
 leads_to: "다음에 이것만 하세요"가 현재 상태에 맞음
@@ -25,14 +25,19 @@ leads_to: "다음에 이것만 하세요"가 현재 상태에 맞음
 - 활성 레포에서 "프로젝트를 시작하세요" 멘트가 안 나온다. 신규(빈/초기) 레포에선 기존 온보딩 멘트 유지(퇴행 0).
 
 ## Completion Check (작은 단위)
-- [ ] doctor/status가 커밋 수(또는 .vhk/context 존재)로 신규/기존 판정 헬퍼
-- [ ] 기존 레포 분기: 변경 유무에 따른 맥락 next-step
-- [ ] 신규 레포 분기: 기존 온보딩 멘트 보존
-- [ ] printNextStep 패턴·이중 안내(터미널/Cursor) 유지
-- [ ] 회귀 테스트(신규/기존 각 분기 출력 단언)
-- [ ] COMMANDS.md·README 영향 시 갱신
-- [ ] check-goal-84.mjs
-- [ ] 공통 게이트 통과, 회귀 0
+- [x] 판정 헬퍼 — `src/lib/project-maturity.ts`: `classifyMaturity`(순수) + `gatherMaturitySignals`(.vhk/context 존재 OR 커밋수≥5) + `projectMaturity`(cwd 래퍼)
+- [x] 기존 레포 분기 — doctor all-OK: `vhk 시작` 대신 `vhk work`("이어서 작업"). status clean: 변경 있으면 diff / 없으면 goal next(established 유지)
+- [x] 신규 레포 분기 — doctor/status 모두 new → 기존 온보딩(`vhk 시작`) 보존(퇴행 0)
+- [x] printNextStep 패턴·이중 안내(터미널/Cursor) 유지(분기 함수가 같은 shape 반환)
+- [x] 회귀 테스트 `tests/project-maturity.test.ts` — 분류 3 + doctor 2 + status 4(established/new/diff/하위호환)
+- [x] COMMANDS.md·README — next-step 문구만 변경(사용법 불변)이라 갱신 불요
+- [x] check-goal-84.mjs
+- [x] 공통 게이트 통과, 회귀 0
+
+## 구현 노트 (선조사)
+- 카드 premise 대체로 정확. 단 **status 는 과장**: clean 시 이미 `vhk goal next`(established 적절) — `vhk 시작` 온보딩 아님. 진짜 D9 는 **doctor**(`ko.doctor.nextOkMessage`="이제 프로젝트를 시작하세요" + `vhk 시작`)가 396커밋 레포에도 떴던 것. doctor 가 핵심 수정, status 는 new-repo 케이스 보강(온보딩).
+- 판정 신호: `.vhk/context.md` 존재(vhk 사용 흔적) OR 커밋수≥5(`ESTABLISHED_COMMIT_THRESHOLD`). gitOut 재사용(신규 execSync 0).
+- 라이브: 이 레포(396+커밋)에서 `vhk doctor` → "환경 점검 통과 — 이어서 작업하세요 / vhk work".
 
 ## Forbidden Actions (OUT)
 - 신규 사용자 온보딩 경험 퇴행 0 (기존 멘트는 신규 레포에서 유지)

--- a/goals/README.md
+++ b/goals/README.md
@@ -2,7 +2,7 @@
 
 # goals/ 인덱스
 
-> 총 84 goal — DONE 79 · IN_PROGRESS 2 · NOT_STARTED 3
+> 총 84 goal — DONE 80 · IN_PROGRESS 2 · NOT_STARTED 2
 > 공통 게이트 = [_meta.md](_meta.md) · 카드 형식/상태 의미는 각 파일 frontmatter 참조.
 
 | # | 제목 | 상태 | 우선순위 | 다음 연결 |
@@ -90,4 +90,4 @@
 | 81 | 제품 설명 단일 SoT — package.json.description 주입 — P1 | ✅ DONE | P1 | 제품 설명 드리프트 0 (G54 버전 SoT의 설명판 보완) |
 | 82 | .vhk 런타임 산출물 gitignore 정합 — git status 청결 — P2 | ✅ DONE | P2 | vhk 명령 사용 후 git status 노이즈 0 |
 | 83 | 보안 scan 테스트 픽스처 false positive allowlist — P2 | ✅ DONE | P2 | secure scan 노이즈 ↓ (진짜 시크릿 신호 보존) |
-| 84 | doctor/status next-step 맥락 인지 — 신규 vs 기존 레포 분기 — P2 | ⬜ NOT_STARTED | P2 | "다음에 이것만 하세요"가 현재 상태에 맞음 |
+| 84 | doctor/status next-step 맥락 인지 — 신규 vs 기존 레포 분기 — P2 | ✅ DONE | P2 | "다음에 이것만 하세요"가 현재 상태에 맞음 |

--- a/scripts/check-goal-84.mjs
+++ b/scripts/check-goal-84.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// scripts/check-goal-84.mjs — goal 84: doctor/status next-step 맥락 인지 (신규 vs 기존 레포 분기).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역.
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 84 gate.')
+  process.exit(1)
+}
+
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 84] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 84 고유 검증 ───────────────────────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+const mat = read('src/lib/project-maturity.ts') ?? ''
+must(/export function classifyMaturity/.test(mat), 'classifyMaturity() 순수 분류 export')
+must(/export function gatherMaturitySignals/.test(mat), 'gatherMaturitySignals() 신호 수집(gitOut 재사용)')
+must(/export function projectMaturity/.test(mat), 'projectMaturity() 편의 래퍼 export')
+must(/contextExists/.test(mat) && /commitCount/.test(mat), '신호 = .vhk/context 존재 + 커밋 수')
+// 실제 호출(execSync(...)) 또는 child_process import 만 차단 — 주석의 단어는 무관.
+must(!/execSync\s*\(/.test(mat) && !/from 'node:child_process'/.test(mat), '신규 execSync 호출 미사용(gitOut 단일통로)')
+
+const doc = read('src/commands/doctor.ts') ?? ''
+must(/export function selectDoctorOkNextStep/.test(doc), 'doctor selectDoctorOkNextStep() 분기 함수')
+must(/selectDoctorOkNextStep\(projectMaturity\(cwd\)\)/.test(doc), 'doctor all-OK 분기가 maturity 로 next-step 선택')
+must(/maturity === 'established'[\s\S]*?command: 'vhk work'/.test(doc), 'established → vhk work(시작 아님, D9 해소)')
+must(/command: 'vhk 시작'/.test(doc), 'new → vhk 시작(온보딩 유지 — 퇴행 0)')
+
+const st = read('src/commands/status.ts') ?? ''
+must(/maturity: 'new' \| 'established' = 'established'/.test(st), 'selectStatusNextStep maturity 인자(기본 established — 하위호환)')
+must(/maturity === 'new'[\s\S]*?command: 'vhk 시작'/.test(st), 'status new → 온보딩(vhk 시작)')
+must(/selectStatusNextStep\(hasChanges, projectMaturity\(process\.cwd\(\)\)\)/.test(st), 'status 호출부가 maturity 전달(doctor 와 동일 cwd 앵커)')
+
+must(/nextNewRepoMessage/.test(read('src/i18n/ko.ts') ?? ''), 'ko.ts status.nextNewRepoMessage')
+must(existsSync('tests/project-maturity.test.ts'), '회귀 테스트 tests/project-maturity.test.ts')
+
+const goal = read('goals/84-contextual-next-step.md') ?? ''
+must(/status:\s*DONE/.test(goal), 'goals/84 status DONE')
+
+if (pass) { console.log('✅ goal 84 gate passes'); process.exit(0) }
+console.log('❌ goal 84 gate failed'); process.exit(1)

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { printNextStep } from '../lib/next-step.js'
 import { ko } from '../i18n/ko.js'
+import { projectMaturity } from '../lib/project-maturity.js'
 import { readJsonFile } from '../lib/read-json.js'
 import { safeExecFile } from '../lib/exec.js'
 import { checkRuleDrift, checkContextDrift } from '../lib/drift.js'
@@ -25,6 +26,30 @@ import type { DiagDeps, DoctorOptions, DiagFn } from '../doctor/types.js'
 // (doctor.test.ts 의 `from doctor.js` import 경로 보존) + 내부 사용.
 import { fetchLatestNpmVersion, compareSemver, recordLatest } from '../lib/version-check.js'
 export { fetchLatestNpmVersion, compareSemver }
+
+/**
+ * Goal 84: doctor 통과 시 next-step — 신규/기존 레포 맥락 분기(D9).
+ *   established: "이제 프로젝트를 시작하세요(vhk 시작)" 대신 이어서 작업(vhk work).
+ *   new: 기존 온보딩 멘트 유지(퇴행 0 — Forbidden). 진단 항목 자체는 불변.
+ */
+export function selectDoctorOkNextStep(maturity: 'new' | 'established'): {
+  message: string
+  command: string
+  cursorHint: string
+} {
+  if (maturity === 'established') {
+    return {
+      message: ko.doctor.nextEstablishedMessage,
+      command: 'vhk work',
+      cursorHint: ko.doctor.nextEstablishedCursor,
+    }
+  }
+  return {
+    message: ko.doctor.nextOkMessage,
+    command: 'vhk 시작',
+    cursorHint: '프로젝트 만들어줘',
+  }
+}
 
 export interface CheckResult {
   name: string
@@ -182,11 +207,8 @@ export async function doctor(opts: DoctorOptions = {}) {
     })
   } else {
     console.log(chalk.green.bold(`  ${ko.doctor.allOk}`))
-    printNextStep({
-      message: ko.doctor.nextOkMessage,
-      command: 'vhk 시작',
-      cursorHint: '프로젝트 만들어줘',
-    })
+    // Goal 84: 활성(기존) 레포면 "프로젝트를 시작하세요" 대신 맥락 맞는 다음 행동(D9).
+    printNextStep(selectDoctorOkNextStep(projectMaturity(cwd)))
   }
 
   // SoT(3층) CI 게이트: --strict 면 규칙 드리프트를 실패로 승격(exit 1). 기본 호출은 경고만 유지.

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -9,6 +9,7 @@ import { okOut, currentBranch, statusPorcelain, recentCommits } from '../lib/git
 import { readJsonFile } from '../lib/read-json.js'
 import { printNextStep, printContextResumeHint } from '../lib/next-step.js'
 import { t } from '../i18n/ko.js'
+import { projectMaturity } from '../lib/project-maturity.js'
 
 export interface FileChangeCounts {
   staged: number
@@ -102,13 +103,24 @@ export interface StatusNextStep {
  * status 다음 액션 — 변경사항이 있어도 곧장 `vhk save` 를 권하지 않는다(데이터 안전).
  * 먼저 `vhk diff`("뭐 바뀌었어")로 확인 → 저장은 그 다음(alternative)으로 안내. (배치3 §2)
  */
-export function selectStatusNextStep(hasChanges: boolean): StatusNextStep {
+export function selectStatusNextStep(
+  hasChanges: boolean,
+  maturity: 'new' | 'established' = 'established'
+): StatusNextStep {
   if (hasChanges) {
     return {
       message: t('status.nextWithChangesMessage'),
       command: 'vhk diff',
       cursorHint: t('status.nextWithChangesCursor'),
       alternative: t('status.nextWithChangesAlt'),
+    }
+  }
+  // Goal 84: 신규(초기) 레포는 온보딩, 기존(활성) 레포는 다음 미션(vhk goal next) — 맥락 분기.
+  if (maturity === 'new') {
+    return {
+      message: t('status.nextNewRepoMessage'),
+      command: 'vhk 시작',
+      cursorHint: t('status.nextNewRepoCursor'),
     }
   }
   return {
@@ -182,7 +194,9 @@ export async function status(): Promise<void> {
   }
 
   const hasChanges = counts.staged + counts.unstaged + counts.untracked > 0
-  printNextStep(selectStatusNextStep(hasChanges))
+  // Goal 84: maturity 앵커는 cwd — .vhk/context.md 가 cwd 기준으로 쓰이므로(doctor 와 동일 앵커로 통일,
+  //          gitRoot 사용 시 서브디렉터리에서 doctor 와 분류 불일치). commitCount 는 git 이 루트 해석.
+  printNextStep(selectStatusNextStep(hasChanges, projectMaturity(process.cwd())))
   // Goal 10: 세션 진입 명령에서 `vhk context` 발견성 노출 (복원/생성/갱신 안내).
   // context 는 cwd 기준 .vhk/context.md 에 쓰므로 cwd(인자 생략)로 점검 — gitRoot 와 앵커 불일치 방지.
   printContextResumeHint()

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -29,6 +29,9 @@ export const ko = {
     nextWithChangesAlt: '확인했으면 vhk save 로 저장하세요',
     nextCleanMessage: '클린 상태! 다음 미션으로 넘어가세요.',
     nextCleanCursor: '다음 목표 알려줘',
+    // Goal 84: 신규(초기) 레포 — 활성 레포의 "다음 미션" 대신 온보딩 안내.
+    nextNewRepoMessage: '환경 준비됐어요. 새 프로젝트를 시작해보세요.',
+    nextNewRepoCursor: '프로젝트 만들어줘',
   },
   save: {
     title: '저장하기',
@@ -220,6 +223,9 @@ export const ko = {
     projectFiles: '📁 프로젝트 파일 확인:',
     envNotIgnored: '⚠️ .env가 .gitignore에 없음! 추가하세요',
     nextOkMessage: '환경 점검 통과! 이제 프로젝트를 시작하세요.',
+    // Goal 84: 기존(활성) 레포 — 온보딩 대신 이어서 작업 안내(D9).
+    nextEstablishedMessage: '환경 점검 통과 — 이어서 작업하세요.',
+    nextEstablishedCursor: '이어서 작업할래',
     nextRetryMessage: '위 도구를 설치한 후 다시 점검하세요.',
     updateAvailable: (latest: string) =>
       `🆕 v${latest} 사용 가능 — npm i -g @byh3071/vhk`,

--- a/src/lib/project-maturity.ts
+++ b/src/lib/project-maturity.ts
@@ -1,0 +1,45 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { gitOut } from './git-repo.js'
+
+/**
+ * Goal 84: 레포가 "신규(온보딩 대상)" 인지 "기존(활성 작업 중)" 인지 판정 신호.
+ *   doctor/status next-step 이 396커밋 활성 레포에도 "이제 프로젝트를 시작하세요" 온보딩을 뱉던 D9 해소용.
+ */
+export interface MaturitySignals {
+  /** `.vhk/context.md` 존재 — vhk 를 이미 써온 흔적(맥락 파일 생성됨). */
+  contextExists: boolean
+  /** HEAD 까지 커밋 수. git 레포 아님/커밋 0 → 0. */
+  commitCount: number
+}
+
+/** 이 값 이상의 커밋이면 "기존(활성) 레포". 초기 1~몇 커밋의 신규 레포와 구분. */
+export const ESTABLISHED_COMMIT_THRESHOLD = 5
+
+/**
+ * 순수 분류 — 신호로 신규/기존 판정(IO 없음 → 테스트 용이).
+ * context 흔적이 있거나 커밋이 임계 이상이면 기존, 아니면 신규.
+ */
+export function classifyMaturity(s: MaturitySignals): 'new' | 'established' {
+  if (s.contextExists) return 'established'
+  return s.commitCount >= ESTABLISHED_COMMIT_THRESHOLD ? 'established' : 'new'
+}
+
+/** cwd 에서 신호 수집(IO — git 통로는 기존 gitOut 재사용, 신규 execSync 없음). */
+export function gatherMaturitySignals(cwd: string): MaturitySignals {
+  const contextExists = existsSync(join(cwd, '.vhk', 'context.md'))
+  let commitCount = 0
+  try {
+    const out = gitOut(['rev-list', '--count', 'HEAD'], cwd).trim()
+    const n = Number.parseInt(out, 10)
+    if (Number.isFinite(n)) commitCount = n
+  } catch {
+    /* 비-git/커밋 0 → 0 (신규로 취급) */
+  }
+  return { contextExists, commitCount }
+}
+
+/** 편의: cwd 를 직접 분류(수집 + 분류). */
+export function projectMaturity(cwd: string): 'new' | 'established' {
+  return classifyMaturity(gatherMaturitySignals(cwd))
+}

--- a/tests/project-maturity.test.ts
+++ b/tests/project-maturity.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifyMaturity,
+  ESTABLISHED_COMMIT_THRESHOLD,
+} from '../src/lib/project-maturity.js'
+import { selectDoctorOkNextStep } from '../src/commands/doctor.js'
+import { selectStatusNextStep } from '../src/commands/status.js'
+
+// Goal 84: doctor/status next-step 이 신규 vs 기존 레포를 맥락 판정.
+//   D9: 396커밋 활성 레포에서도 "이제 프로젝트를 시작하세요(vhk 시작)" 온보딩이 떠 안내 신뢰도 저하.
+//   Forbidden: 신규 레포에선 온보딩 멘트 유지(퇴행 0).
+
+describe('Goal 84 — project maturity 분류 (순수)', () => {
+  it('.vhk/context.md 존재 → established (커밋 수 무관)', () => {
+    expect(classifyMaturity({ contextExists: true, commitCount: 0 })).toBe('established')
+  })
+  it('커밋 수 ≥ 임계 → established', () => {
+    expect(classifyMaturity({ contextExists: false, commitCount: ESTABLISHED_COMMIT_THRESHOLD })).toBe('established')
+    expect(classifyMaturity({ contextExists: false, commitCount: 396 })).toBe('established')
+  })
+  it('커밋 적고 context 없음 → new (신규/초기 레포)', () => {
+    expect(classifyMaturity({ contextExists: false, commitCount: 1 })).toBe('new')
+    expect(classifyMaturity({ contextExists: false, commitCount: 0 })).toBe('new')
+  })
+})
+
+describe('Goal 84 — doctor 통과 next-step 맥락 분기', () => {
+  it('established → "프로젝트를 시작하세요" 아님 (이어서 작업, vhk work)', () => {
+    const s = selectDoctorOkNextStep('established')
+    expect(s.command).toBe('vhk work')
+    expect(s.command).not.toMatch(/시작/)
+    expect(s.message).not.toMatch(/프로젝트를 시작/)
+  })
+  it('new → 기존 온보딩 멘트 유지 (vhk 시작) — 퇴행 0', () => {
+    const s = selectDoctorOkNextStep('new')
+    expect(s.command).toBe('vhk 시작')
+    expect(s.message).toMatch(/시작/)
+  })
+})
+
+describe('Goal 84 — status next-step 맥락 분기', () => {
+  it('clean + established → vhk goal next (기존 동작 유지)', () => {
+    expect(selectStatusNextStep(false, 'established').command).toBe('vhk goal next')
+  })
+  it('clean + new → 온보딩 (vhk 시작)', () => {
+    expect(selectStatusNextStep(false, 'new').command).toMatch(/시작/)
+  })
+  it('변경 있으면 maturity 무관하게 vhk diff (데이터 안전 — 기존 동작)', () => {
+    expect(selectStatusNextStep(true, 'new').command).toBe('vhk diff')
+    expect(selectStatusNextStep(true, 'established').command).toBe('vhk diff')
+  })
+  it('maturity 생략 시 established 기본 (하위호환 — 기존 호출부)', () => {
+    expect(selectStatusNextStep(false).command).toBe('vhk goal next')
+  })
+})


### PR DESCRIPTION
## Goal 84 — doctor/status next-step 맥락 인지 (P2, RFC 0053 §4 D9)

**한 줄:** `vhk doctor`/`status` 의 "다음에 이것만 하세요"가 **신규 vs 기존 레포**를 판정해 맥락 분기 — 396커밋 활성 레포에도 "이제 프로젝트를 시작하세요" 온보딩이 뜨던 거짓 안내 해소.

### 선조사 (카드 부분 정정)
- 진짜 D9 = **doctor**(`ko.doctor.nextOkMessage`="이제 프로젝트를 시작하세요" + `vhk 시작` 이 활성 레포에도 노출).
- **status 는 과장**: clean 시 이미 `vhk goal next`("다음 미션") — 온보딩 아님. 신규(초기) 레포 케이스만 보강.

### 무엇
- `src/lib/project-maturity.ts`(신규): `classifyMaturity`(순수 — `.vhk/context.md` 존재 OR 커밋수≥`ESTABLISHED_COMMIT_THRESHOLD`=5 → established) + `gatherMaturitySignals`(IO, `gitOut` 재사용) + `projectMaturity`(래퍼).
- `doctor.ts`: `selectDoctorOkNextStep(maturity)` — established → `vhk work`("이어서 작업"), new → `vhk 시작`(온보딩 유지).
- `status.ts`: `selectStatusNextStep(hasChanges, maturity='established')` — new clean → 온보딩. (기본 established = 하위호환).

### 제약 준수 (Forbidden)
- 신규 레포 온보딩 보존(퇴행 0 — new → `vhk 시작`) · 진단 항목 자체 변경 0(next-step 분기만).

### 적대 리뷰(12-에이전트, read-only) 반영
- **앵커 통일**: doctor=`cwd`/status=`gitRoot` 불일치 → 서브디렉터리에서 분류 갈림 → **둘 다 cwd**(context.md 기록 위치).
- **i18n**: doctor established 멘트 하드코딩 → `ko.doctor.nextEstablishedMessage`/`Cursor` 키 추출.

### 검증
- 라이브: 이 레포(396+커밋) `vhk doctor` → "환경 점검 통과 — 이어서 작업하세요 / vhk work".
- 테스트 **1791 pass**(신규 9) · `check-goal-84.mjs` 16 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로젝트 성숙도를 자동으로 판정하여 신규 저장소와 기존 프로젝트에 맞춤형 안내를 제공합니다.
  * 환경 점검 완료 후 프로젝트 상태에 따라 다른 다음 단계 명령을 동적으로 제시합니다.

* **테스트**
  * 성숙도 판정 및 맞춤형 안내 로직에 대한 회귀 테스트를 추가했습니다.

* **문서**
  * Goal 84 "맥락 인식 다음 단계" 항목을 완료 처리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->