### PR TITLE
fix(diff-cover): 비ASCII 경로·untracked·손상 coverage 거짓보고 3건 (#319 #320 #321)

### DIFF
--- a/docs/log/2026-06-23-diff-cover.md
+++ b/docs/log/2026-06-23-diff-cover.md
@@ -1,0 +1,36 @@
+# 2026-06-23 — diff-cover 거짓 '측정 대상 없음'/은폐 결함 3건 수정 (#319 #320 #321)
+
+> append-only. 추가만, 수정·삭제 금지.
+
+## 배경
+2026-06-22 미니 심시티 도그푸딩 자동 버그수색이 diff-cover(자문형 품질 게이트)에서
+조용한 false-negative·은폐 결함 3건을 격리 temp 독립 재현으로 적발. TDD 로 일괄 수정.
+
+## 결함 3건
+- **#319 (P2)** 한글/비ASCII 경로 소스 변경이 통째 누락 → 거짓 '측정 대상 없음'(exit 0).
+  - 원인: `diffUnified0`(`git diff --unified=0 HEAD`)가 `core.quotepath=false` 미전달 →
+    Git 기본 quotepath 가 비ASCII 경로를 `"b/src/lib/\355\225\234...ts"`(따옴표+8진 이스케이프)로 출력.
+    `diff-hunks.ts` 의 `+++` 정규식 `(?:b\/)?` 가 선두 따옴표 매칭 실패 → 파일 드롭.
+  - 수정: ① `diffUnified0` argv 에 `-c core.quotepath=false` 선행(따옴표 자체 차단).
+    ② `diff-hunks.ts` 에 `decodeGitDiffPath()` 추가 — 따옴표/8진 이스케이프를 방어적으로 디코드
+    (다른 경로로 quotepath 가 켜져 들어와도 견디는 belt-and-suspenders).
+- **#320 (P3)** untracked 신규 소스(가장 미검증 위험)를 diff-cover 가 못 봄 → 거짓 '측정 대상 없음'.
+  - 원인: `diff HEAD` 는 정의상 untracked 미포함. `added.size===0` 분기가 untracked 확인 없이 단정.
+  - 수정: `diff-cover.ts` 가 `untrackedFiles()`(이미 존재하는 헬퍼) 로 untracked 기능소스를 확인 →
+    있으면 '측정 대상 없음' 단정 대신 'untracked N개는 git add 후 측정' 정직 안내.
+    순수 추출 `untrackedFeatureSources()` 로 테스트 가능화.
+- **#321 (P3)** 손상/빈 coverage-final.json(파일은 실재)이 '리포트 없음'으로 보고 → 손상 은폐.
+  - 원인: `fileCoverageByFile` 가 부재(`!existsSync`)와 파싱실패(`catch`)를 동일 `null` 로 붕괴.
+  - 수정: 파싱 실패 시 별도 sentinel `COVERAGE_CORRUPT` 반환. 호출부 2곳(diff-cover·receipt) 구분 소비:
+    diff-cover → '리포트 손상(재생성 필요)' exit 1 / receipt → 측정 불가(empty) 처리.
+
+## 회귀 주의
+- #239 에서 강화된 `diff-hunks` 상태머신(`+++` 본문 오인 차단)은 그대로 유지 — 디코드는 헤더 영역에서만.
+- `receipt.collectDiffCover` 의 `covered === null` 분기에 corrupt 도 empty 로 합류시켜 측정 불가 유지.
+- `git-session.test.ts` 의 `diffUnified0` argv 단언을 `-c core.quotepath=false` 포함으로 갱신.
+
+## 수용 기준(테스트)
+- 비ASCII 경로 파일 인식(따옴표 경로 디코드 + quotepath=false argv)
+- untracked 신규파일 정직 안내(은폐 0)
+- 손상 coverage 파일 → '손상'으로 정직 보고(부재와 구분)
+- 정상 케이스 회귀 0

--- a/src/commands/diff-cover.ts
+++ b/src/commands/diff-cover.ts
@@ -1,13 +1,26 @@
 import { join } from 'node:path'
 import chalk from 'chalk'
 import { safeExecFile } from '../lib/exec.js'
-import { diffUnified0 } from '../lib/git-session.js'
+import { diffUnified0, untrackedFiles } from '../lib/git-session.js'
 import { addedLinesByFile } from '../lib/diff-hunks.js'
-import { fileCoverageByFile } from '../lib/coverage-parse.js'
+import { fileCoverageByFile, COVERAGE_CORRUPT } from '../lib/coverage-parse.js'
 import { diffCoverage, type DiffCoverageResult } from '../lib/diff-coverage.js'
+import { isFeatureSource, toPosix } from '../lib/test-mapping.js'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
 
 const COVERAGE_JSON_REL = 'coverage/coverage-final.json'
+
+/**
+ * #320: `git ls-files --others --exclude-standard` 출력 → untracked 기능소스(src/commands·src/lib)만(순수, 정렬).
+ * diff HEAD 는 untracked 를 못 본다 → 신규 미검증 모듈을 '측정 대상 없음'으로 오도하지 않게 별도 안내용.
+ */
+export function untrackedFeatureSources(lsFilesOut: string): string[] {
+  return lsFilesOut
+    .split(/\r?\n/)
+    .map((l) => toPosix(l.trim()))
+    .filter((p) => p.length > 0 && isFeatureSource(p))
+    .sort((a, b) => a.localeCompare(b))
+}
 
 /** diff-coverage 결과 → 표시 라인(순수, chalk 없음 — 테스트 용이). */
 export function formatReport(r: DiffCoverageResult): string[] {
@@ -46,12 +59,32 @@ export async function diffCover(): Promise<void> {
   const diffRes = diffUnified0(cwd)
   const added = addedLinesByFile(diffRes.ok ? diffRes.out : '')
   if (added.size === 0) {
+    // #320: tracked 변경은 없어도 untracked 신규 기능소스(가장 미검증 위험)가 있으면
+    // '측정 대상 없음' 단정 금지 — diff HEAD 범위 밖임을 정직히 알리고 git add 안내.
+    const untracked = untrackedFeatureSources(untrackedFiles(cwd).out)
+    if (untracked.length > 0) {
+      console.log(
+        chalk.yellow(
+          `\n  ⚠️  추적 안 된(untracked) 신규 기능소스 ${untracked.length}개 — diff HEAD 범위 밖이라 미측정:`
+        )
+      )
+      for (const f of untracked) console.log(chalk.yellow(`     ${f}`))
+      console.log(chalk.cyan('\n     → git add 후 다시 실행하면 측정합니다 (신규 모듈일수록 미검증 위험 ↑).'))
+      return
+    }
     console.log(chalk.green('\n  ✅ HEAD 대비 변경된 기능소스(src/commands·src/lib) 없음 — 측정 대상 없음.'))
     return
   }
 
   const covPath = join(cwd, COVERAGE_JSON_REL)
   const covered = fileCoverageByFile(covPath, cwd)
+  if (covered === COVERAGE_CORRUPT) {
+    // #321: 파일은 실재하나 JSON.parse 실패 — '없음'으로 오인 보고하면 손상 은폐. 손상으로 정직 보고.
+    console.error(chalk.red(`\n  ❌ 커버리지 리포트 손상(${COVERAGE_JSON_REL}) — 파싱 실패. 재생성하세요:`))
+    console.error(chalk.cyan('     pnpm test:run --coverage'))
+    process.exitCode = 1
+    return
+  }
   if (covered === null) {
     console.error(chalk.yellow(`\n  ⚠️  커버리지 리포트 없음(${COVERAGE_JSON_REL}). 먼저 생성하세요:`))
     console.error(chalk.cyan('     pnpm test:run --coverage'))

--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -12,7 +12,7 @@ import { getCommitInfo } from '../lib/git-repo.js'
 import { verifyEvidence } from './verify.js'
 import { diffUnified0 } from '../lib/git-session.js'
 import { addedLinesByFile } from '../lib/diff-hunks.js'
-import { fileCoverageByFile } from '../lib/coverage-parse.js'
+import { fileCoverageByFile, COVERAGE_CORRUPT } from '../lib/coverage-parse.js'
 import { diffCoverage } from '../lib/diff-coverage.js'
 import {
   buildReceipt,
@@ -81,7 +81,8 @@ export function collectDiffCover(cwd: string): ReceiptDiffCover {
     const added = addedLinesByFile(diffRes.ok ? diffRes.out : '')
     if (added.size === 0) return empty // 변경된 기능소스 없음 — 측정 대상 없음(advisory 부재).
     const covered = fileCoverageByFile(join(cwd, COVERAGE_JSON_REL), cwd)
-    if (covered === null) return empty // 커버리지 리포트 없음 — advisory 부재(차단 사유 아님).
+    // #321: 부재(null)·손상(COVERAGE_CORRUPT) 모두 측정 불가 — 영수증은 advisory 부재로 둔다(차단 사유 아님).
+    if (covered === null || covered === COVERAGE_CORRUPT) return empty
     const r = diffCoverage(added, covered)
     return {
       measured: true,

--- a/src/lib/coverage-parse.ts
+++ b/src/lib/coverage-parse.ts
@@ -16,9 +16,17 @@ export interface FileCoverage {
   executable: Set<number>
 }
 
+// #319/#321 의 #321: 리포트 파일이 *실재하나* JSON.parse 실패(잘림/빈 파일)인 손상 상태를
+// 부재(null)와 구분하는 sentinel. 호출부가 '리포트 없음(새로 생성)' 대신 '리포트 손상(재생성)'으로
+// 정직 보고하게 한다(은폐 차단). null=부재, COVERAGE_CORRUPT=손상, Map=정상.
+export const COVERAGE_CORRUPT = Symbol('coverage-corrupt')
+export type CoverageResult = Map<string, FileCoverage> | null | typeof COVERAGE_CORRUPT
+
 /**
  * v8 coverage-final.json → 기능소스(src/commands·src/lib)별 {커버된 라인, 실행가능 라인}.
- * - 리포트 파일 부재/손상 → null (측정 불가 — diff-cover 가 "먼저 --coverage" 안내).
+ * - 리포트 파일 부재 → null (측정 불가 — diff-cover 가 "먼저 --coverage" 안내).
+ * - 리포트 파일 실재 but JSON.parse 실패(잘림/빈 파일) → COVERAGE_CORRUPT (#321 — 부재와 구분해
+ *   '리포트 손상(재생성)'으로 정직 보고하게 함. 과거엔 둘 다 null 로 붕괴해 손상을 '없음'으로 은폐).
  * - 리포트 존재 but 특정 파일 부재 → 맵에 없음(= 테스트가 import 안 함 → diff-coverage 가 coarse 처리).
  * executable 을 따로 노출하는 이유: "미검증 변경분"은 *실행가능* 추가라인 중 미커버만 세야 한다.
  * 비실행 라인(import·주석·타입·중괄호)까지 세면 false-completion 신호가 노이즈에 묻힘(도그푸딩이 잡은 결함).
@@ -27,14 +35,14 @@ export interface FileCoverage {
 export function fileCoverageByFile(
   jsonPath: string,
   cwd: string = process.cwd()
-): Map<string, FileCoverage> | null {
+): CoverageResult {
   if (!existsSync(jsonPath)) return null
   let data: Record<string, V8FileCov>
   try {
     // 프로젝트 단일 JSON 통로(BOM 처리 + raw JSON.parse 가드 회피).
     data = readJsonFile<Record<string, V8FileCov>>(jsonPath)
   } catch {
-    return null
+    return COVERAGE_CORRUPT // #321: 파일 실재 but 파싱 실패 = 손상(부재 null 과 구분).
   }
   const out = new Map<string, FileCoverage>()
   for (const [absKey, cov] of Object.entries(data)) {

--- a/src/lib/diff-hunks.ts
+++ b/src/lib/diff-hunks.ts
@@ -1,5 +1,48 @@
 import { isFeatureSource, toPosix } from './test-mapping.js'
 
+// #319: Git 기본(core.quotepath=true)은 비ASCII 경로를 `"b/src/lib/\355\225\234.ts"`
+// (따옴표로 감싸고 UTF-8 바이트를 8진 이스케이프)로 출력한다. diffUnified0 가 quotepath=false 를
+// 넘기지만, 다른 경로로 quotepath 가 켜진 diff 가 들어와도 견디도록 헤더 영역에서 디코드한다.
+/**
+ * git 따옴표 경로(`"...\NNN..."`)를 원래 UTF-8 경로로 디코드. 따옴표 없으면 그대로 반환(순수).
+ * 8진 이스케이프(`\NNN`)는 바이트로 모아 UTF-8 디코드, 표준 C 이스케이프(`\t\n\\"`)도 처리.
+ */
+export function decodeGitDiffPath(raw: string): string {
+  if (raw.length < 2 || raw[0] !== '"' || raw[raw.length - 1] !== '"') return raw
+  const body = raw.slice(1, -1)
+  const bytes: number[] = []
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i]
+    if (ch !== '\\') {
+      // 비이스케이프 문자: ASCII 1바이트로 인코딩(quotepath 는 ASCII 외엔 항상 이스케이프).
+      bytes.push(ch.charCodeAt(0) & 0xff)
+      continue
+    }
+    const next = body[i + 1]
+    if (next === undefined) {
+      bytes.push(0x5c) // 끝의 고립 백슬래시 — 그대로.
+      break
+    }
+    if (next >= '0' && next <= '7') {
+      // 8진 이스케이프 \NNN (최대 3자리) → 단일 바이트.
+      let oct = ''
+      let j = i + 1
+      while (j < body.length && j <= i + 3 && body[j] >= '0' && body[j] <= '7') {
+        oct += body[j]
+        j++
+      }
+      bytes.push(parseInt(oct, 8) & 0xff)
+      i = j - 1
+      continue
+    }
+    // 표준 C 이스케이프.
+    const map: Record<string, number> = { t: 9, n: 10, r: 13, '"': 34, '\\': 92 }
+    bytes.push(map[next] ?? next.charCodeAt(0) & 0xff)
+    i++
+  }
+  return Buffer.from(bytes).toString('utf8')
+}
+
 /**
  * `git diff --unified=0 HEAD` 텍스트 → 기능소스(src/commands·src/lib)별 추가 라인번호 집합. 순수 함수.
  * 헌트 헤더(@@ -a,b +c,d @@)만으로 추가 라인 계산(컨텍스트 0이라 본문 +라인 셀 필요 없음).
@@ -19,9 +62,12 @@ export function addedLinesByFile(diffText: string): Map<string, Set<number>> {
       continue
     }
     if (!inHunks) {
-      const plus = raw.match(/^\+\+\+ (?:b\/)?(.+)$/)
+      // `+++ ` 뒤 전체를 캡처 → 먼저 디코드(따옴표/8진 경로 #319)한 뒤 b/ 접두 제거.
+      // 정규식 단계에서 (?:b\/)? 로 벗기면 따옴표 경로(`"b/...`)가 막혀 누락됐었다.
+      const plus = raw.match(/^\+\+\+ (.+)$/)
       if (plus) {
-        const path = plus[1].trim()
+        const decoded = decodeGitDiffPath(plus[1].trim())
+        const path = decoded.replace(/^b\//, '')
         curFile = path !== '/dev/null' && isFeatureSource(path) ? toPosix(path) : null
         continue
       }

--- a/src/lib/git-session.ts
+++ b/src/lib/git-session.ts
@@ -66,9 +66,16 @@ export function numstatHead(cwd: string = process.cwd()): ExecResult {
   return safeExecFile('git', ['diff', '--numstat', 'HEAD'], { cwd })
 }
 
-/** git diff --unified=0 HEAD — 헌트 헤더(@@ -a,b +c,d @@)로 추가 라인번호 추출용. raw 보존. */
+// #319: core.quotepath=false 로 비ASCII(한글) 경로를 8진 이스케이프 없이 raw UTF-8 로 받는다.
+// Git 기본(quotepath=true)은 `"b/src/lib/\355...ts"`(따옴표+8진)로 출력 → diff-hunks 의 +++ 정규식이
+// 선두 따옴표에 막혀 한글 소스를 통째 누락(거짓 '측정 대상 없음'). `-c key=val`은 git 글로벌 옵션이라
+// 서브커맨드(diff) 앞에 와야 한다. diff-hunks 도 디코드로 belt-and-suspenders 방어.
+/** git -c core.quotepath=false diff --unified=0 HEAD — 헌트 헤더로 추가 라인번호 추출용. raw 보존. */
 export function diffUnified0(cwd: string = process.cwd()): ExecResult {
-  return safeExecFile('git', ['diff', '--unified=0', 'HEAD'], { cwd, trimOutput: false })
+  return safeExecFile('git', ['-c', 'core.quotepath=false', 'diff', '--unified=0', 'HEAD'], {
+    cwd,
+    trimOutput: false,
+  })
 }
 
 /** git log --format=%h %ad %s --date=short -n — recap 용 날짜 포함 히스토리. */

--- a/tests/coverage-parse.test.ts
+++ b/tests/coverage-parse.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest'
 import { writeFileSync, rmSync, mkdtempSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { fileCoverageByFile } from '../src/lib/coverage-parse.js'
+import { fileCoverageByFile, COVERAGE_CORRUPT } from '../src/lib/coverage-parse.js'
 
 const dirs: string[] = []
 function tmpDir(): string {
@@ -44,11 +44,20 @@ describe('fileCoverageByFile — v8 coverage-final.json → {covered, executable
     expect(fileCoverageByFile('/no/such/coverage-final.json', '/x')).toBeNull()
   })
 
-  it('손상된 json → null', () => {
+  // #321: 손상(파일은 실재, JSON.parse 실패)은 부재(null)와 구분돼야 한다 — 호출부가
+  // '리포트 없음(새로 생성)' 대신 '리포트 손상(재생성 필요)'로 정직 보고하도록.
+  it('#321 손상된 json(파일 실재) → COVERAGE_CORRUPT sentinel (null=부재와 구분)', () => {
     const cwd = tmpDir()
     const p = join(cwd, 'coverage-final.json')
     writeFileSync(p, '{not json', 'utf-8')
-    expect(fileCoverageByFile(p, cwd)).toBeNull()
+    expect(fileCoverageByFile(p, cwd)).toBe(COVERAGE_CORRUPT)
+  })
+
+  it('#321 빈 파일(0바이트, 실재)도 COVERAGE_CORRUPT (부재 아님)', () => {
+    const cwd = tmpDir()
+    const p = join(cwd, 'coverage-final.json')
+    writeFileSync(p, '', 'utf-8')
+    expect(fileCoverageByFile(p, cwd)).toBe(COVERAGE_CORRUPT)
   })
 
   it('기능소스 아닌 파일(tests/)은 제외', () => {

--- a/tests/diff-cover.test.ts
+++ b/tests/diff-cover.test.ts
@@ -3,16 +3,20 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 // diffCover() 오케스트레이션 분기 테스트용 — 저수준 IO/순수 의존을 mock.
 // (diff-coverage 는 실제 순수함수 사용 — 교차 로직은 그대로 검증.)
 vi.mock('../src/lib/exec.js', () => ({ safeExecFile: vi.fn() }))
-vi.mock('../src/lib/git-session.js', () => ({ diffUnified0: vi.fn() }))
+vi.mock('../src/lib/git-session.js', () => ({ diffUnified0: vi.fn(), untrackedFiles: vi.fn() }))
 vi.mock('../src/lib/diff-hunks.js', () => ({ addedLinesByFile: vi.fn() }))
-vi.mock('../src/lib/coverage-parse.js', () => ({ fileCoverageByFile: vi.fn() }))
+// COVERAGE_CORRUPT 는 실값(sentinel) 유지 — fileCoverageByFile 만 mock.
+vi.mock('../src/lib/coverage-parse.js', async (orig) => {
+  const actual = await orig<typeof import('../src/lib/coverage-parse.js')>()
+  return { ...actual, fileCoverageByFile: vi.fn() }
+})
 vi.mock('../src/lib/hard-stop-guard.js', () => ({ ensureNotHardStopped: vi.fn(() => true) }))
 
-import { formatReport, diffCover } from '../src/commands/diff-cover.js'
+import { formatReport, diffCover, untrackedFeatureSources } from '../src/commands/diff-cover.js'
 import { safeExecFile } from '../src/lib/exec.js'
-import { diffUnified0 } from '../src/lib/git-session.js'
+import { diffUnified0, untrackedFiles } from '../src/lib/git-session.js'
 import { addedLinesByFile } from '../src/lib/diff-hunks.js'
-import { fileCoverageByFile } from '../src/lib/coverage-parse.js'
+import { fileCoverageByFile, COVERAGE_CORRUPT } from '../src/lib/coverage-parse.js'
 import type { DiffCoverageResult } from '../src/lib/diff-coverage.js'
 import type { FileCoverage } from '../src/lib/coverage-parse.js'
 
@@ -61,6 +65,7 @@ describe('diffCover — 오케스트레이션 분기(자문형·차단 0)', () =
   const mockDiff = vi.mocked(diffUnified0)
   const mockAdded = vi.mocked(addedLinesByFile)
   const mockCov = vi.mocked(fileCoverageByFile)
+  const mockUntracked = vi.mocked(untrackedFiles)
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -69,10 +74,11 @@ describe('diffCover — 오케스트레이션 분기(자문형·차단 0)', () =
     vi.spyOn(console, 'log').mockImplementation((m?: unknown) => { logs.push(String(m)) })
     vi.spyOn(console, 'error').mockImplementation((m?: unknown) => { errs.push(String(m)) })
     process.exitCode = undefined
-    // 기본값: 저장소 O, diff 있음, 변경 1파일.
+    // 기본값: 저장소 O, diff 있음, 변경 1파일, untracked 없음.
     mockExec.mockReturnValue({ ok: true, out: 'true' })
     mockDiff.mockReturnValue({ ok: true, out: 'irrelevant(mocked)' })
     mockAdded.mockReturnValue(new Map([['src/lib/a.ts', new Set([10, 11])]]))
+    mockUntracked.mockReturnValue({ ok: true, out: '' })
   })
   afterEach(() => {
     vi.restoreAllMocks()
@@ -86,18 +92,41 @@ describe('diffCover — 오케스트레이션 분기(자문형·차단 0)', () =
     expect(errs.join('\n')).toContain('git 저장소')
   })
 
-  it('변경된 기능소스 없음 → 측정 대상 없음(exit 0)', async () => {
+  it('변경된 기능소스 없음(untracked 도 없음) → 측정 대상 없음(exit 0)', async () => {
     mockAdded.mockReturnValue(new Map())
     await diffCover()
     expect(process.exitCode).not.toBe(1)
     expect(logs.join('\n')).toContain('측정 대상 없음')
   })
 
-  it('커버리지 리포트 없음 → exit 1 + 안내', async () => {
+  // #320: tracked 변경은 없지만 untracked 신규 기능소스가 있으면 '측정 대상 없음' 단정 금지 —
+  // 가장 미검증 위험 높은 신규 모듈을 능동적으로 오도하지 않게 정직 안내.
+  it('#320 변경 없음 but untracked 기능소스 있음 → "git add 후 측정" 안내(은폐 0)', async () => {
+    mockAdded.mockReturnValue(new Map())
+    mockUntracked.mockReturnValue({ ok: true, out: 'src/lib/brandnew.ts\nREADME.md' })
+    await diffCover()
+    const out = logs.join('\n') + errs.join('\n')
+    expect(out).not.toContain('측정 대상 없음') // 거짓 단정 금지
+    expect(out).toContain('src/lib/brandnew.ts') // 위험 파일 명시
+    expect(out).toMatch(/git add/) // 조치 안내
+    expect(out).not.toContain('README.md') // 기능소스 아닌 건 제외
+  })
+
+  it('커버리지 리포트 없음(부재) → exit 1 + 안내', async () => {
     mockCov.mockReturnValue(null)
     await diffCover()
     expect(process.exitCode).toBe(1)
     expect(errs.join('\n')).toContain('커버리지 리포트 없음')
+  })
+
+  // #321: 손상(파일 실재, parse 실패)을 '없음'으로 보고하면 은폐 — '손상'으로 구분 보고.
+  it('#321 커버리지 리포트 손상 → "손상" 보고(exit 1, "없음" 아님)', async () => {
+    mockCov.mockReturnValue(COVERAGE_CORRUPT)
+    await diffCover()
+    expect(process.exitCode).toBe(1)
+    const out = errs.join('\n')
+    expect(out).toContain('손상')
+    expect(out).not.toContain('리포트 없음') // 부재로 오인 금지
   })
 
   it('정상 — 미검증 변경분 있어도 advisory(exit 0) + 보고', async () => {
@@ -109,5 +138,28 @@ describe('diffCover — 오케스트레이션 분기(자문형·차단 0)', () =
     expect(out).toContain('미검증 변경분')
     expect(out).toContain('11') // 미커버 라인
     expect(out).toContain('자문형')
+  })
+})
+
+describe('untrackedFeatureSources — ls-files 출력 → 기능소스만(순수, #320)', () => {
+  it('src/commands·src/lib 의 .ts 만 골라낸다(문서·테스트·기타 제외)', () => {
+    const out = [
+      'src/lib/brandnew.ts',
+      'src/commands/new-cmd.ts',
+      'README.md',
+      'src/lib/x.test.ts',
+      'docs/note.md',
+      'src/other/z.ts',
+    ].join('\n')
+    expect(untrackedFeatureSources(out)).toEqual(['src/commands/new-cmd.ts', 'src/lib/brandnew.ts'])
+  })
+
+  it('빈 출력 → 빈 배열', () => {
+    expect(untrackedFeatureSources('')).toEqual([])
+    expect(untrackedFeatureSources('   \n  ')).toEqual([])
+  })
+
+  it('Windows 백슬래시 경로도 posix 정규화 후 인식', () => {
+    expect(untrackedFeatureSources('src\\lib\\foo.ts')).toEqual(['src/lib/foo.ts'])
   })
 })

--- a/tests/diff-hunks.test.ts
+++ b/tests/diff-hunks.test.ts
@@ -85,4 +85,31 @@ describe('addedLinesByFile — unified=0 diff → 기능소스별 추가 라인'
     ].join('\n')
     expect([...(addedLinesByFile(diff).get('src/lib/a.ts') ?? [])]).toEqual([6, 30])
   })
+
+  // #319: Git 기본 quotepath 가 비ASCII 경로를 따옴표+8진 이스케이프로 출력(`"b/src/lib/\355...ts"`).
+  // 정규식 `(?:b\/)?` 가 선두 따옴표 매칭 실패 → 한글 소스 통째 누락(거짓 '측정 대상 없음').
+  // 디코드로 방어(quotepath=false 미적용 diff 가 들어와도 견딤).
+  it('#319 따옴표+8진 이스케이프(한글) 경로를 디코드해 인식', () => {
+    // "한글파일.ts" 의 git quotepath 8진 이스케이프(UTF-8 바이트).
+    const quoted = '"b/src/lib/\\355\\225\\234\\352\\270\\200\\355\\214\\214\\354\\235\\274.ts"'
+    const diff = [
+      'diff --git "a/src/lib/\\355\\225\\234\\352\\270\\200\\355\\214\\214\\354\\235\\274.ts" "b/src/lib/\\355\\225\\234\\352\\270\\200\\355\\214\\214\\354\\235\\274.ts"',
+      `+++ ${quoted}`,
+      '@@ -1,0 +2,1 @@',
+      '+x',
+    ].join('\n')
+    const m = addedLinesByFile(diff)
+    expect([...(m.get('src/lib/한글파일.ts') ?? [])]).toEqual([2])
+  })
+
+  it('#319 따옴표 없는 비ASCII 경로(quotepath=false)도 정상 인식', () => {
+    const diff = [
+      'diff --git a/src/lib/한글.ts b/src/lib/한글.ts',
+      '+++ b/src/lib/한글.ts',
+      '@@ -1,0 +1,2 @@',
+      '+a',
+      '+b',
+    ].join('\n')
+    expect([...(addedLinesByFile(diff).get('src/lib/한글.ts') ?? [])]).toEqual([1, 2])
+  })
 })

--- a/tests/git-session.test.ts
+++ b/tests/git-session.test.ts
@@ -86,10 +86,11 @@ describe('git-session — git argv SoT (같은 질문 = 함수 하나)', () => {
     expect(lastArgv()).toEqual(['diff', '--numstat', 'HEAD'])
   })
 
-  it('diffUnified0 → git diff --unified=0 HEAD (raw 보존)', () => {
+  it('diffUnified0 → git -c core.quotepath=false diff --unified=0 HEAD (raw 보존)', () => {
     session.diffUnified0('/repo')
     expect(lastBin()).toBe('git')
-    expect(lastArgv()).toEqual(['diff', '--unified=0', 'HEAD'])
+    // #319: core.quotepath=false 로 비ASCII(한글) 경로를 8진 이스케이프 없이 받는다.
+    expect(lastArgv()).toEqual(['-c', 'core.quotepath=false', 'diff', '--unified=0', 'HEAD'])
     // 헌트 헤더(@@ -a,b +c,d @@) 라인번호 보존 위해 trimOutput:false.
     expect(lastOpts()).toMatchObject({ cwd: '/repo', trimOutput: false })
   })


### PR DESCRIPTION
## 요약
diff-cover(자문형 품질 게이트)의 조용한 false-negative·은폐 결함 3건을 TDD로 일괄 수정. 2026-06-22 미니 심시티 도그푸딩 자동 버그수색이 격리 temp 독립 재현으로 적발한 이슈.

## 수정 내용
### #319 — 한글/비ASCII 경로 소스 통째 누락 (거짓 '측정 대상 없음')
- 원인: `diffUnified0`가 `core.quotepath=false` 미전달 → Git 기본이 비ASCII 경로를 `"b/src/lib/\355...ts"`(따옴표+8진)로 출력 → `diff-hunks`의 `+++` 정규식 `(?:b\/)?`가 선두 따옴표에 막혀 드롭.
- 수정: ① `diffUnified0` argv에 `-c core.quotepath=false` 선행. ② `diff-hunks.ts`에 `decodeGitDiffPath()` 추가 — 따옴표/8진 이스케이프를 방어적 디코드(quotepath 켜진 diff도 견딤).

### #320 — untracked 신규 소스를 못 봄 (가장 미검증 위험에 거짓 '측정 대상 없음')
- 원인: `diff HEAD`는 정의상 untracked 미포함. `added.size===0` 분기가 untracked 확인 없이 단정.
- 수정: `untrackedFiles()`(기존 헬퍼)로 untracked 기능소스 확인 → 있으면 위험 파일 명시 + 'git add 후 측정' 정직 안내. 순수 추출 `untrackedFeatureSources()`로 테스트 가능화.

### #321 — 손상/빈 coverage-final.json을 '리포트 없음'으로 은폐
- 원인: `fileCoverageByFile`가 부재(`!existsSync`)와 파싱실패(`catch`)를 동일 `null`로 붕괴.
- 수정: 파싱 실패 시 `COVERAGE_CORRUPT` sentinel 반환. 호출부 2곳(diff-cover→'손상' 보고 / receipt→측정불가) 구분 소비.

## 검증
- 신규/갱신 테스트: diff-hunks(따옴표·8진 경로 디코드 2건), git-session(quotepath argv), coverage-parse(손상·빈파일 sentinel 2건), diff-cover(untracked 안내·손상 보고·untrackedFeatureSources 순수 3블록).
- 게이트: `pnpm build` 성공 · 전체 **1905 테스트 green**(180 파일) · `secure scan` CRITICAL:0.
- E2E: 세 이슈의 복붙 재현 시나리오로 실제 빌드 CLI 직접 확인(은폐 0). 회귀(변경/untracked 둘 다 없음 → '측정 대상 없음' 유지) 확인.

## 회귀 주의
- #239에서 강화된 `diff-hunks` 상태머신(`+++` 본문 오인 차단)은 그대로 유지 — 디코드는 헤더 영역에서만.
- `receipt.collectDiffCover`의 `covered === null` 분기에 corrupt도 측정불가로 합류.

Closes #319, Closes #320, Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 추적되지 않은 신규 소스 파일 감지 시 경고 메시지 출력

* **버그 수정**
  * 한글 및 비ASCII 경로 파일의 추가 라인 추적 실패 해결
  * 손상된 커버리지 리포트를 누락된 리포트와 구분하여 명확한 오류 처리

* **테스트**
  * 추가 테스트 케이스로 비ASCII 경로, 손상된 리포트, 미추적 소스 시나리오 검증

<!-- end of auto-generated comment: release notes by coderabbit.ai -->