### PR TITLE
fix(sync,init): 멱등성 결함 2건 정규화 누락 수정 (#325 #326)

### DIFF
--- a/docs/log/2026-06-23-marker-dedup.md
+++ b/docs/log/2026-06-23-marker-dedup.md
@@ -1,0 +1,38 @@
+# 2026-06-23 — 멱등성 버그 2건 TDD 수정 (#325 마커쌍 중복 · #326 gitignore 슬래시)
+
+> 성격: append-only dev log. 도그푸딩 자동 버그수색(2026-06-22)이 발견한 멱등성 결함 2건을 TDD로 수정.
+> 작업방: worktree `vhk-fix-marker-dedup` / 브랜치 `fix/325-326-marker-dedup`.
+
+## 한 줄 결론
+
+`vhk sync`·`vhk init`의 멱등성을 깨던 결함 2건을 RED→GREEN TDD로 수정. 둘 다 **정규화 누락**이 근본 원인 — 같은 의미의 변형(마커쌍 중복 / 슬래시 유무)을 dedup 못 해 중복 누적·자기치유 실패.
+
+## #325 — CLAUDE.md 마커쌍 2개면 sync가 관리 블록 통째 중복
+
+- **증상**: `<!-- vhk:rules:start/end -->` 마커쌍이 2개(병합/복붙 사고)면 sync가 첫 쌍만 재생성하고 둘째 쌍을 사용자영역으로 verbatim 보존 → 관리 규칙 블록(코딩/기록/기술스택/커밋)이 통째로 중복. 추가 sync 해도 2쌍으로 고착(자기치유 실패) → 단일출처(SoT) 보증 깨짐.
+- **근본 원인**: `src/commands/sync.ts` `splitVhkBlock` 이 `indexOf` 로 첫 START·첫 END 만 잡아 분리. `after = slice(첫 end 이후)` 에 둘째 vhk 블록 전체가 사용자영역으로 포함되고 `toClaudeMd` 가 그대로 보존.
+- **수정**: `stripAllVhkBlocks(s)` 헬퍼 신설 — 문자열에서 완결된 vhk 마커블록(START…END, 비중첩 non-greedy)을 전부 제거. `splitVhkBlock` 이 분리한 `before`/`after` 사용자영역에 이를 적용해, 마커쌍이 2개·3개여도 관리 블록은 항상 1개로 수렴. 짝 없는 잔존 마커는 기존 `stripLegacyAutogen` 폴백 경로가 처리하므로 여기선 완결 쌍만 다룸.
+
+## #326 — 루트 .gitignore 슬래시 변형 중복 추가
+
+- **증상**: 기존 .gitignore 에 슬래시 없는 변형(`node_modules`)이 있으면 init 이 슬래시 버전(`node_modules/`)을 중복 추가 → 같은 의미 줄 2개 공존. 같은 레포의 `ensureVhkIgnored` 는 슬래시 정규화를 하므로 정책 불일치.
+- **근본 원인**: `src/commands/init.ts` `ensureRootGitignore` 가 `new Set(...trim())` 후 정확일치(`!existing.has(e)`)로만 dedup. 트레일링 슬래시 정규화 누락.
+- **수정**: `ensureVhkIgnored`(`src/lib/backup.ts`)와 동일하게 `norm = s.trim().replace(/\/$/, '')` 적용 — 슬래시 유무만 다른 동치 항목은 미추가.
+
+## TDD 증거
+
+- RED: 신규 테스트 6건(#325 4건 + #326 2건) 먼저 작성 → `npx vitest run` 6 fail 확인.
+- GREEN: 수정 후 동일 테스트 6건 + 회귀(sync/init/backup 119건) 전부 pass.
+- 게이트: `pnpm build` ✅ · `pnpm lint` ✅ · `node dist/index.js secure scan` CRITICAL:0 ✅.
+- 전체 `pnpm test`: 1961 pass / e2e 타임아웃 6건(`standup-anchor`·`safety-guard`·`cli-arg-dx` — CLI 서브프로세스 spawn, 풀스위트 병렬 부하서만 5s 초과 / 격리 재실행 시 26/26 pass). 본 수정(순수함수 sync.ts·init.ts)과 무관한 기존 플레이키.
+
+## 변경 파일
+
+- `src/commands/sync.ts` — `stripAllVhkBlocks` 추가 + `splitVhkBlock` 가 before/after 에 적용
+- `src/commands/init.ts` — `ensureRootGitignore` 트레일링 슬래시 정규화
+- `tests/sync-guard.test.ts` — #325 마커쌍 중복 정규화 4건
+- `tests/init.test.ts` — #326 gitignore 슬래시 변형 dedup 2건
+
+## 교훈
+
+같은 코드베이스 안에서 "정규화 정책"이 갈리면(여기선 `ensureVhkIgnored` 는 슬래시 정규화 / `ensureRootGitignore` 는 안 함) 멱등성이 조용히 깨진다. 동치 판정(equality)은 한 곳에 모으거나, 최소한 같은 정규화 함수를 공유해야 한다.

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -379,8 +379,11 @@ export function ensureRootGitignore(projectDir: string): 'created' | 'updated' |
   }
 
   const content = fs.readFileSync(gitignorePath, 'utf-8')
-  const existing = new Set(content.split('\n').map(l => l.trim()))
-  const missing = ROOT_GITIGNORE_ENTRIES.filter(e => !existing.has(e))
+  // 트레일링 슬래시 정규화 — git 은 디렉터리에서 `node_modules` 와 `node_modules/` 를 동치로
+  // 취급한다. ensureVhkIgnored 와 동일 정규화로 슬래시 변형만 다른 중복 추가를 막는다 (#326).
+  const norm = (s: string): string => s.trim().replace(/\/$/, '')
+  const existing = new Set(content.split('\n').map(norm))
+  const missing = ROOT_GITIGNORE_ENTRIES.filter(e => !existing.has(norm(e)))
   if (missing.length === 0) return 'unchanged'
 
   const prefix = content.endsWith('\n') ? '' : '\n'

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -204,16 +204,36 @@ function buildVhkBlock(managedSections: RulesSection[]): string {
 }
 
 /**
+ * 문자열에서 완결된 vhk 마커블록(START…END)을 전부 제거. 마커쌍이 여러 개일 때(#325 병합/복붙
+ * 사고) 첫 쌍 밖에 남은 다른 관리 블록들을 사용자영역에서 지워 중복을 수렴시킨다.
+ * 각 블록 = START 위치부터 그 뒤 첫 END 끝까지(비중첩, non-greedy). 짝 없는 잔존 START/END 는
+ * stripLegacyAutogen 처럼 폴백 경로에서 정리되므로 여기선 완결 쌍만 다룬다.
+ */
+function stripAllVhkBlocks(s: string): string {
+  let out = s
+  for (;;) {
+    const start = out.indexOf(VHK_BLOCK_START)
+    if (start === -1) break
+    const end = out.indexOf(VHK_BLOCK_END, start + VHK_BLOCK_START.length)
+    if (end === -1) break // 완결 쌍 없음 → 잔존 START 는 그대로 (폴백서 처리)
+    out = out.slice(0, start) + out.slice(end + VHK_BLOCK_END.length)
+  }
+  return out
+}
+
+/**
  * 마커 쌍을 찾아 바깥(before/after = 사용자 영역)을 분리. 마커 없거나 훼손(start/end 누락·역전)이면
  * null → 호출부가 마이그레이션 경로(stripLegacyAutogen)로 폴백.
+ * 첫 쌍 기준으로 분리하되, before/after 에 남은 **다른 완결 마커블록**은 stripAllVhkBlocks 로
+ * 제거된다 — 마커쌍이 2개 이상이어도(병합/복붙 사고) 관리 블록은 항상 1개로 수렴 (#325 자기치유).
  */
 function splitVhkBlock(existing: string): { before: string; after: string } | null {
   const start = existing.indexOf(VHK_BLOCK_START)
   const end = existing.indexOf(VHK_BLOCK_END)
   if (start === -1 || end === -1 || end < start) return null
   return {
-    before: existing.slice(0, start),
-    after: existing.slice(end + VHK_BLOCK_END.length),
+    before: stripAllVhkBlocks(existing.slice(0, start)),
+    after: stripAllVhkBlocks(existing.slice(end + VHK_BLOCK_END.length)),
   }
 }
 

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -267,6 +267,31 @@ describe('vhk init — 루트 .gitignore 보장', () => {
     expect(ensureRootGitignore(dir)).toBe('unchanged')
     fs.rmSync(dir, { recursive: true })
   })
+
+  // #326: 슬래시 유무만 다른 동치 항목을 중복 추가하던 결함
+  it('슬래시 없는 변형(node_modules)이 이미 있으면 슬래시 버전(node_modules/)을 중복 추가 안 함', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-gi-'))
+    fs.writeFileSync(path.join(dir, '.gitignore'), 'node_modules\ndist\n', 'utf-8')
+    ensureRootGitignore(dir)
+    const content = fs.readFileSync(path.join(dir, '.gitignore'), 'utf-8')
+    const lines = content.split('\n').map(l => l.trim())
+    // node_modules 와 node_modules/ 가 공존하면 안 됨 (동치 = 1개)
+    expect(lines.filter(l => l.replace(/\/$/, '') === 'node_modules').length).toBe(1)
+    expect(lines.filter(l => l.replace(/\/$/, '') === 'dist').length).toBe(1)
+    fs.rmSync(dir, { recursive: true })
+  })
+
+  it('슬래시 없는 변형만 있으면 정규화로 추가 없음 → unchanged 분기 (멱등)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-gi-'))
+    // ROOT_GITIGNORE_ENTRIES 전부를 슬래시 없는 변형으로 미리 채움
+    fs.writeFileSync(
+      path.join(dir, '.gitignore'),
+      '.env\n.env.local\n.env.*.local\nnode_modules\ndist\n*.tsbuildinfo\n.DS_Store\n',
+      'utf-8'
+    )
+    expect(ensureRootGitignore(dir)).toBe('unchanged')
+    fs.rmSync(dir, { recursive: true })
+  })
 })
 
 describe('docs/spec.md 규격', () => {

--- a/tests/sync-guard.test.ts
+++ b/tests/sync-guard.test.ts
@@ -278,6 +278,54 @@ describe('toClaudeMd — 마커 기반 사용자 섹션 보존 (배치1: 사용�
   })
 })
 
