### PR TITLE
fix: goal·mission UX 메시지/어포던스 정확도 (#327 #328 #329 #330)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -52,7 +52,7 @@ Cursor에게 한국어로 말해도 됩니다.
 | 하고 싶은 것 | 터미널 명령 | Cursor에게 말하기 |
 |-------------|-----------|------------------|
 | 작업 범위 선언 | `vhk mission set --objective "..." --scope "src/**" --forbidden "**/*.env"` | "미션 정해줘" |
-| 현재 계약 보기 | `vhk mission` | "미션 보여줘" |
+| 현재 계약 보기 | `vhk mission` (또는 `vhk mission show`) | "미션 보여줘" |
 | 변경이 계약 안인지 검증 | `vhk mission check` | "미션 검증해" |
 | 계약 삭제 | `vhk mission clear` | — |
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ vhk mcp
 | 규칙/맥락 | `vhk sync`, `vhk context`, `vhk context-show`, `vhk brief`, `vhk loop-brief`, `vhk remind`, `vhk work`, `vhk work handoff` | 규칙 동기화, 프로젝트 맥락 생성, 루프 1틱 의도 앵커, 치명 규칙 재주입, 세션 시작/인수인계 |
 | 풀사이클 뒷단 | `vhk content`, `vhk launch`, `vhk ops`, `vhk sell` | 콘텐츠/런칭/운영/판매 초안 프롬프트 생성 (초안만, 게시·발송·결제는 사람이 · `launch`≠`ship`(코드 배포)) |
 | Goal | `vhk goal init/list/next/check/done/sync/drift` | 단계별 목표, 게이트, 상태 드리프트 관리 |
-| Trust | `vhk verify`, `vhk review`, `vhk receipt`, `vhk preflight`, `vhk testmap`, `vhk mission set/check/clear` | 증거 생성, 거짓완료 탐지, 증거 영수증(4대 기계증거 판정), 출고 전 점검, 테스트 매핑, 작업 범위 계약 |
+| Trust | `vhk verify`, `vhk review`, `vhk receipt`, `vhk preflight`, `vhk testmap`, `vhk mission set/show/check/clear` | 증거 생성, 거짓완료 탐지, 증거 영수증(4대 기계증거 판정), 출고 전 점검, 테스트 매핑, 작업 범위 계약 |
 | 안전 | `vhk blocker`, `vhk resume --confirm`, `vhk mode`, `vhk secure scan` | HARD_STOP, safety mode, 시크릿 스캔 |
 | Git | `vhk status`, `vhk diff`, `vhk save`, `vhk undo`, `vhk restore`, `vhk recap` | 상태/변경 확인, 커밋/푸시, 되돌리기, 세션 로그 |
 | 환경/품질 | `vhk doctor`, `vhk check`, `vhk env`, `vhk env-check`, `vhk harness`, `vhk audit`, `vhk worktree check/add` | 개발환경, RULES 린트, env, 통합 품질, 보안 감사, worktree 가드 |

--- a/docs/log/2026-06-23-goal-mission-ux.md
+++ b/docs/log/2026-06-23-goal-mission-ux.md
@@ -1,0 +1,25 @@
+# 2026-06-23 — fix #327·#328·#329·#330 goal/mission UX 정확도
+
+## 배경
+2026-06-22 미니 심시티 도그푸딩 자동 버그수색에서 나온 goal/mission UX 결함 4건(전부 P3, 손상·차단 없음, 메시지/어포던스 정확도 문제). worktree `fix/327-330-goal-mission-ux` 에서 TDD 로 처리.
+
+## 한 일
+- **#327 `vhk mission show` 깨짐** — `show` 서브커맨드 미등록이라 commander 가 `show` 를 mission(0-arity)의 위치인자로 보고 `too many arguments` cryptic 에러. set/check/clear 와 대칭으로 `show` 서브커맨드 등록.
+  - `src/index.ts`: `missionCmd.command('show')` 추가(`.action(missionShow)`). bare `vhk mission` 의 default action 도 그대로 유지(둘 다 missionShow).
+  - `src/lib/command-registry.ts`: `CONTAINER_SUBCOMMANDS.mission` 에 `'show'` 추가 — 안 하면 R1 드리프트 가드(command-registry.test.ts)가 실패(실제 commander 서브커맨드 ↔ 레지스트리 일치 강제). 이 가드가 #327 의 회귀 테스트 역할.
+- **#328 첫 `goal next` 가 init 스캐폴드를 '수동 편집본'으로 오탐** — `STATE_NEXT_TASK_TEMPLATE` 에 auto-update 마커(``via `vhk goal next` ``)가 없어 휴리스틱이 무조건 manual 판정. 템플릿 본문에 마커 1줄 주입 → 휴리스틱 변경 없이 오탐 0.
+  - `src/commands/goal.ts STATE_NEXT_TASK_TEMPLATE`: `_Auto-updated via \`vhk goal next\`._` 줄 추가.
+- **#329 전부 DONE / 0개일 때 check·done 의 generic '대상 결정 불가'** — `goal next`(VHK-017)는 0개=`📭 정의된 goal 없음`, 전부완료=`🎉 모든 goal 완료`로 구분하나 check/done 은 `resolveGoalId===null` 을 단일 문구로 뭉갬. null 분기를 goalNext 와 동일하게 0개/전부완료로 갈라 안내(명령 동사만 check/done 으로 치환).
+  - `src/commands/goal.ts goalCheck·goalDone`: `id===null` 분기를 goals.length 로 갈라 `📭 정의된 goal 없음` / `🎉 모든 goal 완료(검사/완료할 대상 없음)` 안내. 0개·전부완료는 정상 상태이므로 exit 0(이전엔 exit 1 — '설정 오류'로 오해 유발).
+- **#330 비숫자 `--id abc` 모순 안내 — 이미 #317 로 해결됨(중복).** 현 main(0b80c05 #317 머지) 기준 `goal check --id abc` 는 이미 `유효하지 않은 goal 번호: 'abc' — 양의 정수만 됩니다` 로 정확히 지목. 회귀 방지용 명시 테스트만 추가(check·done 둘 다). 코드 변경 없음.
+
+## 검증 (TDD)
+- `tests/command-registry.test.ts`: 기존 드리프트 가드가 #327 회귀 가드(show 누락 시 자동 실패). + `vhk mission show` 가 commander 서브커맨드로 등록됐는지 명시 검증 추가.
+- `tests/goal.test.ts`:
+  - #328: init 직후 첫 goalNext 가 '수동 편집본' 경고를 내지 않음(red→green).
+  - #329: 전부 DONE·0개 각각 goalCheck/goalDone 이 next 와 일관된 문구 + exit 0(red→green).
+  - #330: goalCheck/goalDone `--id abc` 가 '유효하지 않은 goal 번호' 지목 + '대상 결정 불가' 로 새지 않음(회귀 가드).
+
+## 남은 위험
+- #329 에서 전부완료/0개를 exit 0 으로 바꿈 — 이전 exit 1 에 의존하던 스크립트가 있다면 동작 변화. 다만 두 상태는 '정상'이고 next 가 이미 exit 0 이라 일관성↑. CLI 사용자 영향 미미(P3).
+- #327 `show` 는 bare `vhk mission` 과 동일 출력 — 의도된 별칭(어포던스 보강).

--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -29,6 +29,19 @@ const STATUS_ICON: Record<GoalStatus, string> = {
   BLOCKED: '🛑',
 }
 
+// #329: --id 없이 active goal 이 null 일 때, goalNext(VHK-017)와 동일하게 0개/전부완료를 구분 안내.
+//        이전엔 둘 다 generic '대상 결정 불가'(exit 1)로 뭉개 '설정 오류'처럼 오해를 줬다.
+//        0개·전부완료는 정상 상태 → 안내만 하고 exit 0. (true 반환 = 정상 종료 신호)
+function reportNoActiveGoal(goals: ParsedGoal[]): boolean {
+  if (goals.length === 0) {
+    console.log(chalk.yellow('  📭 정의된 goal 이 없습니다.'))
+    console.log(chalk.dim('  vhk goal init 으로 시작하세요.'))
+    return true
+  }
+  console.log(chalk.green('  🎉 모든 goal 이 완료되었습니다 — 검사/완료할 대상이 없습니다.'))
+  return true
+}
+
 // active goal 선택: IN_PROGRESS 우선, 없으면 첫 NOT_STARTED.
 // (BLOCKED 는 자동 선택 안 함 — 사람이 풀어야 함.)
 export function selectActiveId(goals: ParsedGoal[]): number | null {
@@ -236,7 +249,10 @@ priority: P0
 게이트 스크립트는 \`vhk goal sync\` 로 \`scripts/check-goal-<id>.mjs\` 를 백필한다.
 `
 
-const STATE_NEXT_TASK_TEMPLATE = '# Next Task\n\n```\nTASK: (vhk goal next 로 자동 갱신)\n```\n'
+// #328: 스캐폴드 본문에 auto-update 마커(`via \`vhk goal next\``)를 포함 — 없으면 첫 goal next 가
+//        이 init 산출물을 '수동 편집본'으로 오탐(goalNext 의 isManual 휴리스틱이 마커 부재로 판정).
+const STATE_NEXT_TASK_TEMPLATE =
+  '# Next Task\n\n_Auto-updated via `vhk goal next`._\n\n```\nTASK: (vhk goal next 로 자동 갱신)\n```\n'
 const STATE_BLOCKERS_TEMPLATE =
   '# Blockers\n\n_Append-only. 해결 항목은 ~~취소선~~으로 표기._\n'
 const STATE_LEARNINGS_TEMPLATE =
@@ -320,10 +336,8 @@ export async function goalCheck(opts: { id?: string; force?: boolean }): Promise
     return
   }
   if (id === null) {
-    console.log(
-      chalk.yellow('  ⚠ 대상 goal 을 결정할 수 없습니다 (--id 명시 또는 active goal 필요).')
-    )
-    process.exitCode = 1
+    // #329: --id 없이 active 없음 = 0개 또는 전부완료(정상). next 와 일관 안내 + exit 0.
+    reportNoActiveGoal(goals)
     return
   }
   // ② 없는 goal id 는 게이트 검사 전에 통일된 메시지로 거부 (done 과 동일).
@@ -396,10 +410,8 @@ export async function goalDone(opts: { id?: string }): Promise<void> {
     return
   }
   if (id === null) {
-    console.log(
-      chalk.yellow('  ⚠ 대상 goal 을 결정할 수 없습니다 (--id 명시 또는 active goal 필요).')
-    )
-    process.exitCode = 1
+    // #329: --id 없이 active 없음 = 0개 또는 전부완료(정상). next 와 일관 안내 + exit 0.
+    reportNoActiveGoal(goals)
     return
   }
   const target = goals.find((g) => g.frontmatter.id === id)

--- a/src/index.ts
+++ b/src/index.ts
@@ -620,6 +620,13 @@ missionCmd
   .description('미션 계약 선언/갱신 (옵션 미지정 시 기존 scope/forbidden 보존)')
   .action(async (opts: { objective?: string; scope?: string[]; forbidden?: string[]; clearScope?: boolean; clearForbidden?: boolean; yes?: boolean }) => { await missionSet(opts) })
 
+// #327: bare `vhk mission` 의 default action(missionShow)을 명시 서브커맨드로도 노출.
+//        미등록 시 'show' 가 mission(0-arity)의 위치인자로 처리돼 cryptic 'too many arguments' 에러.
+missionCmd
+  .command('show')
+  .description('현재 미션 계약 출력 (bare `vhk mission` 과 동일)')
+  .action(async () => { await missionShow() })
+
 missionCmd
   .command('check')
   .description('변경 파일이 계약(scope/forbidden) 안인지 검증 — forbidden 위반 시 exit 1')

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -16,7 +16,7 @@ export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
   design: ['palette'],
   env: ['check'],
   mode: ['lite', 'standard', 'strict'],
-  mission: ['set', 'check', 'clear'],
+  mission: ['set', 'show', 'check', 'clear'],
   pattern: ['detect', 'list', 'dismiss'],
   evolve: ['suggest', 'negatives', 'list', 'apply', 'reject', 'undo'],
   work: ['handoff'],

--- a/tests/command-registry.test.ts
+++ b/tests/command-registry.test.ts
@@ -17,6 +17,17 @@ describe('R1 드리프트 가드 — command-registry 단일 소스', () => {
     }
   })
 
