### PR TITLE
fix: goal·memory 파괴적 입력 검증 강화 (#317 #318)

### DIFF
--- a/docs/log/2026-06-23-fix-317-318-destructive-parse.md
+++ b/docs/log/2026-06-23-fix-317-318-destructive-parse.md
@@ -1,0 +1,14 @@
+# 2026-06-23 — fix #317·#318 파괴적 입력 검증 (부분파싱/강제변환)
+
+## 한 일
+- #317 `goal check/done --id`: `Number('')===0`·`Number(' 1')===1` 강제변환이 빈/공백/소수/앞뒤공백 `--id`를 통과시켜 엉뚱한 goal(특히 goal 0)을 조용히 DONE 처리하던 데이터 오염 차단.
+  - `src/commands/goal.ts resolveGoalId`: 엄격 정수 정규식 `/^\d+$/`(앞뒤 공백조차 거부)로 검증, 거부 시 sentinel 반환 → 호출부(goalCheck·goalDone) 둘 다 친절 메시지(`ko.goal.invalidId`)로 exit 1.
+- #318 `memory remove/archive`: `parseInt('2zzz',10)=2`·`parseInt('1.5',10)=1` 부분파싱이 NaN 검사를 통과해 범위 안이면 엉뚱한 항목을 조용히 삭제/보관하던 파괴적 버그 차단.
+  - `src/commands/memory.ts resolveIndex`: `/^\d+$/` + `Number.isInteger` 엄격 검증. remove·archive 공용 경로라 둘 다 가드됨.
+
+## 검증 (TDD)
+- goal.test.ts: #317 describe 추가(빈·공백·`' 1'`·문자·소수·음수 거부 + 정상 `'1'` 회귀 + goalCheck 차단) → red→green.
+- memory.test.ts: #318 describe 추가(remove·archive 각각 `'2zzz'`·`'1.5'`·`' 2'`·빈·문자·음수 거부, 삭제/보관 0 + exit 1, 정상 정수 회귀) → red→green.
+
+## 남은 위험
+- 강제변환 거부 정책을 raw 문자열 기준(`' 1'` 거부)으로 통일 — trim 후 허용이 더 관대하나, 수용 기준이 `' 1'` 거부를 명시해 raw 검증 채택. CLI UX상 사용자가 공백 포함 입력할 일은 드묾.

--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -42,11 +42,18 @@ export function selectActiveId(goals: ParsedGoal[]): number | null {
   return null
 }
 
-function resolveGoalId(optId: string | undefined, goals: ParsedGoal[]): number | null {
+// #317: --id 는 양의 정수 문자열만 허용. Number() 강제변환은 ''·'   '→0, ' 1'→1, '1.5'→1.5 처럼
+//        빈/공백/소수/앞뒤공백을 조용히 통과시켜 엉뚱한 goal(특히 goal 0)을 파괴적으로 건드린다.
+//        엄격 정수 정규식 /^\d+$/ 로 거부 → 호출부가 친절 메시지를 띄우도록 sentinel 반환.
+const INVALID_GOAL_ID = Symbol('invalid-goal-id')
+function resolveGoalId(
+  optId: string | undefined,
+  goals: ParsedGoal[]
+): number | null | typeof INVALID_GOAL_ID {
   if (optId !== undefined) {
-    const n = Number(optId)
-    if (!Number.isFinite(n)) return null
-    return n
+    // 앞뒤 공백조차 거부 — ' 1' 은 Number(' 1')===1 로 엉뚱한 goal 을 가리키는 파괴적 입력.
+    if (!/^\d+$/.test(optId)) return INVALID_GOAL_ID
+    return Number(optId)
   }
   return selectActiveId(goals)
 }
@@ -306,6 +313,12 @@ export async function goalCheck(opts: { id?: string; force?: boolean }): Promise
   console.log(chalk.bold(`\n${ko.goal.checkTitle}\n`))
   const goals = listGoals(GOALS_DIR)
   const id = resolveGoalId(opts.id, goals)
+  // #317: 빈/공백/소수/문자 --id 는 강제변환 전에 거부 (goal 0 오염 방지).
+  if (id === INVALID_GOAL_ID) {
+    console.log(chalk.red(`  ❌ ${ko.goal.invalidId(opts.id ?? '')}`))
+    process.exitCode = 1
+    return
+  }
   if (id === null) {
     console.log(
       chalk.yellow('  ⚠ 대상 goal 을 결정할 수 없습니다 (--id 명시 또는 active goal 필요).')
@@ -376,6 +389,12 @@ export async function goalDone(opts: { id?: string }): Promise<void> {
   console.log(chalk.bold(`\n${ko.goal.doneTitle}\n`))
   const goals = listGoals(GOALS_DIR)
   const id = resolveGoalId(opts.id, goals)
+  // #317: 잘못된 --id 로 goal 0 을 조용히 DONE 처리하던 데이터 오염 차단.
+  if (id === INVALID_GOAL_ID) {
+    console.log(chalk.red(`  ❌ ${ko.goal.invalidId(opts.id ?? '')}`))
+    process.exitCode = 1
+    return
+  }
   if (id === null) {
     console.log(
       chalk.yellow('  ⚠ 대상 goal 을 결정할 수 없습니다 (--id 명시 또는 active goal 필요).')

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -381,8 +381,13 @@ export async function memoryList(opts: { type?: MemBucket; all?: boolean } = {})
 }
 
 function resolveIndex(indexStr: string, len: number): number | null {
-  const idx = parseInt(indexStr, 10) - 1
-  if (Number.isNaN(idx) || idx < 0 || idx >= len) return null
+  // #318: parseInt 부분파싱('2zzz'→2, '1.5'→1)으로 엉뚱한 항목을 조용히 삭제/보관하던 파괴적 버그.
+  //        엄격 정수 정규식으로 비정수·소수·문자혼입·공백·빈문자를 거부. remove 는 되돌릴 수 없어 특히 엄격.
+  if (!/^\d+$/.test(indexStr)) return null
+  const n = Number(indexStr)
+  if (!Number.isInteger(n)) return null
+  const idx = n - 1
+  if (idx < 0 || idx >= len) return null
   return idx
 }
 

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -507,6 +507,8 @@ export const ko = {
     skippedFiles: (n: number) =>
       `⚠ 스키마 불일치로 무시된 파일 ${n}개 (goal 로 안 잡힘 — silent skip):`,
     notFound: (id: number) => `goal id ${id} 없음 — vhk goal list 로 확인하세요.`,
+    invalidId: (raw: string) =>
+      `유효하지 않은 goal 번호: '${raw}' — 양의 정수만 됩니다 (예: --id 3). vhk goal list 로 확인하세요.`,
     driftTitle: '🔍 Goal 상태↔코드 드리프트 점검',
     driftClean: 'goal 상태 드리프트 없음 (구현 흔적 있는데 NOT_STARTED 인 goal 0건)',
     driftFound: (n: number) =>

--- a/tests/goal.test.ts
+++ b/tests/goal.test.ts
@@ -671,6 +671,79 @@ describe('goal 엣지케이스 보강 (roadmap §4)', () => {
     }
   })
 
+  // #317: 빈/공백/소수/문자 --id 는 Number() 강제변환으로 goal 0 을 조용히 건드리면 안 됨.
+  //        (Number('')===0, Number('   ')===0, Number(' 1')===1 모두 finite 라 옛 코드는 통과시켰다.)
+  describe('#317 goalDone — 파괴적 --id 강제변환 차단 (goal 0 오염 방지)', () => {
+    // goal 0 + 통과하는 게이트를 깔아두고, 잘못된 --id 가 goal 0 을 DONE 으로 바꾸지 않음을 확인.
+    function setupGoalZero(label: string): string {
+      const dir = tmpProject(label)
+      makeGoalFile(dir, 0, 'NOT_STARTED')
+      mkdirSync(join(dir, 'scripts'), { recursive: true })
+      writeFileSync(join(dir, 'scripts/check-goal-0.sh'), '#!/usr/bin/env bash\nexit 0\n', 'utf-8')
+      mockSafeExecFile.mockReturnValue({ ok: true, out: 'ok', err: '' })
+      return dir
+    }
+
+    for (const bad of ['', '   ', ' 1', 'abc', '1.5', '2zzz', '-1', '0x1']) {
+      it(`--id ${JSON.stringify(bad)} → 거부 + goal 0 상태 변경 0`, async () => {
+        const dir = setupGoalZero('id-bad')
+        const before = readFileSync(join(dir, 'goals/0-test.md'), 'utf-8')
+        process.chdir(dir)
+        try {
+          const { goalDone } = await import('../src/commands/goal.js')
+          const logSpy = vi.spyOn(console, 'log')
+          await goalDone({ id: bad })
+          const after = readFileSync(join(dir, 'goals/0-test.md'), 'utf-8')
+          // 파괴적 부작용 0: frontmatter 완전 보존
+          expect(after).toBe(before)
+          expect(after).toContain('status: NOT_STARTED')
+          // 친절 메시지로 거부
+          const out = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+          expect(out).toMatch(/유효하지 않은 goal 번호/)
+        } finally {
+          process.chdir(origCwd)
+          rmSync(dir, { recursive: true, force: true })
+        }
+      })
+    }
+
+    it('정상 --id "1" 회귀 — 게이트 통과 시 DONE 처리됨', async () => {
+      const dir = tmpProject('id-good')
+      makeGoalFile(dir, 1, 'NOT_STARTED')
+      mkdirSync(join(dir, 'scripts'), { recursive: true })
+      writeFileSync(join(dir, 'scripts/check-goal-1.sh'), '#!/usr/bin/env bash\nexit 0\n', 'utf-8')
+      mockSafeExecFile.mockReturnValue({ ok: true, out: 'ok', err: '' })
+      process.chdir(dir)
+      try {
+        const { goalDone } = await import('../src/commands/goal.js')
+        await goalDone({ id: '1' })
+        const after = readFileSync(join(dir, 'goals/1-test.md'), 'utf-8')
+        expect(after).toContain('status: DONE')
+      } finally {
+        process.chdir(origCwd)
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('goalCheck 도 동일하게 빈 --id 거부 (게이트 실행 전 차단)', async () => {
+      const dir = tmpProject('check-bad')
+      makeGoalFile(dir, 0, 'NOT_STARTED')
+      process.chdir(dir)
+      try {
+        const { goalCheck } = await import('../src/commands/goal.js')
+        const logSpy = vi.spyOn(console, 'log')
+        await goalCheck({ id: '' })
+        const out = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+        expect(out).toMatch(/유효하지 않은 goal 번호/)
+        // goal 0 을 "없음"으로 잘못 보고하지 않음 (강제변환 0 으로 새지 않음)
+        expect(out).not.toMatch(/goal id 0 없음/)
+      } finally {
+        process.chdir(origCwd)
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+  })
+
   // ② 없는 --id 메시지 통일 — check 와 done 이 같은 메시지
   it('goalCheck/goalDone — 없는 --id 면 둘 다 "goal id N 없음" 통일', async () => {
     const dir = tmpProject('notfound')

--- a/tests/memory-v2-edge.test.ts
+++ b/tests/memory-v2-edge.test.ts
@@ -232,15 +232,17 @@ describe('memory v2 엣지 D — id/index 경계', () => {
     rm(d)
   })
 
-  it('[characterization] 소수 index("2.9") → parseInt 절삭 → 2번 항목 archive', async () => {
+  // #318: 소수 index 는 더 이상 parseInt 절삭으로 수용되지 않는다 — 엄격 정수 검증으로 거부.
+  it('소수 index("2.9") → 거부 (parseInt 절삭 금지) + 보관 0 + exit 1', async () => {
     const d = tmp()
     process.chdir(d)
     await memoryAdd('첫째')
     await memoryAdd('둘째')
-    await memoryArchive('2.9') // parseInt('2.9')=2 → idx1
+    await memoryArchive('2.9') // 옛 동작: parseInt('2.9')=2 → idx1 archive. 이제 거부.
     const mem = readMem(d)
     expect(mem.decisions[0].status).toBe('active')
-    expect(mem.decisions[1].status).toBe('archived')
+    expect(mem.decisions[1].status).toBe('active') // 엉뚱한 절삭 보관 없음
+    expect(process.exitCode).toBe(1)
     process.chdir(origCwd)
     rm(d)
   })

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -281,6 +281,77 @@ describe('memory v2 — 커맨드 (tmp+chdir)', () => {
     fs.rmSync(d, { recursive: true, force: true })
   })
 
+  // #318: parseInt 부분파싱('2zzz'→2, '1.5'→1)으로 엉뚱한 항목을 조용히 삭제/보관하던 파괴적 버그.
+  //        엄격 정수 검증으로 비정수·소수·문자혼입·공백·빈문자 전부 거부 (특히 remove 는 되돌릴 수 없어 엄격).
+  describe('#318 memory remove/archive — 부분파싱 차단 (파괴적 오삭제 방지)', () => {
+    // 2개 항목을 깔고, 잘못된 indexStr 가 어느 것도 건드리지 않음을 확인.
+    function seedTwo(d: string): void {
+      const v2: MemoryFileV2 = {
+        schemaVersion: 2,
+        decisions: [
+          { id: 'd1', content: 'FIRST', tags: [], createdAt: '', status: 'active' },
+          { id: 'd2', content: 'SECOND', tags: [], createdAt: '', status: 'active' },
+        ],
+        failures: [], successes: [], patterns: [],
+      }
+      fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+      fs.writeFileSync(path.join(d, MEMORY_PATH_REL), JSON.stringify(v2, null, 2) + '\n', 'utf-8')
+    }
+
+    for (const bad of ['2zzz', '1.5', ' 2', '', '   ', 'abc', '-1']) {
+      it(`memoryRemove(${JSON.stringify(bad)}) → 거부 + 삭제 0 + exit 1`, async () => {
+        const d = tmp()
+        seedTwo(d)
+        process.chdir(d)
+        await memoryRemove(bad)
+        const mem = read(d)
+        // 파괴적 부작용 0: 두 항목 모두 보존
+        expect(mem.decisions).toHaveLength(2)
+        expect(mem.decisions.map((x) => x.content)).toEqual(['FIRST', 'SECOND'])
+        expect(process.exitCode).toBe(1)
+        process.chdir(origCwd)
+        fs.rmSync(d, { recursive: true, force: true })
+      })
+
+      it(`memoryArchive(${JSON.stringify(bad)}) → 거부 + 보관 0 + exit 1`, async () => {
+        const d = tmp()
+        seedTwo(d)
+        process.chdir(d)
+        await memoryArchive(bad)
+        const mem = read(d)
+        // 어느 항목도 archived 로 바뀌지 않음
+        expect(mem.decisions.every((x) => x.status === 'active')).toBe(true)
+        expect(process.exitCode).toBe(1)
+        process.chdir(origCwd)
+        fs.rmSync(d, { recursive: true, force: true })
+      })
+    }
+
+    it('정상 정수 인덱스 회귀 — remove("2") 는 두 번째만 삭제', async () => {
+      const d = tmp()
+      seedTwo(d)
+      process.chdir(d)
+      await memoryRemove('2')
+      const mem = read(d)
+      expect(mem.decisions).toHaveLength(1)
+      expect(mem.decisions[0].content).toBe('FIRST')
+      process.chdir(origCwd)
+      fs.rmSync(d, { recursive: true, force: true })
+    })
+
+    it('정상 정수 인덱스 회귀 — archive("1") 은 첫 항목만 보관', async () => {
+      const d = tmp()
+      seedTwo(d)
+      process.chdir(d)
+      await memoryArchive('1')
+      const mem = read(d)
+      expect(mem.decisions[0].status).toBe('archived')
+      expect(mem.decisions[1].status).toBe('active')
+      process.chdir(origCwd)
+      fs.rmSync(d, { recursive: true, force: true })
+    })
+  })
+
   it('memoryAdd — 잘못된 --type 거부(exit 1), 저장/입력 유실 없음 (#L)', async () => {
     const d = tmp()
     process.chdir(d)


### PR DESCRIPTION
## 무엇을

부분파싱/강제변환이 잘못된 인덱스를 조용히 수용해 엉뚱한 대상을 **파괴적으로** 건드리던 버그 2건(같은 테마)을 엄격 정수 검증으로 차단.

### #317 `goal check/done --id` 빈/공백/소수 강제변환
- 증상: `goal done --id ""` 가 `Number('')===0` 으로 해석돼 **goal 0 을 조용히 DONE 처리**(데이터 오염). `--id "   "`·`--id " 1"` 도 동일.
- 수정: `resolveGoalId` 를 엄격 정수 정규식 `/^\d+$/`(앞뒤 공백조차 거부)로 검증. 거부 시 sentinel 반환 → `goalCheck`·`goalDone` 둘 다 친절 메시지(`ko.goal.invalidId`)로 `exit 1`.

### #318 `memory remove/archive` 부분파싱
- 증상: `memory remove "2zzz"` 가 `parseInt('2zzz',10)=2` 로 잘려 **항목 2 삭제**. `memory archive "1.5"` → `parseInt('1.5',10)=1`. 범위 안이면 조용히 수용.
- 수정: `resolveIndex` 를 `/^\d+$/` + `Number.isInteger` 로 엄격 검증. `remove`·`archive` 공용 경로라 둘 다 가드. remove 는 되돌릴 수 없어 특히 엄격.

## 검증 (TDD)
- `tests/goal.test.ts`: #317 describe — `""`·`"   "`·`" 1"`·`"abc"`·`"1.5"`·음수 전부 거부 + goal 상태 변경 0, 정상 `"1"` 회귀, `goalCheck` 차단. (red→green)
- `tests/memory.test.ts`: #318 describe — remove·archive 각각 `"2zzz"`·`"1.5"`·`" 2"`·빈·문자·음수 거부(삭제/보관 0 + exit 1), 정상 정수 회귀. (red→green)
- `tests/memory-v2-edge.test.ts`: 옛 buggy `parseInt` 절삭 characterization 을 **거부 동작**으로 갱신.
- 게이트: `pnpm build` ✅ (DTS strict 통과) · `pnpm test` — 결정적 테스트 1825/1825 ✅. 단, `standup-anchor.e2e` 가 풀스위트 부하에서 간헐 spawn 타임아웃(5s) — 격리 실행 시 통과, 본 변경(파싱 검증)과 무관.

## 남은 위험
- 강제변환 거부를 raw 문자열 기준(`" 1"` 거부)으로 통일 — 수용 기준이 `" 1"` 거부를 명시해 trim 미적용. CLI UX상 공백 입력은 드묾.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 목표 명령의 ID 입력 검증이 강화되어, 정수 형식이 아닌 입력(공백, 소수, 문자 혼입 등)이 정확히 거부됩니다.
  * 메모리 명령의 인덱스 검증이 개선되어, 부분 파싱으로 인한 의도하지 않은 삭제/보관이 방지됩니다.

* **개선 사항**
  * 유효하지 않은 목표 번호 입력 시 명확한 오류 메시지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->