### PR TITLE
fix: 인자 없는 vhk 비-TTY 폴백 — 대화형 메뉴 대신 --help (#333)

### DIFF
--- a/docs/log/2026-06-23-nontty-help.md
+++ b/docs/log/2026-06-23-nontty-help.md
@@ -1,0 +1,22 @@
+# 2026-06-23 — 인자 없는 vhk 비-TTY 폴백 (#333)
+
+> 6-22 도그푸딩 배치 이슈 중 #333. 별도 worktree(fix/333-nontty-help)에서 1건 PR.
+
+## 증상 (#333)
+- 인자 없는 `vhk` 의 기본 액션이 대화형 inquirer 메뉴인데 TTY 가드가 없어, 비-TTY(파이프·리다이렉트·CI·headless)에서도 메뉴 ANSI 를 그대로 쏟음. `--help` 폴백 부재.
+- recap(#288)·undo(#337) 와 같은 "대화형 강제, 비대화 폴백 부재" 계열이나, 이쪽은 **no-args 진입점**에만 가드가 빠진 케이스.
+
+## 수정
+- `src/index.ts` 의 `program.action()`(no-args 기본 액션) 진입부에 `if (!isInteractive()) { program.outputHelp(); return }` 가드 추가.
+- 다른 대화형 명령(gate/ship/design/recap 등)이 쓰는 것과 동일 축인 `isInteractive()`(stdin.isTTY + VHK_FORCE_INTERACTIVE 탈출구, src/lib/interactive.ts)에 묶어 일관성 유지.
+- help 는 정상 안내라 exit 0(미인식 실패 신호 아님). 대화형(TTY/VHK_FORCE_INTERACTIVE=1)은 기존 메뉴 그대로 — 회귀 0.
+
+## 테스트 (TDD)
+- `tests/noargs-nontty.e2e.test.ts` 신규 2케이스. 실제 빌드된 dist 를 spawnSync(stdin 'ignore'=EOF, stdout 'pipe'=비-TTY)로 띄워 함수 mock 으로 재현 불가한 진입 경로 검증.
+  - 비-TTY: 메뉴 마커(`뭘 도와드릴까요`/`Use arrow keys`) 0, `명령어:`(help) 출력, exit 0.
+  - VHK_FORCE_INTERACTIVE=1: 메뉴 유지(폴백이 메뉴를 잡아먹지 않음 — isInteractive 축 확인).
+- red 확인: 수정 전 메뉴 ANSI + `ERR_USE_AFTER_CLOSE` 크래시 재현 → green.
+
+## 게이트
+- build ✓ · lint(eslint src) ✓ · 전체 테스트 1963 pass(182 파일, --test-timeout=30000) · secure scan CRITICAL 0/HIGH 0/MEDIUM 0.
+- 주의: 기본 5s 타임아웃 풀런 시 e2e spawn 테스트 6~7건이 부하성 timeout 으로 깜빡임 → main 베이스라인(내 변경 stash 후)에서도 동일 재현 → 환경성 플래키(내 변경 무관). 타임아웃 상향 시 전건 green.

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ import { receipt } from './commands/receipt.js'
 import { missionSet, missionShow, missionCheck, missionClear } from './commands/mission.js'
 import { runGuarded } from './lib/safety-guard.js'
 import { ensureNotHardStopped } from './lib/hard-stop-guard.js'
-import { isPromptAbortError, TTY_REQUIRED_EXIT_CODE } from './lib/interactive.js'
+import { isPromptAbortError, isInteractive, TTY_REQUIRED_EXIT_CODE } from './lib/interactive.js'
 
 /**
  * CLI high-risk 작업 가드 — 단일 chokepoint(runGuarded) 경유.
@@ -978,6 +978,14 @@ program.on('command:*', (operands: string[]) => {
 })
 
 program.action(async () => {
+  // #333: 인자 없는 `vhk` 의 기본 액션은 대화형 inquirer 메뉴다. 비-TTY(파이프/CI/headless)에선
+  //       메뉴를 띄울 수 없으므로(ANSI 잔상·EOF 크래시) --help 로 폴백한다. 다른 대화형 명령이
+  //       쓰는 isInteractive() 와 동일 축(stdin.isTTY + VHK_FORCE_INTERACTIVE 탈출구)으로 판정.
+  //       help 는 정상 안내라 exit 0(미인식 실패 아님).
+  if (!isInteractive()) {
+    program.outputHelp()
+    return
+  }
   // 헤더: 현재 버전(즉시·네트워크 0) + 업데이트 알림(캐시 기반 "가끔 자동 확인") + 직접입력 안내.
   const info = getUpdateInfo()
   // 메뉴 헤더는 브랜드 태그라인(짧은 별칭) — npm 제품 설명(package.json.description, --help 노출)과

--- a/tests/noargs-nontty.e2e.test.ts
+++ b/tests/noargs-nontty.e2e.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import fs from 'node:fs'
+import os from 'node:os'
+
+// #333: 인자 없는 `vhk` 가 비-TTY(파이프/CI/headless)에서 대화형 inquirer 메뉴 ANSI 를
+// 쏟던 버그의 회귀 가드. spawnSync 의 기본 stdio('pipe')는 자식에게 비-TTY stdin/stdout 을
+// 주므로 — 추가 mock 없이 — 실제 비대화형 진입을 재현한다(함수 단위 mock 으론 불충분).
+const bin = path.join(process.cwd(), 'dist', 'index.js')
+
+function runNoArgs(cwd: string, extraEnv: Record<string, string> = {}) {
+  return spawnSync(process.execPath, [bin], {
+    encoding: 'utf-8',
+    cwd,
+    // stdin 'ignore' = 즉시 EOF(</dev/null 동치). stdout/stderr 'pipe' = 비-TTY.
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, CI: '1', ...extraEnv },
+  })
+}
+
+describe('no-args vhk — 비-TTY 폴백 (#333)', () => {
+  it('비-TTY 에서 대화형 메뉴 ANSI 대신 --help 를 출력한다', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-noargs-nontty-'))
+    try {
+      const r = runNoArgs(tmp)
+      const out = String(r.stdout ?? '') + String(r.stderr ?? '')
+
+      // 대화형 메뉴 마커가 없어야 한다(회귀 핵심).
+      expect(out).not.toMatch(/뭘 도와드릴까요/)
+      expect(out).not.toMatch(/Use arrow keys/)
+
+      // --help 폴백: 명령어 목록(usage)이 출력돼야 한다.
+      expect(out).toMatch(/명령어:|Usage:|Commands:/)
+
+      // 합리적 종료 코드(크래시 아님). help 폴백은 정상 종료(0).
+      expect(r.status).toBe(0)
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('대화형(VHK_FORCE_INTERACTIVE=1)이면 기존 메뉴를 유지한다 (회귀 0)', () => {
+    // VHK_FORCE_INTERACTIVE=1 = isInteractive() true 탈출구 → TTY 동치.
+    // 가드가 stdin.isTTY 가 아닌 isInteractive() 축에 묶였는지 확인(폴백이 메뉴를 안 잡아먹음).
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-noargs-tty-'))
+    try {
+      const r = runNoArgs(tmp, { VHK_FORCE_INTERACTIVE: '1' })
+      const out = String(r.stdout ?? '') + String(r.stderr ?? '')
+      // 대화형 메뉴 진입 마커가 그대로 떠야 한다(폴백 미적용).
+      expect(out).toMatch(/뭘 도와드릴까요/)
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/noargs-nontty.e2e.test.ts
+++ b/tests/noargs-nontty.e2e.test.ts
@@ -36,8 +36,13 @@ describe('no-args vhk — 비-TTY 폴백 (#333)', () => {
       // 합리적 종료 코드(크래시 아님). help 폴백은 정상 종료(0).
       expect(r.status).toBe(0)
     } finally {
-      // Windows: spawnSync 자식이 cwd 핸들을 늦게 풀어 rmdir 가 일시 EBUSY → 재시도로 흡수.
-      fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+      // Windows: spawnSync 자식이 cwd 핸들을 늦게 풀어 rmdir 가 EBUSY 날 수 있음.
+      // 임시 dir 정리 실패는 무해(OS 가 회수) → 테스트 결과에 영향 주지 않게 흡수.
+      try {
+        fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+      } catch {
+        /* 임시 dir 정리 실패 무시 — 어서션은 이미 통과 */
+      }
     }
   })
 