+  // #327: `vhk mission show` 가 commander 서브커맨드로 등록돼야 함.
+  // 미등록이면 'show' 가 mission(0-arity) 위치인자로 처리돼 'too many arguments' cryptic 에러.
+  it('#327 mission 에 show 서브커맨드가 등록돼 있음 (set/check/clear 와 대칭)', () => {
+    const mission = program.commands.find((c) => c.name() === 'mission')
+    expect(mission, 'mission 컨테이너 명령이 commander 에 없음').toBeDefined()
+    const subs = mission!.commands.map((c) => c.name())
+    expect(subs).toContain('show')
+    // 회귀: 기존 서브커맨드도 그대로
+    expect(subs).toEqual(expect.arrayContaining(['set', 'check', 'clear', 'show']))
+  })
+
   it('레지스트리가 cli-args R1 가드를 실제로 작동시킴', () => {
     // goal check / mode strict 가 commander 로 가야 함(자연어 라우터 가로채기 금지)
     expect(detectNaturalLanguageInput(['node', 'vhk', 'goal', 'check'])).toBeNull()

--- a/tests/goal.test.ts
+++ b/tests/goal.test.ts
@@ -771,3 +771,200 @@ describe('goal 엣지케이스 보강 (roadmap §4)', () => {
     }
   })
 })
