### PR TITLE
fix: .vhk 일회성·사적 산출물 4종 gitignore 등록 (#331)

### DIFF
--- a/docs/log/2026-06-23-fix-vhk-gitignore-gap.md
+++ b/docs/log/2026-06-23-fix-vhk-gitignore-gap.md
@@ -1,0 +1,23 @@
+# 2026-06-23 — .vhk/.gitignore 갭 수정 (#331 + 갭⑤)
+
+## 한 일
+일회성/사적 산출물 4종이 git 으로 새던 갭을 막음.
+
+- `src/templates/vhk-dir.ts` `VHK_GITIGNORE_TEMPLATE`: `recall-log.jsonl`·`eval/recall-eval.json` 추가
+  (`ops-prompt.md`·`sell-prompt.md` 는 이미 템플릿에 있었음 — 확인). README 트래킹 표에도 2행 추가.
+- 런타임 자기방어(이미 init 된 기존 프로젝트도 보호): `logRecall`(recall-log.ts) 와
+  `memoryEvalInit`(memory-eval.ts) 가 쓰기 시 `ensureVhkIgnored` 로 멱등 등록.
+  verify.ts 의 `reports/` 자기방어 패턴 답습.
+
+## 경계(준수)
+`.vhk/ledger.jsonl`·`.vhk/events/*` 는 repo 영속 증거(goal 45/82/85)라 의도적 추적 → gitignore 에
+넣지 않음. 회귀 가드 테스트로 고정(템플릿에 ledger·events 가 들어가면 실패).
+
+## 테스트
+- init.test.ts: 4종 등록 + ledger/events 미등록 회귀 가드
+- recall-log.test.ts: logRecall 자동 등록 + 멱등(라인 1개)
+
+## 후속(범위 밖)
+- #326 슬래시 변형 중복 추가(`backups` vs `backups/` 외 변형)는 별 이슈.
+- 메인 repo 자체 `.vhk/.gitignore` 는 stale(work-prompt.md 등 독립 항목 존재) — 다음 recall/eval
+  실행 시 런타임 자기방어로 자가치유됨.

--- a/src/commands/memory-eval.ts
+++ b/src/commands/memory-eval.ts
@@ -8,6 +8,7 @@ import { readRecallLog } from '../lib/recall-log.js'
 import { readJsonFile } from '../lib/read-json.js'
 import { atomicWriteFile } from '../lib/atomic-write.js'
 import { ensureInteractive } from '../lib/interactive.js'
+import { ensureVhkIgnored } from '../lib/backup.js'
 
 /**
  * recall 검증 명령 (RFC 0049 ③). 별도 파일 = memory↔recall-eval 순환 의존 회피.
@@ -107,6 +108,12 @@ async function memoryEvalInit(): Promise<void> {
   }
   const p = join(cwd, EVAL_PATH_REL)
   mkdirSync(dirname(p), { recursive: true })
+  // #331: 라벨셋은 검색어 원문을 담아 프라이버시 → 저장과 동시에 .vhk/.gitignore 로 자기방어(멱등).
+  try {
+    ensureVhkIgnored(cwd, 'eval/recall-eval.json')
+  } catch {
+    /* gitignore 갱신 실패는 치명적 아님 — 평가셋은 이미 저장됨 */
+  }
   atomicWriteFile(p, JSON.stringify({ labels } satisfies EvalFile, null, 2) + '\n')
   console.log(chalk.green(`\n✅ 평가셋 저장됨 (${labels.length}개 라벨) → ${EVAL_PATH_REL}`))
   console.log(chalk.gray('   점수 보기: vhk memory eval'))

