### PR TITLE
docs(rfc-0056): 구현 전 적대 검증 + Goal 85·86 등록 — 탐지범위·#315

### DIFF
--- a/docs/log/2026-06-23-rfc0056-adversarial-review.md
+++ b/docs/log/2026-06-23-rfc0056-adversarial-review.md
@@ -1,0 +1,42 @@
+# 2026-06-23 — RFC 0056 구현 전 적대 검증: 탐지범위 역설 + #315 자기참조
+
+> 성격: append-only dev log. RFC 0056(Evidence Receipt) T1 착수 **전**, "거짓완료 탐지기" 정체성의 두 급소를 코드로 검증한 세션. Claude(Opus 4.8) 단독 분석, **코드 변경 0(조사만)**. 노션 전체 로드맵 + RFC 0055/0056 + ADR-006 종합에서 출발.
+
+## 한 줄 결론
+
+VHK "거짓완료 탐지기"의 두 급소를 코드로 확인했다: **① diff-cover는 "실행됐나"만 재고 "맞나"는 원리적으로 못 잰다(탐지범위 역설). ② verify가 추적 ledger를 append해 자기 dirty를 만든다(#315 실재).** 둘 다 RFC 0056 킬조건 #4와 직결 — T1 전 선결 대상.
+
+## A. 탐지 범위의 역설 (코드 근거)
+
+- `src/lib/diff-coverage.ts:42-48` — `covered = fc.covered.has(ln)` = "테스트 실행 중 그 라인을 **지나갔나**". 정확성과 무관.
+- ⟹ assertion 0 테스트도 covered. `return a - b`(덧셈인데 빼기 버그)도 호출만 되면 초록불. **"그럴듯하게 틀린 코드"를 원리적으로 미탐지.**
+- `src/commands/diff-cover.ts:69` — `// 측정 결과로는 exit 0 유지(advisory)`. 차단 0. receipt "4대 증거" 중 diff-cover는 `decision=block`을 **못 만드는 약신호**. 실차단력 = 종료코드·dirty·stale 3개뿐.
+- **시사:** 0056 킬조건 #4("미묘히 틀린 코드 구조적 미탐")는 *정밀도* 문제가 아니라 **"커버리지=실행도달" 측정 정의 자체의 한계** → 정밀화로 안 풀림. 단 "테스트가 아예 안 닿은 새 코드"(가장 흔한 게으른 거짓완료)는 잡는다 = 잔존 가치.
+
+## B. #315 자기참조 진단 (코드 근거)
+
+- **writer:** `src/commands/verify.ts:351` — verify 종료 시 `appendLedgerEntry`를 **무조건 시도** → `.vhk/ledger.jsonl` append.
+- **추적이 의도:** `src/lib/evidence-ledger.ts:12-16` 주석 — goal 45가 "repo 영속 증거"로 ledger를 **일부러 추적**(gitignore 제외 안 함). events/ai-actions.jsonl도 동일(`action-ledger.ts:9`, `safety-guard.ts:47`). append = dirty.
+- **완화장치:** `src/lib/evidence-ledger.ts:60` dedup — 마지막 항목과 (version·sha·status·dirty) 동일 시 skip. ⟹ **"가만 두고 verify 반복 = 늘 빨강"은 과장.**
+- **그러나 핵심 시나리오 미차단:** 커밋까지 완료(clean) → receipt/verify → 새 커밋이라 sha 변경 → dedup 통과 못 함 → ledger append → **ledger.jsonl만 dirty** → "dirty면 block" → **다 끝냈는데 vhk 자신이 남긴 한 줄 때문에 block.** (ledger 끝줄 `dirty:true`가 흔적.)
+- **일상명령은 안전:** `vhk status`는 추적파일 무변경(재현 확인).
+- **판정: #315 실재.** 근본은 **딜레마** — 추적(0056 핵심 "repo 증거") ↔ dirty(자기검증 붕괴)의 정면충돌. 0056 §6 선결 "자기파일 제외"가 정답 방향이나, **그 제외 자체가 새 사각지대**(자기 ledger 위조 미탐) = ②자기참조의 연장.
+
+## 5개 전략 긴장 (요약 — 노션+RFC 종합)
+
+1. **탐지범위 역설** — 잡는 건 게으른 거짓완료뿐, 위험한 건 원리적 미탐(§A).
+2. **자기참조 저주** — secure 거짓green·스텁게이트·#315 3중. 치명적이자 최강 도그푸딩 자산.
+3. **해자 = 거인의 무관심** — 강한 해자는 기술이 아니라 "벤더 이해상충". 내 실력 아님 → 시간 싸움(0056 §4 자인, 킬 #3).
+4. **타겟 180° 전환** — 노션 1조 비전(비개발자 대중)↔0056(개발자 니치). 이유는 "시장 매력"이 아니라 **"1인이 혼자 측정 가능"**(0056 §3).
+5. **성공기준이 쉬운 질문에만 답** — 90일 #1(작동하나)은 자기 레포서 통과 가능, 진짜 사인 #2(수요 있나)는 6개월로 유보.
+
+## 시사점 / 다음
+
+- **T1 선결(#315 봉인):** dirty 판정에서 자기 산출 추적파일(`.vhk/ledger.jsonl`·`events/*.jsonl`) 제외 화이트리스트 + **그 제외를 테스트로 고정**(사각지대 최소화).
+- **승부처 = ②(자기 거짓완료 봉인 + 정직 공개)와 ①(탐지범위).** ③④⑤는 ①②가 풀려야 의미.
+- **별개 갭:** `.vhk/.gitignore`에 `ops-prompt.md`·`sell-prompt.md` 누락(work/handoff/content/launch-prompt는 등록됨) — goal 76·77 산물, next-task ④와 동일.
+
+## 산출물 색인
+
+- [RFC 0056 §6 선결(#315) · 킬조건 #4](../rfc/0056-vhk-evidence-receipt.md) — 본 검증이 코드로 뒷받침
+- 진입점: 이 파일

--- a/docs/rfc/0056-vhk-evidence-receipt.md
+++ b/docs/rfc/0056-vhk-evidence-receipt.md
@@ -98,6 +98,8 @@ VHK가 파는 것은 "코드 생성"도 "더 똑똑한 리뷰"도 아니다. **"
 
 를 수집해 `.vhk/receipts/<날짜-슬러그>.{json,md}` 영수증 1장으로 굳히고, 기계증거가 모순이면(dirty/stale/red) **decision=block을 LLM 판단 0으로** 낸다.
 
+> **정직 경계(2026-06-23 적대검증 반영 · §11):** ④ diff-cover는 advisory 약신호다 — "테스트 실행 도달"이지 "정확성"이 아니라, 그럴듯하게 틀린 코드(assertion 0·틀린 assert)는 구조적으로 못 잡는다(`diff-coverage.ts:42`·`diff-cover.ts:69`). 따라서 receipt가 실제로 잡는 것은 **"게으른 거짓완료"(빌드 깨짐·미커밋·stale)에 한정**되며, 이는 정밀화로 넓혀지지 않는다(한계가 정밀도가 아니라 "커버리지=실행도달" 정의). 그러므로 4대 증거를 "거짓완료를 전부 잡는다"로 팔지 않고, 산출물 .md 정직성 1줄에 경계를 박는다 — *"이 영수증은 게으른 거짓완료를 잡지, 미묘한 오류는 못 잡는다."*
+
 **기존 자산 재사용(신규 발명 금지):** `verifyEvidence`(실종료코드)·`review`(거짓완료 교차검증)·`checkEvidenceFreshness`(stale 강등)·evidence-ledger·`reports/latest.json` 병합 — 이미 디스크 작동. receipt는 이들을 1장으로 조립하는 글루코드.
 
 **90일 밖(제외):** 표준화·proof 6객체·CI status check·외부발송·무인 머지·history replay·다타겟 sync 전부.
@@ -152,6 +154,15 @@ typecheck/test/build 필드는 `manual:true`/self-report 입력을 **소스 asse
 | 휴대용 두뇌(sync) | 4.5 | 3 | 가장 약한 자산을 쐐기로 격상, 핵심자산 버림, 수익화 0 |
 | 블랙박스(부검) | 4.0 | 3 | history replay 그린필드 + 외부레포 실행 헌법충돌 |
 | 관제탑(무인머지) | 3.8 | 3 | auto-merge 실제 G3·G4가 LLM이라 "기계증거만" 자기모순 |
+
+---
+
+## §11. 구현 전 적대 검증 (2026-06-23)
+
+T1 착수 전 Claude(Opus 4.8)가 정체성의 두 급소를 코드로 검증 → 진입점 [docs/log/2026-06-23-rfc0056-adversarial-review.md](../log/2026-06-23-rfc0056-adversarial-review.md).
+
+- **① 탐지범위 역설** — `diff-coverage.ts:42`의 covered는 "실행 도달"이지 "정확성"이 아니다(assertion 0 테스트도 covered). diff-cover는 advisory라 block도 못 냄(`diff-cover.ts:69`). 킬조건 #4는 *정밀도*가 아니라 "커버리지=실행도달" 정의의 한계 → 정밀화로 안 풀림. 잔존가치 = "테스트 0인 새 코드"는 잡음.
+- **② #315 실재** — `verify.ts:351`이 추적 ledger를 무조건 append → 자기 dirty. `evidence-ledger.ts:60` dedup이 "연속 반복 늘 빨강"은 완화하나, 커밋 직후 첫 검증은 sha 변경으로 append→dirty→자기 block. 근본은 추적(repo 증거) ↔ dirty(자기검증)의 딜레마. T1 선결 "자기파일 제외"는 정답이나 새 사각지대(자기 ledger 위조 미탐).
 
 ---
 

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -9,6 +9,7 @@
 
 ## 다음 할 일 (measure-first 최우선)
 - **⓪ [새 전략 최우선 · 2026-06-22 · RFC 0056] `vhk receipt` MVP** → 진입점 [docs/log/2026-06-22-rfc0056-evidence-receipt.md](../log/2026-06-22-rfc0056-evidence-receipt.md). VHK 정체성을 "멀티툴 솔로용 거짓완료 탐지기(Evidence Receipt)"로 재정의([RFC 0056](../rfc/0056-vhk-evidence-receipt.md)·[ADR-006](../adr/ADR-006-vhk-identity-evidence-receipt.md)). **선결**: vhk가 추적파일(`.vhk/events/*.jsonl`) 갱신→작업트리 늘 dirty→receipt 늘 block 봉인(세션시작 `git status M .vhk/events/ai-actions.jsonl` 관찰). **T1** `vhk receipt`(4대 기계증거→`.vhk/receipts/<id>.{json,md}`, decision 기계만, 등록 4지점+드리프트 테스트 수용기준) → T2 위조방어+.md → T3 거짓완료 적발 1건 입증(현 0/8). **90일 단일 성공기준=적발 1건, 0건이면 가설 폐기.** ※ RFC 0055 §8/§7 폐기, §3·§4·§9는 결함 정정 후 재사용. measure-first와 같은 방향(거짓완료 측정).
+  - **★2026-06-23 적대검증 + goal 등록**: 탐지범위 역설(diff-cover는 "실행됐나"만 잼·정밀화로 안 풀림 → "게으른 거짓완료"로 정직화, 0056 §6·§11)·#315 실재(verify가 추적 ledger append → 자기 dirty) **코드 확정**. → **[Goal 85](../../goals/85-receipt-self-reference-seal.md)(#315 봉인·T1 선결) · [Goal 86](../../goals/86-receipt-mvp.md)(receipt MVP T1)** 신규 등록. 진입점 [docs/log/2026-06-23-rfc0056-adversarial-review.md](../log/2026-06-23-rfc0056-adversarial-review.md). **코드 미착수(등록만)** — T1 선결 = Goal 85.
 - **[완료] 도그푸딩 하드닝 (RFC 0053 · goals 78~84)** → 실 사용자 전수 감사(`docs/log/2026-06-20-dogfood-audit.md`) 기반 전 goal 머지.
   - ✅ **78**(#303): `goal next` 비파괴화 + `vhk goal peek`. ✅ **79**(#304): recall-log timeout 30s + TS-004(환경분리는 YAGNI 관찰).
   - ✅ **80**(#310): 증거 신선도 SHA 강등(review가 SHA≠HEAD/dirty 감지, goal 44 소비측 완결).

--- a/goals/85-receipt-self-reference-seal.md
+++ b/goals/85-receipt-self-reference-seal.md
@@ -1,0 +1,47 @@
+---
+vhk_format: 1
+type: goal
+id: 85
+title: receipt/verify dirty 판정에서 자기 산출 추적파일 제외 (#315 자기참조 봉인) — P0
+status: NOT_STARTED
+priority: P0
+created: 2026-06-23
+leads_to: receipt가 자기 ledger 때문에 늘 block되는 자기모순 제거 (RFC 0056 T1 선결)
+---
+
+# Goal 85: #315 자기참조 봉인 — dirty 판정에서 자기파일 제외
+
+> 출처: RFC 0056 §6 선결 · #315 · [dev log 2026-06-23 적대검증 §B](../docs/log/2026-06-23-rfc0056-adversarial-review.md).
+
+## 근거 (실측 — 코드 확정)
+- `src/commands/verify.ts:351` — verify 종료 시 `appendLedgerEntry`를 **무조건 시도** → `.vhk/ledger.jsonl` append.
+- `src/lib/evidence-ledger.ts:12-16` 주석 — 이 파일은 goal 45가 "repo 영속 증거"로 **의도적으로 git 추적**(gitignore 제외 안 함). 즉 append = 작업트리 dirty.
+- `src/lib/evidence-ledger.ts:60` dedup — 마지막 항목과 (version·sha·status·dirty) 동일 시 skip → "가만 두면 늘 빨강"은 과장이나, **커밋 직후 첫 verify는 sha 변경으로 append → ledger.jsonl만 dirty**.
+- ⟹ 소스를 커밋까지 끝낸 clean 상태에서도 receipt가 "dirty면 block"이면 **vhk 자신이 남긴 ledger 한 줄 때문에 늘 block** = 자기모순. events/ai-actions.jsonl도 동일(`safety-guard.ts:47`).
+
+## 동작
+- dirty 판정(`checkEvidenceFreshness` / 향후 receipt decision)에서 **자기 산출 추적파일 화이트리스트**(`.vhk/ledger.jsonl`·`.vhk/events/*.jsonl`)를 제외. git status 파싱 시 해당 경로만 필터.
+
+## 수용 기준
+- 소스 커밋 완료(clean) 후 verify→receipt가 자기 ledger append만으로는 dirty/block 되지 않는다.
+- **퇴행 0**: 진짜 소스 변경(미커밋)은 여전히 dirty/block. 제외 범위 과확장 0.
+- 화이트리스트는 한 곳(SoT) — 분산 금지.
+
+## Completion Check (작은 단위 — 미착수)
+- [ ] 자기파일 화이트리스트 상수 (SoT 한 곳, glob/경로)
+- [ ] dirty 판정에 필터 적용 (checkEvidenceFreshness/receipt decision 경로)
+- [ ] 사각지대 방지 테스트 — 자기파일은 제외하되 그 외 `.vhk` 파일·소스 변경은 여전히 dirty로 잡힘(과확장 0)
+- [ ] 한계 명시 — "제외 = vhk가 자기 ledger를 위조해도 receipt가 못 잡는다"는 ②자기참조 사각지대를 주석/문서에 정직하게 박음
+- [ ] 공통 게이트 통과(_meta), 회귀 0
+- [ ] check-goal-85.mjs (vhk goal sync 자동생성)
+
+## 구현 노트 (선조사)
+- goal 82(.vhk gitignore 정합)와 **다른 층위**: 82는 추적 *제외*, 85는 "추적하되 dirty 판정에서 제외". ledger/events는 0056 핵심("repo 영속 증거")이라 추적 유지가 **전제** — gitignore로 빼면 안 됨.
+- ★사각지대(정직): 자기파일을 dirty 판정서 빼면 vhk가 자기 ledger를 조작해도 못 잡는다. → 화이트리스트를 **최소·정확**하게, 테스트로 고정. ②자기참조 문제의 연장이라 "최강 도그푸딩 자산(자기 거짓완료 정직 공개)"과 톤 일치.
+
+## Forbidden Actions (OUT)
+- 진짜 소스 변경(미커밋) dirty 무력화 0 — 자기 산출 추적파일만 제외.
+- ledger/events를 gitignore로 빼서 "dirty 안 나게" 우회 금지 (0056 증거영속 붕괴).
+
+## Mandatory Reading
+- src/commands/verify.ts (appendLedgerEntry·checkEvidenceFreshness) · src/lib/evidence-ledger.ts · src/lib/action-ledger.ts · src/lib/safety-guard.ts · RFC 0056 §6

--- a/goals/86-receipt-mvp.md
+++ b/goals/86-receipt-mvp.md
@@ -1,0 +1,51 @@
+---
+vhk_format: 1
+type: goal
+id: 86
+title: vhk receipt MVP — 4대 기계증거를 영수증 1장으로 (RFC 0056 T1) — P0
+status: NOT_STARTED
+priority: P0
+created: 2026-06-23
+leads_to: 에이전트 "됐어요"를 기계증거 영수증으로 — 거짓완료 탐지 90일 쐐기
+---
+
+# Goal 86: vhk receipt MVP (RFC 0056 T1)
+
+> 출처: [RFC 0056 §6 T1](../docs/rfc/0056-vhk-evidence-receipt.md) · ADR-006(정체성 Accepted) · [dev log 2026-06-23](../docs/log/2026-06-23-rfc0056-adversarial-review.md).
+> **선결: Goal 85(#315 봉인)** — 안 되면 receipt가 늘 block이라 데모 첫 장면이 깨짐.
+
+## 근거
+- VHK 정체성(ADR-006) = "AI 자기보고를 기계증거로 대조해 거짓완료를 잡는 결정론 판정". 90일 단일 성공기준 = 거짓완료 적발 1건(현 0/8).
+- 신규 발명 0 — 기존 디스크 작동 자산(`verifyEvidence`·`review`·`checkEvidenceFreshness`·`reports/latest.json`)을 1장으로 조립하는 글루코드.
+
+## 동작
+- `vhk receipt` — 에이전트 "완료" 시점에 4대 기계증거 수집 → `.vhk/receipts/<날짜-슬러그>.{json,md}` 1장.
+  - ① tsc/test/build 실종료코드 ② git dirty(자기파일 제외 — Goal 85) ③ stale(작업시작 SHA≠HEAD) ④ 변경라인 diff-cover.
+- `decision = block|caution|pass`는 **기계증거로만(LLM 0)**. dirty/stale/red면 block. **caution→pass 격상 금지 단조성 불변식**.
+
+## 수용 기준
+- 등록 4지점(index.ts·command-registry TOP_LEVEL/CONTAINER·cli-args·ko.ts) + nlp-router 키워드 + 한글별칭(`증거영수증`) + 드리프트 테스트 green. (0055 §13-high#3 정면 예방 — 누락 시 첫 게이트서 빌드 깸.)
+- 단조성 불변식(caution→pass 금지) 테스트 고정.
+- **④ diff-cover는 advisory(약신호)로 분리** — decision을 block으로 격하시키지 못함(0056 §6 정직 경계). 실차단 = 종료코드·dirty·stale 3개.
+- `.md`에 정직성 1줄: "게으른 거짓완료를 잡지, 미묘한 오류는 못 잡는다."
+
+## Completion Check (작은 단위 — 미착수)
+- [ ] receipt 수집기 — 4대 증거 기존자산 병합 (순수 + fs 경계 분리)
+- [ ] decision 판정 — 기계증거만, 단조성 불변식 테스트
+- [ ] `.json` + `.md` 산출 — .md는 PR/대화 붙여넣기 1블록(decision 배지+게이트표+사유+정직성 1줄)
+- [ ] 등록 4지점 + nlp-router + 한글별칭 + 드리프트 테스트 green
+- [ ] diff-cover advisory 분리(decision 미격하) 테스트
+- [ ] 공통 게이트(_meta), check-goal-86.mjs
+
+## 구현 노트
+- T1 본체. **선결 Goal 85**(blockedBy). T2(자기보고 위조방어 + 붙여넣기 .md)·T3(거짓완료 적발 1건 공개입증, 사람 율속)는 후속 — RFC 0056 §6.
+- ④ diff-cover의 구조적 한계(covered≠verified)는 Goal 85 노트·RFC 0056 §11·dev log 2026-06-23 §A 참조 — "전부 잡는다"로 과대표현 금지.
+
+## Forbidden Actions (OUT)
+- decision을 LLM 추론으로 내림 0 (기계증거만).
+- 기존 `vhk ship`·`mission` 시그니처 변경 0 (0055 §13-high#1·#4 교훈 — 이름 충돌·두 이름 금지).
+- caution→pass 격상 0.
+- 효과 입증(T3) 없이 수익화·표준화 도약 0 (ADR-006).
+
+## Mandatory Reading
+- RFC 0056 §6·§11 · src/commands/verify.ts (verifyEvidence·checkEvidenceFreshness) · src/commands/review.ts · src/lib/evidence-ledger.ts · goals/85-receipt-self-reference-seal.md

--- a/goals/README.md
+++ b/goals/README.md
@@ -2,7 +2,7 @@
 
 # goals/ 인덱스
 
-> 총 84 goal — DONE 80 · IN_PROGRESS 2 · NOT_STARTED 2
+> 총 86 goal — DONE 80 · IN_PROGRESS 2 · NOT_STARTED 4
 > 공통 게이트 = [_meta.md](_meta.md) · 카드 형식/상태 의미는 각 파일 frontmatter 참조.
 
 | # | 제목 | 상태 | 우선순위 | 다음 연결 |
@@ -91,3 +91,5 @@
 | 82 | .vhk 런타임 산출물 gitignore 정합 — git status 청결 — P2 | ✅ DONE | P2 | vhk 명령 사용 후 git status 노이즈 0 |
 | 83 | 보안 scan 테스트 픽스처 false positive allowlist — P2 | ✅ DONE | P2 | secure scan 노이즈 ↓ (진짜 시크릿 신호 보존) |
 | 84 | doctor/status next-step 맥락 인지 — 신규 vs 기존 레포 분기 — P2 | ✅ DONE | P2 | "다음에 이것만 하세요"가 현재 상태에 맞음 |
+| 85 | receipt/verify dirty 판정에서 자기 산출 추적파일 제외 (#315 자기참조 봉인) — P0 | ⬜ NOT_STARTED | P0 | receipt가 자기 ledger 때문에 늘 block되는 자기모순 제거 (RFC 0056 T1 선결) |
+| 86 | vhk receipt MVP — 4대 기계증거를 영수증 1장으로 (RFC 0056 T1) — P0 | ⬜ NOT_STARTED | P0 | 에이전트 "됐어요"를 기계증거 영수증으로 — 거짓완료 탐지 90일 쐐기 |


### PR DESCRIPTION
## 요약
RFC 0056(Evidence Receipt) T1 착수 **전**, "거짓완료 탐지기" 정체성의 두 급소를 코드로 적대 검증하고 후속 Goal을 등록. **코드 변경 0 (docs·goals만).**

> ℹ️ #358은 동시 세션 git 충돌로 다른 작업 파일이 섞여 닫고, 격리 worktree에서 만든 이 PR로 대체.

## 검증 결과
- **A. 탐지범위 역설** — diff-cover는 `covered`(테스트 실행 도달)만 잼, "정확성"은 원리적 미탐(`diff-coverage.ts:42`). advisory라 차단도 0(`diff-cover.ts:69`). 정밀화로 안 풀림(한계가 "커버리지=실행도달" 정의) → receipt가 잡는 건 "게으른 거짓완료"에 한정.
- **B. #315 자기참조** — `verify.ts:351`이 추적 ledger 무조건 append → 자기 dirty → receipt 늘 block. dedup(`evidence-ledger.ts:60`)은 반복만 완화, 커밋 후 첫 검증은 sha 변경으로 append. **실재 확정.**

## 변경 (6 파일 · 코드 0)
- \`docs/rfc/0056\` §6 정직화(게으른 거짓완료로 좁힘) + §11 적대검증
- \`goals/85\` #315 자기참조 봉인 (T1 선결) — NOT_STARTED
- \`goals/86\` vhk receipt MVP (T1) — NOT_STARTED, blocked by 85
- \`docs/log/2026-06-23-…\` dev log 진입점(5개 긴장 전수)
- \`docs/state/next-task.md\` 핸드오프 + \`goals/README.md\` 인덱스 재생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 영수증 검증 메커니즘의 경계 조건 명시 및 구현 전 적대 검증 항목 추가
  * 자기참조 봉인과 영수증 MVP 관련 새로운 목표 문서 추가
  * 프로젝트 목표 현황 업데이트 (84 → 86개)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->