### PR TITLE
fix(cli): 미인식 명령을 exit 1 + stderr 로 — exit 0 성공 위장 차단 (#346)

### DIFF
--- a/docs/log/2026-06-23-unknown-cmd-exit-346.md
+++ b/docs/log/2026-06-23-unknown-cmd-exit-346.md
@@ -1,0 +1,16 @@
+# 2026-06-23 — 미인식 명령 exit 0 위장 수정 (#346)
+
+> 6-22 도그푸딩 med. high 7 + resume #353 완료 후 med 착수.
+
+## 문제
+`vhk zzzz`(오타·미지 명령)가 **exit 0 + stdout ❓ 안내** → `vhk <오타> && 다음작업` 류가 조용히 통과(CI/스크립트 무인 실패 누락). commander 는 옵션오류·잘못된 서브커맨드를 exit 1 로 처리하는데 '최상위 미지 명령'만 0 으로 누출.
+
+## 수정
+- `nlp-run.ts` runNaturalLanguageRoute: 미매칭(route===null) → `console.log` → **`console.error`(stderr) + `process.exitCode=1`**. commander 의 exit 1 관례와 일관.
+
+## 검증
+- E2E(파이프 없이 — `$?` 가림 방지): `zzzz`·다중토큰 → exit 1 + stderr ❓ / `status` → exit 0(회귀 0).
+- 회귀 테스트 `nlp-run-exit.test.ts`(미인식 → exitCode 1).
+
+## 남은 med/low
+#345(유령 KNOWN 토큰)·#344(레지스트리 드리프트 env/design)·#330(goal id 비숫자) — 별도 추적.

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -188,7 +188,10 @@ export async function runNaturalLanguageRoute(input: string): Promise<void> {
   const route = routeNaturalLanguage(input)
 
   if (!route) {
-    console.log(chalk.yellow(`\n  ❓ "${input}" — ${ko.nlp.notMatched}\n`))
+    // #346: 미인식 명령은 실패 — stderr + exit 1 (`vhk <오타> && 다음작업` 이 조용히 통과하지 않게).
+    // commander 가 옵션오류·잘못된 서브커맨드를 exit 1 로 처리하는 것과 일관.
+    console.error(chalk.yellow(`\n  ❓ "${input}" — ${ko.nlp.notMatched}\n`))
+    process.exitCode = 1
     return
   }
 

--- a/tests/nlp-run-exit.test.ts
+++ b/tests/nlp-run-exit.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { runNaturalLanguageRoute } from '../src/lib/nlp-run.js'
+
+// #346: 미인식 명령(vhk zzzz 등)이 exit 0 으로 '성공' 처리되던 회귀 방지.
+// NL 미매칭은 실패(process.exitCode=1) + stderr 안내여야 한다.
+
+describe('runNaturalLanguageRoute 미인식 — exit 1 (#346)', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.exitCode = 0 // 다른 테스트 오염 방지
+    vi.restoreAllMocks()
+  })
+
+  it('미인식 입력은 process.exitCode=1 로 실패 신호 (stdout 아님)', async () => {
+    await runNaturalLanguageRoute('zzzz존재하지않는명령qqq')
+    expect(process.exitCode).toBe(1)
+  })
+})


### PR DESCRIPTION
도그푸딩 med — `vhk zzzz`(오타·미지 명령)가 exit 0 + stdout ❓ 로 처리돼 `vhk <오타> && 다음작업` 이 조용히 통과(CI/스크립트 무인 실패 누락).

## 수정
nlp-run 미매칭(route===null) → `console.error`(stderr) + `process.exitCode=1`. commander 가 옵션오류·잘못된 서브커맨드를 exit 1 처리하는 것과 일관.

## 검증
- E2E(파이프 없이): zzzz·다중토큰 → exit 1 + stderr / status → exit 0(회귀 0)
- 회귀 테스트 nlp-run-exit.test.ts

> ⚠️ 동시 세션 충돌로 동일 커밋이 docs/rfc0056-adversarial-review(origin)에도 섞임 — 그 브랜치 정리는 해당 세션에서.

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 자연어 명령 인식 실패 시 에러 상태가 올바르게 반영되도록 개선했습니다. 이제 호출 프로그램이 실패를 정확하게 인지할 수 있습니다.

* **Tests**
  * 명령 인식 실패 시 적절한 에러 처리가 이루어지는지 확인하는 회귀 방지 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->