### PR TITLE
fix: 레지스트리/라우터 드리프트 3건 — 친절 처리로 raw 에러·오라우팅 0 (#314 #344 #345)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -162,8 +162,8 @@ vhk doctor
 | `vhk env` | .env → .env.example 동기화 |
 | `vhk env-check` | 필수 환경변수 누락 검사 |
 | `vhk publish` | npm 배포 (버전 범프 → 빌드 → 테스트) |
-| `vhk design` | 디자인 토큰 생성 (`design palette` = 팔레트 선택 서브커맨드) |
-| `vhk design-palette` | 컬러 팔레트 프리셋 선택 (위와 동일 별칭 진입점) |
+| `vhk design` | 디자인 토큰 생성 (팔레트 선택은 별도 `vhk design-palette` 명령) |
+| `vhk design-palette` | 컬러 팔레트 프리셋 선택 (별도 top-level 명령 — `design palette` 아님) |
 | `vhk theme` | 다크/라이트 모드 CSS 생성 |
 | `vhk ref` | 레퍼런스 URL 관리 (add/list/open) |
 | `vhk harness` | 통합 품질 점검 (lint+type+test+build) |

--- a/docs/log/2026-06-23-registry-drift.md
+++ b/docs/log/2026-06-23-registry-drift.md
@@ -1,0 +1,31 @@
+# 2026-06-23 — 레지스트리/라우터 드리프트 3건 수정 (#314 #344 #345)
+
+> worktree `vhk-fix-registry-drift` / 브랜치 `fix/314-344-345-registry-drift`. TDD.
+> 세 이슈 공통 = 등록 4지점(index·command-registry·cli-args·ko) 드리프트.
+
+## 문제 (도그푸딩 6-22 격리재현)
+- **#314** 컨테이너+무효서브 cross-misroute: `vhk memory "왜 안 되나"` → NL 라우터가 문장 전체를 가로채 **doctor** 가 조용히 실행(exit 0). `goal "뭐 해야 하나"`→help, `goal "어떻게 진행"`→status. 같은 무효서브라도 트리거 단어 없으면(`memory zzz`) commander raw 에러 → 비일관.
+- **#344** 유령 서브커맨드: `env check`·`design palette` 가 raw `too many arguments`(exit 1). env·design 은 leaf 인데 registry 가 `env:[check]`·`design:[palette]` 거짓 선언 → R1 가드가 "실제 경로" 오판 → commander 가 leaf 의 추가인자 거부. (정답은 별도 top-level `env-check`·`design-palette`)
+- **#345** 유령 KNOWN 토큰: `현황`·`스캔`·`scan`·`help` 가 미지 단어(`우주선엔진`=친절 ❓)보다 나쁜 raw 에러. KNOWN_COMMAND_TOKENS 에 등록됐으나 실제 commander 명령/별칭 미배선 → 단일토큰 분기에서 `return null` → commander raw 에러.
+
+## 근본 원인 = 양방향 드리프트
+- KNOWN_COMMAND_TOKENS ⊄ 실제 명령/별칭 (유령 토큰 4종)
+- CONTAINER_SUBCOMMANDS ⊃ 실제 commander 서브 (유령 서브 env/design) — 기존 드리프트 가드는 commander→registry 방향만 검사해 역방향 유령을 못 잡음
+- NL 라우터가 컨테이너+무효서브를 **다른** 명령으로 라우팅하는 걸 막는 가드 부재
+
+## 수정 (src + tests)
+- `cli-args.ts`:
+  - #345 KNOWN_COMMAND_TOKENS 에서 `scan`·`스캔`·`현황`·`help` 제거 → NL 로 흘러 친절 처리(현황→status, help→help, 스캔/scan→친절 ❓ 폴백).
+  - #314 cross-misroute 차단: `detectNaturalLanguageInput` 에 컨테이너+무효서브일 때 NL 라우트가 **컨테이너 자기 명령**일 때만 가로채기 허용(`isContainerOwnRoute`). 보안 확인→secure(자기)=허용, memory 왜안되나→doctor(타)=차단.
+  - 신규 `detectInvalidCommandUsage(argv)`: 등록 명령의 잘못된 인자 조합을 raw 영어 에러 대신 한국어 친절 안내로. (#344 leaf+추가인자→형제명령 유도 `LEAF_ARG_SUGGEST`, #314 컨테이너+무효서브→유효 서브 목록 안내). index.ts 에서 NL 감지보다 먼저 호출 + exit 1.
+- `command-registry.ts`: #344 `CONTAINER_SUBCOMMANDS` 에서 env·design 제거 + `CONTAINER_ALIASES` 에서 환경변수·디자인 제거(무효 컨테이너 가리킴 방지).
+- `index.ts`: `detectInvalidCommandUsage` 배선(친절 안내 + exit 1).
+- `command-registry.test.ts`: #344 **역방향 유령 서브 가드** 추가(registry 컨테이너 = commander 서브 또는 positional 인자 보유 강제).
+- `registry-drift-usage.test.ts`(신규): 세 이슈 재현 케이스 + 회귀 가드 18건.
+
+## 검증
+- E2E(격리 temp): #314 memory/goal 무효서브 → 친절 invalid-subcommand(doctor/help/status 오라우팅 0). #344 env check/design palette(+한글 별칭) → "env-check/design-palette 실행하세요". #345 현황→status, help→help, scan/스캔→친절 ❓. raw `too many arguments` 0.
+- 회귀: 보안 확인→secure NL, secure scan/memory list/goal check→commander, 클라우드 백업→cloud-push, env-check/env 단독 정상.
+- `pnpm test` 1916 pass · `tsc --noEmit` 0 · `eslint src` 0 · `secure scan` CRITICAL 0.
+- 드리프트 가드: KNOWN ⊆ 실제명령 + registry ⊆ 실제서브(양방향) 테스트로 재발 차단.
+- COMMANDS.md 의 stale 표기(`design palette = 서브커맨드`) 정정.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url'
 import fs from 'node:fs'
 import chalk from 'chalk'
 import { prompt } from './lib/prompt.js'
-import { detectNaturalLanguageInput } from './lib/cli-args.js'
+import { detectNaturalLanguageInput, detectInvalidCommandUsage } from './lib/cli-args.js'
 import { runNaturalLanguageRoute } from './lib/nlp-run.js'
 import { getVhkVersion, getVhkDescription } from './lib/version.js'
 import { gate } from './commands/gate.js'
@@ -1065,11 +1065,19 @@ if (isMainModule) {
   // VHK-014: parseAsync 를 try/catch 로 감싸 unsettled top-level await 경고 제거 +
   // 비-TTY/EOF 프롬프트 크래시(ERR_USE_AFTER_CLOSE)를 friendly 종료로 처리.
   try {
-    const nlInput = detectNaturalLanguageInput(process.argv)
-    if (nlInput !== null) {
-      await runNaturalLanguageRoute(nlInput)
+    // 드리프트 3종(#314·#344·#345): 등록 명령에 잘못된 인자 조합 → raw 영어 에러/cross-misroute 대신
+    // 한국어 친절 안내 + exit 1(미인식과 동일 실패 신호 — 조용한 성공 위장 차단).
+    const usageMsg = detectInvalidCommandUsage(process.argv)
+    if (usageMsg !== null) {
+      console.error(chalk.yellow(`\n  ❓ ${usageMsg}\n`))
+      process.exitCode = 1
     } else {
-      await program.parseAsync(process.argv)
+      const nlInput = detectNaturalLanguageInput(process.argv)
+      if (nlInput !== null) {
+        await runNaturalLanguageRoute(nlInput)
+      } else {
+        await program.parseAsync(process.argv)
+      }
     }
   } catch (err) {
     if (isPromptAbortError(err)) {

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -9,13 +9,17 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'recap', '정리', '오늘',
   'sync', '맞추기', '규칙',
   'check', '점검', '린트',
-  'secure', '보안', 'scan', '스캔',
+  // #345: 'scan'·'스캔' 은 secure 의 서브-별칭일 뿐 최상위 명령/별칭이 아니다 → 유령 KNOWN 토큰.
+  // KNOWN 에 두면 단일토큰일 때 detect 가 null 반환 → commander raw 'too many arguments'(미지 단어보다 나쁨).
+  // 빼면 NL 라우터로 흘러 친절 처리된다. (KNOWN ⊆ 실제 명령/별칭 — registry-drift-usage 테스트가 강제)
+  'secure', '보안',
   'ship',
   'doctor', '환경', '진단',
   'save', '저장',
   'undo', '되돌리기',
   'restore', '복원',
-  'status', '상태', '현황',
+  // #345: '현황' 은 status 의 별칭이 아니다(status 는 '상태'만) → 유령 KNOWN 토큰. 빼면 NL→status 로 친절 라우팅.
+  'status', '상태',
   'stats', '통계',
   'diff', '변경', '차이',
   'diff-cover', '커버리지',
@@ -65,7 +69,8 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'evolve', '진화',
   'work', '작업',
   'seo',
-  'help',
+  // #345: 'help' 은 최상위 명령으로 미등록(commander 의 --help 옵션과 별개) → 유령 KNOWN 토큰.
+  // 빼면 단일토큰 'help' 가 NL→help quick actions 로 친절 라우팅(raw 에러 대신).
 ])
 
 function isOptionToken(token: string): boolean {
@@ -110,6 +115,52 @@ function isRealSubcommandPath(first: string, second: string | undefined): boolea
 }
 
 /**
+ * 컨테이너(서브커맨드 보유) 명령 → 그 명령 자신의 NLP 커맨드명.
+ * #314: `vhk memory 왜 안 되나` 처럼 컨테이너+무효서브에 트리거 단어가 섞이면, NL 라우터가
+ * 문장 전체를 가로채 **다른** 명령(doctor/help/status)으로 조용히 오라우팅된다(cross-misroute).
+ * 반대로 `vhk 보안 확인`은 NL 이 secure(=컨테이너 자기 명령)로 라우팅되므로 가로채기가 안전하다.
+ * → "NL 라우트가 컨테이너 자기 명령일 때만" 가로채기를 허용하는 판별에 쓴다.
+ * (NlpCommand 와 1:1 인 컨테이너만 등재 — worktree/seo 등 NL 비대상은 의도적으로 제외해 무효서브 시 차단된다.)
+ */
+const CONTAINER_OWN_NLP_COMMAND: Record<string, string> = {
+  secure: 'secure',
+  memory: 'memory',
+  goal: 'goal',
+  work: 'work',
+  ref: 'ref',
+  pattern: 'pattern',
+  evolve: 'evolve',
+  mission: 'mission',
+  cloud: 'cloud-push', // 클라우드 백업/복원 → cloud-push/cloud-pull (둘 다 cloud 컨테이너 소속)
+}
+function isContainerOwnRoute(first: string, routeCommand: string): boolean {
+  const canonicalFirst = CONTAINER_ALIASES[first] ?? first
+  const own = CONTAINER_OWN_NLP_COMMAND[canonicalFirst]
+  if (own === undefined) return false
+  if (canonicalFirst === 'cloud') return routeCommand === 'cloud-push' || routeCommand === 'cloud-pull'
+  return routeCommand === own
+}
+
+/** 컨테이너(서브커맨드 보유) 명령인가 — 영문명 또는 한글 별칭. */
+function isContainerCommand(first: string): boolean {
+  const canonical = CONTAINER_ALIASES[first] ?? first
+  return CONTAINER_SUBCOMMANDS[canonical] !== undefined
+}
+
+/**
+ * 서브커맨드 없는 leaf 명령에 추가 토큰이 붙었을 때, 의도한 형제 명령으로 유도하기 위한 맵.
+ * #344: `vhk env check`·`vhk design palette` 는 leaf 인데 정답이 별도 top-level 명령
+ * (env-check·design-palette)이라, raw 'too many arguments' 대신 정확한 명령을 친절히 안내한다.
+ * key 는 영문 leaf 명령 + 한글 별칭 모두. (영문 별칭 단어로만 매칭 — 첫 추가 토큰이 일치할 때 유도)
+ */
+const LEAF_ARG_SUGGEST: Record<string, { arg: string; suggest: string }> = {
+  env: { arg: 'check', suggest: 'env-check' },
+  환경변수: { arg: 'check', suggest: 'env-check' },
+  design: { arg: 'palette', suggest: 'design-palette' },
+  디자인: { arg: 'palette', suggest: 'design-palette' },
+}
+
+/**
  * `vhk "보안 확인"`, `vhk 보안 확인`, `vhk 프로젝트 현황` 등
  * 서브커맨드가 아닌 자연어 입력을 감지. 감지 시 전체 문장 반환.
  */
@@ -139,11 +190,56 @@ export function detectNaturalLanguageInput(argv: string[]): string | null {
     // R1 가드: 실제 서브커맨드 경로(goal check, ref add, memory list 등)는
     // 명령어 매칭을 우선해 commander 가 처리한다 — 자연어 라우터가 절대 가로채지 않는다.
     if (isRealSubcommandPath(first, rest[1])) return null
+    const route = routeNaturalLanguage(input)
+    // #314: 첫 토큰이 컨테이너 명령(memory/goal 등)이고 둘째가 무효 서브커맨드면, NL 라우트가
+    // **다른** 명령으로 새는 cross-misroute 를 차단한다. (memory 왜안되나 → doctor, goal 어떻게 → status)
+    // 컨테이너 자기 명령으로 라우팅될 때만(보안 확인 → secure) NL 가로채기를 허용해 회귀를 막는다.
+    // 가로채기를 막은 케이스는 detectInvalidCommandUsage 가 친절 invalid-subcommand 안내를 낸다.
+    if (isContainerCommand(first) && route && !isContainerOwnRoute(first, route.command)) return null
     // vhk 보안 확인 → secure 단독이 아니라 문장 전체를 NLP로 (자연어는 fallback)
-    if (routeNaturalLanguage(input)) return input
+    if (route) return input
     return null
   }
 
   // 첫 토큰이 알려진 명령이 아님 → 자연어
   return input
+}
+
+/**
+ * 등록된 명령에 잘못된 인자 조합을 줬을 때, commander 의 raw 영어 에러('too many arguments')
+ * 대신 한국어 친절 안내 메시지를 만든다. 감지 못 하면 null(평소 흐름 그대로).
+ * index.ts 에서 detectNaturalLanguageInput 보다 **먼저** 호출해 raw 에러/cross-misroute 를 가로챈다.
+ *
+ * 잡는 케이스(드리프트 3종):
+ *  - #344 leaf+추가인자: env check → "env-check 명령을 쓰세요" (정답 형제 명령 유도)
+ *  - #314 컨테이너+무효서브: memory 왜안되나 → 유효 서브커맨드 목록 안내(엉뚱한 doctor 실행 금지)
+ */
+export function detectInvalidCommandUsage(argv: string[]): string | null {
+  const rest = argv.slice(2)
+  if (rest.length < 2) return null
+
+  const first = rest[0]
+  if (isOptionToken(first)) return null
+  // 옵션이 섞이면 commander 가 정상 파싱 — 손대지 않는다.
+  if (rest.some(isOptionToken)) return null
+
+  // #344: leaf 명령 + 정답이 형제 top-level 명령인 경우 → 형제 명령으로 유도.
+  const leaf = LEAF_ARG_SUGGEST[first]
+  if (leaf && rest[1] === leaf.arg) {
+    return `'vhk ${first} ${leaf.arg}' 는 없는 명령이에요. 'vhk ${leaf.suggest}' 를 실행하세요.`
+  }
+
+  // #314: 컨테이너 명령 + 무효 서브커맨드 → 유효 서브커맨드 목록 안내(NL cross-misroute 차단).
+  // 단, NL 이 컨테이너 자기 명령으로 라우팅되는 경우(보안 확인 → secure, 기억 보여줘 → memory)는
+  // 자연어로 정상 처리되므로 친절안내 대상이 아니다 — detectNaturalLanguageInput 과 동일 판별.
+  const canonical = CONTAINER_ALIASES[first] ?? first
+  const subs = CONTAINER_SUBCOMMANDS[canonical]
+  if (subs && !isRealSubcommandPath(first, rest[1])) {
+    const input = rest.join(' ').trim()
+    const route = routeNaturalLanguage(input)
+    if (route && isContainerOwnRoute(first, route.command)) return null // 자연어로 정상 처리
+    return `'${rest[1]}' 는 ${first} 의 서브커맨드가 아니에요. 사용 가능: ${subs.join(', ')} (예: vhk ${first} ${subs[0]})`
+  }
+
+  return null
 }

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -13,8 +13,10 @@ export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
   memory: ['add', 'list', 'remove', 'archive', 'resolve', 'unarchive', 'migrate', 'eval'],
   cloud: ['push', 'pull'],
   secure: ['scan'],
-  design: ['palette'],
-  env: ['check'],
+  // #344: env·design 은 서브커맨드 없는 leaf 다(env-check·design-palette 는 별도 top-level 명령).
+  // 여기 env:['check']·design:['palette'] 를 두면 R1 가드가 'env check' 를 "실제 서브 경로"로 오판 →
+  // commander 가 leaf 에 추가 인자를 거부해 raw 'too many arguments'. leaf+추가인자는 cli-args 의
+  // LEAF_ARG_SUGGEST 로 친절 안내(env-check/design-palette 유도). (drift 가드: registry-drift-usage 테스트)
   mode: ['lite', 'standard', 'strict'],
   mission: ['set', 'check', 'clear'],
   pattern: ['detect', 'list', 'dismiss'],
@@ -32,8 +34,9 @@ export const CONTAINER_ALIASES: Record<string, string> = {
   기억: 'memory',
   클라우드: 'cloud',
   보안: 'secure',
-  디자인: 'design',
-  환경변수: 'env',
+  // #344: env·design 은 컨테이너가 아닌 leaf 라 CONTAINER_SUBCOMMANDS 에서 제거됨 →
+  // 그 한글 별칭(환경변수·디자인)도 컨테이너 별칭에서 제거(별칭이 무효 컨테이너를 가리키지 않게).
+  // 한글 별칭의 leaf+추가인자 유도는 cli-args 의 LEAF_ARG_SUGGEST 가 직접 처리한다.
   모드: 'mode',
   미션: 'mission',
   패턴: 'pattern',

--- a/tests/command-registry.test.ts
+++ b/tests/command-registry.test.ts
@@ -17,6 +17,21 @@ describe('R1 드리프트 가드 — command-registry 단일 소스', () => {
     }
   })
 
+  // #344 유령 서브커맨드 가드(역방향): registry 에만 있고 commander 엔 없는 '유령 서브'를 잡는다.
+  // (기존 가드는 commander→registry 방향만 검사해 env:[check]·design:[palette] 같은 유령을 못 잡았다.)
+  it('registry 의 서브커맨드 보유 컨테이너는 commander 서브커맨드 또는 positional 인자를 실제로 가진다 (유령 서브 0)', () => {
+    for (const name of Object.keys(CONTAINER_SUBCOMMANDS)) {
+      const cmd = program.commands.find((c) => c.name() === name)
+      if (!cmd) continue
+      const hasSubs = cmd.commands.length > 0
+      const hasPositional = cmd.registeredArguments.length > 0
+      expect(
+        hasSubs || hasPositional,
+        `'${name}' 는 commander 에 서브커맨드도 positional 인자도 없는 leaf 인데 registry 가 서브커맨드를 선언함 → 유령 서브 → 'vhk ${name} <x>' 가 raw too-many-arguments`
+      ).toBe(true)
+    }
+  })
+
   it('레지스트리가 cli-args R1 가드를 실제로 작동시킴', () => {
     // goal check / mode strict 가 commander 로 가야 함(자연어 라우터 가로채기 금지)
     expect(detectNaturalLanguageInput(['node', 'vhk', 'goal', 'check'])).toBeNull()

--- a/tests/registry-drift-usage.test.ts
+++ b/tests/registry-drift-usage.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import { program } from '../src/index.js'
+import {
+  detectNaturalLanguageInput,
+  detectInvalidCommandUsage,
+  KNOWN_COMMAND_TOKENS,
+} from '../src/lib/cli-args.js'
+import { routeNaturalLanguage } from '../src/lib/nlp-router.js'
+
+// 세 이슈(#314·#344·#345) 공통 = 레지스트리/라우터 드리프트.
+// raw commander 에러("too many arguments")·cross-misroute(엉뚱한 명령 조용히 실행)를 0으로.
+
+describe('#345 유령 KNOWN 토큰 제거 — KNOWN ⊆ 실제 commander 명령/별칭', () => {
+  // KNOWN_COMMAND_TOKENS 에 든 단어가 실제 최상위 명령/별칭이 아니면(유령 토큰),
+  // 단일토큰일 때 detectNaturalLanguageInput 이 null 을 반환 → commander 가 raw 에러를 낸다.
+  // (미지 단어보다 나쁜 역설). 모든 KNOWN 토큰은 실제 등록된 명령/별칭이어야 한다.
+  it('모든 KNOWN_COMMAND_TOKENS 가 실제 commander 명령/별칭이다 (유령 토큰 0)', () => {
+    const real = new Set<string>()
+    for (const c of program.commands) {
+      real.add(c.name())
+      for (const a of c.aliases()) real.add(a)
+    }
+    const phantom = [...KNOWN_COMMAND_TOKENS].filter((t) => !real.has(t))
+    expect(phantom, `유령 KNOWN 토큰(미등록 명령): ${phantom.join(', ')}`).toEqual([])
+  })
+
+  it('현황(미등록 단일토큰) → 자연어로 흘러 status 로 친절 라우팅', () => {
+    const input = detectNaturalLanguageInput(['node', 'vhk', '현황'])
+    expect(input).toBe('현황')
+    expect(routeNaturalLanguage(input!)?.command).toBe('status')
+  })
+
+  it('help(미등록 단일토큰) → 자연어로 흘러 help quick actions 로 라우팅', () => {
+    const input = detectNaturalLanguageInput(['node', 'vhk', 'help'])
+    expect(input).toBe('help')
+    expect(routeNaturalLanguage(input!)?.command).toBe('help')
+  })
+
+  it('스캔/scan(미등록 단일토큰) → 자연어로 흘러 친절 폴백(미지 단어와 동급, raw 에러 아님)', () => {
+    // 스캔/scan 은 secure 의 서브-별칭일 뿐 최상위 아님 → KNOWN 에서 빠져 NL 로 흐른다.
+    // NL 라우터가 잡으면 라우팅, 못 잡으면 친절 ❓ 폴백 — 어느 쪽이든 raw commander 에러는 아니다.
+    expect(detectNaturalLanguageInput(['node', 'vhk', '스캔'])).toBe('스캔')
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'scan'])).toBe('scan')
+  })
+})
+
+describe('#344 유령 서브커맨드 제거 — env check·design palette 가 친절 처리', () => {
+  // env·design 은 서브커맨드 없는 leaf 인데 registry 가 env:[check]·design:[palette] 를
+  // 거짓 선언 → R1 가드가 "실제 경로"로 오판 → commander 가 raw 'too many arguments'.
+  it('CONTAINER_SUBCOMMANDS 의 모든 컨테이너가 실제 commander 서브커맨드를 가진다 (유령 서브 0)', async () => {
+    const { CONTAINER_SUBCOMMANDS } = await import('../src/lib/command-registry.js')
+    for (const name of Object.keys(CONTAINER_SUBCOMMANDS)) {
+      const cmd = program.commands.find((c) => c.name() === name)
+      // 위치 인자형(mode/cost) 은 서브커맨드가 아니라 positional → 별도 허용
+      if (!cmd) continue
+      const positionalArity = cmd.registeredArguments.length
+      const hasSubs = cmd.commands.length > 0
+      expect(
+        hasSubs || positionalArity > 0,
+        `'${name}' 는 서브커맨드도 positional 인자도 없는 leaf 인데 registry 가 서브커맨드를 선언함 → 유령 서브`
+      ).toBe(true)
+    }
+  })
+
+  it('env check → leaf+추가인자: 친절 안내(env-check 유도), null 아님', () => {
+    const msg = detectInvalidCommandUsage(['node', 'vhk', 'env', 'check'])
+    expect(msg).not.toBeNull()
+    expect(msg).toMatch(/env-check/)
+  })
+
+  it('design palette → leaf+추가인자: 친절 안내(design-palette 유도), null 아님', () => {
+    const msg = detectInvalidCommandUsage(['node', 'vhk', 'design', 'palette'])
+    expect(msg).not.toBeNull()
+    expect(msg).toMatch(/design-palette/)
+  })
+
+  it('한글 별칭: 환경변수 check / 디자인 palette 도 동일 친절 안내', () => {
+    expect(detectInvalidCommandUsage(['node', 'vhk', '환경변수', 'check'])).toMatch(/env-check/)
+    expect(detectInvalidCommandUsage(['node', 'vhk', '디자인', 'palette'])).toMatch(/design-palette/)
+  })
+
+  it('회귀: 정답 형태 env-check / design-palette 는 친절안내 대상 아님(null)', () => {
+    expect(detectInvalidCommandUsage(['node', 'vhk', 'env-check'])).toBeNull()
+    expect(detectInvalidCommandUsage(['node', 'vhk', 'design-palette'])).toBeNull()
+  })
+
+  it('회귀: env / design 단독은 친절안내 대상 아님(null — leaf 정상 실행)', () => {
+    expect(detectInvalidCommandUsage(['node', 'vhk', 'env'])).toBeNull()
+    expect(detectInvalidCommandUsage(['node', 'vhk', 'design'])).toBeNull()
+  })
+})
+
+describe('#314 컨테이너 무효 서브 + 트리거 단어 → cross-misroute 차단', () => {
+  // memory/goal 컨테이너에 유효 서브가 아닌 첫 토큰('왜 안 되나' 등)을 주면
+  // NL 라우터가 문장 전체를 가로채 doctor/help/status 로 조용히 오라우팅(exit 0).
+  // → 컨테이너 자기 명령으로의 라우팅만 허용, 다른 명령으로의 cross-misroute 는 차단.
+  it('memory "왜 안 되나" → NL 가로채기 차단 (doctor 로 오라우팅 안 됨)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'memory', '왜', '안', '되나'])).toBeNull()
+  })
+
+  it('goal "뭐 해야 하나" → NL 가로채기 차단 (help 로 오라우팅 안 됨)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'goal', '뭐', '해야', '하나'])).toBeNull()
+  })
+
+  it('goal "어떻게 진행" → NL 가로채기 차단 (status 로 오라우팅 안 됨)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'goal', '어떻게', '진행'])).toBeNull()
+  })
+
+  it('컨테이너 무효 서브는 친절한 invalid-subcommand 안내를 받는다', () => {
+    const msg = detectInvalidCommandUsage(['node', 'vhk', 'memory', '왜', '안', '되나'])
+    expect(msg).not.toBeNull()
+    // 유효 서브커맨드 목록을 안내해야 함
+    expect(msg).toMatch(/list/)
+  })
+
+  it('회귀: 보안 확인 → 여전히 자연어 (secure 자기 명령으로의 라우팅은 허용)', () => {
+    // 보안(secure) 컨테이너 + 확인 → NL 이 secure(=같은 명령)로 라우팅 → 가로채기 허용 유지.
+    expect(detectNaturalLanguageInput(['node', 'vhk', '보안', '확인'])).toBe('보안 확인')
+  })
+
+  it('회귀: 기억 보여줘 → 여전히 자연어 (memory 자기 명령으로의 라우팅 허용)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '기억', '보여줘'])).toBe('기억 보여줘')
+  })
+
+  it('회귀: 목표 점검 → 여전히 자연어 (goal 자기 명령으로 라우팅)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '목표', '점검'])).toBe('목표 점검')
+  })
+
+  it('회귀: 실제 서브커맨드 경로(memory list / goal check)는 commander 로 (null)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'memory', 'list'])).toBeNull()
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'goal', 'check'])).toBeNull()
+  })
+})


