### PR TITLE
feat(receipt): vhk receipt MVP — 4대 기계증거를 영수증 1장으로 (Goal 86, RFC 0056 T1)

### DIFF
--- a/.vhk/.gitignore
+++ b/.vhk/.gitignore
@@ -12,3 +12,4 @@ backups/
 .synced
 cost.jsonl
 evolve/
+receipts/

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -37,6 +37,16 @@ Cursor에게 한국어로 말해도 됩니다.
 
 > `review` 는 증거(latest.json)와 goal 완료조건을 교차검증해 "거짓완료 의심"을 찾습니다. 판정은 신뢰도 신호이며 보장이 아닙니다(미검증·stale 증거는 통과로 취급하지 않음).
 
+## 증거 영수증 (receipt — RFC 0056 T1)
+
+| 하고 싶은 것 | 터미널 명령 | Cursor에게 말하기 |
+|-------------|-----------|------------------|
+| 영수증 떼기 (4대 기계증거) | `vhk receipt` | "증거 영수증 떼줘" |
+| 작업시작 기준선 기록 | `vhk receipt --mark-start` | "작업 시작점 찍어줘" |
+| 기계용 JSON 출력 | `vhk receipt --json` | — |
+
+> `receipt` 는 에이전트가 "됐어요"라고 한 순간, **4대 기계증거**(① tsc/test/build 실종료코드 ② git dirty ③ 작업시작 SHA≠HEAD stale ④ 변경라인 diff-cover)를 모아 `.vhk/receipts/<날짜-decision-시각>.{json,md}` 영수증 1장으로 굳힙니다. `decision = block|caution|pass` 는 **기계증거로만(LLM 추론 0)** — 실차단 3종(red·dirty·stale) 중 하나라도면 block, ④ diff-cover 는 advisory(약신호)라 차단시키지 못합니다. block 이면 exit 1. **이 영수증은 게으른 거짓완료(빌드 깨짐·미커밋·낡은 증거)를 잡지, 미묘한 오류(그럴듯하게 틀린 코드)는 못 잡습니다.**
+
 ## 미션 계약 (mission)
 
 | 하고 싶은 것 | 터미널 명령 | Cursor에게 말하기 |
@@ -170,6 +180,7 @@ vhk doctor
 | `vhk standup` | 아침 브리핑 (어제 한 일 + 오늘 추천 goal + 미해결) |
 | `vhk today` | 저녁 자축·회고 (오늘 커밋·완료 goal 카운트 + 격려) |
 | `vhk review` | 적대적 자기검증 (거짓완료 의심 탐지) |
+| `vhk receipt` | 증거 영수증 — 4대 기계증거로 거짓완료 판정 (block/caution/pass) |
 | `vhk mission` | 미션 계약 — 작업 목표·허용/금지 범위 선언·검증 |
 | `vhk context-show` | 컨텍스트 파일 내용 출력 |
 | `vhk memory` | 기억 관리 v2 (decisions/failures/successes) |

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ vhk mcp
 | 규칙/맥락 | `vhk sync`, `vhk context`, `vhk context-show`, `vhk brief`, `vhk loop-brief`, `vhk remind`, `vhk work`, `vhk work handoff` | 규칙 동기화, 프로젝트 맥락 생성, 루프 1틱 의도 앵커, 치명 규칙 재주입, 세션 시작/인수인계 |
 | 풀사이클 뒷단 | `vhk content`, `vhk launch`, `vhk ops`, `vhk sell` | 콘텐츠/런칭/운영/판매 초안 프롬프트 생성 (초안만, 게시·발송·결제는 사람이 · `launch`≠`ship`(코드 배포)) |
 | Goal | `vhk goal init/list/next/check/done/sync/drift` | 단계별 목표, 게이트, 상태 드리프트 관리 |
-| Trust | `vhk verify`, `vhk review`, `vhk preflight`, `vhk testmap`, `vhk mission set/check/clear` | 증거 생성, 거짓완료 탐지, 출고 전 점검, 테스트 매핑, 작업 범위 계약 |
+| Trust | `vhk verify`, `vhk review`, `vhk receipt`, `vhk preflight`, `vhk testmap`, `vhk mission set/check/clear` | 증거 생성, 거짓완료 탐지, 증거 영수증(4대 기계증거 판정), 출고 전 점검, 테스트 매핑, 작업 범위 계약 |
 | 안전 | `vhk blocker`, `vhk resume --confirm`, `vhk mode`, `vhk secure scan` | HARD_STOP, safety mode, 시크릿 스캔 |
 | Git | `vhk status`, `vhk diff`, `vhk save`, `vhk undo`, `vhk restore`, `vhk recap` | 상태/변경 확인, 커밋/푸시, 되돌리기, 세션 로그 |
 | 환경/품질 | `vhk doctor`, `vhk check`, `vhk env`, `vhk env-check`, `vhk harness`, `vhk audit`, `vhk worktree check/add` | 개발환경, RULES 린트, env, 통합 품질, 보안 감사, worktree 가드 |

--- a/docs/log/2026-06-23-goal-86-receipt-mvp.md
+++ b/docs/log/2026-06-23-goal-86-receipt-mvp.md
@@ -1,0 +1,57 @@
+# 2026-06-23 — Goal 86: vhk receipt MVP (RFC 0056 T1) — 4대 기계증거를 영수증 1장으로
+
+## 무엇
+에이전트의 "됐어요"를 **기계증거 영수증** 1장으로 바꾸는 신규 명령 `vhk receipt`. VHK 새 정체성
+(ADR-006 / RFC 0056 — 멀티툴 솔로용 거짓완료 탐지기)의 첫 쐐기. 완료 시점에 4대 기계증거를 모아
+`.vhk/receipts/<날짜-decision-시각>.{json,md}` 로 굳히고 `decision = block|caution|pass` 를
+**기계증거로만(LLM 추론 0)** 낸다.
+
+- ① tsc/test/build 실종료코드(`verifyEvidence` 재사용 — 자기보고 거부, 실제 프로세스만)
+- ② git dirty(`getCommitInfo` 재사용 — Goal 85 `filterSelfTrackedLines` 로 자기 ledger 제외)
+- ③ stale = 작업시작 기준선 SHA ≠ 현재 HEAD(`.vhk/receipts/.base-sha` 또는 `--since <sha>`)
+- ④ 변경라인 diff-cover(`diffCoverage` 재사용 — **advisory 약신호**)
+
+## 핵심 불변식(테스트로 고정 — tests/receipt.test.ts)
+1. **decision 은 기계증거만.** 실차단 3종(red·dirty·stale) 중 하나라도면 block.
+2. **단조성: caution → pass 격상 절대 금지.** `decideReceipt` 는 "block? → caution? → pass" 폭포라
+   부정 신호가 늘면 pass→caution→block 한 방향으로만 간다(역행 분기 없음). `order[pass]<caution<block` 로 단조 고정.
+3. **④ diff-cover 는 advisory** — block 분기(`e.gates.red || e.dirty || (e.staleKnown && e.stale)`)에
+   들어가지 않는다. 0% 미커버여도 최대 caution. 실차단은 종료코드·dirty·stale **3종만**.
+4. **stale 미상(기준선 미기록)은 거짓 block 금지** — `staleKnown=false` 면 모르는 걸 빨강으로 위장하지 않고 caution.
+
+## 설계 — 순수/경계 분리
+- `src/lib/receipt.ts` = **순수 핵심**(IO 0): `decideReceipt`·`buildReceipt`·`renderReceiptMarkdown`·`HONESTY_LINE`.
+  불변식 테스트가 여기 고정.
+- `src/commands/receipt.ts` = **경계**(IO): verify/git/diff-cover 수집 + .json/.md 쓰기 + `printNextStep`.
+  신규 발명 최소 — 기존 디스크 작동 자산 조립 글루코드.
+- `.md` = PR/대화 붙여넣기 1블록(decision 배지 + 게이트표 + 사유 + 정직성 1줄).
+
+## 자기-dirty 봉인 (★중요)
+영수증 자신이 작업트리를 dirty 만들어 다음 receipt 의 증거 ②를 오염(자기모순=늘 block)시키지 않게
+`.vhk/receipts/`(+`.base-sha`)를 `.vhk/.gitignore` 에 등록(`ensureVhkIgnored`)·init 씨앗(`templates/vhk-dir.ts`)에 동봉.
+ledger/events(repo 영속 증거)와 달리 receipt 는 로컬 산출물이라 **추적 제외**가 정합(Goal 85 와 다른 층위).
+→ 실측: receipt 생성 후 `git status` 에 receipt 가 안 잡힘(자기 dirty 0).
+
+## 등록 4지점 + 드리프트
+index.ts · command-registry(TOP_LEVEL) · cli-args(KNOWN_COMMAND_TOKENS) · ko.ts + nlp-router(+nlp-run dispatch) +
+한글별칭 `증거영수증`. `tests/receipt-registration.test.ts`(4지점 introspect) + 기존 `tests/command-registry.test.ts`·
+`tests/nlp-router.test.ts`(영문 `receipt`·한글 `증거영수증` 라우팅, review 와 충돌 0) 드리프트 가드.
+COMMANDS.md·README·goals/README 동기화(드리프트 테스트 통과).
+
+## 핵심 교훈
+- **tsup 빌드는 타입체크 안 한다** — `tsc --noEmit`(check-goal-86 게이트)만이 unused import(writeFileSync) 잡음.
+  게이트가 빌드 통과를 신뢰 못 하게 한 게 정답.
+- nlp 규칙 순서: receipt 를 review **앞**에 두되 트리거를 '영수증/receipt' 로 한정 — bare '거짓완료' 는 review 유지.
+
+## 한계(정직 — 잔존 위험)
+- **diff-cover 구조적 한계(RFC 0056 §11 ①)**: covered=실행 도달≠정확성. 영수증은 **게으른 거짓완료**
+  (빌드 깨짐·미커밋·stale)만 잡고 "그럴듯하게 틀린 코드"는 못 잡는다. .md 하단 `HONESTY_LINE` 에 박음.
+- **자기 ledger 위조 사각지대(Goal 85 ②)**: dirty 판정에서 자기파일을 빼므로 vhk 가 자기 ledger 를 위조하면 못 잡는다.
+- **virgin repo 첫-실행 edge**: `.vhk/.gitignore` 가 아직 미커밋(untracked)인 가상 레포에선 그 untracked 자체가 dirty→block.
+  실제 프로젝트는 `vhk init` 후 `.vhk/` 를 커밋하므로 해소. Goal 85 의 최소 화이트리스트 원칙을 지키려 **whitelist 과확장 안 함**(정직).
+- **stale 은 사람이 `--mark-start` 로 기준선을 찍어야** 판정 가능(세션 자동 훅은 T2+ 범위). 미기록 시 caution.
+
+## 산출물
+- 신규: `src/lib/receipt.ts`, `src/commands/receipt.ts`, `tests/receipt.test.ts`, `tests/receipt-registration.test.ts`, `scripts/check-goal-86.mjs`
+- 수정: `src/index.ts`, `src/lib/command-registry.ts`, `src/lib/cli-args.ts`, `src/lib/nlp-router.ts`, `src/lib/nlp-run.ts`, `src/i18n/ko.ts`, `src/templates/vhk-dir.ts`, `COMMANDS.md`, `README.md`, `goals/86-receipt-mvp.md`, `goals/README.md`
+- 게이트: `pnpm build` ✓ · 전체 테스트 1897 pass(180 files) · `secure scan` CRITICAL 0/HIGH 0 · check-goal-86 ✓