@@ -51,8 +56,13 @@ describe('no-args vhk — 비-TTY 폴백 (#333)', () => {
       // 대화형 메뉴 진입 마커가 그대로 떠야 한다(폴백 미적용).
       expect(out).toMatch(/뭘 도와드릴까요/)
     } finally {
-      // Windows: spawnSync 자식이 cwd 핸들을 늦게 풀어 rmdir 가 일시 EBUSY → 재시도로 흡수.
-      fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+      // Windows: spawnSync 자식이 cwd 핸들을 늦게 풀어 rmdir 가 EBUSY 날 수 있음.
+      // 임시 dir 정리 실패는 무해(OS 가 회수) → 테스트 결과에 영향 주지 않게 흡수.
+      try {
+        fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+      } catch {
+        /* 임시 dir 정리 실패 무시 — 어서션은 이미 통과 */
+      }
     }
   })
 })

--- a/tests/noargs-nontty.e2e.test.ts
+++ b/tests/noargs-nontty.e2e.test.ts
@@ -36,7 +36,8 @@ describe('no-args vhk — 비-TTY 폴백 (#333)', () => {
       // 합리적 종료 코드(크래시 아님). help 폴백은 정상 종료(0).
       expect(r.status).toBe(0)
     } finally {
-      fs.rmSync(tmp, { recursive: true, force: true })
+      // Windows: spawnSync 자식이 cwd 핸들을 늦게 풀어 rmdir 가 일시 EBUSY → 재시도로 흡수.
+      fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
     }
   })
 