### PR DESCRIPTION
## 요약 (두괄식)
레지스트리/라우터 **양방향 드리프트** 3건을 TDD로 수정. 등록 명령에 잘못된 인자를 줬을 때 raw 영어 에러(`too many arguments`)·조용한 cross-misroute(엉뚱한 명령 exit 0 실행)를 **한국어 친절 처리**로 전환. 세 이슈 공통 = 등록 4지점(index·command-registry·cli-args·ko) 드리프트.

## 이슈별 수정
### #314 컨테이너+무효서브 cross-misroute
`vhk memory "왜 안 되나"` → NL 라우터가 문장을 가로채 **doctor** 가 조용히 실행(exit 0). `goal "뭐 해야 하나"`→help, `goal "어떻게 진행"`→status.
- **수정**: NL 라우트가 **컨테이너 자기 명령**일 때만 가로채기 허용(`isContainerOwnRoute`). `보안 확인`→secure(자기)=허용, `memory 왜안되나`→doctor(타 명령)=차단 → 친절 invalid-subcommand 안내(유효 서브 목록).

### #344 유령 서브커맨드
`env check`·`design palette` raw `too many arguments`(exit 1). env·design 은 leaf 인데 registry 가 `env:[check]`·`design:[palette]` 거짓 선언.
- **수정**: `CONTAINER_SUBCOMMANDS`/`CONTAINER_ALIASES` 에서 env·design(+환경변수·디자인) 제거 + `LEAF_ARG_SUGGEST` 로 정답 형제 명령(`env-check`·`design-palette`) 유도.

