### PR TITLE
fix(undo): HARD_STOP 우회(#338) + non-TTY 크래시(#337) 차단

### DIFF
--- a/docs/log/2026-06-23-issue-high-undo.md
+++ b/docs/log/2026-06-23-issue-high-undo.md
@@ -1,0 +1,17 @@
+# 2026-06-23 — 도그푸딩 high 이슈 처리 시작 (#337/#338 undo 안전)
+
+> 6-22 도그푸딩 배치(이슈 15개) 중 severity:high 부터. 1건씩 PR.
+
+## 세션 시작 정리
+- stale 원격 브랜치 7개 삭제(머지/대체분) · 로컬 main pull(d5895c6) · 임시파일(ledger·vitest-result) 정리.
+- #347(goal 컨테이너 description peek 누락 — help 정합) fix → #351 머지·close.
+
+## undo 안전 (#337 + #338, 한 PR)
+- **#338 HARD_STOP 우회**: undo 가 `guardCliDefer`(가드 면제 함수)를 쓰는데 거기엔 `ensureNotHardStopped` 가 없어 HARD_STOP 활성 시에도 실행 경로 진입. resume(해제 명령)만 면제돼야 하므로 `action !== 'resume' && !ensureNotHardStopped(action)` 가드 추가(index.ts). → HARD_STOP 시 undo 차단 확인(E2E).
+- **#337 non-TTY 크래시**: undo() 가 비대화형에서 number 프롬프트 호출 → `ERR_USE_AFTER_CLOSE` raw 스택트레이스. restore 패턴(isTTY 가드 + nonTtyHint)을 undo.ts 에 적용(+ ko.ts 메시지). high-risk 라 무인 default reset 대신 graceful 안내 후 종료. → 회귀 테스트 tests/undo.test.ts.
+- **검증**: typecheck·build ✓ · E2E 3종(HARD_STOP+undo 차단 / non-TTY graceful / resume 면제 유지) · undo.test 6 pass.
+
+## 발견 — resume exit 127 (별개 기존 버그, 이슈 등록)
+- `vhk resume --confirm` 이 **exit 127 + HARD_STOP 미해제**(파일 안 지워짐). `git stash`로 내 변경 제거 후 **main 에서도 동일 재현** → 내 #337/#338 과 무관한 기존 버그.
+- 정적 분석으로 원인 미상: runGuarded(approved→run 정상)·clearHardStop(rmSync import 정상)·isHardStopActive(ensureNotHardStopped 와 공유, 정상). resume() 제목 출력 후 silent exit 127 — 런타임 디버깅 필요.
+- 영향: HARD_STOP 해제 경로가 깨짐(수동 `rm .vhk/HARD_STOP` 우회 가능). #338(차단)과 연쇄되나 별개 추적.

--- a/src/commands/undo.ts
+++ b/src/commands/undo.ts
@@ -75,6 +75,12 @@ export async function undo(): Promise<void> {
   })
 
   const maxUndo = commits.length
+  // #337: 비대화형(파이프/CI/에이전트 하네스)에서 number/confirm 프롬프트는 ERR_USE_AFTER_CLOSE 로
+  // 크래시한다 → restore 패턴처럼 graceful 안내 후 종료(high-risk git reset 을 무인 default 로 실행 안 함).
+  if (!process.stdout.isTTY) {
+    console.log(chalk.yellow(`\n${t('undo.nonTtyHint')}`))
+    return
+  }
   const { count } = await prompt<{ count: number }>([{
     type: 'number',
     name: 'count',

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -66,6 +66,7 @@ export const ko = {
     noCommits: '되돌릴 커밋이 없습니다.',
     recentHeader: '📋 최근 커밋:',
     howMany: '몇 개의 커밋을 되돌릴까요?',
+    nonTtyHint: '비대화형 모드 — 되돌릴 커밋 수 선택이 필요합니다. TTY 터미널에서 vhk undo 를 실행하세요.',
     alreadyPushed: '이 커밋은 이미 원격에 올라갔습니다. 되돌리면 충돌이 생길 수 있어요.',
     noUpstreamWarning:
       'upstream 브랜치가 없습니다. 이미 push한 커밋일 수 있어요. 되돌린 뒤 force push가 필요할 수 있습니다.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,9 @@ async function guardCliDefer(
   approved: boolean,
   run: () => Promise<void> | void,
 ): Promise<void> {
+  // #338: undo 등 high-risk 는 HARD_STOP 활성 시 차단. resume 만 예외 — resume 은 HARD_STOP
+  // *해제* 명령이라 가드하면 자기 자신을 막는 역설(resume --confirm 이 유일한 트립와이어 해제 통로).
+  if (action !== 'resume' && !ensureNotHardStopped(action)) return
   await runGuarded(
     action,
     {

--- a/tests/undo.test.ts
+++ b/tests/undo.test.ts
@@ -43,6 +43,24 @@ describe('undo', () => {
       expect.objectContaining({ encoding: 'utf-8' }),
     )
   })
+
+  it('비대화형(non-TTY) 에서 프롬프트 없이 graceful 종료 — #337', async () => {
+    const orig = process.stdout.isTTY
+    // @ts-expect-error 테스트에서 TTY 상태 강제
+    process.stdout.isTTY = false
+    vi.mocked(execFileSync).mockImplementation((_file, args) => {
+      if (Array.isArray(args) && args[0] === 'rev-parse') return 'true'
+      if (Array.isArray(args) && args[0] === 'log') return 'abc1234 c2\ndef5678 c1'
+      return ''
+    })
+    const logSpy = vi.spyOn(console, 'log')
+    const { undo } = await import('../src/commands/undo.js')
+    // ERR_USE_AFTER_CLOSE 크래시 없이 graceful 종료 + 안내 출력
+    await expect(undo()).resolves.not.toThrow()
+    expect(logSpy.mock.calls.flat().join(' ')).toContain('비대화형')
+    // @ts-expect-error 복원
+    process.stdout.isTTY = orig
+  })
 })
 
 describe('vhk undo helpers', () => {


### PR DESCRIPTION
도그푸딩 high 2건(undo 안전).

## #338 — undo 가 HARD_STOP 우회
`undo` 가 가드 면제 함수 `guardCliDefer` 를 쓰는데 거기엔 `ensureNotHardStopped` 가 없어 HARD_STOP 활성 시에도 실행 경로 진입. resume(해제 명령)만 면제돼야 하므로 `action !== 'resume'` 가드 추가. → HARD_STOP 시 undo 차단.

## #337 — undo non-TTY 크래시
undo() 가 비대화형에서 number 프롬프트 호출 → `ERR_USE_AFTER_CLOSE` raw 스택트레이스. restore 패턴(isTTY 가드 + nonTtyHint) 적용 — high-risk 라 무인 reset 대신 graceful 안내.

## 검증
- typecheck·build ✓ · undo.test 6 pass(non-TTY 회귀 추가)
- E2E 3종: HARD_STOP+undo 차단 / non-TTY graceful(크래시 해소) / resume 면제 유지

## 발견 (별개)
`vhk resume --confirm` 이 exit 127 + HARD_STOP 미해제 — **main 에서도 재현되는 기존 버그**(이 PR 무관). 별도 이슈 등록 예정.

Closes #337
Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 비대화형 환경에서 되돌리기 명령 실행 시 안내 메시지를 표시하고 안정적으로 종료하도록 개선
  * 특정 작업 상태에서의 예외 처리 로직 개선

* **Tests**
  * 비대화형 환경에서의 되돌리기 명령 동작 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->