### PR TITLE
fix(resume): clearHardStop rmSync→unlinkSync — exit 127 수정 (#353)

### DIFF
--- a/docs/log/2026-06-23-resume-353.md
+++ b/docs/log/2026-06-23-resume-353.md
@@ -1,0 +1,20 @@
+# 2026-06-23 — resume exit 127 수정 (#353)
+
+> 6-23 발견·등록한 별개 기존 버그(undo #337/#338 무관). 런타임 디버깅.
+
+## 근본 원인
+`vhk resume --confirm` 이 `▶️ HARD_STOP 해제` 출력 후 **exit 127 + HARD_STOP 미해제**. 정적 분석 실패 → tsx 격리 디버깅:
+1. resume() 직접 → `📋 사유`(L88) 후 죽음 → clearHardStop(L102) 의심
+2. clearHardStop 격리 → 호출 후 exit 127 → 내부 rmSync 의심
+3. rmSync 옵션별 → **`rmSync(파일)`(옵션 무관)이 이 Node 환경에서 silent exit 127**, `unlinkSync` 는 정상. → TS-005.
+
+## 수정
+- `state-files.ts` clearHardStop: `rmSync(HARD_STOP_PATH, {force})` → `unlinkSync(HARD_STOP_PATH)`(존재는 위 existsSync 가드).
+
+## 검증
+- typecheck·build ✓
+- **E2E**: `resume --confirm` → `✅ HARD_STOP 해제` + 파일 삭제 + exit 0.
+- 기존 clearHardStop 단위(state-files.test:209) 유지 — vitest 환경은 rmSync 가 통과해 #353 미포착(환경 차이), CLI/E2E 가 진짜. 로컬 forks 는 TS-004.
+
+## 후속 (TS-005)
+파일 rmSync 잔여 — atomic-write.ts:24(atomicWriteFile 실패 cleanup)·mission.ts:234(mission clear) → unlinkSync 전환 권장. 디렉토리 rmSync(backup·migrate, {recursive})는 미검증.

--- a/docs/troubleshooting/TS-005-rmsync-file-exit127.md
+++ b/docs/troubleshooting/TS-005-rmsync-file-exit127.md
@@ -1,0 +1,24 @@
+# TS-005 — rmSync(파일)이 silent exit 127 (이 Node 환경)
+
+> 출처: #353 resume exit 127 런타임 디버깅(2026-06-23).
+
+## 증상
+`rmSync(파일경로, …)` 가 이 환경(Windows/Node)에서 **에러도 stderr 도 없이 exit 127** 로 프로세스를 즉시 죽인다. `unlinkSync` 는 정상 동작.
+
+## 발견 경로
+`vhk resume --confirm` 이 `▶️ HARD_STOP 해제` 출력 후 exit 127, HARD_STOP 미해제(#353). 정적 분석 실패 → tsx 격리 디버깅:
+1. resume() 직접 호출 → `📋 사유`(L88) 후 죽음 → `clearHardStop`(L102) 의심
+2. clearHardStop 격리 → `B about to clearHardStop` 후 exit 127 → 내부 `rmSync` 의심
+3. rmSync 옵션별 격리 → `unlinkSync` OK · `rmSync(file)` (옵션 없음·`{force}`·`{recursive,force}` 모두) **exit 127**
+
+## 원인
+미상(Node 코어 rmSync 의 파일 삭제 경로가 이 환경에서 silent 127). 재현은 결정적: `rmSync(<파일>)` 한 줄로 즉사.
+
+## 조치
+- ✅ **clearHardStop**(state-files.ts:115): `rmSync` → `unlinkSync` (#353 — resume 해제 복구).
+- ⚠️ **파일 rmSync 잔여(후속 점검)**: `atomic-write.ts:24` `rmSync(tmp,{force})`(atomicWriteFile 실패 cleanup — 평소 미실행이나 탈 시 exit 127 위험) · `mission.ts:234` `rmSync(p)`(mission clear). 둘 다 `unlinkSync` 권장.
+- ❓ **디렉토리 rmSync**(backup.ts:148·migrate.ts:87, `{recursive,force}`): rmdir 계열이라 별개일 수 있음 — 미검증, 후속 확인.
+
+## 패턴 (회귀 방지)
+- **파일 삭제 = `unlinkSync`**(존재 불확실하면 `existsSync` 가드). 디렉토리 = `rmSync(dir,{recursive})` (검증 후).
+- 신규 `rmSync(<파일>)` 금지.

--- a/src/lib/state-files.ts
+++ b/src/lib/state-files.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, appendFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, appendFileSync, unlinkSync } from 'node:fs'
 import { atomicWriteFile } from './atomic-write.js'
 import { join } from 'node:path'
 import { localDate } from './date.js'
@@ -112,6 +112,6 @@ export function readHardStopReason(): string | null {
 // 명시적 해제. 자동 호출 금지 (Forbidden) — 호출자가 사용자 의도 (--confirm) 확인 책임.
 export function clearHardStop(): boolean {
   if (!existsSync(HARD_STOP_PATH)) return false
-  rmSync(HARD_STOP_PATH, { force: true })
+  unlinkSync(HARD_STOP_PATH) // #353: rmSync(파일)이 이 Node 환경에서 silent exit 127 → unlinkSync (존재는 위 existsSync 로 확인). 상세 TS-005.
   return true
 }


### PR DESCRIPTION
## 근본 원인 (런타임 디버깅)
`vhk resume --confirm` 이 `▶️ HARD_STOP 해제` 출력 후 exit 127 + HARD_STOP 미해제. 정적 분석 실패 → tsx 격리 디버깅으로 **`rmSync(파일)` 이 이 Node 환경에서 silent exit 127**(옵션 무관), `unlinkSync` 는 정상임을 확정.

## 수정
- state-files.ts clearHardStop: `rmSync(HARD_STOP_PATH,{force})` → `unlinkSync`
- TS-005 troubleshooting: rmSync(파일) 버그 + 전수 목록(atomic-write:24·mission:234 파일 rmSync 후속 권장, 디렉토리 rmSync 미검증)

## 검증
- typecheck·build ✓
- E2E: resume --confirm → `✅ HARD_STOP 해제` + 파일 삭제 + exit 0
- 기존 clearHardStop 단위(state-files.test) 유지 — vitest 는 rmSync 가 통과해 #353 미포착(환경 차이), CLI/E2E 가 진짜

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 특정 Node/Windows 환경에서 발생하는 프로세스 종료 문제에 대한 트러블슈팅 가이드 추가

* **버그 수정**
  * 파일 삭제 로직을 개선하여 환경 호환성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->