### #345 유령 KNOWN 토큰
`현황`·`스캔`·`scan`·`help` 가 미지 단어(`우주선엔진`=친절 ❓)보다 나쁜 raw 에러.
- **수정**: `KNOWN_COMMAND_TOKENS` 에서 제거 → NL 로 흘러 친절 처리(`현황`→status, `help`→help quick actions, `scan`/`스캔`→친절 ❓ 폴백).

## 신규/가드
- `detectInvalidCommandUsage(argv)`: 등록 명령의 잘못된 인자 조합 → 한국어 친절 안내 + exit 1(#346 정책과 일관, index.ts 에서 NL 감지보다 먼저).
- **양방향 드리프트 가드 테스트**: 기존은 commander→registry 방향만 검사 → 역방향 유령 서브 가드 추가(`registry ⊆ 실제 서브 or positional`). `KNOWN ⊆ 실제 명령/별칭` 가드 추가.
- `tests/registry-drift-usage.test.ts`(신규 18건): 세 이슈 재현 + 회귀 가드.
- COMMANDS.md stale 표기(`design palette = 서브커맨드`) 정정.

## 검증
- `pnpm test` **1916 pass** (신규 18 포함) · `tsc --noEmit` 0 · `eslint src` 0 · `secure scan` **CRITICAL 0**.
- 격리 temp e2e: 세 이슈 재현 케이스 친절 처리 + raw 에러/오라우팅 **0**. 회귀(보안 확인→secure NL, secure scan/memory list/goal check→commander, 클라우드 백업→cloud-push, env-check/env 단독 정상) 확인.

## 남은 위험
- `secure asdf` 류(컨테이너 자기 명령으로 NL 라우팅되는 무효 토큰)는 secure 가 실행됨 — 컨테이너 자기 명령이라 무해(설계상 허용). 데이터·안전 영향 없음.

Closes #314
Closes #344
Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 명령어 유효성 검사 로직 강화로 잘못된 명령 조합 감지 시 한국어 오류 메시지 출력
  * 컨테이너 명령어의 무효한 서브명령 입력에 대한 친절한 안내 메시지 추가

* **Documentation**
  * 명령어 카탈로그 설명 수정으로 `design palette`와 `vhk design-palette`의 관계 명확화

* **Tests**
  * 명령어 레지스트리 검증 테스트 추가
  * CLI 라우팅 회귀 방지를 위한 종합 테스트 스위트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->