### PR TITLE
feat(diff-cover): 측정 결과 .vhk/events/diff-cover.jsonl 영속화 (#371)

### DIFF
--- a/docs/log/2026-06-23-diffcover-persist.md
+++ b/docs/log/2026-06-23-diffcover-persist.md
@@ -1,0 +1,33 @@
+# 2026-06-23 — diff-cover 측정 결과 영속화 (#371)
+
+## 한 일
+`vhk diff-cover` 측정 결과가 콘솔로만 출력되고 휘발 → 커버리지 추세 분석이 불가능했다.
+매 실행 시 결과를 `.vhk/events/diff-cover.jsonl` 에 **append**(append-only JSONL)로 영속화.
+
+- 신규 `src/lib/diff-cover-log.ts`
+  - `buildDiffCoverEntries(result, commit, ts)` — 순수. 파일 단위 1엔트리.
+  - `appendDiffCoverLog(cwd, entries)` — 원자적 쓰기(temp→rename). 빈 배열이면 미생성·0 반환.
+  - `readDiffCoverLog(cwd)` — JSONL 파싱(손상 줄 skip·BOM-safe·최소 스키마 검증).
+  - 스키마: `{ts, sha, shortSha, dirty, file, added, uncovered, ratio, inCoverage}` — 측정치만(미커버 라인 원문은 안 남김).
+- `src/commands/diff-cover.ts` — 측정·출력 직후 best-effort 로 영속(try-catch). exit code·콘솔 출력 불변.
+
+## 결정
+- **위치**: `.vhk/events/diff-cover.jsonl` (이슈 제안 그대로).
+- **gitignore 정합 = 추적(gitignore 안 함)**. 근거: 측정치(커버율·SHA·라인 수)만 담고 검색어/사적 경로 원문은 안 남긴다 → recall-log(gitignore) 가 아니라 ledger/events(추적) 패턴.
+  - `.gitattributes events/*.jsonl merge=union` 가 이미 커버(멀티PC append 분기 줄 보존).
+  - `self-tracked.ts` 의 `.vhk/events/*.jsonl` prefix 제외 → diff-cover 가 스스로 append 해도 `getCommitInfo` dirty 판정에서 빠짐(자기참조 봉인, #315 동일 구조). 별도 코드 변경 불필요.
+  - `vhk-dir.ts` 템플릿이 이미 events 추적·.gitattributes 를 스캐폴딩 → 템플릿 변경 불필요.
+
+## 테스트
+- `tests/diff-cover-log.test.ts` (신규) — build/append/read·append-only·빈배열·손상줄 skip·비-git null.
+- `tests/diff-cover.test.ts` — git-repo·diff-cover-log mock 으로 부수효과 격리 + persist 호출 검증 + best-effort(throw 해도 exit 0·출력 불변) + 측정대상 없으면 미호출.
+- `tests/self-tracked.test.ts` — `.vhk/events/diff-cover.jsonl → true` 명시 고정.
+
+## 게이트
+- `pnpm build` green · `pnpm lint` (eslint src) green · `pnpm test` 1973 pass(182 files).
+- `node dist/index.js secure scan` CRITICAL:0 (INFO 1 = 테스트 픽스처).
+- 샌드박스 e2e: diff-cover 실행 → 콘솔 출력·exit 0 불변 + jsonl 1줄 생성, 재실행 시 2줄(append 확인).
+
+## 남은 위험/후속
+- 멱등(같은 sha 중복 방지)은 이슈 수용기준상 후속(#branch 보강). 현재는 매 실행 append.
+- `uncoveredBranch`·`classify` 필드는 후속 이슈에서 채움(line 기반 우선).

--- a/src/commands/diff-cover.ts
+++ b/src/commands/diff-cover.ts
@@ -7,6 +7,8 @@ import { fileCoverageByFile, COVERAGE_CORRUPT } from '../lib/coverage-parse.js'
 import { diffCoverage, type DiffCoverageResult } from '../lib/diff-coverage.js'
 import { isFeatureSource, toPosix } from '../lib/test-mapping.js'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
+import { getCommitInfo } from '../lib/git-repo.js'
+import { buildDiffCoverEntries, appendDiffCoverLog } from '../lib/diff-cover-log.js'
 
 const COVERAGE_JSON_REL = 'coverage/coverage-final.json'
 
@@ -99,5 +101,15 @@ export async function diffCover(): Promise<void> {
   console.log(
     chalk.dim('\n  ℹ️  자문형(advisory) — 차단하지 않습니다. 미검증 변경분은 테스트 보강을 권장하는 신호입니다.')
   )
+
+  // #371: 측정 결과를 .vhk/events/diff-cover.jsonl 에 영속(추세 분석 토대). best-effort —
+  // 기록 실패는 본 측정/출력/exit 0 을 절대 막지 않는다(advisory 도구). 자기 산출 추적파일이라
+  // dirty 판정에서 제외(self-tracked.ts) → diff-cover 가 스스로 append 해도 freshness 봉인 안 깨짐.
+  try {
+    const entries = buildDiffCoverEntries(result, getCommitInfo(cwd), new Date().toISOString())
+    appendDiffCoverLog(cwd, entries)
+  } catch {
+    /* best-effort — 영속 실패가 측정 본 기능을 막지 않음 */
+  }
   // 측정 결과로는 exit 0 유지(advisory).
 }

--- a/src/lib/diff-cover-log.ts
+++ b/src/lib/diff-cover-log.ts
@@ -1,0 +1,100 @@
+import { existsSync, readFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { atomicWriteFile } from './atomic-write.js'
+import { stripBom } from './read-json.js'
+import type { DiffCoverageResult } from './diff-coverage.js'
+import type { CommitInfo } from './git-repo.js'
+
+// #371: diff-cover 측정 결과 영속화 — 콘솔 휘발 → 커버리지 추세 분석 토대.
+//
+// 위치 결정(.vhk/events/diff-cover.jsonl):
+//   evidence-ledger(.vhk/ledger.jsonl)·action-ledger(.vhk/events/ai-actions.jsonl) 와 동일한
+//   "추적되는 증거 원장" 패턴을 따른다. recall-log 처럼 gitignore 하지 않는 이유 —
+//   이 로그는 측정치(커버율·미커버 라인 수·SHA)만 담고 검색어/사적 경로 원문은 안 남긴다.
+//   추세 분석(RFC0050 §5 미검증 변경 추세)에 레포 차원의 영속 가치가 있어 **추적**한다.
+//   - .gitattributes: events/*.jsonl merge=union → 멀티PC 양쪽 append 분기 시 줄 보존.
+//   - self-tracked.ts: .vhk/events/*.jsonl prefix 제외 → diff-cover 가 스스로 append 해도
+//     getCommitInfo 의 dirty 판정에서 빠진다(자기참조 봉인, #315 와 동일 구조).
+//
+// best-effort: 로그 실패는 diff-cover 본 측정/출력을 절대 막지 않는다(advisory 도구).
+
+export const DIFF_COVER_LOG_REL = join('.vhk', 'events', 'diff-cover.jsonl')
+
+export interface DiffCoverLogEntry {
+  /** ISO 타임스탬프(실행 시각) */
+  ts: string
+  /** 측정 기준 HEAD 전체 SHA. 비-git/커밋 0개 → null */
+  sha: string | null
+  /** 사람용 짧은 SHA(7자) */
+  shortSha: string | null
+  /** 측정 시 working tree dirty 여부(자기 산출 추적파일 제외 판정) */
+  dirty: boolean | null
+  /** 측정 대상 파일(레포 상대 posix 경로) */
+  file: string
+  /** 분모 — 실행가능 추가라인 수(inCoverage 시) */
+  added: number
+  /** 미검증(미커버) 추가라인 수 = uncoveredNew.length. 라인 원문은 남기지 않음(측정치만). */
+  uncovered: number
+  /** 커버율 = covered/added (added===0 → 1) */
+  ratio: number
+  /** 커버리지 리포트에 이 파일이 있었나(false = 테스트 미import → coarse) */
+  inCoverage: boolean
+}
+
+/**
+ * DiffCoverageResult + 커밋정보 → 파일별 로그 엔트리(순수, fs/시간 부수효과 0).
+ * ts 는 호출부에서 주입(테스트 결정성). 파일 단위 1엔트리 — 추세 분석에 파일별 분해가 유용.
+ */
+export function buildDiffCoverEntries(
+  result: DiffCoverageResult,
+  commit: CommitInfo | null,
+  ts: string
+): DiffCoverLogEntry[] {
+  return result.files.map((f) => ({
+    ts,
+    sha: commit?.sha ?? null,
+    shortSha: commit?.shortSha ?? null,
+    dirty: commit?.dirty ?? null,
+    file: f.file,
+    added: f.added,
+    uncovered: f.uncoveredNew.length,
+    ratio: f.ratio,
+    inCoverage: f.inCoverage,
+  }))
+}
+
+/**
+ * .vhk/events/diff-cover.jsonl 파싱(JSONL). 파일 없음 → []. 손상 라인 skip. BOM-safe.
+ * 최소 스키마(file:string, added:number) 검증 — 형태 안 맞는 줄은 무시.
+ */
+export function readDiffCoverLog(cwd: string): DiffCoverLogEntry[] {
+  const p = join(cwd, DIFF_COVER_LOG_REL)
+  if (!existsSync(p)) return []
+  const out: DiffCoverLogEntry[] = []
+  for (const line of stripBom(readFileSync(p, 'utf-8')).split(/\r?\n/)) {
+    const t = line.trim()
+    if (!t) continue
+    try {
+      const e = JSON.parse(t) as DiffCoverLogEntry
+      if (e && typeof e.file === 'string' && typeof e.added === 'number') out.push(e)
+    } catch {
+      /* 손상 라인 skip — 원장이 한 줄 깨졌다고 죽지 않음 */
+    }
+  }
+  return out
+}
+
+/**
+ * 측정 엔트리들을 append(append-only). 원자적 쓰기(temp→rename — 쓰기 중 kill 에도 손상 방지).
+ * 빈 배열이면 파일 미생성·0 반환(측정 대상 없을 때 churn 0).
+ * @returns 추가한 줄 수.
+ */
+export function appendDiffCoverLog(cwd: string, entries: DiffCoverLogEntry[]): number {
+  if (entries.length === 0) return 0
+  const p = join(cwd, DIFF_COVER_LOG_REL)
+  mkdirSync(join(cwd, '.vhk', 'events'), { recursive: true })
+  const existing = existsSync(p) ? stripBom(readFileSync(p, 'utf-8')).replace(/\n*$/, '') : ''
+  const body = (existing ? existing + '\n' : '') + entries.map((e) => JSON.stringify(e)).join('\n') + '\n'
+  atomicWriteFile(p, body)
+  return entries.length
+}

--- a/tests/diff-cover-log.test.ts
+++ b/tests/diff-cover-log.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  buildDiffCoverEntries,
+  appendDiffCoverLog,
+  readDiffCoverLog,
+  DIFF_COVER_LOG_REL,
+  type DiffCoverLogEntry,
+} from '../src/lib/diff-cover-log.js'
+import type { DiffCoverageResult } from '../src/lib/diff-coverage.js'
+
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-diffcoverlog-'))
+}
+
+const SHA = 'a'.repeat(40)
+const COMMIT = { sha: SHA, shortSha: SHA.slice(0, 7), dirty: false }
+
+function result(): DiffCoverageResult {
+  return {
+    files: [
+      { file: 'src/lib/a.ts', added: 4, covered: 2, uncoveredNew: [3, 4], ratio: 0.5, inCoverage: true },
+      { file: 'src/lib/b.ts', added: 2, covered: 2, uncoveredNew: [], ratio: 1, inCoverage: true },
+    ],
+    totalAdded: 6,
+    totalCovered: 4,
+    totalUncovered: 2,
+    ratio: 4 / 6,
+  }
+}
+
+describe('buildDiffCoverEntries — DiffCoverageResult → 파일별 로그 엔트리(순수)', () => {
+  it('파일 1개당 엔트리 1개, 측정 필드(added·uncovered·ratio·inCoverage) 보존', () => {
+    const entries = buildDiffCoverEntries(result(), COMMIT, '2026-06-23T00:00:00.000Z')
+    expect(entries).toHaveLength(2)
+    const a = entries.find((e) => e.file === 'src/lib/a.ts')!
+    expect(a).toMatchObject({
+      ts: '2026-06-23T00:00:00.000Z',
+      sha: SHA,
+      shortSha: SHA.slice(0, 7),
+      dirty: false,
+      file: 'src/lib/a.ts',
+      added: 4,
+      uncovered: 2,
+      inCoverage: true,
+    })
+    expect(a.ratio).toBeCloseTo(0.5)
+  })
+
+  it('커밋 정보 없음(비-git) → sha 계열 null', () => {
+    const entries = buildDiffCoverEntries(result(), null, '2026-06-23T00:00:00.000Z')
+    expect(entries[0].sha).toBeNull()
+    expect(entries[0].shortSha).toBeNull()
+    expect(entries[0].dirty).toBeNull()
+  })
+
+  it('uncovered 는 uncoveredNew.length 와 일치(라인 원문은 안 남김 — 측정치만)', () => {
+    const a = buildDiffCoverEntries(result(), COMMIT, 't').find((e) => e.file === 'src/lib/a.ts')!
+    expect(a.uncovered).toBe(2)
+    // 사적 경로/라인 원문(uncoveredNew 배열)은 엔트리에 노출하지 않는다(측정 추세에 불필요).
+    expect((a as unknown as Record<string, unknown>).uncoveredNew).toBeUndefined()
+  })
+})
+
+describe('appendDiffCoverLog / readDiffCoverLog — append-only JSONL', () => {
+  const mk = (file: string, ts: string): DiffCoverLogEntry => ({
+    ts,
+    sha: SHA,
+    shortSha: SHA.slice(0, 7),
+    dirty: false,
+    file,
+    added: 4,
+    uncovered: 2,
+    ratio: 0.5,
+    inCoverage: true,
+  })
+
+  it('빈 로그 → append 시 .vhk/events/diff-cover.jsonl 생성 + N줄', () => {
+    const d = tmp()
+    const n = appendDiffCoverLog(d, [mk('src/lib/a.ts', 't1'), mk('src/lib/b.ts', 't1')])
+    expect(n).toBe(2)
+    expect(fs.existsSync(path.join(d, DIFF_COVER_LOG_REL))).toBe(true)
+    expect(readDiffCoverLog(d)).toHaveLength(2)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('append-only — 두 번째 실행분이 누적된다(기존 줄 보존)', () => {
+    const d = tmp()
+    appendDiffCoverLog(d, [mk('src/lib/a.ts', 't1')])
+    appendDiffCoverLog(d, [mk('src/lib/a.ts', 't2')])
+    const all = readDiffCoverLog(d)
+    expect(all).toHaveLength(2)
+    expect(all.map((e) => e.ts)).toEqual(['t1', 't2'])
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('빈 배열 append → 파일 미생성, 0 반환(측정 대상 없을 때 churn 0)', () => {
+    const d = tmp()
+    expect(appendDiffCoverLog(d, [])).toBe(0)
+    expect(fs.existsSync(path.join(d, DIFF_COVER_LOG_REL))).toBe(false)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('손상 줄은 skip 하고 정상 줄만 읽는다(원장이 한 줄 깨져도 안 죽음)', () => {
+    const d = tmp()
+    appendDiffCoverLog(d, [mk('src/lib/a.ts', 't1')])
+    const p = path.join(d, DIFF_COVER_LOG_REL)
+    fs.appendFileSync(p, '{ broken json\n', 'utf-8')
+    appendDiffCoverLog(d, [mk('src/lib/b.ts', 't2')])
+    const all = readDiffCoverLog(d)
+    expect(all).toHaveLength(2)
+    expect(all.map((e) => e.file)).toEqual(['src/lib/a.ts', 'src/lib/b.ts'])
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('파일 부재 → readDiffCoverLog 는 빈 배열', () => {
+    const d = tmp()
+    expect(readDiffCoverLog(d)).toEqual([])
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})

--- a/tests/diff-cover.test.ts
+++ b/tests/diff-cover.test.ts
@@ -11,12 +11,19 @@ vi.mock('../src/lib/coverage-parse.js', async (orig) => {
   return { ...actual, fileCoverageByFile: vi.fn() }
 })
 vi.mock('../src/lib/hard-stop-guard.js', () => ({ ensureNotHardStopped: vi.fn(() => true) }))
+// #371: 영속화 부수효과 격리 — 실제 git/fs 를 안 건드리도록 mock. persist 호출 여부만 검증.
+vi.mock('../src/lib/git-repo.js', () => ({ getCommitInfo: vi.fn(() => null) }))
+vi.mock('../src/lib/diff-cover-log.js', () => ({
+  buildDiffCoverEntries: vi.fn(() => []),
+  appendDiffCoverLog: vi.fn(() => 0),
+}))
 
 import { formatReport, diffCover, untrackedFeatureSources } from '../src/commands/diff-cover.js'
 import { safeExecFile } from '../src/lib/exec.js'
 import { diffUnified0, untrackedFiles } from '../src/lib/git-session.js'
 import { addedLinesByFile } from '../src/lib/diff-hunks.js'
 import { fileCoverageByFile, COVERAGE_CORRUPT } from '../src/lib/coverage-parse.js'
+import { buildDiffCoverEntries, appendDiffCoverLog } from '../src/lib/diff-cover-log.js'
 import type { DiffCoverageResult } from '../src/lib/diff-coverage.js'
 import type { FileCoverage } from '../src/lib/coverage-parse.js'
 
@@ -138,6 +145,34 @@ describe('diffCover — 오케스트레이션 분기(자문형·차단 0)', () =
     expect(out).toContain('미검증 변경분')
     expect(out).toContain('11') // 미커버 라인
     expect(out).toContain('자문형')
+  })
+
+  // #371: 측정 후 결과를 영속(append)한다 — 추세 분석 토대.
+  it('#371 정상 측정 시 diff-cover 로그에 append 한다(영속화)', async () => {
+    const fc: FileCoverage = { covered: new Set([10]), executable: new Set([10, 11]) }
+    mockCov.mockReturnValue(new Map([['src/lib/a.ts', fc]]))
+    await diffCover()
+    expect(vi.mocked(buildDiffCoverEntries)).toHaveBeenCalledOnce()
+    expect(vi.mocked(appendDiffCoverLog)).toHaveBeenCalledOnce()
+  })
+
+  // #371: 영속 실패는 본 측정/출력/exit 0 을 절대 막지 않는다(best-effort).
+  it('#371 영속화 throw 해도 측정 출력·exit 0 불변(best-effort)', async () => {
+    const fc: FileCoverage = { covered: new Set([10]), executable: new Set([10, 11]) }
+    mockCov.mockReturnValue(new Map([['src/lib/a.ts', fc]]))
+    vi.mocked(appendDiffCoverLog).mockImplementationOnce(() => {
+      throw new Error('disk full')
+    })
+    await diffCover()
+    expect(process.exitCode).not.toBe(1)
+    expect(logs.join('\n')).toContain('미검증 변경분')
+  })
+
+  // #371: 측정 대상 없을 때(변경 0)는 영속 호출이 그 전에 return 되어 일어나지 않는다(churn 0).
+  it('#371 측정 대상 없으면 영속 호출 안 함', async () => {
+    mockAdded.mockReturnValue(new Map())
+    await diffCover()
+    expect(vi.mocked(appendDiffCoverLog)).not.toHaveBeenCalled()
   })
 })
 

--- a/tests/self-tracked.test.ts
+++ b/tests/self-tracked.test.ts
@@ -19,6 +19,11 @@ describe('isSelfTrackedPath — vhk 자기 산출 추적파일 화이트리스�
   it('.vhk/events/ 하위 임의 *.jsonl(미래 확장) → true', () => {
     expect(isSelfTrackedPath('.vhk/events/something-new.jsonl')).toBe(true)
   })
+  // #371: diff-cover 측정 로그(.vhk/events/diff-cover.jsonl)도 자기 산출 추적파일 →
+  // diff-cover 실행이 스스로 이 줄을 append 해도 dirty 로 잡히지 않아야 함(자기참조 봉인).
+  it('#371 diff-cover 측정 로그 .vhk/events/diff-cover.jsonl → true', () => {
+    expect(isSelfTrackedPath('.vhk/events/diff-cover.jsonl')).toBe(true)
+  })
   it('Windows 백슬래시 경로도 정규화해서 매칭', () => {
     expect(isSelfTrackedPath('.vhk\\ledger.jsonl')).toBe(true)
     expect(isSelfTrackedPath('.vhk\\events\\ai-actions.jsonl')).toBe(true)


### PR DESCRIPTION
## 무엇을

`vhk diff-cover` 측정 결과가 **콘솔로만 출력돼 휘발** → 커버리지 추세 분석 불가(도그푸딩 14회 측정 전부 소실). 매 실행 시 파일별 측정치를 `.vhk/events/diff-cover.jsonl` 에 **append-only JSONL** 로 영속화한다.

## 변경

- **신규 `src/lib/diff-cover-log.ts`**
  - `buildDiffCoverEntries(result, commit, ts)` — 순수. 파일당 1엔트리.
  - `appendDiffCoverLog(cwd, entries)` — 원자적 쓰기(temp→rename). 빈 배열이면 미생성·0 반환(churn 0).
  - `readDiffCoverLog(cwd)` — JSONL 파싱(손상 줄 skip·BOM-safe·최소 스키마 검증).
  - 스키마: `{ts, sha, shortSha, dirty, file, added, uncovered, ratio, inCoverage}` — **측정치만**(미커버 라인 원문은 안 남김).
- **`src/commands/diff-cover.ts`** — 측정·출력 직후 best-effort 영속(try-catch). exit code·콘솔 출력 **불변**.

## gitignore 정합 결정 = 추적(gitignore 안 함)

측정치(커버율·SHA·라인 수)만 담고 검색어/사적 경로 원문은 안 남긴다 → `recall-log`(gitignore)가 아니라 `ledger`/`events`(추적) 패턴(#331 선례 기준 정직 판단).
- `.gitattributes events/*.jsonl merge=union` 가 이미 커버(멀티PC append 분기 줄 보존).
- `self-tracked.ts` 의 `.vhk/events/*.jsonl` prefix 제외 → diff-cover 가 스스로 append 해도 `getCommitInfo` dirty 판정에서 빠짐(자기참조 봉인, #315 동일 구조). **별도 코드 변경 불필요**.
- `vhk-dir.ts` 템플릿이 이미 events 추적·.gitattributes 스캐폴딩 → 템플릿 변경 불필요.

## 테스트 (TDD)

- `tests/diff-cover-log.test.ts` (신규) — build/append/read·append-only·빈배열·손상줄 skip·비-git null.
- `tests/diff-cover.test.ts` — git-repo·diff-cover-log mock 부수효과 격리 + persist 호출 검증 + best-effort(throw 해도 exit 0·출력 불변) + 측정대상 없으면 미호출.
- `tests/self-tracked.test.ts` — `.vhk/events/diff-cover.jsonl → true` 명시 고정.

## 게이트

- `pnpm build` green · `pnpm lint` green · `pnpm test` **1973 pass(182 files)**.
- `node dist/index.js secure scan` **CRITICAL:0**.
- 샌드박스 e2e: 콘솔 출력·exit 0 불변 + jsonl 생성, 재실행 시 append 누적 확인.

## 후속(이슈 수용기준상 별도)

- 멱등(같은 sha 중복 방지)·`uncoveredBranch`·`classify` 는 후속(#branch 보강). 우선 line 기반.

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * diff-cover 측정 결과가 자동으로 기록되어 나중에 참조할 수 있습니다. 기록 실패는 측정 결과 출력에 영향을 주지 않습니다.

* **테스트**
  * 측정 결과 기록 기능에 대한 테스트 커버리지를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->