### PR TITLE
fix(cli): recall/회상 자유형식 쿼리를 NL 라우터 가로채기에서 제외 (#313)

### DIFF
--- a/docs/log/2026-06-23-fix-313-recall-router.md
+++ b/docs/log/2026-06-23-fix-313-recall-router.md
@@ -1,0 +1,20 @@
+# 2026-06-23 — fix #313: recall/회상 NL 라우터 가로채기 차단
+
+## 증상
+`vhk recall "이거 어떻게 해"`처럼 검색 쿼리 본문에 NLP 트리거 단어(어떻게·보안·롤백 등)가
+섞이면, 명시한 recall 서브커맨드가 무시되고 NL 라우터가 문장을 가로채 status/secure/undo 등
+엉뚱한 명령이 실행됨. recall 은 자유형식 검색이라 어떤 단어가 와도 항상 `🔎 기억 회상`이 나와야 함.
+
+## 근본 원인
+`src/lib/cli-args.ts` 의 `FREEFORM_ARG_COMMANDS` 가 `learn/교훈/blocker/블로커` 만 포함하고
+`recall/회상` 누락. recall 은 `.command('recall [query...]')` 자유형식인데 freeform 예외에서
+빠져 `detectNaturalLanguageInput` 분기에서 NL 라우팅됨(#147이 learn/blocker에 적용한 패턴 누락).
+
+## 수정
+- `FREEFORM_ARG_COMMANDS` 에 `'recall', '회상'` 추가 (#147 패턴 그대로).
+- 회귀 가드 `tests/memory-recall.test.ts` 에 트리거 단어 포함 케이스 6건 추가
+  (어떻게·보안·롤백·한글별칭 + 대조군 publish + learn/blocker 회귀).
+
+## 게이트
+- `pnpm build` ✅ / `pnpm test` ✅ (177 files · 1805 tests pass)
+- TDD: RED(4 fail) → 구현 → GREEN.

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -76,7 +76,13 @@ function isOptionToken(token: string): boolean {
  * 라우터가 문장 전체를 가로채 엉뚱한 명령(sync 등)이 실행되므로, 이 명령들은 NL 가로채기를
  * 건너뛰고 항상 commander 가 인자 그대로 처리한다. (영문 + 한글 별칭 모두 포함)
  */
-const FREEFORM_ARG_COMMANDS = new Set(['learn', '교훈', 'blocker', '블로커'])
+const FREEFORM_ARG_COMMANDS = new Set([
+  'learn', '교훈',
+  'blocker', '블로커',
+  // #313: recall 은 자유형식 검색 쿼리라 '어떻게·보안·롤백' 등 트리거 단어가 본문에 와도
+  // 항상 commander 로 위임돼야 한다(NL 라우터 가로채기 금지 — learn/blocker 와 동일).
+  'recall', '회상',
+])
 
 /**
  * 서브커맨드를 갖는 컨테이너 명령 → 실제 서브커맨드 이름 목록.

--- a/tests/memory-recall.test.ts
+++ b/tests/memory-recall.test.ts
@@ -143,3 +143,44 @@ describe('recall 명령 NL 라우팅 가드 (RFC 0049)', () => {
     expect(detectNaturalLanguageInput(['node', 'vhk', '회상', '배포'])).toBeNull()
   })
 })
+
+// #313: 쿼리 본문에 NLP 트리거 단어(어떻게·보안·롤백 등)가 섞여도 recall 은 자유형식 검색이므로
+// NL 라우터에 가로채이지 않고 항상 commander 로 위임돼야 한다 (learn/blocker 와 동일 — #147 패턴).
+describe('recall 명령 자유형식 쿼리 가드 (#313 — 트리거 단어 포함)', () => {
+  it('recall "이거 어떻게 해"(status 트리거)도 NL 라우팅 안 됨 (null)', () => {
+    expect(
+      detectNaturalLanguageInput(['node', 'vhk', 'recall', '이거', '어떻게', '해'])
+    ).toBeNull()
+  })
+
+  it('recall "보안 이슈"(secure 트리거)도 NL 라우팅 안 됨 (null)', () => {
+    expect(
+      detectNaturalLanguageInput(['node', 'vhk', 'recall', '보안', '이슈'])
+    ).toBeNull()
+  })
+
+  it('recall "롤백 방법"(undo 트리거)도 NL 라우팅 안 됨 (null)', () => {
+    expect(
+      detectNaturalLanguageInput(['node', 'vhk', 'recall', '롤백', '방법'])
+    ).toBeNull()
+  })
+
+  it('회상 "어떻게 하지"(한글 별칭 + status 트리거)도 NL 라우팅 안 됨 (null)', () => {
+    expect(
+      detectNaturalLanguageInput(['node', 'vhk', '회상', '어떻게', '하지'])
+    ).toBeNull()
+  })
+
+  it('대조군 recall "publish"(트리거 없음) 회귀 0 (null)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'recall', 'publish'])).toBeNull()
+  })
+
+  it('learn/blocker 자유형식 쿼리 회귀 0 (트리거 단어 포함도 null)', () => {
+    expect(
+      detectNaturalLanguageInput(['node', 'vhk', 'learn', '보안', '롤백'])
+    ).toBeNull()
+    expect(
+      detectNaturalLanguageInput(['node', 'vhk', 'blocker', '어떻게', '해'])
+    ).toBeNull()
+  })
+})


### PR DESCRIPTION
## 문제 (#313)
`vhk recall "이거 어떻게 해"`처럼 검색 쿼리 본문에 NLP 트리거 단어(어떻게·보안·롤백·변경·왜 등)가 섞이면, 명시한 `recall` 서브커맨드가 무시되고 NL 라우터가 문장을 가로채 `status`/`secure`/`undo` 등 엉뚱한 명령이 실행됐다. recall 은 자유형식 검색이라 어떤 단어가 와도 항상 `🔎 기억 회상`이 나와야 한다(learn·blocker 와 동일).

## 근본 원인
`src/lib/cli-args.ts` 의 `FREEFORM_ARG_COMMANDS` 가 `learn/교훈/blocker/블로커` 만 포함하고 `recall/회상` 누락. recall 은 `.command('recall [query...]')` 자유형식인데 freeform 예외에서 빠져 `detectNaturalLanguageInput` 분기에서 NL 라우팅됨. #147 이 learn/blocker 에 적용한 패턴이 recall 에는 빠진 갭.

## 수정
- `FREEFORM_ARG_COMMANDS` 에 `'recall', '회상'` 추가 → 항상 commander 로 위임.
- 회귀 가드 6건 추가 (`tests/memory-recall.test.ts`):
  - `recall "이거 어떻게 해"`(status 트리거), `recall "보안 이슈"`(secure), `recall "롤백 방법"`(undo), `회상 "어떻게 하지"`(한글별칭) → 전부 null(NL 라우팅 안 됨)
  - 대조군 `recall "publish"` 회귀 0
  - learn/blocker 자유형식(트리거 단어 포함)도 회귀 0

## 게이트
- TDD: RED(4 fail) → 구현 → GREEN
- `pnpm build` ✅ / `pnpm test` ✅ — 177 files · 1805 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * recall 명령어가 자유형식 쿼리를 올바르게 처리하도록 개선되었습니다.
  * recall 명령어 뒤 특정 단어들이 있을 때 의도하지 않은 자동 라우팅이 발생하던 문제가 해결되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->