### PR TITLE
fix(hardstop): goal sync·seo init·seo submit HARD_STOP 가드 누락 (#334 #335 #336)

### DIFF
--- a/docs/log/2026-06-23-hardstop-guards.md
+++ b/docs/log/2026-06-23-hardstop-guards.md
@@ -1,0 +1,17 @@
+# 2026-06-23 — HARD_STOP 가드 누락 묶음 (#334/#335/#336)
+
+> 6-22 도그푸딩 high 후속. undo(#338)와 같은 패턴(`ensureNotHardStopped` 누락) 3건 일괄.
+
+## 수정
+- **#334 goal sync**: goalSync 가 HARD_STOP 활성 시 게이트 스크립트(check-goal-N.mjs) 생성 → 함수 시작에 가드(`GoalSyncResult` 기본 반환).
+- **#335 seo init**: seoInit 가 config(`.vhk/seo/config.json`) 기록 → 가드 + import 추가.
+- **#336 seo submit**: seoSubmit 가 IndexNow 키 생성·제출 → 가드 + import 추가.
+
+## 검증
+- typecheck·build ✓
+- E2E: HARD_STOP 활성 tmp 에서 `goal sync`·`seo init`·`seo submit` 전부 `🛑 HARD STOP 활성` 차단 확인(실행경로 미진입).
+- 회귀 테스트: goal-hardstop.test.ts(+goalSync 케이스) · 신규 seo-hardstop.test.ts(seoInit/seoSubmit).
+- ⚠️ 로컬 vitest forks 는 chdir 패턴 + 환경 불안정(TS-004)으로 worker crash → **CI 가 진실원**(기존 goal-hardstop 이 동일 chdir 패턴으로 CI green).
+
+## 연관
+- undo #337/#338 → #352 머지. resume exit 127 → #353 등록(별개 기존 버그).

--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -513,6 +513,7 @@ export interface GoalSyncResult {
 }
 
 export async function goalSync(): Promise<GoalSyncResult> {
+  if (!ensureNotHardStopped('goal sync')) return { created: [], skipped: [] } // #334: HARD_STOP 활성 시 게이트 스크립트 생성 차단
   console.log(chalk.bold(`\n${ko.goal.syncTitle}\n`))
   const goals = listGoals(GOALS_DIR)
   const result: GoalSyncResult = { created: [], skipped: [] }

--- a/src/commands/seo/init.ts
+++ b/src/commands/seo/init.ts
@@ -14,6 +14,7 @@ import {
   SEO_SERVICE_KEYS,
   type SeoConfig,
 } from '../../lib/seo-config.js'
+import { ensureNotHardStopped } from '../../lib/hard-stop-guard.js'
 
 export interface SeoInitOptions {
   domain?: string
@@ -30,6 +31,7 @@ export interface SeoInitOptions {
  * @param root 테스트·멀티루트용 작업 디렉터리 (기본 process.cwd()).
  */
 export async function seoInit(opts: SeoInitOptions = {}, root: string = process.cwd()): Promise<void> {
+  if (!ensureNotHardStopped('seo init')) return // #335: HARD_STOP 활성 시 config 기록 차단
   console.log(chalk.bold(`\n${ko.seo.init.title}\n`))
 
   let domain = opts.domain?.trim()

--- a/src/commands/seo/submit.ts
+++ b/src/commands/seo/submit.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk'
 import { log } from '../../utils/logger.js'
 import { atomicWriteFile } from '../../lib/atomic-write.js'
 import { readSeoConfig, resolveSecretPresence } from '../../lib/seo-config.js'
+import { ensureNotHardStopped } from '../../lib/hard-stop-guard.js'
 
 /**
  * Goal 22: `vhk seo submit` — 사이트맵(GSC·Bing) 제출 + IndexNow 한 방 핑(빙·네이버·얀덱스).
@@ -80,6 +81,7 @@ export function ensureIndexNowKey(root: string = process.cwd()): string {
 // ── 커맨드 핸들러 ──────────────────────────────────────────────────────────────
 
 export async function seoSubmit(_opts: { yes?: boolean } = {}, root: string = process.cwd()): Promise<void> {
+  if (!ensureNotHardStopped('seo submit')) return // #336: HARD_STOP 활성 시 IndexNow 키 생성·제출 차단
   log.bold('\n🚀 vhk seo submit — 사이트맵 + IndexNow 제출\n')
 
   const cfg = readSeoConfig(root)

--- a/tests/goal-hardstop.test.ts
+++ b/tests/goal-hardstop.test.ts
@@ -81,4 +81,20 @@ describe('goal 명령군 HARD_STOP 가드 (Goal 34)', () => {
       rmSync(dir, { recursive: true, force: true })
     }
   })
+
+  it('HARD_STOP 활성 → goalSync 가 게이트 스크립트를 만들지 않는다 (#334)', async () => {
+    const dir = tmpProject('sync-blocked')
+    makeGoalFile(dir, 0, 'NOT_STARTED')
+    writeHardStop(dir)
+    process.chdir(dir)
+    try {
+      const { goalSync } = await import('../src/commands/goal.js')
+      const res = await goalSync()
+      expect(res).toEqual({ created: [], skipped: [] })
+      expect(existsSync(join(dir, 'scripts', 'check-goal-0.mjs'))).toBe(false)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
 })

--- a/tests/seo-hardstop.test.ts
+++ b/tests/seo-hardstop.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// #335/#336: seo init/submit HARD_STOP 가드 회귀 테스트.
+// HARD_STOP 활성 시 config/IndexNow 키 등 산출물을 쓰면 안 된다(가드 누락 회귀 차단).
+
+function tmpProject(label: string): string {
+  const dir = join(tmpdir(), `vhk-seohs-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+function writeHardStop(dir: string): void {
+  mkdirSync(join(dir, '.vhk'), { recursive: true })
+  writeFileSync(join(dir, '.vhk', 'HARD_STOP'), '2026-06-23T00:00:00Z\nauto: test\n', 'utf-8')
+}
+
+describe('seo 명령 HARD_STOP 가드 (#335/#336)', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    process.exitCode = 0 // ensureNotHardStopped 가 설정한 exitCode 리셋
+    vi.restoreAllMocks()
+  })
+
+  it('HARD_STOP 활성 → seoInit 가 config 를 쓰지 않는다 (#335)', async () => {
+    const dir = tmpProject('init-blocked')
+    writeHardStop(dir)
+    process.chdir(dir)
+    try {
+      const { seoInit } = await import('../src/commands/seo/init.js')
+      await seoInit({ domain: 'ex.com', yes: true }, dir)
+      expect(existsSync(join(dir, '.vhk', 'seo', 'config.json'))).toBe(false)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('HARD_STOP 활성 → seoSubmit 가 IndexNow 키를 만들지 않는다 (#336)', async () => {
+    const dir = tmpProject('submit-blocked')
+    writeHardStop(dir)
+    process.chdir(dir)
+    try {
+      const { seoSubmit } = await import('../src/commands/seo/submit.js')
+      await seoSubmit({ yes: true }, dir)
+      expect(existsSync(join(dir, '.vhk', 'seo', 'indexnow-key.txt'))).toBe(false)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
도그푸딩 high 묶음 — undo(#338)와 같은 패턴(`ensureNotHardStopped` 누락) 3건.

## 수정
- **#334 goal sync**: goalSync 가 HARD_STOP 활성 시 게이트 스크립트 생성 → 가드 추가(GoalSyncResult 기본 반환)
- **#335 seo init**: seoInit 가 config 기록 → 가드 + import
- **#336 seo submit**: seoSubmit 가 IndexNow 키 생성·제출 → 가드 + import

## 검증
- typecheck·build ✓
- **E2E**: HARD_STOP tmp 에서 goal sync·seo init·seo submit 전부 `🛑 HARD STOP 활성` 차단 확인
- 회귀 테스트: goal-hardstop.test.ts(+goalSync) · 신규 seo-hardstop.test.ts
- 로컬 vitest forks 는 chdir 패턴+환경(TS-004)으로 crash → CI 가 진실원(기존 goal-hardstop 동일 패턴 green)

Closes #334
Closes #335
Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * HARD_STOP 상태가 활성화된 경우 목표 동기화, SEO 설정 초기화, SEO 제출 명령이 즉시 중단되도록 개선되었습니다.

* **Tests**
  * HARD_STOP 상태에서 각 명령이 올바르게 작동하는지 검증하는 회귀 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->