### PR TITLE
fix(memory): eval 형식검증·recency clamp — 거짓 Recall·raw 에러·무한증폭 차단 (#322 #323 #324)

### DIFF
--- a/docs/log/2026-06-23-memory-cluster.md
+++ b/docs/log/2026-06-23-memory-cluster.md
@@ -22,3 +22,7 @@
 ## 남은 위험
 - `validateEvalLabels`는 `--init` 정상 경로 라벨도 통과(회귀 0). 수동편집/오타 라벨만 거부 — 의도된 동작.
 - #324 clamp는 미래를 '최신'으로 간주(점수 약간 상위). 미래 날짜는 비정상 데이터라 허용 가능한 트레이드오프(대안: 미래 페널티는 과설계).
+
+## 후속 (CI lint gate)
+- PR #381 CI gate 실패 — 로컬은 `pnpm test`만 돌렸으나 CI는 `pnpm lint`(eslint)도 실행. `src/lib/recall-eval.ts:59` `expectIds as string[]` 단언이 `@typescript-eslint/no-unnecessary-type-assertion` 에러(직전 `.every(typeof id === 'string')`로 이미 `string[]`로 좁혀짐 → 단언 무의미).
+- 단언 제거(`{ query, expectIds }`). 타입·런타임 불변 확인(DTS 빌드·1913 test green). 교훈: 로컬 게이트에 `pnpm lint` 포함 필수.

--- a/docs/log/2026-06-23-memory-cluster.md
+++ b/docs/log/2026-06-23-memory-cluster.md
@@ -1,0 +1,24 @@
+# 2026-06-23 — fix #322·#323·#324 memory eval/recall 버그 클러스터
+
+## 한 일 (도그푸딩 자동 버그수색 3건, TDD)
+
+- **#322** `memory eval` 라벨의 `expectIds`가 배열 아닌 문자열이면 `scoreEval`의 `expectIds.includes(id)`가 `String.includes`(부분일치)로 갈려 실제 id를 부분문자열로만 포함해도(`'XYZd1'.includes('d1')`) 거짓 100% Recall@5/MRR 1.00으로 통과 → Kill-gate(RFC 0049 ③·ML 도입 결정) 조용히 오염.
+  - `src/lib/recall-eval.ts`: `validateEvalLabels(raw)` 추가 — `expectIds`를 비어있지 않은 string 배열로 강제(문자열 금지), 원소 타입까지 검증. 배열만 통과하므로 `scoreEval`은 항상 `Array.includes`(정확매칭).
+- **#323** 평가셋이 구조적 형식 불량(`labels` 비배열·라벨에 `query`/`expectIds` 누락)이면 깨진 JSON과 달리 친절 메시지 없이 raw JS 에러(`labels.map is not a function`·`Cannot read ... toLowerCase/includes`) 노출.
+  - `src/lib/recall-eval.ts`: 전용 `EvalFormatError` + `validateEvalLabels`가 구조 불량을 던짐. `labels` 누락(undefined)·빈 배열은 '빈 평가셋'으로 정상 취급.
+  - `src/commands/memory-eval.ts`: `readJsonFile<unknown>` → `validateEvalLabels` 통과. 파싱 실패(깨진 JSON)와 `EvalFormatError`(구조 불량)를 동일 친절 메시지 분기로 흡수 + 형식오류 상세 안내 + `--init` 재생성 가이드. 내부 스택 미노출.
+- **#324** `memory.json` 항목 `createdAt`이 미래 날짜면 `recencyScore = Math.exp(-days/90)`에서 days<0 → exp(양수)가 1.0을 무한 초과(e+127)해 키워드 관련성을 압도하고 과학표기가 비개발자에게 노출(clock skew·수동편집·백업복원·타임존으로 현실 발생).
+  - `src/commands/memory.ts recencyScore`: 반환을 `Math.min(1, Math.exp(...))`로 clamp(미래=최신으로 간주). '약한 보너스(상한 1.0)' 설계 복원.
+
+## 검증 (TDD · red→green)
+
+- `tests/recall-eval.test.ts`: `validateEvalLabels` describe 추가 — 정상/빈/누락 통과, labels 비배열·루트 비객체·query 누락/빈·expectIds 누락/문자열/빈배열/비문자원소 → `EvalFormatError`, 한국어 메시지 검증. + `scoreEval` 정확매칭 회귀(`expectIds:['XYZf1']`이 실 id `f1` 못 잡음 = 거짓통과 0).
+- `tests/memory-recall.test.ts`: `recallMemories` recency clamp 추가 — 미래 날짜(2099·+5일) recency ≤ 1.0 + score 폭증/과학표기 없음 + 과거 날짜 정상 반감기 회귀.
+- E2E: 각 이슈 재현 복붙 확인. #322 문자열 expectIds → 친절 형식오류(거짓 100% 0). #323 3종 모두 친절 메시지(raw 에러 0). #324 미래 d1 `점수 1.69(최근 1.00)`·정상 d2 `1.39` — e+127 소멸.
+
+## 게이트
+- `pnpm build` 성공 · `pnpm test` 1913 pass(180 파일) · `secure scan` CRITICAL:0/HIGH:0/MEDIUM:0(INFO 1=테스트 픽스처).
+
+## 남은 위험
+- `validateEvalLabels`는 `--init` 정상 경로 라벨도 통과(회귀 0). 수동편집/오타 라벨만 거부 — 의도된 동작.
+- #324 clamp는 미래를 '최신'으로 간주(점수 약간 상위). 미래 날짜는 비정상 데이터라 허용 가능한 트레이드오프(대안: 미래 페널티는 과설계).

--- a/src/commands/memory-eval.ts
+++ b/src/commands/memory-eval.ts
@@ -3,7 +3,13 @@ import { join, dirname } from 'node:path'
 import chalk from 'chalk'
 import { prompt } from '../lib/prompt.js'
 import { readMemory, recallMemories, type FailEntry } from './memory.js'
-import { scoreEval, RECALL_EVAL_THRESHOLD, type EvalLabel } from '../lib/recall-eval.js'
+import {
+  scoreEval,
+  validateEvalLabels,
+  EvalFormatError,
+  RECALL_EVAL_THRESHOLD,
+  type EvalLabel,
+} from '../lib/recall-eval.js'
 import { readRecallLog } from '../lib/recall-log.js'
 import { readJsonFile } from '../lib/read-json.js'
 import { atomicWriteFile } from '../lib/atomic-write.js'
@@ -40,9 +46,13 @@ export async function memoryEval(opts: { init?: boolean } = {}): Promise<void> {
   }
   let labels: EvalLabel[]
   try {
-    labels = readJsonFile<EvalFile>(p).labels ?? []
-  } catch {
-    console.log(chalk.red(`❌ ${EVAL_PATH_REL} 읽기/파싱 실패 (손상 의심).`))
+    // raw JSON 을 TS 캐스트로만 받지 않고 형식검증 통과시킨다 (#322 expectIds 정확매칭 · #323 구조검증).
+    labels = validateEvalLabels(readJsonFile<unknown>(p))
+  } catch (e) {
+    // 깨진 JSON(파싱 실패)·구조 형식 불량(EvalFormatError) 모두 동일한 친절 메시지로 흡수 — 내부 스택 미노출.
+    const detail = e instanceof EvalFormatError ? ` ${e.message}` : ''
+    console.log(chalk.red(`❌ ${EVAL_PATH_REL} 읽기/형식 검증 실패 (손상 의심).${detail}`))
+    console.log(chalk.gray('   vhk memory eval --init 으로 평가셋을 다시 만드세요.'))
     process.exitCode = 1
     return
   }

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -613,12 +613,17 @@ function buildIdf(entries: MemEntry[]): Map<string, number> {
   return idf
 }
 
-/** 생성시점 기반 약한 최근성 보너스(주신호 아님) — 90일 반감기. 파싱 실패 시 0. */
+/**
+ * 생성시점 기반 약한 최근성 보너스(주신호 아님) — 90일 반감기. 파싱 실패 시 0.
+ * #324: createdAt 미래(clock skew·수동편집·복원)면 days<0 → exp(양수)가 1.0 을 무한 초과(e+127)해
+ *       '약한 보너스(상한 1.0)' 설계를 무력화하고 과학표기가 사용자에게 노출됨 →
+ *       미래 날짜는 '최신'으로 간주해 1.0 으로 clamp.
+ */
 function recencyScore(createdAt: string, nowMs: number): number {
   const ts = Date.parse(createdAt)
   if (Number.isNaN(ts)) return 0
   const days = (nowMs - ts) / 86_400_000
-  return Math.exp(-days / 90)
+  return Math.min(1, Math.exp(-days / 90))
 }
 
 /**

--- a/src/lib/recall-eval.ts
+++ b/src/lib/recall-eval.ts
@@ -56,7 +56,7 @@ export function validateEvalLabels(raw: unknown): EvalLabel[] {
     if (!expectIds.every((id) => typeof id === 'string')) {
       throw new EvalFormatError(`평가셋 형식 오류 — ${at} 의 expectIds 원소는 모두 문자열이어야 합니다.`)
     }
-    return { query, expectIds: expectIds as string[] }
+    return { query, expectIds }
   })
 }
 

--- a/src/lib/recall-eval.ts
+++ b/src/lib/recall-eval.ts
@@ -14,6 +14,52 @@ export interface EvalLabel {
   expectIds: string[]
 }
 
+/** 평가셋 형식 불량(구조 오류) — 깨진 JSON 과 동일하게 친절 메시지로 처리하기 위한 전용 에러 (#323). */
+export class EvalFormatError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'EvalFormatError'
+  }
+}
+
+/**
+ * 외부/수동 편집된 평가셋 JSON 의 런타임 형식검증 (PAT-002 — raw parse 금지, 추출기+검증).
+ * #322: expectIds 가 문자열이면 scoreEval 의 includes 가 String.includes(부분일치)로 갈려
+ *       거짓 100% Recall@5 를 만든다 → 배열 강제 + 원소 string 강제로 정확매칭만 허용.
+ * #323: labels 비배열·query/expectIds 누락 등 구조 불량은 raw JS 에러 대신 EvalFormatError 로 던져
+ *       호출부가 깨진 JSON 과 동일한 친절 메시지 분기로 흡수하게 한다.
+ * labels 누락(undefined)·빈 배열은 '빈 평가셋'으로 정상 취급(throw 아님).
+ */
+export function validateEvalLabels(raw: unknown): EvalLabel[] {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new EvalFormatError('평가셋 형식 오류 — 최상위는 { "labels": [...] } 객체여야 합니다.')
+  }
+  const labels = (raw as { labels?: unknown }).labels
+  if (labels === undefined) return []
+  if (!Array.isArray(labels)) {
+    throw new EvalFormatError('평가셋 형식 오류 — labels 는 배열이어야 합니다.')
+  }
+  return labels.map((label, i) => {
+    const at = `라벨 #${i + 1}`
+    if (typeof label !== 'object' || label === null || Array.isArray(label)) {
+      throw new EvalFormatError(`평가셋 형식 오류 — ${at} 가 객체가 아닙니다.`)
+    }
+    const { query, expectIds } = label as { query?: unknown; expectIds?: unknown }
+    if (typeof query !== 'string' || query.trim() === '') {
+      throw new EvalFormatError(`평가셋 형식 오류 — ${at} 의 query 가 비어있거나 문자열이 아닙니다.`)
+    }
+    if (!Array.isArray(expectIds) || expectIds.length === 0) {
+      throw new EvalFormatError(
+        `평가셋 형식 오류 — ${at} 의 expectIds 는 비어있지 않은 배열이어야 합니다(문자열 금지).`
+      )
+    }
+    if (!expectIds.every((id) => typeof id === 'string')) {
+      throw new EvalFormatError(`평가셋 형식 오류 — ${at} 의 expectIds 원소는 모두 문자열이어야 합니다.`)
+    }
+    return { query, expectIds: expectIds as string[] }
+  })
+}
+
 export interface EvalPerQuery {
   query: string
   found: boolean

--- a/tests/memory-recall.test.ts
+++ b/tests/memory-recall.test.ts
@@ -107,6 +107,35 @@ describe('recallMemories (순수)', () => {
     const b = recallMemories(m, 'publish', 5, NOW).map((h) => h.entry.id)
     expect(a).toEqual(b)
   })
+
+  // #324: 미래 날짜 createdAt 이 recency 점수를 무한 증폭(e+127) → '약한 보너스(상한 1.0)' 무력화.
+  //        미래 날짜는 '최신'으로 간주해 recency 를 1.0 으로 clamp 해야 한다.
+  it('미래 날짜 createdAt → recency 1.0 으로 clamp (무한증폭·과학표기 차단)', () => {
+    const m = mem([
+      fail('f1', '배포 파이프라인 설정', ['publish'], { createdAt: '2099-01-01T00:00:00Z' }),
+    ])
+    const [hit] = recallMemories(m, '배포 파이프라인 설정', 5, NOW)
+    expect(hit.signals.recency).toBeLessThanOrEqual(1)
+    // 점수도 e+127 같은 폭증값이 아니어야 한다(과학표기 노출 차단).
+    expect(hit.score).toBeLessThan(100)
+    expect(Number.isFinite(hit.score)).toBe(true)
+  })
+
+  it('가벼운 미래 날짜(+5일)도 recency ≤ 1.0 (설계 상한 초과 금지)', () => {
+    const future = new Date(NOW + 5 * 86_400_000).toISOString()
+    const m = mem([fail('f1', 'publish 차단', ['publish'], { createdAt: future })])
+    const [hit] = recallMemories(m, 'publish', 5, NOW)
+    expect(hit.signals.recency).toBeLessThanOrEqual(1)
+  })
+
+  it('과거 날짜 recency 회귀 — 정상 반감기 유지 (0<recency≤1)', () => {
+    const m = mem([
+      fail('f1', 'publish 차단', ['publish'], { createdAt: '2025-01-01T00:00:00Z' }),
+    ])
+    const [hit] = recallMemories(m, 'publish', 5, NOW)
+    expect(hit.signals.recency).toBeGreaterThan(0)
+    expect(hit.signals.recency).toBeLessThanOrEqual(1)
+  })
 })
 
 describe('recallForAction (just-in-time · precision 우선)', () => {

--- a/tests/recall-eval.test.ts
+++ b/tests/recall-eval.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { scoreEval, RECALL_EVAL_THRESHOLD, type EvalLabel } from '../src/lib/recall-eval.js'
+import {
+  scoreEval,
+  validateEvalLabels,
+  EvalFormatError,
+  RECALL_EVAL_THRESHOLD,
+  type EvalLabel,
+} from '../src/lib/recall-eval.js'
 import { type MemoryFileV2, type FailEntry } from '../src/commands/memory.js'
 
 const NOW = Date.parse('2026-06-09T00:00:00Z')
@@ -57,6 +63,88 @@ describe('scoreEval (순수)', () => {
   it('빈 label → n=0, recallAt5=0', () => {
     const r = scoreEval(M, [], NOW)
     expect(r.n).toBe(0)
+    expect(r.recallAt5).toBe(0)
+  })
+})
+
+// #322: expectIds 가 배열 아닌 문자열이면 String.includes(부분일치)로 거짓 100% Recall@5 → Kill-gate 오염.
+//        검증기가 문자열 expectIds 를 거부해 부분일치 거짓통과를 원천 차단해야 한다.
+// #323: labels 비배열·query/expectIds 누락 등 구조 불량은 raw JS 에러 대신 EvalFormatError(친절 메시지).
+describe('validateEvalLabels (#322 정확매칭 · #323 형식검증)', () => {
+  it('정상 라벨 → 그대로 통과', () => {
+    const labels = validateEvalLabels({ labels: [{ query: 'tRPC', expectIds: ['d1'] }] })
+    expect(labels).toEqual([{ query: 'tRPC', expectIds: ['d1'] }])
+  })
+
+  it('빈 labels 배열 → 빈 배열 (정상)', () => {
+    expect(validateEvalLabels({ labels: [] })).toEqual([])
+  })
+
+  it('labels 누락(undefined) → 빈 배열 (정상 — 빈 평가셋과 동치)', () => {
+    expect(validateEvalLabels({})).toEqual([])
+  })
+
+  // #323
+  it('labels 가 배열 아님(문자열) → EvalFormatError', () => {
+    expect(() => validateEvalLabels({ labels: 'oops' })).toThrow(EvalFormatError)
+  })
+
+  it('루트가 객체 아님(배열·null) → EvalFormatError', () => {
+    expect(() => validateEvalLabels(null)).toThrow(EvalFormatError)
+    expect(() => validateEvalLabels([{ query: 'x', expectIds: ['d1'] }])).toThrow(EvalFormatError)
+  })
+
+  it('query 누락 → EvalFormatError', () => {
+    expect(() => validateEvalLabels({ labels: [{ expectIds: ['d1'] }] })).toThrow(EvalFormatError)
+  })
+
+  it('query 가 빈 문자열 → EvalFormatError', () => {
+    expect(() => validateEvalLabels({ labels: [{ query: '  ', expectIds: ['d1'] }] })).toThrow(
+      EvalFormatError
+    )
+  })
+
+  it('expectIds 누락 → EvalFormatError', () => {
+    expect(() => validateEvalLabels({ labels: [{ query: 'tRPC' }] })).toThrow(EvalFormatError)
+  })
+
+  // #322 핵심: expectIds 가 문자열이면 거부 (부분일치 거짓통과 차단)
+  it('expectIds 가 배열 아닌 문자열 → EvalFormatError', () => {
+    expect(() => validateEvalLabels({ labels: [{ query: 'tRPC', expectIds: 'XYZd1' }] })).toThrow(
+      EvalFormatError
+    )
+  })
+
+  it('expectIds 가 빈 배열 → EvalFormatError (정답 없는 라벨은 무의미)', () => {
+    expect(() => validateEvalLabels({ labels: [{ query: 'tRPC', expectIds: [] }] })).toThrow(
+      EvalFormatError
+    )
+  })
+
+  it('expectIds 원소가 문자열 아님 → EvalFormatError', () => {
+    expect(() =>
+      validateEvalLabels({ labels: [{ query: 'tRPC', expectIds: [1, 2] }] })
+    ).toThrow(EvalFormatError)
+  })
+
+  it('EvalFormatError 메시지는 한국어 친절 안내(스택 미노출)', () => {
+    try {
+      validateEvalLabels({ labels: 'oops' })
+      expect.unreachable('던져야 함')
+    } catch (e) {
+      expect(e).toBeInstanceOf(EvalFormatError)
+      expect((e as Error).message).toMatch(/형식|평가셋|labels/)
+    }
+  })
+})
+
+// #322 회귀: scoreEval 은 검증 통과한 배열 expectIds 만 받으므로 정확매칭이어야 한다.
+//        (부분일치였다면 expectIds:['XYZd1'] 가 실제 id 'd1' 을 못 잡아야 정상 — 거짓 100% 0.)
+describe('scoreEval 정확매칭 회귀 (#322)', () => {
+  it('expectIds 가 실제 id 의 상위문자열이어도 부분일치로 거짓 통과하지 않음', () => {
+    // 실제 id 는 'f1'. expectIds 에 'XYZf1' 을 넣어도 정확매칭이라 미발견이어야 한다.
+    const r = scoreEval(M, [{ query: 'publish', expectIds: ['XYZf1'] }], NOW)
+    expect(r.perQuery[0]).toMatchObject({ found: false, rank: null })
     expect(r.recallAt5).toBe(0)
   })
 })


### PR DESCRIPTION
## 요약 (두괄식)
도그푸딩 자동 버그수색이 잡은 memory eval/recall 결함 3건을 TDD로 수정. 게이트 전부 green.

## 변경 (3 버그)
- **#322** `memory eval` 라벨의 `expectIds`가 배열 아닌 문자열이면 `scoreEval`의 `expectIds.includes(id)`가 `String.includes`(부분일치)로 갈려 거짓 100% Recall@5/MRR 1.00 → Kill-gate(ML 도입 결정) 오염.
  → `src/lib/recall-eval.ts`에 `validateEvalLabels`가 `expectIds`를 비어있지 않은 string 배열로 강제(문자열 거부). 배열만 통과 → `scoreEval`은 항상 `Array.includes`(정확매칭).
- **#323** 구조적 형식 불량(`labels` 비배열·`query`/`expectIds` 누락)이면 친절 메시지 없이 raw JS 에러 노출.
  → 전용 `EvalFormatError` + `validateEvalLabels`로 검증. `src/commands/memory-eval.ts`가 깨진 JSON과 동일한 친절 메시지 분기로 흡수(스택 미노출). `labels` 누락/빈 배열은 '빈 평가셋'으로 정상 취급.
- **#324** `createdAt` 미래 날짜면 `recencyScore = exp(-days/90)`가 1.0을 무한 초과(e+127)해 관련성 압도 + 과학표기 노출.
  → `src/commands/memory.ts`에서 `Math.min(1, exp(...))`로 clamp(미래=최신). '약한 보너스(상한 1.0)' 설계 복원.

## 테스트 (TDD red→green)
- `tests/recall-eval.test.ts`: `validateEvalLabels` 정상/형식불량 전수 + `EvalFormatError` 한국어 메시지 + `scoreEval` 정확매칭 회귀(`['XYZf1']`이 실 id `f1` 못 잡음).
- `tests/memory-recall.test.ts`: 미래 날짜(2099·+5일) recency ≤ 1.0 + score 비폭증 + 과거 날짜 정상 반감기 회귀.
- E2E: 각 이슈 재현 복붙으로 #322 거짓통과 0·#323 raw 에러 0·#324 e+127 소멸 확인.

## 게이트
- `pnpm build` 성공 / `pnpm test` **1913 pass(180 파일)** / `secure scan` **CRITICAL:0** (INFO 1=테스트 픽스처).

Closes #322
Closes #323
Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 미래 날짜로 설정된 항목의 최근성 점수가 1.0을 초과하지 않도록 수정했습니다.

* **개선사항**
  * 평가셋 파일 로드 시 검증 로직을 강화하여 형식 오류를 더 명확하게 감지합니다.
  * 파일 로드 실패 시 더 자세한 에러 메시지를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->