### PR TITLE
fix(mcp): NL 미인식·audit 불명 거짓 보고 차단 (#340 #341)

### DIFF
--- a/docs/log/2026-06-23-mcp-honesty.md
+++ b/docs/log/2026-06-23-mcp-honesty.md
@@ -1,0 +1,19 @@
+# 2026-06-23 — MCP 거짓 보고 수정 (#340/#341)
+
+> 6-22 도그푸딩 high. MCP 가 실패/불명을 성공으로 위장하는 2건(같은 주제 — 정직성).
+
+## #340 — runVhkCli 가 NL 미인식을 ✅ 로 위장
+- runVhkCli(server.ts)가 헤드라인을 exit code + `isGuardBlockedOutput` 만으로 결정 → NL 라우터 미인식 폴백(`❓ 무슨 뜻인지 모르겠어요`, exit 0)이 `✅` 거짓 성공으로 표시(content/launch/ops/sell/remind).
+- `isNotMatchedOutput` 추가 → runVhkCli 분기에서 `❓ 미인식` prefix. 주석(L64)이 "막는다"던 바로 그 케이스 봉인.
+
+## #341 — MCP audit 이 감사 불가를 '취약점 0건'으로
+- MCP audit 핸들러가 `parseAuditOutput`(.summary 만, indeterminate 폐기) → ENOLOCK·빈/형식불량 출력을 0건 단정(CLI 는 '결과 불명' exit 1).
+- `parseAuditOutputDetailed` 로 교체 → `indeterminate` 면 '감사 결과를 해석하지 못했습니다 (결과 불명)'(CLI parity).
+
+## 검증
+- typecheck·build ✓
+- **tsx 직접검증 4/4**: isNotMatchedOutput(미인식=true·정상=false) · parseAuditOutputDetailed(빈=indeterminate true·정상=false)
+- 회귀 테스트 mcp-cli-contract.test.ts(#340 ❓ prefix + isNotMatchedOutput + #341 결과불명) — 로컬 forks 환경(TS-004) crash, **CI 진실원**.
+
+## 남은 high
+#339 MCP 글로벌 vhk 우선(cli-path 버전 스큐) — 별도 PR.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,7 +8,7 @@ import { isGitRepo } from '../lib/git-repo.js'
 import { parseEnvKeys } from '../commands/env.js'
 import { resolveDeployTarget } from '../commands/deploy.js'
 import { bumpVersion } from '../commands/publish.js'
-import { detectCurrentPM, parseAuditOutput, runAuditJson } from '../commands/audit.js'
+import { detectCurrentPM, parseAuditOutputDetailed, runAuditJson } from '../commands/audit.js'
 import { readJsonFile } from '../lib/read-json.js'
 import { isHardStopActive, readHardStopReason } from '../lib/state-files.js'
 import { filterSevereFindings, scanProjectForSecrets } from '../lib/scan-secrets.js'
@@ -67,6 +67,12 @@ export function isGuardBlockedOutput(body: string): boolean {
   return /위험 작업\(/.test(body) && body.includes('실행하지 않았습니다')
 }
 
+// #340: NL 라우터 미인식 폴백(nlp-run: '❓ … 무슨 뜻인지 모르겠어요')은 exit 0 으로 끝나
+// runVhkCli 가 ✅ 거짓 성공으로 위장한다 — 미인식 문구를 감지해 실패 신호로 표면화.
+export function isNotMatchedOutput(body: string): boolean {
+  return body.includes('무슨 뜻인지 모르겠어요')
+}
+
 function runVhkCli(
   args: string[],
   headline: string
@@ -79,7 +85,9 @@ function runVhkCli(
   const prefix = result.ok
     ? isGuardBlockedOutput(body)
       ? `⛔ ${headline} 실행 안 됨 (가드 차단 — 승인 필요)`
-      : `✅ ${headline}`
+      : isNotMatchedOutput(body)
+        ? `❓ ${headline} 미인식 — 명령을 인식하지 못했습니다`
+        : `✅ ${headline}`
     : `❌ ${headline} 실패`
   return { content: [{ type: 'text', text: `${prefix}\n${body}`.trim() }] }
 }
@@ -537,7 +545,13 @@ export function createVhkMcpServer(): McpServer {
       // MCP 는 TTY 없어 prompt 가 영구 hang → CLI 위임 금지. 여기서 직접 audit JSON 만 호출.
       const pm = detectCurrentPM()
       const output = runAuditJson(pm)
-      const summary = parseAuditOutput(output, pm)
+      const { summary, indeterminate } = parseAuditOutputDetailed(output, pm)
+      // #341: 감사 불가(ENOLOCK·빈/형식불량 출력)를 0건으로 단정 금지 — CLI 와 동일하게 '결과 불명' 구분.
+      if (indeterminate) {
+        return {
+          content: [{ type: 'text', text: `⚠️ ${pm}: 감사 결과를 해석하지 못했습니다 (결과 불명). \`vhk audit\` 로 확인하세요.` }],
+        }
+      }
       if (summary.total === 0) {
         return {
           content: [{ type: 'text', text: `🎉 ${pm}: 취약점 0건.` }],

--- a/tests/mcp-cli-contract.test.ts
+++ b/tests/mcp-cli-contract.test.ts
@@ -162,6 +162,29 @@ describe('MCP↔CLI 계약 — C. 래퍼 충실도 (ANSI strip · 한글 보존 
     expect(isGuardBlockedOutput('✅ 동기화 완료 — 7개 파일 갱신')).toBe(false)
     expect(isGuardBlockedOutput('🔎 위험 작업(undo) 미리보기\n실행하지 않았습니다 — 승인 후 재시도')).toBe(true)
   })
+
+  it('NL 미인식(exit 0): ✅ 거짓 성공 대신 ❓ 미인식 prefix (#340)', async () => {
+    // nlp-run 미인식 폴백 흉내 — exit 0 으로 끝나 과거엔 ✅ 로 위장됐다.
+    execFileSync.mockReturnValue(
+      Buffer.from('❓ "remind" — 무슨 뜻인지 모르겠어요. vhk를 입력하면 메뉴에서 선택할 수 있습니다.')
+    )
+    const out = text(await callTool('remind'))
+    expect(out.startsWith('❓ remind 미인식')).toBe(true)
+    expect(out.startsWith('✅')).toBe(false)
+  })
+
+  it('isNotMatchedOutput: 미인식 문구 감지, 일반 출력은 false (#340)', async () => {
+    const { isNotMatchedOutput } = await import('../src/mcp/server.js')
+    expect(isNotMatchedOutput('❓ "x" — 무슨 뜻인지 모르겠어요.')).toBe(true)
+    expect(isNotMatchedOutput('✅ 정상 완료')).toBe(false)
+  })
+
+  it('audit: 감사 불가(빈 출력) → 취약점 0건 단정 대신 결과 불명 (#341)', async () => {
+    execFileSync.mockReturnValue(Buffer.from('')) // ENOLOCK·빈/형식불량 → indeterminate
+    const out = text(await callTool('audit'))
+    expect(out).toContain('결과 불명')
+    expect(out).not.toContain('취약점 0건')
+  })
 })
 
 // ─── D. 공유함수 패리티 (#152 cross-단언) ────────────────────────────────


### PR DESCRIPTION
도그푸딩 high — MCP 가 실패/불명을 성공으로 위장하는 2건(정직성).

## #340 — runVhkCli NL 미인식 ✅ 위장
runVhkCli 가 헤드라인을 exit code + isGuardBlockedOutput 만으로 결정 → NL 미인식 폴백(`❓ 무슨 뜻인지 모르겠어요`, exit 0)이 ✅ 거짓 성공. `isNotMatchedOutput` 추가 → `❓ 미인식` prefix.

## #341 — MCP audit '취약점 0건' 거짓 안심
MCP audit 이 parseAuditOutput(.summary, indeterminate 폐기) → ENOLOCK·빈 출력을 0건 단정. `parseAuditOutputDetailed` 로 교체 → '결과 불명'(CLI parity).

## 검증
- typecheck·build ✓ · tsx 직접검증 4/4(isNotMatchedOutput · parseAuditOutputDetailed indeterminate)
- 회귀 테스트 mcp-cli-contract(#340 ❓ prefix·isNotMatchedOutput·#341 결과불명)
- 로컬 forks 는 환경(TS-004) crash → CI 진실원

Closes #340
Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 개선된 CLI 감사 결과 해석: 불명확한 결과를 "결과 불명"으로 명확히 표시하여 오류 방지
  * 명령 인식 오류 처리 강화: 미인식 명령에 대한 피드백 정확성 향상

* **Tests**
  * CLI 출력 해석 계약 관련 회귀 테스트 3개 추가로 신뢰성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->