+
+// #328: goal init 직후 첫 goal next 가 init 스캐폴드를 '수동 편집본'으로 오탐하면 안 됨.
+describe('#328 goalNext — init 스캐폴드 오탐 방지', () => {
+  let origCwd: string
+  beforeEach(() => {
+    origCwd = process.cwd()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    vi.restoreAllMocks()
+  })
+
+  it('init 직후 첫 next 는 "수동 편집본" 경고를 내지 않음', async () => {
+    const dir = tmpProject('first-next')
+    process.chdir(dir)
+    try {
+      const { goalInit, goalNext } = await import('../src/commands/goal.js')
+      await goalInit() // init 이 스캐폴드 next-task.md 생성
+      makeGoalFile(dir, 1, 'NOT_STARTED')
+      const logSpy = vi.spyOn(console, 'log')
+      await goalNext() // 스캐폴드 위에서 첫 next
+      const out = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(out).not.toMatch(/수동 편집본/)
+      // 정상 갱신은 됐어야 함
+      expect(out).toMatch(/next-task\.md 갱신/)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('실제 수동 편집본(마커 없는 임의 내용)은 여전히 경고', async () => {
+    const dir = tmpProject('manual-next')
+    mkdirSync(join(dir, 'docs/state'), { recursive: true })
+    writeFileSync(join(dir, 'docs/state/next-task.md'), '사용자가 손으로 쓴 메모\n', 'utf-8')
+    makeGoalFile(dir, 1, 'NOT_STARTED')
+    process.chdir(dir)
+    try {
+      const { goalNext } = await import('../src/commands/goal.js')
+      const logSpy = vi.spyOn(console, 'log')
+      await goalNext()
+      const out = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(out).toMatch(/수동 편집본/) // 회귀: 진짜 수동 편집은 계속 잡아야 함
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+// #329: 전부 DONE / 0개일 때 check·done 이 next 와 일관된 안내 + exit 0.
+describe('#329 goalCheck/goalDone — 전부완료·0개 일관 안내', () => {
+  let origCwd: string
+  let origExitCode: number | string | undefined
+  beforeEach(() => {
+    origCwd = process.cwd()
+    origExitCode = process.exitCode
+    process.exitCode = 0
+    mockSafeExecFile.mockReset()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    process.exitCode = origExitCode
+    vi.restoreAllMocks()
+  })
+
+  it('전부 DONE 이면 check 가 "모든 goal 완료" 안내 + exit 0 (generic 문구 아님)', async () => {
+    const dir = tmpProject('check-alldone')
+    makeGoalFile(dir, 1, 'DONE')
+    process.chdir(dir)
+    try {
+      const { goalCheck } = await import('../src/commands/goal.js')
+      const logSpy = vi.spyOn(console, 'log')
+      await goalCheck({})
+      const out = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(out).toMatch(/모든 goal/)
+      expect(out).not.toMatch(/대상 goal 을 결정할 수 없습니다/)
+      expect(process.exitCode).not.toBe(1)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('전부 DONE 이면 done 이 "모든 goal 완료" 안내 + exit 0', async () => {
+    const dir = tmpProject('done-alldone')
+    makeGoalFile(dir, 1, 'DONE')
+    process.chdir(dir)
+    try {
+      const { goalDone } = await import('../src/commands/goal.js')
+      const logSpy = vi.spyOn(console, 'log')
+      await goalDone({})
+      const out = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(out).toMatch(/모든 goal/)
+      expect(out).not.toMatch(/대상 goal 을 결정할 수 없습니다/)
+      expect(process.exitCode).not.toBe(1)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('0개(빈)일 때 check 가 "정의된 goal 없음" 안내 (next 와 일관) + exit 0', async () => {
+    const dir = tmpProject('check-empty')
+    mkdirSync(join(dir, 'goals'), { recursive: true })
+    process.chdir(dir)
+    try {
+      const { goalCheck } = await import('../src/commands/goal.js')
+      const logSpy = vi.spyOn(console, 'log')
+      await goalCheck({})
+      const out = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(out).toMatch(/정의된 goal 이 없습니다/)
+      expect(out).not.toMatch(/대상 goal 을 결정할 수 없습니다/)
+      expect(process.exitCode).not.toBe(1)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('0개일 때 done 도 "정의된 goal 없음" 안내 + exit 0', async () => {
+    const dir = tmpProject('done-empty')
+    mkdirSync(join(dir, 'goals'), { recursive: true })
+    process.chdir(dir)
+    try {
+      const { goalDone } = await import('../src/commands/goal.js')
+      const logSpy = vi.spyOn(console, 'log')
+      await goalDone({})
+      const out = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(out).toMatch(/정의된 goal 이 없습니다/)
+      expect(out).not.toMatch(/대상 goal 을 결정할 수 없습니다/)
+      expect(process.exitCode).not.toBe(1)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('active goal 이 있는데 --id 없으면 정상 동작(회귀) — generic 차단 메시지 안 뜸', async () => {
+    const dir = tmpProject('check-active')
+    makeGoalFile(dir, 1, 'NOT_STARTED')
+    process.chdir(dir)
+    try {
+      const { goalCheck } = await import('../src/commands/goal.js')
+      const logSpy = vi.spyOn(console, 'log')
+      await goalCheck({}) // 스크립트 없음 → '게이트 스크립트 없음' 으로 진입(대상은 정상 결정)
+      const out = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(out).not.toMatch(/대상 goal 을 결정할 수 없습니다/)
+      expect(out).not.toMatch(/모든 goal/)
+      expect(out).not.toMatch(/정의된 goal 이 없습니다/)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+// #330: 비숫자 --id 는 '유효하지 않은 goal 번호' 로 진짜 원인 지목 (#317 로 이미 해결 — 회귀 가드).
+describe('#330 goalCheck/goalDone — 비숫자 --id 진짜 원인 지목', () => {
+  let origCwd: string
+  let origExitCode: number | string | undefined
+  beforeEach(() => {
+    origCwd = process.cwd()
+    origExitCode = process.exitCode
+    process.exitCode = 0
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    process.exitCode = origExitCode
+    vi.restoreAllMocks()
+  })
+
+  for (const cmd of ['goalCheck', 'goalDone'] as const) {
+    it(`${cmd} --id abc → '유효하지 않은 goal 번호' 지목 + 모순 '대상 결정 불가' 안 뜸`, async () => {
+      const dir = tmpProject(`nonnum-${cmd}`)
+      makeGoalFile(dir, 1, 'NOT_STARTED')
+      process.chdir(dir)
+      try {
+        const goal = await import('../src/commands/goal.js')
+        const logSpy = vi.spyOn(console, 'log')
+        await goal[cmd]({ id: 'abc' })
+        const out = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+        expect(out).toMatch(/유효하지 않은 goal 번호/)
+        expect(out).toMatch(/abc/)
+        // 모순 메시지(--id 명시 필요)로 새지 않음
+        expect(out).not.toMatch(/대상 goal 을 결정할 수 없습니다/)
+        expect(process.exitCode).toBe(1)
+      } finally {
+        process.chdir(origCwd)
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+  }
+})


### PR DESCRIPTION
## 요약
2026-06-22 도그푸딩에서 나온 goal/mission UX 결함 4건(전부 P3, 손상·차단 없음, 메시지/어포던스 정확도)을 TDD로 수정.

| 이슈 | 증상 | 수정 |
|---|---|---|
| #327 | `vhk mission show` → cryptic `too many arguments` (show 미등록) | set/check/clear 와 대칭으로 `show` 서브커맨드 등록 |
| #328 | 첫 `goal next` 가 init 스캐폴드를 '수동 편집본'으로 오탐 | 스캐폴드 템플릿에 auto-update 마커 1줄 주입(휴리스틱 불변) |
| #329 | 전부 DONE/0개일 때 check·done 의 generic '대상 결정 불가' | `goal next`(VHK-017)와 동일하게 0개/전부완료 구분 안내 + 정상상태 exit 0 |
| #330 | 비숫자 `--id abc` 모순 안내 | **#317 로 이미 해결됨(중복)** — 회귀 가드 테스트만 추가, 코드 변경 없음 |

## 변경 파일
- `src/index.ts` — `mission show` 서브커맨드 등록 (#327)
- `src/lib/command-registry.ts` — `mission` 서브커맨드에 `show` 추가 (R1 드리프트 가드 동기화)
- `src/commands/goal.ts` — 스캐폴드 마커(#328), `reportNoActiveGoal` 헬퍼로 check·done 의 0개/전부완료 구분(#329)
- `tests/command-registry.test.ts`·`tests/goal.test.ts` — #327~#330 TDD 테스트
- `COMMANDS.md`·`README.md` — `mission show` 사용법 노출
- `docs/log/2026-06-23-goal-mission-ux.md` — dev log(append)

## 검증
- `pnpm build` green
- `pnpm test` — **1907 pass / 0 fail**
- `node dist/index.js secure scan` — **CRITICAL: 0** (INFO 1: 테스트 픽스처 토큰)
- 4개 이슈 모두 빌드 dist 로 격리 temp 재현 → 수정 확인(한글 별칭 `미션 show` 포함)

## 동작 변화 주의
- #329: 전부완료/0개 상태를 exit 1 → **exit 0** 으로 변경(정상 상태이므로 `goal next` 와 일관). 이전 exit 1 에 의존하던 스크립트 영향 가능(P3, 영향 미미).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * `mission show` 서브커맨드 추가

* **버그 수정**
  * goal 명령어에서 활성 goal이 없을 때 오류 종료 대신 정상 종료로 처리
  * next-task.md 템플릿에 자동 갱신 마커 추가로 오탐 방지

* **문서**
  * 명령 문서에 `mission show` 서브커맨드 반영

* **테스트**
  * mission 및 goal 관련 회귀 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->