--- a/src/lib/recall-log.ts
+++ b/src/lib/recall-log.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { atomicWriteFile } from './atomic-write.js'
+import { ensureVhkIgnored } from './backup.js'
 
 /**
  * recall 사용 로그 (RFC 0049 ④) — 실쿼리 축적으로 정직한 검증(eval) 가능케 + 미래 데이터 씨앗.
@@ -23,6 +24,9 @@ export function logRecall(cwd: string, entry: Omit<RecallLogEntry, 'ts'>): void 
   try {
     const p = join(cwd, RECALL_LOG_REL)
     mkdirSync(join(cwd, '.vhk'), { recursive: true })
+    // #331: 검색어 원문은 프라이버시 → 기록과 동시에 .vhk/.gitignore 로 자기방어(멱등).
+    // 이미 init 된 기존 프로젝트(템플릿 미적용)도 첫 recall 시 자동 보호된다.
+    ensureVhkIgnored(cwd, 'recall-log.jsonl')
     const lines = existsSync(p) ? readFileSync(p, 'utf-8').split('\n').filter((l) => l.trim()) : []
     lines.push(JSON.stringify({ ts: new Date().toISOString(), ...entry }))
     atomicWriteFile(p, lines.slice(-RECALL_LOG_MAX).join('\n') + '\n')

--- a/src/templates/vhk-dir.ts
+++ b/src/templates/vhk-dir.ts
@@ -27,6 +27,8 @@ export function VHK_README_TEMPLATE(): string {
     '| `launch-prompt.md` | ❌ 로컬 전용 | 런칭 게시물 프롬프트 — 재생성물 (`vhk launch`) |',
     '| `ops-prompt.md` | ❌ 로컬 전용 | 운영 회고 프롬프트 — 재생성물 (`vhk ops`) |',
     '| `sell-prompt.md` | ❌ 로컬 전용 | 판매 카피 프롬프트 — 재생성물 (`vhk sell`) |',
+    '| `recall-log.jsonl` | ❌ 로컬 전용 | recall 사용 로그 — 검색어 원문(프라이버시) (`vhk recall`) |',
+    '| `eval/recall-eval.json` | ❌ 로컬 전용 | recall 평가셋 — 라벨 쿼리(프라이버시) (`vhk memory eval --init`) |',
     '| `memory.json` | ❌ 로컬 전용 | 의사결정 메모 (`vhk memory add`) |',
     '| `refs.json` | ❌ 로컬 전용 | 참고 URL (`vhk ref add`) |',
     '| `HARD_STOP` | ❌ 로컬 전용 | 존재하면 모든 자동화 즉시 중단 |',
@@ -61,6 +63,12 @@ export function VHK_GITIGNORE_TEMPLATE(): string {
     'ops-prompt.md',
     '# 판매 카피 프롬프트 — 재생성물(매 실행 갱신, 추적 불필요).',
     'sell-prompt.md',
+    // #331: 사용자 검색어 원문 = 프라이버시. 공개 repo 에 커밋되면 개인 쿼리가 노출된다.
+    // ⚠️ ledger.jsonl·events/ 는 의도적으로 추적(repo 영속 증거 — goal 45/82/85)이라 절대 여기 넣지 말 것.
+    '# recall 사용 로그 — 사용자 검색어 원문 포함(프라이버시). 추적/유출 방지.',
+    'recall-log.jsonl',
+    '# recall 평가셋 — 라벨 쿼리(검색어) 포함(프라이버시). 추적/유출 방지.',
+    'eval/recall-eval.json',
     '# secret gist 포인터 (gistId). 공개 repo 에 커밋되면 백업 gist 가 노출됨 (VHK-022).',
     'cloud.json',
     '# sync 덮어쓰기 전 자동 백업 (로컬 복구용 — vhk restore). 추적/클라우드 제외.',

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -158,6 +158,24 @@ describe('vhk init — .vhk/ 프리셋 씨앗', () => {
     expect(ignore).toContain('refs.json')
     expect(ignore).toContain('HARD_STOP')
   })
+
+  // #331 + 갭⑤: 일회성 프롬프트 산출물(ops/sell)·사용자 검색어 원문(recall-log/recall-eval)이
+  // git 추적으로 새어 프라이버시 노출되던 갭. 4개 모두 .vhk/.gitignore 씨앗에 등록돼야 한다.
+  it('일회성/사적 산출물 4종이 .vhk/.gitignore 씨앗에 등록된다 (#331·갭⑤)', () => {
+    const ignore = generateFiles('p', 'd', ['Node.js'])['.vhk/.gitignore']
+    expect(ignore).toContain('ops-prompt.md')      // 운영 회고 프롬프트(재생성물)
+    expect(ignore).toContain('sell-prompt.md')     // 판매 카피 프롬프트(재생성물)
+    expect(ignore).toContain('recall-log.jsonl')   // 사용자 검색어 원문 = 프라이버시
+    expect(ignore).toContain('eval/recall-eval.json') // 라벨셋(검색어 포함) = 프라이버시
+  })
+
+  // 경계 회귀 가드: ledger.jsonl·events/ 는 repo 영속 증거(goal 45/82/85)라 의도적으로 git 추적.
+  // gitignore 씨앗에 절대 들어가면 안 됨 — 들어가면 증거가 추적에서 빠져 거짓완료 탐지가 무력화.
+  it('ledger.jsonl·events/ 는 gitignore 씨앗에 들어가지 않는다 (추적 유지 — goal 45/82/85)', () => {
+    const ignore = generateFiles('p', 'd', ['Node.js'])['.vhk/.gitignore']
+    expect(ignore).not.toMatch(/(^|\n)\s*ledger\.jsonl\s*(\n|$)/)
+    expect(ignore).not.toMatch(/(^|\n)\s*events\/?\s*(\n|$)/)
+  })
 })
 
 describe('vhk init — 루트 .gitignore 보장', () => {

--- a/tests/recall-log.test.ts
+++ b/tests/recall-log.test.ts
@@ -51,4 +51,25 @@ describe('recall-log (사용 로그)', () => {
   it('파일 없으면 빈 배열', () => {
     expect(readRecallLog(tmp())).toEqual([])
   })
+
+  // #331: 사용자 검색어 원문(recall-log.jsonl)은 프라이버시 → 기록과 동시에 .vhk/.gitignore 로
+  // 자기방어해야 한다(이미 init 된 기존 프로젝트도 첫 recall 시 자동 보호). 템플릿만으론 누락.
+  it('#331: logRecall 이 recall-log.jsonl 을 .vhk/.gitignore 에 자동 등록한다', () => {
+    const dir = tmp()
+    logRecall(dir, { source: 'recall', query: '사적 검색어', hitIds: [], topScore: 0 })
+    const gi = fs.readFileSync(path.join(dir, '.vhk', '.gitignore'), 'utf-8')
+    expect(gi).toMatch(/(^|\n)recall-log\.jsonl(\n|$)/)
+  })
+
+  it('#331: 멱등 — 여러 번 logRecall 해도 recall-log.jsonl 라인은 1개', () => {
+    const dir = tmp()
+    logRecall(dir, { source: 'recall', query: 'a', hitIds: [], topScore: 0 })
+    logRecall(dir, { source: 'recall', query: 'b', hitIds: [], topScore: 0 })
+    logRecall(dir, { source: 'jit', query: 'c', hitIds: [], topScore: 0 })
+    const count = fs
+      .readFileSync(path.join(dir, '.vhk', '.gitignore'), 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim() === 'recall-log.jsonl').length
+    expect(count).toBe(1)
+  })
 })


### PR DESCRIPTION
## 무엇을 / 왜

`.vhk/` 의 일회성·사적 산출물 4종이 git 추적으로 새어 프라이버시가 노출되던 갭을 막습니다.

| 파일 | 성격 | 위험 |
| --- | --- | --- |
| `recall-log.jsonl` | 사용자 검색어 원문 | 개인 쿼리 커밋·노출 (#331) |
| `eval/recall-eval.json` | 라벨셋(검색어 포함) | 개인 쿼리 노출 (#331) |
| `ops-prompt.md` | 운영 회고 프롬프트(재생성물) | untracked 누출 (갭⑤) |
| `sell-prompt.md` | 판매 카피 프롬프트(재생성물) | untracked 누출 (갭⑤) |

> `ops-prompt.md`·`sell-prompt.md` 는 이미 템플릿에 있어, 실제 신규 추가는 recall 2종입니다.

## 변경

- **템플릿** (`VHK_GITIGNORE_TEMPLATE`): `recall-log.jsonl`·`eval/recall-eval.json` 추가 → `vhk init` 신규 프로젝트는 처음부터 보호. README 트래킹 표에도 2행 명시.
- **런타임 자기방어(멱등)**: `logRecall`·`memoryEvalInit` 이 쓰기 시 `ensureVhkIgnored` 로 자동 등록 → **이미 init 된 기존 프로젝트도 첫 사용 시 자가치유**. `verify.ts` 의 `reports/` 패턴 답습(best-effort).

## 경계 (절대 준수)

`.vhk/ledger.jsonl`·`.vhk/events/*` 는 repo 영속 증거(goal 45/82/85)라 **의도적으로 git 추적** → gitignore 에 넣지 않습니다. 회귀 가드 테스트로 고정(템플릿에 들어가면 실패).

## 테스트 (TDD)

- `init.test.ts`: 4종 등록 + ledger/events 미등록 회귀 가드
- `recall-log.test.ts`: `logRecall` 자동 등록 + 멱등(라인 1개)

`pnpm build` 성공 · 관련 테스트 전부 green (전체 1803개 중 실패는 e2e spawn 타임아웃 플레이크뿐 — 본 변경과 무관, 격리 실행 시 전부 통과).

## 후속(범위 밖)

- #326 슬래시 변형 중복 추가는 별 이슈.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 검색어 원문과 평가 데이터가 버전 관리에서 자동으로 제외되어 개인정보 보호가 강화되었습니다.

* **테스트**
  * 프라이버시 보호 기능에 대한 회귀 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->