--- a/goals/86-receipt-mvp.md
+++ b/goals/86-receipt-mvp.md
@@ -3,7 +3,7 @@ vhk_format: 1
 type: goal
 id: 86
 title: vhk receipt MVP — 4대 기계증거를 영수증 1장으로 (RFC 0056 T1) — P0
-status: NOT_STARTED
+status: IN_PROGRESS
 priority: P0
 created: 2026-06-23
 leads_to: 에이전트 "됐어요"를 기계증거 영수증으로 — 거짓완료 탐지 90일 쐐기
@@ -29,13 +29,13 @@ leads_to: 에이전트 "됐어요"를 기계증거 영수증으로 — 거짓완
 - **④ diff-cover는 advisory(약신호)로 분리** — decision을 block으로 격하시키지 못함(0056 §6 정직 경계). 실차단 = 종료코드·dirty·stale 3개.
 - `.md`에 정직성 1줄: "게으른 거짓완료를 잡지, 미묘한 오류는 못 잡는다."
 
-## Completion Check (작은 단위 — 미착수)
-- [ ] receipt 수집기 — 4대 증거 기존자산 병합 (순수 + fs 경계 분리)
-- [ ] decision 판정 — 기계증거만, 단조성 불변식 테스트
-- [ ] `.json` + `.md` 산출 — .md는 PR/대화 붙여넣기 1블록(decision 배지+게이트표+사유+정직성 1줄)
-- [ ] 등록 4지점 + nlp-router + 한글별칭 + 드리프트 테스트 green
-- [ ] diff-cover advisory 분리(decision 미격하) 테스트
-- [ ] 공통 게이트(_meta), check-goal-86.mjs
+## Completion Check (작은 단위 — 완료)
+- [x] receipt 수집기 — 4대 증거 기존자산 병합 (순수 + fs 경계 분리) — `src/lib/receipt.ts`(순수 decideReceipt/buildReceipt/render) + `src/commands/receipt.ts`(verifyEvidence·getCommitInfo·diffCoverage 글루)
+- [x] decision 판정 — 기계증거만(LLM 0), 단조성 불변식 테스트 — `tests/receipt.test.ts`(caution→pass 금지 + pass≤caution≤block 단조 고정)
+- [x] `.json` + `.md` 산출 — .md는 PR/대화 붙여넣기 1블록(decision 배지+게이트표+사유+정직성 1줄, HONESTY_LINE)
+- [x] 등록 4지점(index·command-registry·cli-args·ko.ts) + nlp-router + 한글별칭(증거영수증) + 드리프트 테스트 green — `tests/receipt-registration.test.ts` + 기존 `tests/command-registry.test.ts` 자동 커버
+- [x] diff-cover advisory 분리(decision 미격하) 테스트 — `tests/receipt.test.ts`(0% 미커버여도 block 아님, 실차단 3종만)
+- [x] 공통 게이트(_meta), check-goal-86.mjs — `vhk goal sync` 생성 + goal 고유 검증 손추가, 게이트 통과
 
 ## 구현 노트
 - T1 본체. **선결 Goal 85**(blockedBy). T2(자기보고 위조방어 + 붙여넣기 .md)·T3(거짓완료 적발 1건 공개입증, 사람 율속)는 후속 — RFC 0056 §6.

--- a/goals/README.md
+++ b/goals/README.md
@@ -2,7 +2,7 @@
 
 # goals/ 인덱스
 
-> 총 6 goal — IN_PROGRESS 2 · NOT_STARTED 3 · DONE 1
+> 총 6 goal — IN_PROGRESS 3 · NOT_STARTED 2 · DONE 1
 > 공통 게이트 = [_meta.md](_meta.md) · 카드 형식/상태 의미는 각 파일 frontmatter 참조.
 
 | # | 제목 | 상태 | 우선순위 | 다음 연결 |