@@ -50,7 +51,8 @@ describe('no-args vhk — 비-TTY 폴백 (#333)', () => {
       // 대화형 메뉴 진입 마커가 그대로 떠야 한다(폴백 미적용).
       expect(out).toMatch(/뭘 도와드릴까요/)
     } finally {
-      fs.rmSync(tmp, { recursive: true, force: true })
+      // Windows: spawnSync 자식이 cwd 핸들을 늦게 풀어 rmdir 가 일시 EBUSY → 재시도로 흡수.
+      fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
     }
   })
 })


### PR DESCRIPTION
## 문제 (#333)
인자 없는 `vhk` 의 기본 액션은 대화형 inquirer 메뉴인데 TTY 가드가 없어, 비-TTY(파이프·리다이렉트·CI·headless AI)에서도 메뉴 ANSI 를 그대로 쏟았습니다. `--help` 폴백이 없어 헤드리스로 `vhk` 단독 호출 시 깨진 메뉴 ANSI 를 받아 자동화에 부적합했습니다.

## 수정
- `src/index.ts` 의 no-args 기본 액션(`program.action`) 진입부에 가드 추가:
  ```ts
  if (!isInteractive()) {
    program.outputHelp()
    return
  }
  ```
- 다른 대화형 명령(gate/ship/design/recap/undo)이 쓰는 것과 **동일 축**인 `isInteractive()`(stdin.isTTY + `VHK_FORCE_INTERACTIVE=1` 탈출구)에 묶어 일관성 유지.
- help 는 정상 안내라 **exit 0**(미인식 실패 신호 아님).
- 대화형 환경(TTY / `VHK_FORCE_INTERACTIVE=1`)은 기존 메뉴 그대로 — **회귀 0**.

## 테스트 (TDD)
`tests/noargs-nontty.e2e.test.ts` 신규 2케이스 — 실제 빌드된 dist 를 `spawnSync`(stdin `ignore`=EOF, stdout `pipe`=비-TTY)로 띄워 함수 mock 으로는 재현 불가한 진입 경로를 검증.
- **비-TTY**: 메뉴 마커(`뭘 도와드릴까요`/`Use arrow keys`) 0건, `명령어:`(help) 출력, exit 0.
- **VHK_FORCE_INTERACTIVE=1**: 메뉴 유지(폴백이 메뉴를 잡아먹지 않음 — isInteractive 축 확인).

red(수정 전 메뉴 ANSI + `ERR_USE_AFTER_CLOSE` 크래시 재현) → green 확인.

## 게이트
- `pnpm build` ✓ · `pnpm lint` ✓ · 전체 테스트 **1963 pass**(182 파일) · secure scan **CRITICAL 0 / HIGH 0 / MEDIUM 0**.
- 참고: 기본 5s 타임아웃 풀런 시 e2e spawn 테스트 6~7건이 부하성 timeout 으로 깜빡이나, 내 변경을 stash 한 main 베이스라인에서도 동일 재현 → **환경성 플래키(이 변경 무관)**. 타임아웃 상향 시 전건 green.

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 개선 사항

* **버그 수정**
  * 비-TTY/헤드리스 환경에서 인자 없이 실행 시 대화형 메뉴 대신 즉시 도움말(명령어/사용법)을 표시하도록 동작을 개선했습니다.
  * `VHK_FORCE_INTERACTIVE=1` 환경변수로 대화형 메뉴 표시를 강제할 수 있습니다.
* **테스트**
  * 비-TTY 회귀를 방지하기 위한 E2E 가드 테스트를 추가해, 폴백(도움말)과 강제 대화형(메뉴 유지) 동작을 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->