### PR TITLE
fix(secure): .env.example placeholder 토큰 오탐 차단 (#316)

### DIFF
--- a/docs/log/2026-06-23-fix-316-secure-placeholder.md
+++ b/docs/log/2026-06-23-fix-316-secure-placeholder.md
@@ -1,0 +1,18 @@
+# 2026-06-23 — secure 가 .env.example placeholder 를 진짜 시크릿으로 오탐 (#316)
+
+> 격리 worktree(fix/316-secure-placeholder)에서 TDD 단건 수정.
+
+## 문제
+`.env.example` 의 **비주석** KEY=value placeholder(`GITHUB_TOKEN=ghp_xxxx…`·`NOTION_TOKEN=secret_xxxx…`·`xoxb-your-…`)가 진짜 CRITICAL 시크릿으로 오탐 → secure scan FAIL → verify 게이트 통째 FAIL. 같은 토큰이 **주석줄**이면 정상 무시됨(비대칭).
+
+## 근본 원인
+`scan-secrets.ts` `findSecretsInLine`: 토큰형 패턴(github/notion/slack 등)의 값-기반 `PLACEHOLDER_MARKER` 검사가 `if (isComment && …)` 처럼 isComment 게이트에 묶여 비주석 KEY=value 라인엔 적용 안 됨. generic-api-key 만 `isGenericApiKeyFalsePositive` 로 주석 무관 거름. `risk-policy.ts` 는 `.env.example|.sample|.template` 을 이미 '시크릿 없는 템플릿'으로 예외 처리하는데 scan-secrets 가 그 예외를 공유 안 함(정책 불일치).
+
+## 수정 (A+B 결합, 보수적)
+- 신규 `isEnvTemplateFile(file)` — `.env.example/.sample/.template` 만 true(Windows 역슬래시 정규화). risk-policy·check-secure 의 기존 예외와 정합.
+- `allowValuePlaceholder = isComment || isEnvTemplateFile(relPath)` → env 템플릿 파일에 한해 `PLACEHOLDER_MARKER` 무시를 주석 게이트 없이도 허용. marker 는 '명백한 placeholder 값'(`x{4,}`·`your[_-]`·`<…>`·example 등)만 매칭.
+- ⚠️ isComment 게이트(#218/#250 보호)는 그대로 유지 — 템플릿 파일에서만 **추가로** 푼다. 일반 소스·실제 `.env` 는 동작 불변.
+
+## 검증 (false-negative 0)
+- 신규 테스트 9건(`#316` describe): 템플릿 placeholder 미탐 + **가드** — 진짜처럼 보이는 토큰(x 반복 아님, 36자+)은 `.env.example` 에서도 여전히 CRITICAL / 일반 `.env`·소스의 placeholder 는 완화 안 함 / 주석 진짜 토큰(#218/#250) 불변 / 프로젝트 스캔 회귀(섞인 진짜 토큰은 검출).
+- `scan-secrets`·`check-secure`·`secure` 73건 green. `pnpm build` 성공. 전체 1811 pass(워커 contention 완화 시 — 기본 pnpm test 의 4~5건 timeout 은 Windows spawn e2e 환경 flake, scan-secrets 무관).

--- a/docs/log/2026-06-23-fix-316-secure-placeholder.md
+++ b/docs/log/2026-06-23-fix-316-secure-placeholder.md
@@ -16,3 +16,10 @@
 ## 검증 (false-negative 0)
 - 신규 테스트 9건(`#316` describe): 템플릿 placeholder 미탐 + **가드** — 진짜처럼 보이는 토큰(x 반복 아님, 36자+)은 `.env.example` 에서도 여전히 CRITICAL / 일반 `.env`·소스의 placeholder 는 완화 안 함 / 주석 진짜 토큰(#218/#250) 불변 / 프로젝트 스캔 회귀(섞인 진짜 토큰은 검출).
 - `scan-secrets`·`check-secure`·`secure` 73건 green. `pnpm build` 성공. 전체 1811 pass(워커 contention 완화 시 — 기본 pnpm test 의 4~5건 timeout 은 Windows spawn e2e 환경 flake, scan-secrets 무관).
+
+## 후속 — dogfood self-scan 회귀 (CI 깨짐)
+- 증상: PR #369 의 dogfood 잡(repo 루트 `node dist/index.js secure scan`)이 ubuntu·windows 양쪽 결정적 FAIL. `CRITICAL: 2 Slack Token`.
+- 진짜 원인(코디네이터 가설과 다름): scan-secrets.ts **로직은 무결**. 내가 #316 단위 테스트에 **연속(split 안 한) Slack 토큰 리터럴** `'SLACK_TOKEN=xoxb-your-bot-token-goes-here'` 두 개(scan-secrets.test.ts)를 넣어, 레포 self-scan 이 그 테스트 파일을 읽어 자기탐지. (Goal 83 강등은 medium 만 → critical Slack 은 강등 대상 아님 = 정상. env-template 완화도 테스트 파일엔 비적용 = 정상.) 이 레포는 모든 픽스처 토큰을 `'AKIA'+'…'` 식 split 합성으로 자기탐지를 피하는 컨벤션인데 그걸 어김.
+- 수정: 두 리터럴을 `const SLACK_PLACEHOLDER = 'xoxb-' + 'your-bot-token-goes-here'`(split 합성)로 교체. 런타임 값 동일 → 테스트 의미 불변. **scan-secrets.ts(#316 로직) 무수정** — false-negative·placeholder 완화 영향 0.
+- 회귀 가드(사각 폐쇄): `#316 self-scan 회귀 가드` describe 추가 — 레포 루트를 `scanProjectForSecrets`→`downgradeTestFixtureFindings`→`filterSevereFindings`(dogfood 와 동일 파이프라인)로 스캔해 severe 0 단언. 의도적 연속 리터럴 재주입으로 **가드가 정확히 file:line 짚으며 FAIL** 검증 후 복원.
+- 결과: `secure scan` → `총 1건 | CRITICAL: 0 | INFO: 1` exit 0(main 동일). `pnpm test` 1812 pass.

--- a/src/lib/scan-secrets.ts
+++ b/src/lib/scan-secrets.ts
@@ -23,6 +23,20 @@ function isGenericApiKeyFalsePositive(matchText: string): boolean {
   return PLACEHOLDER_MARKER.test(value)
 }
 
+// #316: .env.example/.sample/.template 은 '시크릿 값 없는 커밋용 템플릿'(risk-policy.ts 의
+//   RISKY_TARGET_PATTERNS 예외·check-secure.ts 의 isSensitiveName(.example/.sample 제외)와 정합). 이 파일들의
+//   비주석 KEY=value placeholder(ghp_xxxx· secret_xxxx 등)는 진짜 시크릿이 아니라 예시값이다.
+//   → 값-기반 PLACEHOLDER_MARKER 검사를 주석 게이트 없이도 허용(아래 findSecretsInLine).
+//   ⚠️ 완화 범위는 '명백한 placeholder 값'(marker 매칭)에 한정 — 진짜처럼 보이는 토큰은 여전히 CRITICAL.
+const ENV_TEMPLATE_SUFFIX = /\.(?:example|sample|template)$/i
+
+/** 파일이 env 템플릿(.env.example/.sample/.template)인가(Windows 역슬래시 정규화). */
+export function isEnvTemplateFile(file: string): boolean {
+  const norm = file.replace(/\\/g, '/')
+  const base = norm.slice(norm.lastIndexOf('/') + 1)
+  return base.startsWith('.env') && ENV_TEMPLATE_SUFFIX.test(base)
+}
+
 /** 한 줄에서 시크릿 패턴 검색 (global regex 중복 버그 방지) */
 export function findSecretsInLine(
   line: string,
@@ -41,6 +55,10 @@ export function findSecretsInLine(
     trimmed.startsWith('#') ||
     trimmed.startsWith('*') ||
     trimmed.startsWith('/*')
+  // #316: env 템플릿(.env.example/.sample/.template)은 placeholder 값-기반 무시를 주석 게이트
+  //       없이도 허용 — 비주석 KEY=value 예시값(ghp_xxxx 등)이 진짜 시크릿으로 오탐되던 버그.
+  //       isComment 게이트 자체는 #218/#250 보호라 유지 — 템플릿 파일에서만 추가로 푼다(보수적).
+  const allowValuePlaceholder = isComment || isEnvTemplateFile(relPath)
 
   for (const pattern of SECRET_PATTERNS) {
     const regex = globalPattern(pattern.pattern)
@@ -48,8 +66,9 @@ export function findSecretsInLine(
       // Generic 패턴은 실제 토큰 형식을 모르는 보조 탐지다. 예제 env 값과
       // missing_api_key 같은 상태 식별자는 값처럼 보여도 자격증명이 아니다.
       if (pattern.id === 'generic-api-key' && isGenericApiKeyFalsePositive(match[0])) continue
-      // placeholder 표식이 매칭값에 있으면(주석 한정) 무시 — your_·fake_·dummy·redacted·changeme·xxxx·<...>
-      if (isComment && PLACEHOLDER_MARKER.test(match[0]))
+      // placeholder 표식이 매칭값에 있으면(주석 또는 env 템플릿 한정) 무시
+      //   — your_·fake_·dummy·redacted·changeme·xxxx·<...>. 명백한 placeholder 값만, false-negative 0.
+      if (allowValuePlaceholder && PLACEHOLDER_MARKER.test(match[0]))
         continue // placeholder 시크릿만 무시
       found.push({
         patternId: pattern.id,

--- a/tests/scan-secrets.test.ts
+++ b/tests/scan-secrets.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import {
   findSecretsInLine,
   scanProjectForSecrets,
@@ -303,8 +304,11 @@ describe('#316 — .env.example placeholder 토큰 오탐 차단', () => {
     expect(findSecretsInLine(line, '.env.example', 1)).toHaveLength(0)
   })
 
+  // split 합성 — 자기 레포 secure self-scan 이 이 테스트 파일을 자기탐지하지 않게(런타임엔 합쳐짐).
+  const SLACK_PLACEHOLDER = 'xoxb-' + 'your-bot-token-goes-here'
+
   it('.env.example 의 xoxb-your-... slack placeholder → 미탐', () => {
-    const line = 'SLACK_TOKEN=xoxb-your-bot-token-goes-here'
+    const line = `SLACK_TOKEN=${SLACK_PLACEHOLDER}`
     expect(findSecretsInLine(line, '.env.example', 1)).toHaveLength(0)
   })
 
@@ -356,7 +360,7 @@ describe('#316 — .env.example placeholder 토큰 오탐 차단', () => {
       const body = [
         'GITHUB_TOKEN=ghp_' + 'x'.repeat(36),
         'NOTION_TOKEN=secret_' + 'x'.repeat(40),
-        'SLACK_TOKEN=xoxb-your-bot-token-goes-here',
+        `SLACK_TOKEN=${SLACK_PLACEHOLDER}`,
         '# 주석 placeholder',
         '# GITHUB_TOKEN=ghp_' + 'x'.repeat(36),
       ].join('\n')
@@ -381,5 +385,25 @@ describe('#316 — .env.example placeholder 토큰 오탐 차단', () => {
     } finally {
       fs.rmSync(d, { recursive: true, force: true })
     }
+  })
+})
+
+// #316 회귀(self-scan 사각): 단위 test 가 self-scan 회귀를 못 잡은 게 이번 사각이었다.
+//   dogfood CI = repo 루트 `secure scan`(scanProjectForSecrets → downgradeTestFixtureFindings → critical/high).
+//   이 레포 자신을 스캔했을 때 severe(critical/high) 가 0 이어야 한다 —
+//   누군가 테스트 픽스처에 '연속(split 안 한) 시크릿 리터럴'을 넣으면 self-scan 이 CRITICAL 로 새고
+//   dogfood 가 깨진다. 이 가드가 그 순간 단위 test 단계에서 잡는다(split 합성 컨벤션 강제).
+describe('#316 self-scan 회귀 가드 — 레포 자기탐지 0 (dogfood 사각 폐쇄)', () => {
+  // 이 테스트 파일 위치에서 레포 루트 추정(tests/ 의 부모).
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+  it('레포 self-scan 의 severe(critical/high) 는 0 (dogfood 와 동일 파이프라인)', () => {
+    const scan = scanProjectForSecrets(repoRoot)
+    // secure scan 과 동일: 픽스처 MEDIUM→INFO 강등 후 critical/high 만 게이팅.
+    const findings = downgradeTestFixtureFindings(scan.findings)
+    const severe = filterSevereFindings(findings)
+    // 실패 시 어느 파일/라인이 새는지 즉시 보이도록 메시지에 노출.
+    const detail = severe.map((f) => `${f.file}:${f.line} [${f.patternId}/${f.severity}]`).join(', ')
+    expect(severe, `self-scan severe leak: ${detail}`).toHaveLength(0)
   })
 })

--- a/tests/scan-secrets.test.ts
+++ b/tests/scan-secrets.test.ts
@@ -8,6 +8,7 @@ import {
   filterSevereFindings,
   downgradeTestFixtureFindings,
   isTestFixturePath,
+  isEnvTemplateFile,
 } from '../src/lib/scan-secrets.js'
 import { MAX_SCAN_FILE_BYTES } from '../src/lib/scan-files.js'
 
@@ -264,5 +265,121 @@ describe('Goal 83 — 테스트 픽스처 false positive 강등', () => {
     const severe = filterSevereFindings(downgradeTestFixtureFindings(findings))
     expect(severe.every((f) => f.severity === 'critical' || f.severity === 'high')).toBe(true)
     expect(severe.some((f) => f.patternId === 'aws-access-key')).toBe(true)
+  })
+})
+
+// #316: .env.example/.sample/.template 의 비주석 KEY=value placeholder(ghp_xxxx·secret_xxxx 등)를
+//   진짜 CRITICAL 시크릿으로 오탐 → secure scan FAIL → verify 게이트 통째 FAIL.
+//   기존 isComment 게이트는 주석에 묶여 비주석 KEY=value 라인엔 placeholder 검사가 적용 안 됐다.
+//   수정: env 템플릿 파일에 한해(risk-policy 의 .env.example|.sample|.template 예외와 정합)
+//         값-기반 PLACEHOLDER_MARKER 를 주석 게이트 없이 적용 — 단 "명백한 placeholder 값"만.
+//   ⚠️ false-negative 0: 진짜처럼 보이는 토큰은 여전히 CRITICAL. 주석 진짜 토큰(#218/#250)도 불변.
+describe('#316 — .env.example placeholder 토큰 오탐 차단', () => {
+  // split 합성 — 자기 레포 secure 스캔이 이 테스트 파일을 자기탐지하지 않게(런타임엔 합쳐짐).
+  // 진짜처럼 보이는(랜덤 영숫자, x 반복 아님) 36자+ 토큰. placeholder 표식 없음 → 여전히 잡혀야.
+  const REAL_GHP = 'ghp_' + 'aB3kZ9mQ1rT7wX2pL5nC8vD4fG6hJ0sKbCdE'
+  const REAL_NOTION = 'secret_' + 'aB3kZ9mQ1rT7wX2pL5nC8vD4fG6hJ0sKbCdE9pQ2'
+
+  it('isEnvTemplateFile: .env.example/.sample/.template 만 true, .env/소스 는 false', () => {
+    expect(isEnvTemplateFile('.env.example')).toBe(true)
+    expect(isEnvTemplateFile('.env.sample')).toBe(true)
+    expect(isEnvTemplateFile('.env.template')).toBe(true)
+    expect(isEnvTemplateFile('config/.env.example')).toBe(true)
+    // Windows 역슬래시 정규화.
+    expect(isEnvTemplateFile('config\\.env.example')).toBe(true)
+    expect(isEnvTemplateFile('.env')).toBe(false)
+    expect(isEnvTemplateFile('.env.local')).toBe(false)
+    expect(isEnvTemplateFile('.env.production')).toBe(false)
+    expect(isEnvTemplateFile('src/commands/secure.ts')).toBe(false)
+  })
+
+  it('.env.example 의 비주석 GITHUB_TOKEN=ghp_xxxx placeholder → 미탐(CRITICAL 0)', () => {
+    const line = 'GITHUB_TOKEN=ghp_' + 'x'.repeat(36)
+    expect(findSecretsInLine(line, '.env.example', 1)).toHaveLength(0)
+  })
+
+  it('.env.example 의 비주석 NOTION_TOKEN=secret_xxxx placeholder → 미탐', () => {
+    const line = 'NOTION_TOKEN=secret_' + 'x'.repeat(40)
+    expect(findSecretsInLine(line, '.env.example', 1)).toHaveLength(0)
+  })
+
+  it('.env.example 의 xoxb-your-... slack placeholder → 미탐', () => {
+    const line = 'SLACK_TOKEN=xoxb-your-bot-token-goes-here'
+    expect(findSecretsInLine(line, '.env.example', 1)).toHaveLength(0)
+  })
+
+  it('.env.sample / .env.template 에도 동일 완화 적용', () => {
+    const line = 'GITHUB_TOKEN=ghp_' + 'x'.repeat(36)
+    expect(findSecretsInLine(line, '.env.sample', 1)).toHaveLength(0)
+    expect(findSecretsInLine(line, '.env.template', 1)).toHaveLength(0)
+  })
+
+  // ── false-negative 가드 (필수) ─────────────────────────────────────────
+  it('가드: .env.example 라도 진짜처럼 보이는 토큰(x 반복 아님)은 여전히 CRITICAL', () => {
+    const line = `GITHUB_TOKEN=${REAL_GHP}`
+    const findings = findSecretsInLine(line, '.env.example', 1)
+    expect(findings.filter((f) => f.patternId === 'github-token')).toHaveLength(1)
+    expect(findings.find((f) => f.patternId === 'github-token')?.severity).toBe('critical')
+  })
+
+  it('가드: .env.example 의 진짜 notion 토큰도 여전히 CRITICAL', () => {
+    const line = `NOTION_TOKEN=${REAL_NOTION}`
+    const findings = findSecretsInLine(line, '.env.example', 1)
+    expect(findings.filter((f) => f.patternId === 'notion-token')).toHaveLength(1)
+  })
+
+  it('가드: 일반 .env(템플릿 아님)의 placeholder 는 완화 대상 아님 — 여전히 탐지', () => {
+    // .env(템플릿 아님)은 실제 시크릿 파일 → placeholder 라도 비주석이면 완화 안 함(보수적).
+    const line = 'GITHUB_TOKEN=ghp_' + 'x'.repeat(36)
+    expect(
+      findSecretsInLine(line, '.env', 1).filter((f) => f.patternId === 'github-token'),
+    ).toHaveLength(1)
+  })
+
+  it('가드: 일반 소스(.ts)의 placeholder 토큰은 완화 안 함(env 템플릿 아님)', () => {
+    const line = 'const t = "ghp_' + 'x'.repeat(36) + '"'
+    expect(
+      findSecretsInLine(line, 'src/config.ts', 1).filter((f) => f.patternId === 'github-token'),
+    ).toHaveLength(1)
+  })
+
+  it('가드: 주석 진짜 토큰(#218/#250)은 env 템플릿 완화와 무관하게 여전히 탐지', () => {
+    const line = `# see example: ${REAL_GHP}`
+    expect(
+      findSecretsInLine(line, 'src/x.ts', 1).filter((f) => f.patternId === 'github-token'),
+    ).toHaveLength(1)
+  })
+
+  it('회귀: .env.example placeholder 만 있는 파일을 프로젝트 스캔이 깨끗하게(severe 0) 처리', () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-scan-316-'))
+    try {
+      const body = [
+        'GITHUB_TOKEN=ghp_' + 'x'.repeat(36),
+        'NOTION_TOKEN=secret_' + 'x'.repeat(40),
+        'SLACK_TOKEN=xoxb-your-bot-token-goes-here',
+        '# 주석 placeholder',
+        '# GITHUB_TOKEN=ghp_' + 'x'.repeat(36),
+      ].join('\n')
+      fs.writeFileSync(path.join(d, '.env.example'), body + '\n', 'utf-8')
+      const { findings } = scanProjectForSecrets(d)
+      expect(filterSevereFindings(findings)).toHaveLength(0)
+    } finally {
+      fs.rmSync(d, { recursive: true, force: true })
+    }
+  })
+
+  it('회귀: .env.example 에 진짜 토큰이 섞이면 프로젝트 스캔이 여전히 CRITICAL 검출', () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-scan-316-real-'))
+    try {
+      const body = [
+        'GITHUB_TOKEN=ghp_' + 'x'.repeat(36), // placeholder → 무시
+        `LEAKED_TOKEN=${REAL_GHP}`, // 진짜 → 검출
+      ].join('\n')
+      fs.writeFileSync(path.join(d, '.env.example'), body + '\n', 'utf-8')
+      const { findings } = scanProjectForSecrets(d)
+      expect(filterSevereFindings(findings).some((f) => f.patternId === 'github-token')).toBe(true)
+    } finally {
+      fs.rmSync(d, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## 문제 (#316)
`.env.example`(/.sample/.template)의 **비주석** KEY=value placeholder(`GITHUB_TOKEN=ghp_xxxx…`·`NOTION_TOKEN=secret_xxxx…`·`SLACK_TOKEN=xoxb-your-…`)가 진짜 CRITICAL 시크릿으로 오탐 → `secure` scan FAIL → `verify` 게이트 통째 FAIL. 같은 토큰이 **주석줄**이면 정상 무시되던 비대칭.

## 근본 원인
`scan-secrets.ts` `findSecretsInLine`: 토큰형 패턴(github/notion/slack 등)의 값-기반 `PLACEHOLDER_MARKER` 검사가 `if (isComment && …)` 게이트에 묶여 **비주석** KEY=value 라인엔 적용 안 됨. `risk-policy.ts` 가 이미 `.env.example|.sample|.template` 을 '시크릿 없는 템플릿'으로 예외 처리하는데 scan-secrets 가 그 예외를 공유하지 않던 정책 불일치.

## 수정 (보수적 A+B 결합)
- 신규 `isEnvTemplateFile(file)` — `.env.example/.sample/.template` 만 식별(Windows 역슬래시 정규화). risk-policy·check-secure 의 기존 예외와 정합.
- `allowValuePlaceholder = isComment || isEnvTemplateFile(relPath)` → **env 템플릿 파일에 한해** `PLACEHOLDER_MARKER` 무시를 주석 게이트 없이 허용.
- marker 는 '명백한 placeholder 값'(`x{4,}`·`your[_-]`·`<…>`·example 등)만 매칭 → **진짜처럼 보이는 토큰은 여전히 CRITICAL**.

## ⚠️ false-negative 0 (보안 회귀 가드)
- `isComment` 게이트(#218/#250 — 주석에 섞인 진짜 시크릿 탐지)는 **그대로 유지**. 템플릿 파일에서만 추가로 완화.
- 일반 소스(.ts)·실제 `.env`(템플릿 아님)의 placeholder 는 완화 안 함(동작 불변).
- `.env.example` 라도 진짜처럼 보이는 36자+ 토큰은 여전히 CRITICAL.
- 가드 테스트 9건 추가(`#316` describe) + 기존 #218/#250/Goal 83 회귀 0.

## 검증
- `scan-secrets`·`check-secure`·`secure` 73건 green. `pnpm build` 성공.
- 전체 1811 pass(177 파일) — 워커 contention 완화 시. 기본 `pnpm test` 의 일부 timeout 은 Windows spawn e2e 환경 flake(scan-secrets 무관, 격리 실행 시 전부 통과).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * `.env.example`, `.env.sample`, `.env.template` 등 환경 설정 템플릿 파일을 자동으로 감지해 처리하도록 개선

* **버그 수정**
  * 템플릿 파일에 들어있는 예시(placeholder) 값이 보안 경고로 잘못 표시되지 않도록 수정

* **테스트**
  * 템플릿 파일 감지/필터링 동작과 실제 토큰 검출 회귀를 포함한 추가 테스트 케이스 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->