### PR TITLE
fix(mcp): 위임 CLI 동봉 dist 우선 — 전역 vhk 버전 스큐 차단 (#339)

### DIFF
--- a/docs/log/2026-06-23-mcp-cli-parity-339.md
+++ b/docs/log/2026-06-23-mcp-cli-parity-339.md
@@ -1,0 +1,14 @@
+# 2026-06-23 — MCP CLI parity #339 (전역 vhk 버전 스큐)
+
+> 6-22 도그푸딩 high 마지막. MCP 위임이 전역 vhk 를 무조건 우선 → 버전 스큐로 6종 깨짐.
+
+## 수정
+- `cli-path.ts` pickCliInvocation: 전역 vhk 우선 → **동봉 dist 우선**. MCP 서버는 mcp-init 이 `node <트리>/dist/mcp/index.js` 로 등록하므로 위임 CLI 도 같은 트리 dist/index.js 여야 parity. 전역이 한 버전이라도 뒤처지면 content/launch/ops/sell/remind/loop-brief 가 조용히 깨지던 것 차단.
+- fallback 필드 의미 갱신(로컬 dist 위임 여부). dist·전역 둘 다 없을 때만 마지막 수단으로 vhk 시도.
+
+## 검증
+- typecheck·build ✓ · mcp-cli-path.test.ts 5 pass(dist 우선 단언 #339 포함)
+- mcp-server/contract 위임 단언은 args 꼬리 비교(bin 무관)라 영향 없음 — CI 확인.
+
+## 도그푸딩 high 완료 (이번 세션)
+#337·#338(undo) · #334·335·336(HARD_STOP 가드) · #340·341(MCP 거짓보고) · #339(parity) = **high 7 + med 1(#334) + low 1(#347) 전부**. resume exit 127 → #353 별개 추적.

--- a/src/mcp/cli-path.ts
+++ b/src/mcp/cli-path.ts
@@ -13,7 +13,7 @@ export interface VhkCliInvocation {
   bin: string
   /** bin 뒤에 먼저 붙는 인자 (node 로 dist/index.js 실행 시 [스크립트경로]) */
   prefixArgs: string[]
-  /** 전역 vhk 대신 로컬 dist/index.js 로 fallback 했는가 */
+  /** 로컬 dist/index.js 위임 여부 (#339: 전역 vhk 버전 스큐 방지 위해 dist 우선) */
   fallback: boolean
 }
 
@@ -26,9 +26,11 @@ export function pickCliInvocation(
   localCli: string,
   localExists: boolean
 ): VhkCliInvocation {
-  if (globalAvailable) return { bin: 'vhk', prefixArgs: [], fallback: false }
+  // #339: 동봉 dist 우선 — MCP 서버와 같은 빌드로 위임해 명령 parity 보장. 전역 vhk 가 한 버전이라도
+  // 뒤처지면 위임 도구(content/launch/ops/sell/remind/loop-brief)가 조용히 깨진다(버전 스큐).
   if (localExists) return { bin: process.execPath, prefixArgs: [localCli], fallback: true }
-  // 마지막 수단: 그래도 vhk 시도 — 실패는 호출부(runVhkCli)가 표면화.
+  if (globalAvailable) return { bin: 'vhk', prefixArgs: [], fallback: false }
+  // 마지막 수단: dist 도 전역도 없으면 vhk 시도 — 실패는 호출부(runVhkCli)가 표면화.
   return { bin: 'vhk', prefixArgs: [], fallback: false }
 }
 

--- a/tests/mcp-cli-path.test.ts
+++ b/tests/mcp-cli-path.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect } from 'vitest'
 import { pickCliInvocation, composeInvocation } from '../src/mcp/cli-path.js'
 
 describe('MCP CLI 경로 resolve fallback (배치3 §5)', () => {
-  it('전역 vhk 가 있으면 vhk 를 그대로 쓴다', () => {
+  it('동봉 dist 가 있으면 전역 vhk 보다 우선 — node 로 로컬 CLI 위임 (parity, #339)', () => {
     const r = pickCliInvocation(true, '/x/dist/index.js', true)
-    expect(r.bin).toBe('vhk')
-    expect(r.prefixArgs).toEqual([])
-    expect(r.fallback).toBe(false)
+    expect(r.bin).toBe(process.execPath)
+    expect(r.prefixArgs).toEqual(['/x/dist/index.js'])
+    expect(r.fallback).toBe(true)
   })
 
   it('전역 vhk 가 없고 로컬 dist/index.js 가 있으면 node 로 로컬 CLI fallback', () => {


### PR DESCRIPTION
도그푸딩 high 마지막.

## 문제
`cli-path.ts` pickCliInvocation 이 전역 vhk 가 PATH 에 있으면 동봉 dist 존재·버전과 무관하게 무조건 전역 위임 → 전역이 한 버전이라도 뒤처지면 content/launch/ops/sell/remind/loop-brief 6종이 조용히 깨짐(버전 스큐).

## 수정
- **동봉 dist 우선** — MCP 서버는 mcp-init 이 `node <트리>/dist/mcp/index.js` 로 등록하므로 위임 CLI 도 같은 트리 dist/index.js 여야 parity. dist 없을 때만 전역 vhk.
- fallback 필드 의미 갱신(로컬 dist 위임 여부).

## 검증
- typecheck·build ✓ · mcp-cli-path.test.ts 5 pass(dist 우선 단언 #339)
- mcp-server/contract 위임 단언은 args 꼬리 비교(bin 무관)라 영향 없음

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항

* **동작 변경**
  * 로컬 CLI가 존재할 경우 전역 CLI보다 우선하여 실행하도록 변경되었습니다. 이제 포함된 로컬 버전을 먼저 사용하며, 없을 경우에만 전역 버전을 실행합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->