### PR TITLE
feat(vhk): 멀티PC dirty-block 해소 — .gitattributes merge=union + verify 저소음 커밋

### DIFF
--- a/.vhk/.gitattributes
+++ b/.vhk/.gitattributes
@@ -1,0 +1,4 @@
+# VHK 증거 원장(events·ledger) — 멀티PC 양쪽 append 분기 커밋 시 양쪽 줄 보존.
+# merge=union 은 git 내장 드라이버(별도 .gitconfig/merge driver 등록 불필요). untrack 금지(RFC0056·#315).
+events/*.jsonl merge=union
+ledger.jsonl merge=union

--- a/docs/log/2026-06-23-gitattributes-merge-union.md
+++ b/docs/log/2026-06-23-gitattributes-merge-union.md
@@ -1,0 +1,56 @@
+# 2026-06-23 — 멀티PC dirty-block 해소 (.gitattributes merge=union + verify 저소음 커밋)
+
+> 진입점: 이 작업은 RFC0056 증거영속(events·ledger git 추적, #315)과 멀티PC 환경의
+> 충돌 지점을 해소한다. 관련 파일 — `src/templates/vhk-dir.ts`(템플릿)·`src/commands/init.ts`(배선)·
+> `src/lib/git-session.ts`(commitPaths)·`src/commands/verify.ts`(저소음 커밋 배선)·`.vhk/.gitattributes`(R1).
+
+## 배경 (문제)
+
+`.vhk/events/ai-actions.jsonl`·`.vhk/ledger.jsonl` 은 런타임 append 되면서 **git 추적**된다
+(RFC0056 증거 영속·#315·goal 45/55/85 — untrack/gitignore 절대 금지, 증거영속 붕괴 방지).
+
+멀티PC 에서 이게 두 가지 마찰을 일으킨다:
+- (A) 양쪽 PC 가 각자 events/ledger 에 append → 분기 커밋 → 병합 시 줄 충돌 위험.
+- (B) 한쪽의 미커밋 증거 변경이 외부 git pull 의 fast-forward 를 막음(DirtySkipped).
+
+## 해결 (두 축)
+
+### A축 — `.gitattributes` merge=union (템플릿 + init 배선 + R1)
+- `VHK_GITATTRIBUTES_TEMPLATE()` 신규(`src/templates/vhk-dir.ts`) — `events/*.jsonl`·`ledger.jsonl`
+  에만 `merge=union`. git 내장 드라이버라 별도 .gitconfig/merge driver 등록 불필요.
+- `generateFiles()` 가 `.vhk/.gitattributes` 를 생성하도록 배선(`src/commands/init.ts`).
+  `.vhk/.gitignore` 본문·루트 .gitignore·.vhkignore 는 불변(events/ledger 추적 유지).
+- R1: 이 레포 자신의 `.vhk/.gitattributes` 도 생성(없으면 vhk 자신의 events/ledger 가
+  union 적용 못 받음). `git check-attr merge -- .vhk/events/ai-actions.jsonl` → `union` 검증.
+
+### B축 — verify 저소음 커밋 (`commitPaths`)
+- `commitPaths(message, paths, cwd)` 신규(`src/lib/git-session.ts`) — `git add -- <paths>` →
+  `git diff --cached --quiet -- <paths>`(변경 없으면 commit skip) → `git commit -m <msg> -- <paths>`.
+  **stageAll(git add .) 미사용** — 명시 경로만. ExecResult 반환(throw 0, 비치명).
+- `verify` 명령 본체에서 `verifyEvidence(cwd)` **직후** 1회 호출
+  (`'.vhk/events/ai-actions.jsonl'`·`LEDGER_PATH_REL`).
+
+## ★핵심 설계 — 커밋 위치 (receipt 무회귀)
+
+커밋을 `verifyEvidence` 본체가 아니라 **verify 명령 함수 본체**에 둔다.
+이유: `collectReceipt`(receipt.ts)는 `verifyEvidence` 호출 직후 `getCommitInfo` 로 HEAD SHA·
+stale(작업시작 SHA≠HEAD) 를 읽는다. verifyEvidence 안에서 커밋하면 HEAD 가 영수증 평가 도중
+이동 → receipt 의 ③stale 이 거짓 true → 거짓 CAUTION/BLOCK. dirty 값은 #315 가 events/ledger 를
+제외하므로 불변 — 문제는 HEAD SHA 이동뿐. 그래서 verifyEvidence 본체는 손대지 않았다.
+
+## 테스트 (TDD — 실패 테스트 먼저)
+- `tests/git-session.test.ts` — commitPaths 단위(명시경로만 stage·"." 금지, staged 없으면
+  skip, 변경 있으면 명시경로 commit, add 실패 즉시반환, cwd 통과).
+- `tests/init.test.ts` — .gitattributes 씨앗 내용·과확장0·.gitignore 불변 + 실 git 레포에서
+  `git check-attr` 로 events/ledger→union, context.md→unspecified 확정.
+- `tests/verify.test.ts` — verify 1회→단일 커밋·직후 clean, 재실행 추가커밋≤1,
+  ★verifyEvidence HEAD 불변(receipt stale 보호)★.
+
+## 교훈
+- 증거영속(추적 유지)과 멀티PC dirty 는 untrack 없이 양립 가능 — merge=union(병합)+저소음
+  커밋(정리)으로 해결. untrack 은 증거영속을 붕괴시키므로 절대 금지.
+- 부수효과(커밋)를 순수 평가 경로(verifyEvidence→receipt) 안에 넣으면 평가 입력(HEAD SHA)을
+  오염시킨다. 커밋은 평가 바깥 명령 본체에 둬야 receipt stale 판정이 정직하다.
+
+## 게이트
+- pnpm build ✅ / pnpm test ✅ (180 files, 1908 tests) / secure scan CRITICAL:0 ✅

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,7 +11,7 @@ import { PRD_TEMPLATE } from '../templates/prd.js'
 import { ARCHITECTURE_TEMPLATE } from '../templates/architecture.js'
 import { ADR_TEMPLATE } from '../templates/adr-template.js'
 import { COMMANDS_MD_TEMPLATE } from '../templates/commands-md.js'
-import { VHK_README_TEMPLATE, VHK_CONTEXT_SEED, VHK_GITIGNORE_TEMPLATE, VHK_IGNORE_TEMPLATE } from '../templates/vhk-dir.js'
+import { VHK_README_TEMPLATE, VHK_CONTEXT_SEED, VHK_GITIGNORE_TEMPLATE, VHK_GITATTRIBUTES_TEMPLATE, VHK_IGNORE_TEMPLATE } from '../templates/vhk-dir.js'
 import { ko } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { printSecurityWarnings } from '../lib/check-secure.js'
@@ -338,6 +338,8 @@ export function generateFiles(
     '.vhk/README.md': VHK_README_TEMPLATE(),
     '.vhk/context.md': VHK_CONTEXT_SEED(name, type || 'unknown', stack),
     '.vhk/.gitignore': VHK_GITIGNORE_TEMPLATE(),
+    // 증거 원장(events·ledger)에 merge=union — 멀티PC append 분기 자동 병합(A축). 추적 유지 전제.
+    '.vhk/.gitattributes': VHK_GITATTRIBUTES_TEMPLATE(),
     '.vhkignore': VHK_IGNORE_TEMPLATE(),
     // core-ruleset 마커블록 상속 — YOHAN_BRAIN_ROOT 있으면 라이브, 없으면 번들 스냅샷
     '.agents/CORE-RULES.md': generateCoreRulesContent(null),

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -14,6 +14,7 @@ import { scanProjectForSecrets, filterSevereFindings } from '../lib/scan-secrets
 import { renderReportHtml } from './verify-report.js'
 import { isInteractive } from '../lib/interactive.js'
 import { safeExecFile } from '../lib/exec.js'
+import { commitPaths } from '../lib/git-session.js'
 import { getCommitInfo, type CommitInfo } from '../lib/git-repo.js'
 import { appendLedgerEntry, buildLedgerEntry, LEDGER_PATH_REL } from '../lib/evidence-ledger.js'
 
@@ -507,6 +508,21 @@ export async function verify(
   }
 
   const { report, path } = verifyEvidence(cwd)
+
+  // 멀티PC dirty-block(B축): verify 가 방금 append 한 증거 원장(events·ledger)을 저소음 단일
+  // 커밋으로 정리한다. 멀티PC 에서 미커밋 증거가 외부 pull 의 fast-forward 를 막던 문제 해소.
+  // ★커밋은 반드시 verifyEvidence 밖(여기 명령 본체)에 둔다★ — verifyEvidence 안에서 커밋하면
+  // HEAD 가 이동해, 직후 receipt(collectReceipt)가 읽는 stale 판정(작업시작 SHA≠HEAD)이 거짓
+  // true 가 되어 거짓 CAUTION/BLOCK 을 낸다. 비치명: 실패해도 증거는 이미 기록됐다.
+  try {
+    commitPaths(
+      'chore(vhk): evidence ledger [skip ci]',
+      [join('.vhk', 'events', 'ai-actions.jsonl'), LEDGER_PATH_REL],
+      cwd
+    )
+  } catch {
+    /* 저소음 커밋 실패는 치명적 아님 — detached HEAD·identity 미설정 등. 증거는 이미 기록됨. */
+  }
 
   // --json: 경로 대신 stdout 으로 리포트 JSON (CI 용). 다른 콘솔 출력 없음.
   if (opts.json) {

--- a/src/lib/git-session.ts
+++ b/src/lib/git-session.ts
@@ -41,6 +41,35 @@ export function push(cwd: string = process.cwd()): ExecResult {
   return safeExecFile('git', ['push'], { cwd })
 }
 
+/**
+ * 명시 경로만 stage·commit 하는 저소음 커밋(멀티PC dirty-block B축).
+ *
+ * stageAll(git add .) 을 쓰지 않는다 — verify 가 의도치 않은 작업트리 파일을 휩쓸어 커밋하면
+ * 안 되므로 events/ledger 같은 명시 경로만 다룬다. 흐름:
+ *   ① git add -- <paths>           (실패면 즉시 반환 — 비치명)
+ *   ② git diff --cached --quiet -- <paths>
+ *        ok(=종료0=staged 변경 없음) → commit skip(잡음 0)
+ *        ok:false(=종료1=staged 변경 있음) → ③
+ *   ③ git commit -m <message> -- <paths>
+ *
+ * 절대 throw 하지 않는다(ExecResult 반환). detached HEAD·커밋 식별 미설정 등으로 commit 이
+ * 실패해도 호출부(verify)는 try/catch 로 무시 — 증거(latest.json)는 이미 기록됐다.
+ */
+export function commitPaths(
+  message: string,
+  paths: string[],
+  cwd: string = process.cwd()
+): ExecResult {
+  const added = safeExecFile('git', ['add', '--', ...paths], { cwd })
+  if (!added.ok) return added
+
+  // diff --cached --quiet: staged 변경 있으면 종료1(ok:false), 없으면 종료0(ok:true).
+  const diff = safeExecFile('git', ['diff', '--cached', '--quiet', '--', ...paths], { cwd })
+  if (diff.ok) return diff // staged 변경 없음 → commit skip(중복 빈 커밋 방지).
+
+  return safeExecFile('git', ['commit', '-m', message, '--', ...paths], { cwd })
+}
+
 /** git reset --soft HEAD~n — 최근 n개 커밋 되돌리기(변경은 스테이징 보존). */
 export function softReset(n: number, cwd: string = process.cwd()): ExecResult {
   return safeExecFile('git', ['reset', '--soft', `HEAD~${n}`], { cwd })

--- a/src/templates/vhk-dir.ts
+++ b/src/templates/vhk-dir.ts
@@ -83,6 +83,22 @@ export function VHK_GITIGNORE_TEMPLATE(): string {
 }
 
 /**
+ * `.vhk/.gitattributes` — 증거 원장(events·ledger)에 merge=union 부여.
+ * 멀티PC 에서 양쪽이 각자 append 한 커밋이 분기됐을 때, union 드라이버가 양쪽 줄을 모두
+ * 보존해 자동 병합한다(충돌·줄 손실 0). events/ledger 는 추적 유지(untrack 금지) 전제 —
+ * RFC0056·#315 증거 영속. 이 파일은 dirty-block(외부 pull fast-forward 차단)의 A축 해소.
+ */
+export function VHK_GITATTRIBUTES_TEMPLATE(): string {
+  return [
+    '# VHK 증거 원장(events·ledger) — 멀티PC 양쪽 append 분기 커밋 시 양쪽 줄 보존.',
+    '# merge=union 은 git 내장 드라이버(별도 .gitconfig/merge driver 등록 불필요). untrack 금지(RFC0056·#315).',
+    'events/*.jsonl merge=union',
+    'ledger.jsonl merge=union',
+    '',
+  ].join('\n')
+}
+
+/**
  * 루트 `.vhkignore` 씨앗 — `vhk cloud push` 백업에서 제외할 .vhk/ 파일 지정.
  * 기본 제외(memory.json·refs.json·HARD_STOP·cloud.json·.gitignore)는 코드에 내장되어
  * 있으므로, 이 파일은 사용자가 추가로 제외할 항목을 적는 용도다.

--- a/tests/git-session.test.ts
+++ b/tests/git-session.test.ts
@@ -117,6 +117,62 @@ describe('git-session — cwd 통과 + 기본값', () => {
   })
 })
 
+// commitPaths — 명시 경로만 stage·commit 하는 저소음 커밋(멀티PC dirty-block B축).
+// stageAll(git add .) 금지 — 의도치 않은 파일 휩쓸기 방지. 변경 없으면 commit skip(잡음 0).
+describe('git-session — commitPaths (명시 경로 저소음 커밋)', () => {
+  const PATHS = ['.vhk/events/ai-actions.jsonl', '.vhk/ledger.jsonl']
+
+  it('명시 경로만 stage (git add -- ...paths, "." 금지)', () => {
+    // add ok → diff --cached --quiet 변경 있음(ok:false) → commit
+    mockExec
+      .mockReturnValueOnce({ ok: true, out: '' }) // add
+      .mockReturnValueOnce({ ok: false, err: '', out: '' }) // diff --cached --quiet → 변경 있음
+      .mockReturnValueOnce({ ok: true, out: '' }) // commit
+    session.commitPaths('msg', PATHS, '/repo')
+    expect(mockExec.mock.calls[0][1]).toEqual(['add', '--', ...PATHS])
+    expect(mockExec.mock.calls[0][1]).not.toContain('.')
+  })
+
+  it('staged 변경 없으면 commit skip (diff --cached --quiet ok → 잡음 0)', () => {
+    mockExec
+      .mockReturnValueOnce({ ok: true, out: '' }) // add
+      .mockReturnValueOnce({ ok: true, out: '' }) // diff --cached --quiet ok=변경 없음
+    const r = session.commitPaths('msg', PATHS, '/repo')
+    // commit 은 호출되지 않음 (add + diff 만 = 2회).
+    expect(mockExec).toHaveBeenCalledTimes(2)
+    expect(mockExec.mock.calls.some((c) => c[1][0] === 'commit')).toBe(false)
+    expect(r.ok).toBe(true) // 변경 없음도 정상(비치명).
+  })
+
+  it('staged 변경 있으면 명시 경로로 commit (git commit -m <msg> -- ...paths)', () => {
+    mockExec
+      .mockReturnValueOnce({ ok: true, out: '' }) // add
+      .mockReturnValueOnce({ ok: false, err: '', out: '' }) // diff --cached --quiet → 변경 있음
+      .mockReturnValueOnce({ ok: true, out: '' }) // commit
+    session.commitPaths('chore: ledger', PATHS, '/repo')
+    const commitCall = mockExec.mock.calls.find((c) => c[1][0] === 'commit')
+    expect(commitCall?.[1]).toEqual(['commit', '-m', 'chore: ledger', '--', ...PATHS])
+  })
+
+  it('add 실패 시 즉시 반환 (diff/commit 호출 안 함, 비치명)', () => {
+    mockExec.mockReturnValueOnce({ ok: false, err: 'add boom', out: '' }) // add 실패
+    const r = session.commitPaths('msg', PATHS, '/repo')
+    expect(mockExec).toHaveBeenCalledTimes(1) // add 만.
+    expect(r.ok).toBe(false)
+  })
+
+  it('cwd 를 모든 git 호출에 통과', () => {
+    mockExec
+      .mockReturnValueOnce({ ok: true, out: '' })
+      .mockReturnValueOnce({ ok: false, err: '', out: '' })
+      .mockReturnValueOnce({ ok: true, out: '' })
+    session.commitPaths('msg', PATHS, '/some/root')
+    for (const call of mockExec.mock.calls) {
+      expect(call[2]).toMatchObject({ cwd: '/some/root' })
+    }
+  })
+})
+
 describe('git-session — ExecResult 통과 + okOut swallow', () => {
   it('ExecResult 를 그대로 반환 (호출부가 .ok/.out/.err 검사)', () => {
     mockExec.mockReturnValue({ ok: false, err: 'boom', out: '', stderr: 'fatal' })

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -175,6 +176,64 @@ describe('vhk init — .vhk/ 프리셋 씨앗', () => {
     const ignore = generateFiles('p', 'd', ['Node.js'])['.vhk/.gitignore']
     expect(ignore).not.toMatch(/(^|\n)\s*ledger\.jsonl\s*(\n|$)/)
     expect(ignore).not.toMatch(/(^|\n)\s*events\/?\s*(\n|$)/)
+  })
+
+  // 멀티PC dirty-block 해소(A축): 증거 원장(events·ledger)은 추적된 채로 두되,
+  // .gitattributes 의 merge=union 으로 양쪽 PC append 분기를 양쪽 줄 보존 자동 병합.
+  it('.vhk/.gitattributes 씨앗이 events/ledger 만 merge=union 으로 등록한다', () => {
+    const attrs = generateFiles('p', 'd', ['Node.js'])['.vhk/.gitattributes']
+    expect(attrs).toBeDefined()
+    expect(attrs).toContain('events/*.jsonl merge=union')
+    expect(attrs).toContain('ledger.jsonl merge=union')
+    // 과확장 0: 그 외 .vhk 파일(context.md 등)에는 union 을 걸지 않는다.
+    expect(attrs).not.toMatch(/context\.md/)
+    // untrack 금지 의도(RFC0056·#315)가 주석으로 박혀 있어야 한다(merge=union 은 추적 전제).
+    expect(attrs).toContain('untrack 금지')
+  })
+
+  // 불변 가드: .gitattributes 추가가 .gitignore 의 ledger/events 비등록(추적 유지)을 바꾸면 안 됨.
+  it('.gitignore 는 불변 — events/ledger 가 여전히 비등록(추적 유지)', () => {
+    const ignore = generateFiles('p', 'd', ['Node.js'])['.vhk/.gitignore']
+    expect(ignore).not.toMatch(/(^|\n)\s*ledger\.jsonl\s*(\n|$)/)
+    expect(ignore).not.toMatch(/(^|\n)\s*events\/?\s*(\n|$)/)
+  })
+})
+
+// 멀티PC dirty-block(A축) — 실 git 레포에서 .gitattributes 가 events/ledger 에만
+// merge 속성 union 을 부여하고, 다른 .vhk 파일에는 과확장하지 않음을 git check-attr 로 확정.
+describe('vhk init — .vhk/.gitattributes (git check-attr 검증)', () => {
+  function makeRepoWithVhkDir(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-attr-'))
+    const g = (args: string[]): void => {
+      execFileSync('git', args, { cwd: d, stdio: 'pipe' })
+    }
+    g(['init'])
+    g(['config', 'user.email', 't@t'])
+    g(['config', 'user.name', 't'])
+    const files = generateFiles('p', 'd', ['Node.js'], {}, 'cli')
+    // .vhk/.gitattributes + 비교 대상 파일(events·ledger·context) 디스크에 배치.
+    writeFile(path.join(d, '.vhk/.gitattributes'), files['.vhk/.gitattributes'])
+    writeFile(path.join(d, '.vhk/context.md'), files['.vhk/context.md'])
+    writeFile(path.join(d, '.vhk/events/ai-actions.jsonl'), '')
+    writeFile(path.join(d, '.vhk/ledger.jsonl'), '')
+    return d
+  }
+
+  // git check-attr 출력은 "<path>: merge: <value>" 형식 → value 만 추출.
+  function attrMerge(dir: string, relPath: string): string {
+    const out = execFileSync('git', ['check-attr', 'merge', '--', relPath], {
+      cwd: dir,
+      encoding: 'utf-8',
+    }).trim()
+    return out.replace(/^.*: merge: /, '')
+  }
+
+  it('events/*.jsonl·ledger.jsonl → union, context.md → unspecified (과확장 0)', () => {
+    const d = makeRepoWithVhkDir()
+    expect(attrMerge(d, '.vhk/events/ai-actions.jsonl')).toBe('union')
+    expect(attrMerge(d, '.vhk/ledger.jsonl')).toBe('union')
+    expect(attrMerge(d, '.vhk/context.md')).toBe('unspecified')
+    fs.rmSync(d, { recursive: true, force: true })
   })
 })
 

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -257,4 +258,99 @@ describe('verify — Goal 59: 스캔 불완전 → secure WARN (거짓 PASS 차�
     expect(r.status).toBe('WARN')
     expect(buildLedgerEntry(r, '1.2.3').status).toBe('WARN')
   })
+})
+
+// 멀티PC dirty-block(B축) — verify 가 events/ledger append 로 만든 dirty 를 저소음 단일 커밋으로
+// 정리한다. 단, 커밋은 verify 명령 본체에만(verifyEvidence 본체는 HEAD 불변 — receipt stale 보호).
+describe('verify — 증거 원장 저소음 커밋 (멀티PC dirty-block B축)', () => {
+  let origCwd: string
+
+  // 커밋 1개 있는 임시 git 레포(전역 identity 없는 CI 대비 -c 주입은 config 로 처리).
+  function makeRepo(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-verify-commit-'))
+    const g = (args: string[]): void => {
+      execFileSync('git', args, { cwd: d, stdio: 'pipe' })
+    }
+    g(['init'])
+    g(['config', 'user.email', 't@t'])
+    g(['config', 'user.name', 't'])
+    // 추적되는 events/ledger 씨앗(이미 추적 상태여야 verify append 가 modified=dirty 가 됨).
+    fs.mkdirSync(path.join(d, '.vhk', 'events'), { recursive: true })
+    fs.writeFileSync(path.join(d, '.vhk', 'events', 'ai-actions.jsonl'), '')
+    fs.writeFileSync(path.join(d, '.vhk', 'ledger.jsonl'), '')
+    fs.writeFileSync(path.join(d, 'package.json'), JSON.stringify({ name: 'tp', version: '0.0.0' }), 'utf-8')
+    g(['add', '.'])
+    g(['commit', '-m', 'seed'])
+    return d
+  }
+
+  const headSha = (d: string): string =>
+    execFileSync('git', ['rev-parse', 'HEAD'], { cwd: d, encoding: 'utf-8' }).trim()
+
+  // .vhk/events·ledger 만 본 porcelain (raw). clean 이면 빈 문자열.
+  const ledgerStatus = (d: string): string =>
+    execFileSync('git', ['status', '--porcelain', '--', '.vhk/events', '.vhk/ledger.jsonl'], {
+      cwd: d,
+      encoding: 'utf-8',
+    }).trim()
+
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    process.exitCode = 0
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+    process.exitCode = 0
+  })
+
+  it('verify 1회 → events/ledger 변경이 단일 커밋으로 정리되고 직후 clean', async () => {
+    const d = makeRepo()
+    const before = headSha(d)
+    process.chdir(d)
+    await verify()
+    process.chdir(origCwd)
+    // events/ledger 가 clean (저소음 커밋이 정리).
+    expect(ledgerStatus(d)).toBe('')
+    // 커밋 정확히 1개 추가(저소음).
+    const after = headSha(d)
+    expect(after).not.toBe(before)
+    const count = execFileSync('git', ['rev-list', '--count', `${before}..${after}`], {
+      cwd: d,
+      encoding: 'utf-8',
+    }).trim()
+    expect(count).toBe('1')
+    fs.rmSync(d, { recursive: true, force: true })
+  }, 30_000)
+
+  it('재실행 시 추가 커밋 0 (diff-cached 가드 — 변경 없으면 commit skip)', async () => {
+    const d = makeRepo()
+    process.chdir(d)
+    await verify() // 1회: 정리 커밋
+    const afterFirst = headSha(d)
+    await verify() // 2회: events/ledger append 후 정리 — 커밋이 새로 생기긴 함(append 가 dirty 유발)
+    process.chdir(origCwd)
+    // 핵심 가드: 매 실행이 정확히 1커밋씩(휩쓸기/중복 커밋 0). 정리 후 항상 clean.
+    expect(ledgerStatus(d)).toBe('')
+    const secondHead = headSha(d)
+    const count = execFileSync('git', ['rev-list', '--count', `${afterFirst}..${secondHead}`], {
+      cwd: d,
+      encoding: 'utf-8',
+    }).trim()
+    expect(Number(count)).toBeLessThanOrEqual(1)
+    fs.rmSync(d, { recursive: true, force: true })
+  }, 30_000)
+
+  // ★receipt 무회귀(치명)★ — verifyEvidence 본체는 HEAD 를 움직이지 않는다.
+  // (커밋은 verify 명령 본체에만. verifyEvidence 가 HEAD 를 옮기면 collectReceipt 가
+  //  verifyEvidence 직후 읽는 stale 판정이 거짓 true 가 됨 → 거짓 CAUTION/BLOCK.)
+  it('verifyEvidence 는 HEAD 를 이동시키지 않는다 (receipt stale 보호)', () => {
+    const d = makeRepo()
+    const before = headSha(d)
+    verifyEvidence(d) // 게이트+증거기록만 — 커밋 없음
+    expect(headSha(d)).toBe(before)
+    fs.rmSync(d, { recursive: true, force: true })
+  }, 30_000)
 })


### PR DESCRIPTION
## 무엇을 / 왜

증거 원장(`.vhk/events/ai-actions.jsonl`·`.vhk/ledger.jsonl`)은 RFC0056 증거영속(#315·goal 45/55/85)으로 **git 추적**된다(untrack 금지 — 증거영속 붕괴 방지). 멀티PC 에서 이게 두 마찰을 낳는다:
- **(A)** 양쪽 PC 가 각자 append → 분기 커밋 → 병합 시 줄 충돌 위험.
- **(B)** 한쪽의 미커밋 증거가 외부 `git pull` fast-forward 를 차단(DirtySkipped).

untrack 없이 두 축으로 해소한다.

## 변경

### A축 — `.gitattributes` merge=union
- `VHK_GITATTRIBUTES_TEMPLATE()` 신규(`src/templates/vhk-dir.ts`): `events/*.jsonl`·`ledger.jsonl` 에만 `merge=union`(git 내장 드라이버 — 별도 .gitconfig 등록 불필요).
- `generateFiles()` 가 `.vhk/.gitattributes` 생성(`src/commands/init.ts`). `.vhk/.gitignore`·루트 `.gitignore`·`.vhkignore` 는 **불변**(events/ledger 추적 유지).
- **R1**: 이 레포 자신의 `.vhk/.gitattributes` 도 동봉(없으면 vhk 자신의 events/ledger 가 union 적용 못 받음).

### B축 — verify 저소음 커밋
- `commitPaths(message, paths, cwd)` 신규(`src/lib/git-session.ts`): `git add -- <paths>` → `git diff --cached --quiet -- <paths>`(변경 없으면 commit skip) → `git commit -m <msg> -- <paths>`. **stageAll(git add .) 미사용** — 명시 경로만. ExecResult 반환(throw 0, 비치명).
- `verify` 명령 본체가 `verifyEvidence(cwd)` **직후** 1회 호출해 방금 append 한 증거를 단일 커밋으로 정리.

## ★핵심 설계 — receipt 무회귀

커밋을 `verifyEvidence` 본체가 아니라 **verify 명령 본체**에 둔다. `collectReceipt`(receipt.ts)는 `verifyEvidence` 직후 `getCommitInfo` 로 HEAD SHA·stale(작업시작 SHA≠HEAD)을 읽는다. verifyEvidence 안에서 커밋하면 HEAD 가 영수증 평가 도중 이동 → stale 이 거짓 true → 거짓 CAUTION/BLOCK. `verifyEvidence` 본체는 미수정(테스트로 HEAD 불변 고정).

## 테스트 (TDD)
- `tests/git-session.test.ts` — commitPaths 단위(명시경로만 stage·"." 금지, staged 없으면 skip, 변경 있으면 명시경로 commit, add 실패 즉시반환, cwd 통과).
- `tests/init.test.ts` — .gitattributes 씨앗 내용·과확장0·.gitignore 불변 + 실 git 레포 `git check-attr` 로 events/ledger→union, context.md→unspecified 확정.
- `tests/verify.test.ts` — verify 1회→단일 커밋·직후 clean, 재실행 추가커밋≤1, **verifyEvidence HEAD 불변(receipt stale 보호)**.

## 게이트
- `pnpm build` ✅ / `pnpm test` ✅ (180 files, 1908 tests) / `secure scan` CRITICAL:0 ✅
- `git check-attr merge` 검증: events/ledger→`union`, context.md/README.md→`unspecified`(과확장 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 멀티PC 환경에서 증거 원장 파일의 병합 충돌을 방지하기 위해 자동 병합 전략 설정 추가로 양쪽 변경사항 보존
  * 증거 검증 완료 후 생성된 변경사항을 자동으로 커밋하는 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->