@@ -12,4 +12,4 @@
 | 65 | pre-commit L2 기록 집행 — 조건부(우회 실측 시에만 착수) — P2 | ⬜ NOT_STARTED | P2 | 기록 집행 우회 경로 0 (ADR-001 L2 트리거 이행) |
 | 79 | verify 로컬 환경의존 테스트 분리 — 선조사 후 범위 재조정(확실한 것만) — P0 | 🔄 IN_PROGRESS | P0 | 로컬 verify 신뢰 — 선조사로 회귀 0 확인, 확실한 조치만 적용 |
 | 85 | receipt/verify dirty 판정에서 자기 산출 추적파일 제외 (#315 자기참조 봉인) — P0 | ✅ DONE | P0 | receipt가 자기 ledger 때문에 늘 block되는 자기모순 제거 (RFC 0056 T1 선결) |
-| 86 | vhk receipt MVP — 4대 기계증거를 영수증 1장으로 (RFC 0056 T1) — P0 | ⬜ NOT_STARTED | P0 | 에이전트 "됐어요"를 기계증거 영수증으로 — 거짓완료 탐지 90일 쐐기 |
+| 86 | vhk receipt MVP — 4대 기계증거를 영수증 1장으로 (RFC 0056 T1) — P0 | 🔄 IN_PROGRESS | P0 | 에이전트 "됐어요"를 기계증거 영수증으로 — 거짓완료 탐지 90일 쐐기 |

--- a/scripts/check-goal-86.mjs
+++ b/scripts/check-goal-86.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// scripts/check-goal-86.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 86 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 86] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 86 고유 검증 (vhk receipt MVP — RFC 0056 T1) ───────────────────────────────
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+
+// ① 순수 핵심(IO 0) — decision/render/build 분리
+const core = read('src/lib/receipt.ts') ?? ''
+must(/export function decideReceipt/.test(core), 'receipt.ts: decideReceipt 순수 판정(LLM 0)')
+must(/export function buildReceipt/.test(core), 'receipt.ts: buildReceipt(.json 구조)')
+must(/export function renderReceiptMarkdown/.test(core), 'receipt.ts: renderReceiptMarkdown(.md 붙여넣기)')
+must(/export const HONESTY_LINE/.test(core), 'receipt.ts: 정직성 1줄 SoT')
+must(/게으른 거짓완료/.test(core) && /미묘한 오류/.test(core), 'receipt.ts: 정직성 경계(게으른 거짓완료 vs 미묘한 오류)')
+// 실차단 3종만 block — diff-cover 는 block 분기에 없어야 함(advisory 분리)
+must(/e\.gates\.red \|\| e\.dirty \|\| \(e\.staleKnown && e\.stale\)/.test(core), 'receipt.ts: 실차단 3종(red·dirty·stale)만 block')
+
+// ② 경계(IO) — 기존 자산 재사용 글루코드(신규 발명 최소)
+const cmd = read('src/commands/receipt.ts') ?? ''
+must(/verifyEvidence/.test(cmd), 'commands/receipt.ts: verifyEvidence 재사용(① 실종료코드)')
+must(/getCommitInfo/.test(cmd), 'commands/receipt.ts: getCommitInfo 재사용(② dirty — Goal 85 자기파일 제외)')
+must(/diffCoverage/.test(cmd), 'commands/receipt.ts: diffCoverage 재사용(④ advisory)')
+must(/ensureVhkIgnored/.test(cmd), 'commands/receipt.ts: .vhk/receipts/ gitignore(자기 dirty 오염 방지)')
+must(/printNextStep/.test(cmd), 'commands/receipt.ts: printNextStep 패턴(사용자대면)')
+
+// ③ 등록 4지점 + nlp + 한글별칭
+must(/\.command\('receipt'\)/.test(read('src/index.ts') ?? ''), 'index.ts: receipt 명령 등록')
+must(/증거영수증/.test(read('src/index.ts') ?? ''), 'index.ts: 한글별칭 증거영수증')
+must(/name: 'receipt'/.test(read('src/lib/command-registry.ts') ?? ''), 'command-registry.ts: TOP_LEVEL receipt')
+must(/'receipt', '증거영수증'/.test(read('src/lib/cli-args.ts') ?? ''), 'cli-args.ts: KNOWN_COMMAND_TOKENS receipt/증거영수증')
+must(/command: 'receipt'/.test(read('src/lib/nlp-router.ts') ?? ''), 'nlp-router.ts: receipt 라우팅 규칙')
+must(/receipt:/.test(read('src/i18n/ko.ts') ?? ''), 'ko.ts: receipt 메시지 네임스페이스')
+
+// ④ 불변식 테스트 존재(단조성·advisory 분리) + 등록 드리프트 테스트
+const t = read('tests/receipt.test.ts') ?? ''
+must(/caution\s*→\s*pass|단조성/.test(t), 'tests/receipt.test.ts: 단조성 불변식(caution→pass 금지) 테스트')
+must(/advisory/.test(t), 'tests/receipt.test.ts: diff-cover advisory 분리(block 미격하) 테스트')
+must(existsSync('tests/receipt-registration.test.ts'), 'tests/receipt-registration.test.ts 존재(등록 4지점 드리프트)')
+
+if (pass) { console.log('✅ goal 86 gate passes'); process.exit(0) }
+console.log('❌ goal 86 gate failed'); process.exit(1)

--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -1,0 +1,238 @@
+import { existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import chalk from 'chalk'
+import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
+import { ensureVhkIgnored } from '../lib/backup.js'
+import { printNextStep } from '../lib/next-step.js'
+import { atomicWriteFile } from '../lib/atomic-write.js'
+import { localDate } from '../lib/date.js'
+import { stripBom } from '../lib/read-json.js'
+import { ko } from '../i18n/ko.js'
+import { getCommitInfo } from '../lib/git-repo.js'
+import { verifyEvidence } from './verify.js'
+import { diffUnified0 } from '../lib/git-session.js'
+import { addedLinesByFile } from '../lib/diff-hunks.js'
+import { fileCoverageByFile } from '../lib/coverage-parse.js'
+import { diffCoverage } from '../lib/diff-coverage.js'
+import {
+  buildReceipt,
+  renderReceiptMarkdown,
+  type Receipt,
+  type ReceiptDecision,
+  type ReceiptDiffCover,
+} from '../lib/receipt.js'
+
+/**
+ * Goal 86 (RFC 0056 T1): vhk receipt — 에이전트 "완료" 시점에 4대 기계증거를 영수증 1장으로.
+ *
+ * 이 파일은 **경계(IO)** — git/verify/diff-cover 에서 증거를 수집하고 .json/.md 를 쓴다.
+ * 판정·렌더의 순수 로직은 src/lib/receipt.ts(불변식 테스트가 거기 고정). 신규 발명 최소 —
+ * 기존 디스크 작동 자산(verifyEvidence·getCommitInfo·diff-coverage)을 조립하는 글루코드.
+ *
+ * ② dirty 는 getCommitInfo 가 Goal 85 filterSelfTrackedLines 를 이미 적용한다(자기 ledger 제외).
+ * ③ stale 은 작업시작 기준선 SHA(.vhk/receipts/.base-sha, 로컬 전용)와 현재 HEAD 비교 —
+ *    기준선이 없으면 stale 미상(거짓 block 안 함, 단 caution).
+ */
+
+export const RECEIPT_DIR_REL = join('.vhk', 'receipts')
+/** 작업시작 기준선 SHA — stale(③) 비교 기준. 로컬 전용(추적 안 함). */
+export const RECEIPT_BASE_REL = join(RECEIPT_DIR_REL, '.base-sha')
+const COVERAGE_JSON_REL = join('coverage', 'coverage-final.json')
+
+/** 작업시작 기준선 SHA 읽기(로컬 전용 파일). 없거나 손상 → null. */
+export function readBaseSha(cwd: string): string | null {
+  const p = join(cwd, RECEIPT_BASE_REL)
+  if (!existsSync(p)) return null
+  try {
+    const v = stripBom(readFileSync(p, 'utf-8')).trim()
+    return v.length > 0 ? v : null
+  } catch {
+    // 읽기 실패는 "미기록"으로 정직 처리(거짓 stale 금지).
+    return null
+  }
+}
+
+/** 작업시작 기준선 SHA 기록(로컬 전용). receipts/ 디렉터리 + gitignore 보장. */
+export function writeBaseSha(cwd: string, sha: string): void {
+  const dir = join(cwd, RECEIPT_DIR_REL)
+  mkdirSync(dir, { recursive: true })
+  atomicWriteFile(join(cwd, RECEIPT_BASE_REL), sha + '\n')
+  ensureReceiptsIgnored(cwd)
+}
+
+/**
+ * `.vhk/receipts/` 를 .vhk/.gitignore 에 등록.
+ * 왜 추적 제외: 영수증 자신이 작업트리를 dirty 만들면 다음 receipt 의 증거 ②(dirty)를 오염시켜
+ * 자기모순(늘 block)이 된다. ledger/events(추적 영속 증거)와 달리 receipt 는 로컬 산출물이므로 제외.
+ */
+function ensureReceiptsIgnored(cwd: string): void {
+  try {
+    ensureVhkIgnored(cwd, 'receipts/')
+  } catch {
+    /* gitignore 갱신 실패는 치명적 아님 — 영수증은 이미 기록됨 */
+  }
+}
+
+/** ④ diff-cover 수집(advisory). 측정 불가(저장소 아님/리포트 없음/변경 없음)면 measured=false. */
+export function collectDiffCover(cwd: string): ReceiptDiffCover {
+  const empty: ReceiptDiffCover = { measured: false, totalAdded: 0, totalUncovered: 0, ratio: 1 }
+  try {
+    const diffRes = diffUnified0(cwd)
+    const added = addedLinesByFile(diffRes.ok ? diffRes.out : '')
+    if (added.size === 0) return empty // 변경된 기능소스 없음 — 측정 대상 없음(advisory 부재).
+    const covered = fileCoverageByFile(join(cwd, COVERAGE_JSON_REL), cwd)
+    if (covered === null) return empty // 커버리지 리포트 없음 — advisory 부재(차단 사유 아님).
+    const r = diffCoverage(added, covered)
+    return {
+      measured: true,
+      totalAdded: r.totalAdded,
+      totalUncovered: r.totalUncovered,
+      ratio: r.ratio,
+    }
+  } catch {
+    // diff-cover 수집 실패는 advisory 부재로 — 영수증 본체(실차단 3종)는 계속 만든다.
+    return empty
+  }
+}
+
+/**
+ * 4대 기계증거를 수집해 영수증 객체를 만든다(경계). LLM 0.
+ * @param baseShaOverride --since <sha> 로 명시 기준선 지정 시. 없으면 .base-sha 파일.
+ */
+export function collectReceipt(cwd: string, baseShaOverride?: string | null): Receipt {
+  // ① 게이트(tsc/test/build/secure) 실종료코드 — 자기보고 거부, 실제 프로세스만(verify.ts 가 보장).
+  const { report } = verifyEvidence(cwd)
+  const failedGateIds = report.gates.filter((g) => g.status === 'fail').map((g) => g.id)
+  const hasSoftWarning = report.gates.some((g) => g.status === 'skip' || g.status === 'warn')
+
+  // ② git dirty — Goal 85 자기파일 제외가 getCommitInfo 안에 이미 적용됨.
+  const commit = getCommitInfo(cwd)
+  const headSha = commit?.sha ?? null
+  const dirty = commit?.dirty ?? false
+
+  // ③ stale — 작업시작 기준선 SHA ≠ 현재 HEAD. 기준선/HEAD 미상이면 stale 미상(거짓 block 금지).
+  const baseSha = baseShaOverride !== undefined ? baseShaOverride : readBaseSha(cwd)
+  const staleKnown = baseSha !== null && headSha !== null
+  const stale = staleKnown ? baseSha !== headSha : false
+
+  // ④ diff-cover — advisory(약신호).
+  const diffCover = collectDiffCover(cwd)
+
+  return buildReceipt(
+    {
+      gates: { red: failedGateIds.length > 0, status: report.status, failedGateIds, hasSoftWarning },
+      dirty,
+      stale,
+      staleKnown,
+      diffCover,
+    },
+    {
+      generatedAt: new Date().toISOString(),
+      date: localDate(),
+      // slug = 날짜(파일명 base 는 writeReceipt 가 실제 decision 으로 확정). 정보용.
+      slug: localDate(),
+      headSha,
+      baseSha,
+    }
+  )
+}
+
+/** 영수증을 .json + .md 로 디스크에 기록. receipts/ gitignore 보장. @returns 두 파일의 상대경로. */
+export function writeReceipt(cwd: string, receipt: Receipt): { jsonPath: string; mdPath: string } {
+  const dir = join(cwd, RECEIPT_DIR_REL)
+  mkdirSync(dir, { recursive: true })
+  // 같은 날 여러 장 충돌 방지: <날짜>-<decision>-<HHMMSS>.
+  const stamp = receipt.generatedAt.slice(11, 19).replace(/:/g, '')
+  const base = `${receipt.date}-${receipt.decision}-${stamp}`
+  const jsonRel = join(RECEIPT_DIR_REL, `${base}.json`)
+  const mdRel = join(RECEIPT_DIR_REL, `${base}.md`)
+  atomicWriteFile(join(cwd, jsonRel), JSON.stringify(receipt, null, 2) + '\n')
+  atomicWriteFile(join(cwd, mdRel), renderReceiptMarkdown(receipt))
+  ensureReceiptsIgnored(cwd)
+  return { jsonPath: jsonRel, mdPath: mdRel }
+}
+
+const DECISION_BADGE: Record<ReceiptDecision, string> = {
+  block: chalk.red.bold('🔴 BLOCK'),
+  caution: chalk.yellow.bold('🟡 CAUTION'),
+  pass: chalk.green.bold('🟢 PASS'),
+}
+
+export interface ReceiptOptions {
+  json?: boolean
+  /** 현재 HEAD 를 작업시작 기준선으로 기록(이후 stale 비교 기준). */
+  markStart?: boolean
+  /** stale 비교 기준 SHA 를 명시(.base-sha 무시). */
+  since?: string
+}
+
+export async function receipt(opts: ReceiptOptions = {}): Promise<void> {
+  // HARD_STOP 활성 → 거부 + exit 1.
+  if (!ensureNotHardStopped('receipt')) return
+  const cwd = process.cwd()
+
+  // --mark-start: 현재 HEAD 를 작업시작 기준선으로 박는다(증거 안 만듦).
+  if (opts.markStart) {
+    const commit = getCommitInfo(cwd)
+    if (!commit) {
+      console.error(chalk.red(`  ❌ ${ko.receipt.noCommit}`))
+      process.exitCode = 1
+      return
+    }
+    writeBaseSha(cwd, commit.sha)
+    console.log(chalk.green(`  ✅ ${ko.receipt.markStartDone} ${chalk.dim(commit.shortSha)}`))
+    process.exitCode = 0
+    return
+  }
+
+  const r = collectReceipt(cwd, opts.since ?? undefined)
+  const { jsonPath, mdPath } = writeReceipt(cwd, r)
+
+  // --json: 기계 소비용 — 영수증 JSON 만 stdout 으로.
+  if (opts.json) {
+    console.log(JSON.stringify(r, null, 2))
+    process.exitCode = r.decision === 'block' ? 1 : 0
+    return
+  }
+
+  console.log(chalk.bold(`\n🧾 ${ko.receipt.title} (receipt)`))
+  console.log(chalk.gray('─'.repeat(44)))
+  console.log(`  판정: ${DECISION_BADGE[r.decision]}`)
+  console.log(
+    chalk.dim(
+      `  HEAD: ${r.head.shortSha ?? '미상'}  ·  작업시작: ${r.base.shortSha ?? '미기록'}  ·  게이트: ${r.evidence.gates.status}`
+    )
+  )
+  console.log('')
+  for (const reason of r.reasons) {
+    const mark = r.decision === 'pass' ? chalk.green('✓') : chalk.yellow('•')
+    console.log(`   ${mark} ${reason}`)
+  }
+  console.log(chalk.dim(`\n  📄 영수증: ${jsonPath}`))
+  console.log(chalk.dim(`  📋 붙여넣기용: ${mdPath}`))
+  console.log(chalk.yellow(`\n  ⚠️  ${r.honesty}`))
+
+  // exit code: block 이면 1(거짓완료 의심 — done 위장 차단), caution/pass 는 0.
+  process.exitCode = r.decision === 'block' ? 1 : 0
+
+  if (r.decision === 'block') {
+    printNextStep({
+      message: ko.receipt.nextBlockMessage,
+      command: 'vhk verify',
+      cursorHint: '막힌 증거부터 고쳐줘',
+      alternative: r.reasons[0],
+    })
+  } else if (r.decision === 'caution') {
+    printNextStep({
+      message: ko.receipt.nextCautionMessage,
+      command: `vhk receipt`,
+      cursorHint: '영수증 다시 떼줘',
+    })
+  } else {
+    printNextStep({
+      message: ko.receipt.nextPassMessage,
+      command: 'vhk goal done',
+      cursorHint: 'goal 완료 처리해줘',
+    })
+  }
+}

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -262,6 +262,15 @@ export const ko = {
     restDay: '오늘은 기록이 없네 — 쉬어가는 것도 하루.',
     restEncourage: '쉬는 것도 페이스의 일부. 내일 또.',
   },
+  // Goal 86 (RFC 0056 T1): 증거 영수증 — 에이전트 "됐어요"를 기계증거로 판정.
+  receipt: {
+    title: '증거 영수증',
+    noCommit: 'git 커밋을 찾을 수 없습니다 — 작업시작 기준선을 기록하려면 커밋이 1개 이상 필요합니다.',
+    markStartDone: '작업시작 기준선 SHA 기록 완료 (이후 stale 비교 기준):',
+    nextBlockMessage: '🔴 기계증거가 "됐어요"와 모순 — 아직 완료 아님. 막힌 증거(red/dirty/stale)부터 고치세요:',
+    nextCautionMessage: '🟡 실차단은 없으나 약신호 있음(수동 확인 권장). 보강 후 다시 떼세요:',
+    nextPassMessage: '🟢 게으른 거짓완료 징후 없음(미묘한 오류는 못 잡음). 완료 처리하려면:',
+  },
   worktree: {
     checkTitle: '🌳 Worktree env 점검',
     addTitle: (b: string) => `🌳 Worktree 생성: ${b}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ import { worktreeAdd, worktreeCheck } from './commands/worktree.js'
 import { standup } from './commands/standup.js'
 import { today } from './commands/today.js'
 import { review } from './commands/review.js'
+import { receipt } from './commands/receipt.js'
 import { missionSet, missionShow, missionCheck, missionClear } from './commands/mission.js'
 import { runGuarded } from './lib/safety-guard.js'
 import { ensureNotHardStopped } from './lib/hard-stop-guard.js'
@@ -589,6 +590,15 @@ program
   .option('--strict', '엄격 모드 — 미검증/커버리지 부족도 실패 (기본 advisory: 강한 모순만 실패) (#157)')
   .description('적대적 자기검증 — latest.json ↔ goal 완료조건 교차검증 (거짓완료 의심 탐지, 보장 아님)')
   .action(async (opts: { id?: string; strict?: boolean }) => { await review(opts) })
+
+program
+  .command('receipt')
+  .alias('증거영수증')
+  .option('--json', '영수증 JSON 을 stdout 으로 출력 (CI/기계용 — block 이면 exit 1)')
+  .option('--mark-start', '현재 HEAD 를 작업시작 기준선으로 기록 (이후 stale 비교 기준)')
+  .option('--since <sha>', 'stale 비교 기준 SHA 를 명시 (.base-sha 무시)')
+  .description('증거 영수증 — 4대 기계증거(종료코드·dirty·stale·diff-cover)로 거짓완료 판정 (.vhk/receipts/)')
+  .action(async (opts: { json?: boolean; markStart?: boolean; since?: string }) => { await receipt(opts) })
 
 // prev 기본 [] — default 미지정이라 옵션 미제공 시 opts 에 키 자체가 없음(undefined = 보존 신호).
 const collectGlob = (v: string, prev: string[] = []): string[] => prev.concat([v])

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -59,6 +59,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'standup', '아침',
   'today', '자축',
   'review', '검토',
+  'receipt', '증거영수증',
   'mission', '미션',
   'pattern', '패턴',
   'evolve', '진화',

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -93,6 +93,7 @@ export const TOP_LEVEL_COMMANDS: ReadonlyArray<{ name: string; desc: string }> =
   { name: 'standup', desc: '아침 브리핑 (어제 한 일 + 오늘 추천 goal + 미해결)' },
   { name: 'today', desc: '저녁 자축·회고 (오늘 커밋·완료 goal 카운트 + 격려)' },
   { name: 'review', desc: '적대적 자기검증 (거짓완료 의심 탐지)' },
+  { name: 'receipt', desc: '증거 영수증 — 4대 기계증거로 거짓완료 판정 (block/caution/pass)' },
   { name: 'mission', desc: '미션 계약 — 작업 목표·허용/금지 범위 선언·검증' },
   { name: 'context-show', desc: '컨텍스트 파일 내용 출력' },
   { name: 'memory', desc: '기억 관리 v2 (decisions/failures/successes)' },

--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -43,6 +43,7 @@ export type NlpCommand =
   | 'mode'
   | 'verify'
   | 'review'
+  | 'receipt'
   | 'mission'
   | 'pattern'
   | 'evolve'
@@ -154,6 +155,14 @@ const RULES: NlpRule[] = [
     // '검증 실행/돌려'·bare '검증해줘' 는 verify 의도 — gate(아이디어 검증)가 가로채지 않게 먼저 흡수.
     test: t =>
       /검증\s*(묶음|실행|돌려|돌리)|사전\s*검증|저장\s*전\s*(검증|확인)|^verify$|^검증\s*(해줘|해)?$/.test(t),
+  },
+  // receipt 는 review 보다 **먼저** 평가 — '영수증/receipt' 한정이라 '거짓완료' 만으로는 review 가
+  // 가져간다('영수증' 동반 시에만 receipt). bare '영수증'·'증거 영수증'·'receipt' 도 흡수.
+  {
+    command: 'receipt',
+    explanation: '증거 영수증 — 4대 기계증거로 거짓완료 판정 (vhk receipt)',
+    confidence: 'high',
+    test: t => /증거\s*영수증|^영수증$|영수증\s*(만들|떼|발급|뽑|생성)|^receipt$|거짓\s*완료\s*영수증/.test(t),
   },
   {
     command: 'review',

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -43,6 +43,7 @@ import { quickActions } from '../commands/help.js'
 import { mode } from '../commands/mode.js'
 import { verify } from '../commands/verify.js'
 import { review } from '../commands/review.js'
+import { receipt } from '../commands/receipt.js'
 import { missionShow } from '../commands/mission.js'
 import { patternList } from '../commands/pattern.js'
 import { evolveList } from '../commands/evolve.js'
@@ -155,6 +156,8 @@ export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<
       return verify()
     case 'review':
       return review()
+    case 'receipt':
+      return receipt()
     case 'mission':
       return missionShow()
     case 'pattern':

--- a/src/lib/receipt.ts
+++ b/src/lib/receipt.ts
@@ -1,0 +1,227 @@
+// Goal 86 (RFC 0056 T1): vhk receipt — 에이전트의 "됐어요"를 기계증거 영수증 1장으로.
+//
+// 정체성(ADR-006 / RFC 0056 §2): VHK 는 "AI 자기보고를 기계증거로 대조해 거짓완료를 잡는
+// 결정론 판정"이다. 이 모듈은 **순수 핵심**(IO 0) — 4대 기계증거를 받아 decision 을 내리고
+// .json/.md 영수증을 만든다. fs/git 수집은 commands/receipt.ts(경계)가 담당한다(테스트 용이).
+//
+// ★핵심 불변식(테스트로 고정 — tests/receipt.test.ts):
+//   ① decision 은 기계증거만으로(LLM 추론 0). 실차단 3종(red·dirty·stale) 중 하나라도면 block.
+//   ② 단조성: caution → pass 격상 절대 금지. 부정 신호가 늘면 결과가 좋아질 수 없다(pass→caution→block).
+//   ③ ④ diff-cover 는 advisory(약신호) — decision 을 block 으로 격하시키지 못한다(차단은 3종만).
+//
+// ★정직 경계(RFC 0056 §11 ①): diff-cover 의 covered 는 "테스트 실행 도달"이지 "정확성"이 아니다.
+//   그러므로 영수증이 잡는 것은 **게으른 거짓완료**(빌드 깨짐·미커밋·stale)에 한정되고, "almost
+//   right but not quite"(미묘하게 틀린 코드)는 구조적으로 못 잡는다. 산출물 .md 하단에 이 경계를 박는다.
+
+import type { ReportStatus } from '../commands/verify.js'
+
+/** 영수증 판정 — 기계증거만(LLM 0). block: 실차단(red/dirty/stale). caution: 약신호만. pass: 전부 clean·확인됨. */
+export type ReceiptDecision = 'block' | 'caution' | 'pass'
+
+/** 게이트(verify) 증거 요약 — 실종료코드 출처(자기보고 거부, verify.ts 가 이미 강제). */
+export interface ReceiptGateEvidence {
+  /** 게이트 하나라도 실제 프로세스 종료코드로 fail 인가(=red). 실차단 사유 ①. */
+  red: boolean
+  /** verify 종합(PASS/WARN/FAIL). 사람 표시·요약용. */
+  status: ReportStatus
+  /** fail 한 게이트 id 들(사유 표기용). */
+  failedGateIds: string[]
+  /** skip/warn 게이트가 있어 결과가 불완전한가(soft 약신호 — caution 사유, block 아님). */
+  hasSoftWarning: boolean
+}
+
+/** ④ diff-cover 증거 — advisory(약신호). decision 을 block 으로 못 만든다. */
+export interface ReceiptDiffCover {
+  /** 커버리지 리포트가 있어 측정됐는가(없으면 부재 — 차단 사유 아님). */
+  measured: boolean
+  totalAdded: number
+  totalUncovered: number
+  ratio: number
+}
+
+/** 영수증 입력 — 4대 기계증거(commands/receipt.ts 가 git/verify/diff-cover 에서 수집). */
+export interface ReceiptEvidence {
+  /** ① tsc/test/build 실종료코드 게이트. */
+  gates: ReceiptGateEvidence
+  /** ② git dirty(자기파일 제외 — Goal 85 filterSelfTrackedLines 적용 후). 실차단 사유 ②. */
+  dirty: boolean
+  /** ③ stale(작업시작 SHA ≠ 현재 HEAD). 실차단 사유 ③. staleKnown=false 면 이 값 무의미. */
+  stale: boolean
+  /** 작업시작 기준선 SHA 를 알 수 있었는가(기준선 미기록 시 false → stale 미상 = caution, block 아님). */
+  staleKnown: boolean
+  /** ④ 변경라인 diff-cover(advisory). */
+  diffCover: ReceiptDiffCover
+}
+
+/** 산출 .md 하단 고정 1줄 — 정직성(능력 경계)을 제품에 박는다(RFC 0056 §6·§11). */
+export const HONESTY_LINE =
+  '이 영수증은 게으른 거짓완료(빌드 깨짐·미커밋·낡은 증거)를 잡지, 미묘한 오류(그럴듯하게 틀린 코드)는 못 잡는다. 판정은 기계증거(종료코드·dirty·SHA) 기반이며 LLM 추론이 아니다.'
+
+/**
+ * 4대 기계증거 → decision. **순수 함수, LLM 0.**
+ *
+ * 실차단 3종(red·dirty·stale) 중 하나라도면 block(불변식 ①). 그게 아니고 약신호(soft 게이트·
+ * stale 미상·diff-cover 미커버)가 있으면 caution. 전부 clean·확인됐을 때만 pass.
+ *
+ * 단조성(불변식 ②): 부정 신호가 늘수록 block ← caution ← pass 한 방향으로만 간다. caution 을
+ * pass 로 격상시키는 분기는 존재하지 않는다(아래는 "block? → caution? → pass" 폭포라 역행 불가).
+ *
+ * ④ diff-cover 는 caution 까지만 올린다(advisory, 불변식 ③) — block 분기에 절대 들어가지 않는다.
+ */
+export function decideReceipt(e: ReceiptEvidence): ReceiptDecision {
+  // 실차단 3종 — diff-cover 는 여기에 없다(advisory 라 block 격하 불가).
+  if (e.gates.red || e.dirty || (e.staleKnown && e.stale)) return 'block'
+
+  // 약신호(soft) — 차단은 아니나 "안심"도 금지 → caution. (단조성: pass 로 못 내려감)
+  const hasUncoveredChange = e.diffCover.measured && e.diffCover.totalUncovered > 0
+  if (e.gates.hasSoftWarning || !e.staleKnown || hasUncoveredChange) return 'caution'
+
+  return 'pass'
+}
+
+/** decision 사유(사람 표시) — 왜 그 색인지 한 줄씩. */
+export function receiptReasons(e: ReceiptEvidence): string[] {
+  const reasons: string[] = []
+  if (e.gates.red) {
+    const ids = e.gates.failedGateIds.length ? e.gates.failedGateIds.join(', ') : '게이트'
+    reasons.push(`게이트 실패(실종료코드 ≠ 0): ${ids} — red`)
+  }
+  if (e.dirty) reasons.push('working tree 가 dirty — 미커밋/untracked 변경 있음(자기파일 제외 후에도)')
+  if (e.staleKnown && e.stale) reasons.push('작업 시작 SHA ≠ 현재 HEAD — 증거가 낡았을 수 있음(stale)')
+  if (!e.staleKnown) reasons.push('작업 시작 기준선 미기록 — stale 판정 불가(vhk receipt --mark-start 로 기준선 고정 가능)')
+  if (e.gates.hasSoftWarning) reasons.push('일부 게이트 skip/warn — 결과 불완전(수동 확인 권장)')
+  if (e.diffCover.measured && e.diffCover.totalUncovered > 0) {
+    const pct = Math.round(e.diffCover.ratio * 100)
+    reasons.push(
+      `변경라인 미검증 ${e.diffCover.totalUncovered}/${e.diffCover.totalAdded} (커버 ${pct}%) — advisory(약신호, 차단 안 함)`
+    )
+  }
+  if (reasons.length === 0) reasons.push('전 게이트 green · clean · 신선 · 변경라인 풀커버')
+  return reasons
+}
+
+export interface ReceiptMeta {
+  /** 머신 타임스탬프(UTC ISO). */
+  generatedAt: string
+  /** 사람용 날짜(localDate). */
+  date: string
+  /** 파일명 슬러그(<날짜-슬러그>). */
+  slug: string
+  /** 현재 HEAD 전체 SHA(미상 → null). */
+  headSha: string | null
+  /** 작업시작 기준선 SHA(미기록 → null). */
+  baseSha: string | null
+}
+
+export interface ReceiptCommit {
+  sha: string | null
+  shortSha: string | null
+}
+
+export const RECEIPT_SCHEMA_VERSION = 1
+
+export interface Receipt {
+  schemaVersion: number
+  generatedAt: string
+  date: string
+  slug: string
+  /** 기계증거만으로 내린 판정. */
+  decision: ReceiptDecision
+  /** 사람용 사유 목록. */
+  reasons: string[]
+  /** 4대 기계증거 원본(기계 소비용). */
+  evidence: ReceiptEvidence
+  /** 현재 HEAD. */
+  head: ReceiptCommit
+  /** 작업시작 기준선(stale 비교 기준). */
+  base: ReceiptCommit
+  /** 정직성 경계 1줄. */
+  honesty: string
+}
+
+function shortOf(sha: string | null): string | null {
+  return sha ? sha.slice(0, 7) : null
+}
+
+/** 증거 + 메타 → 영수증 객체(순수). */
+export function buildReceipt(e: ReceiptEvidence, meta: ReceiptMeta): Receipt {
+  return {
+    schemaVersion: RECEIPT_SCHEMA_VERSION,
+    generatedAt: meta.generatedAt,
+    date: meta.date,
+    slug: meta.slug,
+    decision: decideReceipt(e),
+    reasons: receiptReasons(e),
+    evidence: e,
+    head: { sha: meta.headSha, shortSha: shortOf(meta.headSha) },
+    base: { sha: meta.baseSha, shortSha: shortOf(meta.baseSha) },
+    honesty: HONESTY_LINE,
+  }
+}
+
+const DECISION_BADGE: Record<ReceiptDecision, string> = {
+  block: '🔴 BLOCK',
+  caution: '🟡 CAUTION',
+  pass: '🟢 PASS',
+}
+
+const DECISION_HEADLINE: Record<ReceiptDecision, string> = {
+  block: '기계증거가 "됐어요"와 모순 — 아직 완료 아님(거짓완료 의심)',
+  caution: '실차단은 없으나 약신호 있음 — 수동 확인 권장(안심 금지)',
+  pass: '기계증거상 게으른 거짓완료 징후 없음(미묘한 오류는 못 잡음)',
+}
+
+/**
+ * 영수증 → PR/대화에 그대로 붙는 .md 1블록(순수). decision 배지 + 게이트표 + 사유 + 정직성 1줄.
+ * chalk 없음(붙여넣기용 순수 텍스트). 머신·사람 동시 가독.
+ */
+export function renderReceiptMarkdown(r: Receipt): string {
+  const e = r.evidence
+  const gateRow = (label: string, ok: boolean, note: string) =>
+    `| ${label} | ${ok ? '✅' : '❌'} | ${note} |`
+
+  const dc = e.diffCover
+  const dcPct = dc.measured ? `${Math.round(dc.ratio * 100)}%` : '미측정'
+  const dcNote = dc.measured
+    ? `미검증 ${dc.totalUncovered}/${dc.totalAdded} (커버 ${dcPct}) — advisory(차단 안 함)`
+    : '커버리지 리포트 없음 — advisory(차단 안 함)'
+
+  const lines: string[] = []
+  lines.push(`## ${DECISION_BADGE[r.decision]} — vhk receipt`)
+  lines.push('')
+  lines.push(`> ${DECISION_HEADLINE[r.decision]}`)
+  lines.push('')
+  lines.push(
+    `- 생성: ${r.date} (${r.generatedAt})  ·  HEAD: \`${r.head.shortSha ?? '미상'}\`  ·  작업시작: \`${r.base.shortSha ?? '미기록'}\``
+  )
+  lines.push('')
+  lines.push('| 게이트 | 상태 | 비고 |')
+  lines.push('| --- | --- | --- |')
+  lines.push(
+    gateRow(
+      '① 게이트(tsc/test/build)',
+      !e.gates.red,
+      e.gates.red
+        ? `FAIL: ${e.gates.failedGateIds.join(', ') || '게이트'}`
+        : `${e.gates.status}${e.gates.hasSoftWarning ? ' (skip/warn 포함)' : ''}`
+    )
+  )
+  lines.push(gateRow('② git dirty', !e.dirty, e.dirty ? '미커밋/untracked 변경 있음' : 'clean(자기파일 제외)'))
+  // ③ stale 미상은 ✅(통과)도 ❌(차단)도 아닌 ℹ️(판정 불가) — 모르는 걸 통과로 위장하지 않는다.
+  const staleCell = !e.staleKnown ? 'ℹ️' : e.stale ? '❌' : '✅'
+  const staleNote = !e.staleKnown
+    ? '기준선 미기록 — 판정 불가(vhk receipt --mark-start)'
+    : e.stale
+      ? '작업시작 SHA ≠ HEAD — 낡은 증거 의심'
+      : '신선(SHA 일치)'
+  lines.push(`| ③ stale(작업시작 SHA≠HEAD) | ${staleCell} | ${staleNote} |`)
+  // ④ 는 advisory — 체크표시는 정보용이지 decision 에 영향 없음(표 비고에 명시).
+  lines.push(`| ④ diff-cover(advisory) | ${dc.measured && dc.totalUncovered === 0 ? '✅' : 'ℹ️'} | ${dcNote} |`)
+  lines.push('')
+  lines.push('**사유:**')
+  for (const reason of r.reasons) lines.push(`- ${reason}`)
+  lines.push('')
+  lines.push(`> ⚠️ ${r.honesty}`)
+  lines.push('')
+  return lines.join('\n')
+}

--- a/src/templates/vhk-dir.ts
+++ b/src/templates/vhk-dir.ts
@@ -73,6 +73,11 @@ export function VHK_GITIGNORE_TEMPLATE(): string {
     'cloud.json',
     '# sync 덮어쓰기 전 자동 백업 (로컬 복구용 — vhk restore). 추적/클라우드 제외.',
     'backups/',
+    // Goal 86 (RFC 0056 T1): 증거 영수증은 로컬 산출물. 추적하면 영수증 자신이 작업트리를
+    // dirty 만들어 다음 receipt 의 증거 ②(dirty)를 오염(자기모순=늘 block). ledger/events 와 달리
+    // repo 영속 증거가 아니므로 제외한다(.base-sha 기준선도 함께).
+    '# 증거 영수증 — 로컬 산출물(추적하면 자기 dirty 증거 오염). vhk receipt.',
+    'receipts/',
     '',
   ].join('\n')
 }

--- a/tests/nlp-router.test.ts
+++ b/tests/nlp-router.test.ts
@@ -15,6 +15,18 @@ describe('자연어 라우팅', () => {
     expect(result?.command).toBe('start')
   })
 
+  // Goal 86 (RFC 0056 T1): vhk receipt — 자연어 라우팅(증거영수증/영수증).
+  describe('receipt 라우팅 — 증거 영수증 (Goal 86)', () => {
+    for (const phrase of ['증거 영수증', '영수증 만들어줘', 'receipt', '거짓완료 영수증']) {
+      it(`"${phrase}" → receipt`, () => {
+        expect(routeNaturalLanguage(phrase)?.command).toBe('receipt')
+      })
+    }
+    it('"적대 검증" 은 여전히 review (receipt 가 가로채지 않음)', () => {
+      expect(routeNaturalLanguage('적대 검증')?.command).toBe('review')
+    })
+  })
+
   it('"기획 끝났고 바로 시작" → start (마법사 한 방에 git+문서+MCP+context)', () => {
     const result = routeNaturalLanguage('기획 끝났고 바로 시작')
     expect(result?.command).toBe('start')

--- a/tests/receipt-registration.test.ts
+++ b/tests/receipt-registration.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { program } from '../src/index.js'
+import { TOP_LEVEL_COMMANDS } from '../src/lib/command-registry.js'
+import { KNOWN_COMMAND_TOKENS, detectNaturalLanguageInput } from '../src/lib/cli-args.js'
+import { routeNaturalLanguage } from '../src/lib/nlp-router.js'
+import { ko } from '../src/i18n/ko.js'
+
+// Goal 86 (RFC 0056 T1): vhk receipt 등록 4지점 + nlp-router + 한글별칭 드리프트 가드.
+// 누락 시 첫 게이트(빌드/NL라우터)에서 깨진다(RFC 0055 §13-high#3 정면 예방).
+describe('vhk receipt 등록 4지점 (Goal 86)', () => {
+  it('① index.ts — commander 에 receipt 명령 등록 + 한글별칭 증거영수증', () => {
+    const cmd = program.commands.find((c) => c.name() === 'receipt')
+    expect(cmd, 'commander 에 receipt 명령 없음').toBeDefined()
+    expect(cmd!.aliases(), 'receipt 에 한글별칭 증거영수증 없음').toContain('증거영수증')
+  })
+
+  it('② command-registry — TOP_LEVEL_COMMANDS 에 receipt(설명 포함)', () => {
+    const entry = TOP_LEVEL_COMMANDS.find((c) => c.name === 'receipt')
+    expect(entry, 'TOP_LEVEL_COMMANDS 에 receipt 없음').toBeDefined()
+    expect(entry!.desc.length).toBeGreaterThan(0)
+  })
+
+  it('③ cli-args — KNOWN_COMMAND_TOKENS 에 receipt·증거영수증', () => {
+    expect(KNOWN_COMMAND_TOKENS.has('receipt')).toBe(true)
+    expect(KNOWN_COMMAND_TOKENS.has('증거영수증')).toBe(true)
+  })
+
+  it('④ ko.ts — receipt 메시지 네임스페이스 존재', () => {
+    expect(ko.receipt, 'ko.receipt 네임스페이스 없음').toBeDefined()
+    expect(typeof ko.receipt.title).toBe('string')
+  })
+
+  it('nlp-router — receipt 라우팅 + 증거영수증/영수증 키워드', () => {
+    expect(routeNaturalLanguage('증거 영수증')?.command).toBe('receipt')
+    expect(routeNaturalLanguage('영수증 만들어줘')?.command).toBe('receipt')
+  })
+
+  it('receipt / 증거영수증 단독 입력은 commander 로(자연어 가로채기 금지)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'receipt'])).toBeNull()
+    expect(detectNaturalLanguageInput(['node', 'vhk', '증거영수증'])).toBeNull()
+  })
+
+  it('기존 명령 시그니처 보존 — ship·mission·verify 모두 등록 유지(이름충돌 0)', () => {
+    const names = program.commands.map((c) => c.name())
+    for (const n of ['ship', 'mission', 'verify', 'review']) {
+      expect(names, `${n} 명령이 사라짐(breaking)`).toContain(n)
+    }
+  })
+})

--- a/tests/receipt.test.ts
+++ b/tests/receipt.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest'
+import {
+  decideReceipt,
+  buildReceipt,
+  renderReceiptMarkdown,
+  type ReceiptEvidence,
+  type ReceiptDecision,
+  HONESTY_LINE,
+} from '../src/lib/receipt.js'
+
+// Goal 86 (RFC 0056 T1): vhk receipt — 4대 기계증거 → 영수증 1장.
+// 핵심 불변식(테스트로 고정):
+//  ① decision 은 기계증거만으로(LLM 0). dirty/stale/red 중 하나라도면 block.
+//  ② 단조성: caution → pass 격상 절대 금지(부정 신호가 늘면 결과가 좋아질 수 없다).
+//  ③ ④ diff-cover 는 advisory(약신호) — decision 을 block 으로 격하시키지 못한다.
+
+/** 모든 게이트 green·clean·신선·풀커버 = 깨끗한 기준 증거. */
+function cleanEvidence(): ReceiptEvidence {
+  return {
+    gates: { red: false, status: 'PASS', failedGateIds: [], hasSoftWarning: false },
+    dirty: false,
+    stale: false,
+    staleKnown: true,
+    diffCover: { measured: true, totalAdded: 10, totalUncovered: 0, ratio: 1 },
+  }
+}
+
+describe('decideReceipt — 기계증거만(LLM 0)', () => {
+  it('전부 green·clean·신선·풀커버 → pass', () => {
+    expect(decideReceipt(cleanEvidence())).toBe('pass')
+  })
+
+  it('red(게이트 실패 종료코드) → block', () => {
+    const e = cleanEvidence()
+    e.gates.red = true
+    e.gates.status = 'FAIL'
+    e.gates.failedGateIds = ['test']
+    expect(decideReceipt(e)).toBe('block')
+  })
+
+  it('dirty(미커밋 변경) → block', () => {
+    const e = cleanEvidence()
+    e.dirty = true
+    expect(decideReceipt(e)).toBe('block')
+  })
+
+  it('stale(작업시작 SHA ≠ HEAD) → block', () => {
+    const e = cleanEvidence()
+    e.stale = true
+    expect(decideReceipt(e)).toBe('block')
+  })
+
+  it('실차단 3종(red·dirty·stale) 중 하나라도면 block — 조합 무관', () => {
+    for (const key of ['red', 'dirty', 'stale'] as const) {
+      const e = cleanEvidence()
+      if (key === 'red') e.gates.red = true
+      else e[key] = true
+      expect(decideReceipt(e), `${key} 단독이면 block`).toBe('block')
+    }
+  })
+
+  it('stale 미상(staleKnown=false) 단독은 block 아님 — 모르는 걸 빨강으로 위장 금지', () => {
+    const e = cleanEvidence()
+    e.stale = false
+    e.staleKnown = false
+    // 기준선 미기록 = 알 수 없음 → 거짓 block 안 함(단 pass 도 아니고 caution 으로 정직).
+    expect(decideReceipt(e)).not.toBe('block')
+  })
+})
+
+describe('단조성 불변식 — caution → pass 격상 절대 금지', () => {
+  it('soft 경고(skip/warn 게이트)가 있으면 caution 이지 pass 아님', () => {
+    const e = cleanEvidence()
+    e.gates.status = 'WARN'
+    e.gates.hasSoftWarning = true
+    expect(decideReceipt(e)).toBe('caution')
+  })
+
+  it('diff-cover 미검증 변경분이 있으면 caution 이지 pass 아님(advisory 약신호)', () => {
+    const e = cleanEvidence()
+    e.diffCover = { measured: true, totalAdded: 10, totalUncovered: 4, ratio: 0.6 }
+    expect(decideReceipt(e)).toBe('caution')
+  })
+
+  it('stale 미상도 caution(모르면 안심 금지)', () => {
+    const e = cleanEvidence()
+    e.staleKnown = false
+    expect(decideReceipt(e)).toBe('caution')
+  })
+
+  it('부정 신호를 더해도 결과가 절대 좋아지지 않는다(pass→caution→block 단조)', () => {
+    const order: Record<ReceiptDecision, number> = { pass: 0, caution: 1, block: 2 }
+    const base = cleanEvidence()
+    const baseRank = order[decideReceipt(base)]
+    // caution 유발 신호를 추가 → pass 로 떨어질 수 없음(>= base).
+    const cautioned = cleanEvidence()
+    cautioned.gates.hasSoftWarning = true
+    expect(order[decideReceipt(cautioned)]).toBeGreaterThanOrEqual(baseRank)
+    // block 유발 신호를 추가 → caution 이상.
+    const blocked = cleanEvidence()
+    blocked.gates.hasSoftWarning = true
+    blocked.dirty = true
+    expect(order[decideReceipt(blocked)]).toBeGreaterThanOrEqual(order[decideReceipt(cautioned)])
+    expect(decideReceipt(blocked)).toBe('block')
+  })
+})
+
+describe('④ diff-cover 는 advisory — decision 을 block 으로 격하 못 함', () => {
+  it('diff-cover 0% 미커버여도(나머지 clean) block 아님 — 최대 caution', () => {
+    const e = cleanEvidence()
+    e.diffCover = { measured: true, totalAdded: 20, totalUncovered: 20, ratio: 0 }
+    const d = decideReceipt(e)
+    expect(d).not.toBe('block')
+    expect(d).toBe('caution')
+  })
+
+  it('실차단(dirty)에 더해 diff-cover 가 풀커버여도 여전히 block — 차단은 3종만이 결정', () => {
+    const e = cleanEvidence()
+    e.dirty = true
+    e.diffCover = { measured: true, totalAdded: 10, totalUncovered: 0, ratio: 1 }
+    expect(decideReceipt(e)).toBe('block')
+  })
+
+  it('diff-cover 미측정(리포트 없음)도 block 아님 — advisory 부재는 차단 사유 아님', () => {
+    const e = cleanEvidence()
+    e.diffCover = { measured: false, totalAdded: 0, totalUncovered: 0, ratio: 1 }
+    expect(decideReceipt(e)).not.toBe('block')
+  })
+})
+
+describe('buildReceipt — .json 영수증 구조', () => {
+  it('decision·증거·생성시각·날짜·슬러그를 담는다', () => {
+    const r = buildReceipt(cleanEvidence(), {
+      generatedAt: '2026-06-23T00:00:00.000Z',
+      date: '2026-06-23',
+      slug: 'test-slug',
+      headSha: 'abc1234def',
+      baseSha: 'abc1234def',
+    })
+    expect(r.decision).toBe('pass')
+    expect(r.date).toBe('2026-06-23')
+    expect(r.slug).toBe('test-slug')
+    expect(r.evidence.dirty).toBe(false)
+    expect(r.head.shortSha).toBe('abc1234')
+  })
+})
+
+describe('renderReceiptMarkdown — PR/대화 붙여넣기 1블록', () => {
+  it('decision 배지 + 게이트표 + 정직성 1줄을 포함', () => {
+    const r = buildReceipt(cleanEvidence(), {
+      generatedAt: '2026-06-23T00:00:00.000Z',
+      date: '2026-06-23',
+      slug: 'test-slug',
+      headSha: 'abc1234def',
+      baseSha: 'abc1234def',
+    })
+    const md = renderReceiptMarkdown(r)
+    expect(md).toContain('PASS')
+    expect(md).toContain('게이트')
+    expect(md).toContain(HONESTY_LINE)
+    // 정직성 1줄 — 게으른 거짓완료 vs 미묘한 오류 경계 명시.
+    expect(HONESTY_LINE).toMatch(/게으른 거짓완료|미묘한 오류/)
+  })
+
+  it('block 영수증은 사유(dirty/stale/red)를 표기', () => {
+    const e = cleanEvidence()
+    e.dirty = true
+    e.stale = true
+    e.gates.red = true
+    e.gates.status = 'FAIL'
+    e.gates.failedGateIds = ['build']
+    const r = buildReceipt(e, {
+      generatedAt: '2026-06-23T00:00:00.000Z',
+      date: '2026-06-23',
+      slug: 's',
+      headSha: 'x',
+      baseSha: 'y',
+    })
+    const md = renderReceiptMarkdown(r)
+    expect(md).toContain('BLOCK')
+    expect(md).toMatch(/미커밋|dirty/)
+    expect(md).toMatch(/낡|stale|작업\s*시작/)
+  })
+})


### PR DESCRIPTION
## 무엇 (Goal 86 / RFC 0056 T1)
에이전트의 "됐어요"를 **기계증거 영수증**으로 바꾸는 신규 명령 `vhk receipt`. VHK 새 정체성(ADR-006 — 멀티툴 솔로용 거짓완료 탐지기)의 첫 쐐기. 완료 시점에 4대 기계증거를 모아 `.vhk/receipts/<날짜-decision-시각>.{json,md}` 1장으로 굳히고 `decision = block|caution|pass` 를 **기계증거로만(LLM 추론 0)** 낸다.

- ① tsc/test/build 실종료코드(`verifyEvidence` 재사용 — 자기보고 거부)
- ② git dirty(`getCommitInfo` 재사용 — Goal 85 자기파일 제외 적용)
- ③ stale = 작업시작 기준선 SHA ≠ HEAD(`vhk receipt --mark-start` / `--since`)
- ④ 변경라인 diff-cover(`diffCoverage` 재사용 — **advisory 약신호**)

## 불변식 (테스트로 고정)
- **decision 은 기계증거만.** 실차단 3종(red·dirty·stale) 중 하나라도면 block.
- **단조성: caution → pass 격상 절대 금지.** `pass ≤ caution ≤ block` 단조 고정.
- **④ diff-cover 는 advisory** — block 분기에 안 들어감. 0% 미커버여도 최대 caution. 실차단은 종료코드·dirty·stale **3종만**.
- **stale 미상(기준선 미기록)은 거짓 block 금지** — caution.

## 자기-dirty 봉인
`.vhk/receipts/`(+`.base-sha`)를 `.vhk/.gitignore`·init 씨앗에 등록 → 영수증이 자기 작업트리를 dirty 만들어 다음 receipt 의 증거 ②를 오염(자기모순=늘 block)시키지 않게. 실측: receipt 생성 후 `git status` 에 receipt 안 잡힘.

## 등록 4지점 + 드리프트
index.ts · command-registry(TOP_LEVEL) · cli-args · ko.ts + nlp-router(+dispatch) + 한글별칭 `증거영수증`. `tests/receipt-registration.test.ts`(4지점 introspect) + 기존 `command-registry`·`nlp-router` 드리프트 가드. COMMANDS.md·README·goals/README 동기화.

## 게이트
- `pnpm build` ✓ · 전체 테스트 **1897 pass (180 files)** · `secure scan` **CRITICAL 0 / HIGH 0** · `check-goal-86` ✓
- 기존 `ship`·`mission`·`verify` 시그니처 변경 0

## 한계 (정직)
- diff-cover 는 **게으른 거짓완료**(빌드 깨짐·미커밋·stale)만 잡고 미묘한 오류는 못 잡음(`.md` HONESTY_LINE 에 박음 · RFC 0056 §11).
- 자기 ledger 위조 사각지대(Goal 85 ②) 연장.
- virgin repo 첫-실행 untracked `.vhk/.gitignore` edge → 실프로젝트 `.vhk` 커밋으로 해소(whitelist 과확장 안 함).
- T3(거짓완료 적발 1건 공개입증)는 후속 — 효과 미입증.

진입점: `docs/log/2026-06-23-goal-86-receipt-mvp.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * 새로운 `vhk receipt` 명령 추가: 4가지 기계 증거를 수집하여 거짓 완료 여부를 판정(block/caution/pass)
  * 판정 결과를 JSON 및 Markdown 형식의 영수증 파일로 저장
  * `--mark-start` 옵션으로 비교 기준점 설정 가능

* **Documentation**
  * 새로운 receipt 명령 문서 추가 및 명령 카탈로그 업데이트

* **Tests**
  * Receipt 판정, 생성, 렌더링 동작 검증 테스트 추가
  * Receipt 명령 등록 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->