### PR TITLE
fix(goal): goal 컨테이너 description 에 peek 추가 — help 정합 (#347)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -759,7 +759,7 @@ workCmd
 const goalCmd = program
   .command('goal')
   .alias('목표')
-  .description('Goal 단계별 미션 관리 (init / list / next / check / done / sync / drift)')
+  .description('Goal 단계별 미션 관리 (init / list / next / peek / check / done / sync / drift)')
   .action(async () => { await goalList() })
 
 goalCmd


### PR DESCRIPTION
Closes #347.

goal 78 에서 `vhk goal peek` 서브커맨드를 등록했으나 `goalCmd.description` 의 서브커맨드 목록에 peek 를 빠뜨려 help 정합이 깨졌다(6-22 도그푸딩 #347 발견). description 에 peek 추가(1줄).

검증: typecheck ✓ · build ✓ · `vhk goal --help` 에 peek 노출 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 내부 코드 정렬 및 포맷팅 개선

---

**참고**: 이 업데이트는 사용자에게 보이는 기능 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->