+// #325: 마커쌍이 2개면 splitVhkBlock 이 첫 쌍만 잡고 둘째 vhk 블록을 사용자영역(after)으로
+// verbatim 보존 → 관리 블록 통째 중복. 추가 sync 해도 2개로 고착(자기치유 실패).
+describe('toClaudeMd — 마커쌍 중복 정규화 (#325 자기치유)', () => {
+  const sections = parseRulesMd(RULES)
+  const name = deriveProjectName(RULES)
+  const startCount = (s: string) => (s.match(/<!-- vhk:rules:start -->/g) || []).length
+  const endCount = (s: string) => (s.match(/<!-- vhk:rules:end -->/g) || []).length
+  const bannerCount = (s: string) => (s.match(/⚡ 아래 규칙 섹션은/g) || []).length
+
+  it('마커쌍 2개(병합/복붙 사고) → sync 시 1쌍으로 수렴 (중복 블록 0)', () => {
+    // 정상 마커 블록을 먼저 생성한 뒤, 그 앞에 가짜 마커쌍을 덧대 2쌍 상태를 만든다.
+    const single = toClaudeMd(sections, `# 기록 규칙 (${name})\n\n## 현재 상태\n- **Phase:** P5\n`)
+    const doubled = `<!-- vhk:rules:start -->\n가짜내용\n<!-- vhk:rules:end -->\n\n${single}`
+    expect(startCount(doubled)).toBe(2) // 사전조건: 정말 2쌍
+    const out = toClaudeMd(sections, doubled)
+    expect(startCount(out)).toBe(1)
+    expect(endCount(out)).toBe(1)
+    expect(bannerCount(out)).toBe(1) // 관리 블록 중복 없음
+  })
+
+  it('마커쌍 2개 정규화 후 멱등 (재 sync 시 바이트 동일 + 2쌍 재발 없음)', () => {
+    const single = toClaudeMd(sections, `# 기록 규칙 (${name})\n\n## 현재 상태\n- P5\n`)
+    const doubled = `<!-- vhk:rules:start -->\n가짜\n<!-- vhk:rules:end -->\n\n${single}`
+    const a = toClaudeMd(sections, doubled)
+    expect(startCount(a)).toBe(1)
+    expect(toClaudeMd(sections, a)).toBe(a)
+  })
+
+  it('마커쌍 2개여도 마커 밖 진짜 사용자 섹션은 보존', () => {
+    const single = toClaudeMd(sections, `# 기록 규칙 (${name})\n\n## 프로젝트 정보\n- repo: x\n\n## 현재 상태\n- P5\n`)
+    const doubled = `<!-- vhk:rules:start -->\n중복관리블록\n<!-- vhk:rules:end -->\n\n${single}`
+    const out = toClaudeMd(sections, doubled)
+    expect(startCount(out)).toBe(1)
+    expect(out).toContain('## 프로젝트 정보') // 진짜 사용자 섹션 보존
+    expect(out).toContain('repo: x')
+    expect(out).toContain('## 기록 규칙') // RULES 유래 record 재생성
+  })
+
+  it('마커쌍 3개도 1쌍으로 수렴', () => {
+    const single = toClaudeMd(sections, `# 기록 규칙 (${name})\n\n## 현재 상태\n- P5\n`)
+    const tripled = `<!-- vhk:rules:start -->\nA\n<!-- vhk:rules:end -->\n\n<!-- vhk:rules:start -->\nB\n<!-- vhk:rules:end -->\n\n${single}`
+    expect(startCount(tripled)).toBe(3)
+    const out = toClaudeMd(sections, tripled)
+    expect(startCount(out)).toBe(1)
+    expect(endCount(out)).toBe(1)
+  })
+})
+
 describe('claudeMdMigration — 마이그레이션 보존/제거 집계 (경고용)', () => {
   const name = deriveProjectName(RULES)
 


### PR DESCRIPTION
## 무엇을

`vhk sync`·`vhk init`의 멱등성을 깨던 결함 2건을 TDD로 수정. 둘 다 **정규화 누락**이 근본 원인.

### #325 — CLAUDE.md 마커쌍 2개면 sync가 관리 블록 통째 중복
- **증상**: `<!-- vhk:rules:start/end -->` 마커쌍이 2개(병합/복붙 사고)면 sync가 첫 쌍만 재생성하고 둘째 쌍을 사용자영역으로 verbatim 보존 → 관리 규칙 블록(코딩/기록/기술스택/커밋)이 통째 중복. 추가 sync 해도 2쌍 고착(자기치유 실패) → 단일출처(SoT) 보증 깨짐.
- **수정**: `stripAllVhkBlocks` 헬퍼 신설 — `splitVhkBlock` 이 분리한 `before`/`after` 사용자영역에서 완결 vhk 마커블록을 전부 제거. 마커쌍이 2개·3개여도 관리 블록은 항상 1개로 수렴.

### #326 — 루트 .gitignore 슬래시 변형 중복 추가
- **증상**: 기존 .gitignore 에 `node_modules`(슬래시 없음)가 있으면 init 이 `node_modules/`를 중복 추가. 같은 레포의 `ensureVhkIgnored`는 슬래시 정규화를 하므로 정책 불일치.
- **수정**: `ensureRootGitignore`에 `ensureVhkIgnored`와 동일한 트레일링 슬래시 정규화 적용 → 동치 변형 미추가.

## 검증 (TDD)
- RED: 신규 테스트 6건(#325 4 + #326 2) 먼저 → 6 fail 확인
- GREEN: 수정 후 6건 + 회귀(sync/init/backup 119건) pass
- 게이트: `pnpm build` ✅ · `pnpm lint` ✅ · `secure scan` CRITICAL:0 ✅
- 전체 `pnpm test`: 1961 pass. e2e 타임아웃 6건(`standup-anchor`·`safety-guard`·`cli-arg-dx`)은 CLI 서브프로세스 spawn 플레이키(격리 재실행 26/26 pass), 순수함수 수정과 무관.

## 변경 파일
- `src/commands/sync.ts` — `stripAllVhkBlocks` 추가 + `splitVhkBlock` 적용
- `src/commands/init.ts` — `ensureRootGitignore` 슬래시 정규화
- `tests/sync-guard.test.ts` / `tests/init.test.ts` — 신규 6건
- `docs/log/2026-06-23-marker-dedup.md` — 세션 로그

Closes #325 #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 설정 파일에서 슬래시 표기 변형만 다른 중복 항목이 추가되지 않도록 개선
  * 마크다운 파일의 중복된 관리 블록이 자동으로 정규화되도록 개선

* **Tests**
  * 설정 파일 중복 방지 및 멱등성 검증을 위한 회귀 테스트 추가
  * 마크다운 관리 블록 정규화 동작을 확인하는 회귀 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->