### PR TITLE
feat(verify): 게이트에 lint 추가 — receipt 가 eslint 거짓완료 포획 (#381)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ vhk preflight --publish
 vhk mission check
 ```
 
-- `verify`: tsc/test/build/secure 게이트 실행 후 `.vhk/reports/latest.json` 저장
+- `verify`: tsc/lint/test/build/secure 게이트 실행 후 `.vhk/reports/latest.json` 저장
 - `review`: 최신 증거와 goal 완료조건을 교차검증
 - `testmap`: 변경된 기능 소스와 대응 테스트 누락을 경고
 - `preflight`: 2FA, shim, env, lint, type, test, git, branch를 출고 전 점검

--- a/docs/log/2026-06-24-verify-lint-gate.md
+++ b/docs/log/2026-06-24-verify-lint-gate.md
@@ -1,0 +1,30 @@
+# 2026-06-24 — verify 게이트에 lint 추가 (#381 거짓완료 클래스 포획)
+
+> 동기: receipt(=verify 게이트 소비)가 typecheck/test/build/secure 4종만 봐서 eslint 실패(#381 류)를 못 잡음.
+> lint 추가 → receipt 가 그 거짓완료 클래스도 red 로 포획 + verify 가 CI gate(tsc→eslint→build)와 정합.
+
+## 한 일
+- `src/commands/verify.ts`
+  - `GateResult.id` 유니온에 `'lint'` 추가 + `runScriptGate` 시그니처 동기.
+  - `runGates` 에 lint 게이트 추가(typecheck **바로 뒤** — 정적검사 묶음). `scripts.lint` 있으면 `pm run lint` 실행→실종료코드로 pass/fail, **없으면 skip**(비-lint 프로젝트 fail 0). typecheck/test/build 와 동일 패턴.
+  - `verificationChecklist()` 에 린트 항목 추가(사람용 SoT).
+- `src/commands/review.ts` `impliedGates`: 게이트 풀세트 분기에 lint 추가 + `린트|lint|eslint|biome` 키워드 매핑.
+- `README.md`: verify 게이트 설명 `tsc/lint/test/build/secure` 로 갱신.
+
+## receipt 합류 (수정 0)
+- `src/lib/receipt.ts`·`src/commands/receipt.ts` **무수정**. 수집부(`collectReceipt`)가 `report.gates.filter(status==='fail')` 로 게이트 id 에 일반적 → lint fail 이 `failedGateIds`·`red` 에 자동 합류 → decision=block.
+
+## 검증 (TDD)
+- 신규 테스트(red→green):
+  - `tests/verify.test.ts`: lint fail→FAIL · lint 스크립트 없음→skip(FAIL 아님) · lint pass · 게이트 집합 `[typecheck,lint,test,build,secure]` 5종 단언 + 손상 package.json all-skip 에 lint 추가.
+  - `tests/receipt.test.ts`: 임시 git 레포(base-sha 고정)에서 lint 에러→`evidence.gates.red=true`·`failedGateIds∋lint`·decision=block.
+- 게이트: `pnpm build` ✓ · `pnpm lint` exit 0 ✓ · `pnpm test:run` 1991 pass ✓ · `node dist/index.js secure scan` CRITICAL:0 ✓.
+- E2E(dist): 실패 lint 스크립트 repo → `verify --json` → status=FAIL, gates `typecheck=skip,lint=fail,test=skip,build=skip,secure=pass`, total=5.
+
+## 결정·주의
+- lint 검출 키는 `scripts.lint`(eslint 설정 단독 감지 아님) — typecheck/test/build 가 scripts 우선인 기존 패턴과 일관. preflight 의 `detectHasLinter`(스크립트 OR 설정)와는 의도적으로 다른 층(verify=실행 게이트, preflight=권고).
+- GA: 기존 4게이트 동작·id·시그니처 불변(추가만). `buildReport`/`aggregateStatus` 등 명시 게이트 배열을 받는 함수는 무변경.
+
+## 남은 위험
+- verify 가 lint 만큼 느려짐(consumer 프로젝트에 lint 스크립트 있으면). 비-lint 프로젝트는 skip 이라 영향 0.
+- consumer 의 lint 가 verify 와 별개 설정(예: lint-staged 만)이면 verify 가 전체 lint 를 돌려 더 엄격할 수 있음 — skip 경로로 비-lint 회귀는 0 이나, lint 스크립트 보유 repo 는 이제 lint 통과가 verify PASS 조건에 포함됨(의도된 동작).

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -107,10 +107,11 @@ export function parseCompletionChecks(body: string): CompletionCheck[] {
 /** 완료조건 텍스트 → 함의하는 게이트 id 목록. 빈 배열 = 미검증(unmapped). */
 function impliedGates(text: string): GateResult['id'][] {
   if (/게이트|공통\s*게이트|goal\s*check/i.test(text)) {
-    return ['typecheck', 'test', 'build', 'secure']
+    return ['typecheck', 'lint', 'test', 'build', 'secure']
   }
   const gates: GateResult['id'][] = []
   if (/tsc|typecheck|타입\s*체크/i.test(text)) gates.push('typecheck')
+  if (/린트|lint|eslint|biome/i.test(text)) gates.push('lint')
   if (/테스트|test|회귀|vitest/i.test(text)) gates.push('test')
   if (/빌드|build/i.test(text)) gates.push('build')
   if (/시크릿|secret|secure|누출|보안\s*스캔/i.test(text)) gates.push('secure')

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -21,7 +21,7 @@ import { appendLedgerEntry, buildLedgerEntry, LEDGER_PATH_REL } from '../lib/evi
 /**
  * 저장/위험 작업 전 돌려야 하는 검증 묶음.
  * Goal 13(Evidence Ledger v0): lite 안내층을 **실제 실행 + 증거 기록**으로 승격.
- * 게이트(typecheck/test/build/secure)를 실제로 돌리고 결과를 `.vhk/reports/latest.json` 으로 남긴다.
+ * 게이트(typecheck/lint/test/build/secure)를 실제로 돌리고 결과를 `.vhk/reports/latest.json` 으로 남긴다.
  * 철학: ① 결과는 실제 종료코드에서만(거짓 PASS 금지) ② 성공·실패 무관 항상 증거 ③ Windows 1급
  *      ④ 기존 verify 시그니처 호환(옵션 추가만).
  */
@@ -30,6 +30,7 @@ import { appendLedgerEntry, buildLedgerEntry, LEDGER_PATH_REL } from '../lib/evi
 export function verificationChecklist(): string[] {
   return [
     '타입 체크 — pnpm exec tsc --noEmit',
+    '린트 — pnpm run lint',
     '테스트 — pnpm run test:run',
     '빌드 — pnpm run build',
     '보안 스캔 — vhk secure scan',
@@ -50,7 +51,7 @@ export type ReportStatus = 'PASS' | 'WARN' | 'FAIL'
 
 export interface GateResult {
   /** 안정 식별자 (기계용) */
-  id: 'typecheck' | 'test' | 'build' | 'secure'
+  id: 'typecheck' | 'lint' | 'test' | 'build' | 'secure'
   /** 사람용 라벨 */
   label: string
   status: GateRunStatus
@@ -116,9 +117,9 @@ export function execGate(cmd: string, args: string[], cwd: string): { exitCode: 
   }
 }
 
-/** typecheck/test/build 외부 게이트 1종 실행. 스크립트/설정 없으면 skip(WARN) — 거짓 PASS 금지. */
+/** typecheck/lint/test/build 외부 게이트 1종 실행. 스크립트/설정 없으면 skip(WARN) — 거짓 PASS 금지. */
 function runScriptGate(
-  id: 'typecheck' | 'test' | 'build',
+  id: 'typecheck' | 'lint' | 'test' | 'build',
   label: string,
   cwd: string,
   pm: 'pnpm' | 'yarn' | 'npm',
@@ -158,7 +159,7 @@ export function readPackageScripts(cwd: string): Record<string, string> {
 }
 
 /**
- * 게이트 4종 실행 → 결과 배열. tsc/test/build 는 외부 프로세스(실제 종료코드),
+ * 게이트 5종 실행 → 결과 배열. tsc/lint/test/build 는 외부 프로세스(실제 종료코드),
  * secure 는 in-process 스캐너(시크릿 본문 미수집 — count 만).
  */
 export function runGates(cwd: string): GateResult[] {
@@ -173,6 +174,13 @@ export function runGates(cwd: string): GateResult[] {
       if (existsSync(join(cwd, 'tsconfig.json'))) return pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']
       return null
     })
+  )
+
+  // lint — scripts.lint 있으면 그걸 실행(실종료코드), 없으면 skip. typecheck 바로 뒤(정적검사 묶음).
+  // #381: receipt 가 소비하는 게이트에 lint 가 들어가야 eslint 거짓완료가 영수증 red 로 잡힌다.
+  // 비-lint 프로젝트(eslint/biome 없음)는 scripts.lint 부재 → skip(fail 아님 — typecheck/test 와 동일 패턴).
+  gates.push(
+    runScriptGate('lint', 'lint', cwd, pm, () => (scripts.lint ? ['run', 'lint'] : null))
   )
 
   // test — test:run 우선, vitest test 면 --run, 그 외 test, 없으면 skip

--- a/tests/receipt.test.ts
+++ b/tests/receipt.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import {
   decideReceipt,
   buildReceipt,
@@ -7,6 +11,7 @@ import {
   type ReceiptDecision,
   HONESTY_LINE,
 } from '../src/lib/receipt.js'
+import { collectReceipt } from '../src/commands/receipt.js'
 
 // Goal 86 (RFC 0056 T1): vhk receipt — 4대 기계증거 → 영수증 1장.
 // 핵심 불변식(테스트로 고정):
@@ -181,4 +186,41 @@ describe('renderReceiptMarkdown — PR/대화 붙여넣기 1블록', () => {
     expect(md).toMatch(/미커밋|dirty/)
     expect(md).toMatch(/낡|stale|작업\s*시작/)
   })
+})
+
+// lint 게이트 → receipt 합류 확인(수용기준 1): verify lint fail 이 영수증 red 로 자동 합류 → decision=block.
+// receipt 수집부(collectReceipt)는 게이트 id 에 일반적이라 receipt.ts/순수 로직 수정 없이 lint 가 red 에 든다.
+describe('lint 게이트 → receipt block 합류 (#381 거짓완료 포획)', () => {
+  // 커밋 1개 + base-sha 박은 깨끗한 임시 git 레포 — dirty/stale 가 red 를 가리지 않게 격리.
+  function makeRepo(lintScript: string): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-receipt-lint-'))
+    const g = (args: string[]): void => {
+      execFileSync('git', args, { cwd: d, stdio: 'pipe' })
+    }
+    g(['init'])
+    g(['config', 'user.email', 't@t'])
+    g(['config', 'user.name', 't'])
+    fs.writeFileSync(path.join(d, 'lint-runner.js'), `process.exit(${lintScript})\n`, 'utf-8')
+    fs.writeFileSync(
+      path.join(d, 'package.json'),
+      JSON.stringify({ name: 'tp', version: '0.0.0', scripts: { lint: 'node lint-runner.js' } }),
+      'utf-8'
+    )
+    g(['add', '.'])
+    g(['commit', '-m', 'seed'])
+    // 작업시작 기준선 = 현재 HEAD (stale 미상/거짓 stale 차단).
+    fs.mkdirSync(path.join(d, '.vhk', 'receipts'), { recursive: true })
+    const head = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: d, encoding: 'utf-8' }).trim()
+    fs.writeFileSync(path.join(d, '.vhk', 'receipts', '.base-sha'), head + '\n', 'utf-8')
+    return d
+  }
+
+  it('lint 에러(종료코드 1) → 영수증 evidence.gates.red=true · failedGateIds 에 lint · decision=block', () => {
+    const d = makeRepo('1')
+    const r = collectReceipt(d)
+    expect(r.evidence.gates.red).toBe(true)
+    expect(r.evidence.gates.failedGateIds).toContain('lint')
+    expect(r.decision).toBe('block')
+    fs.rmSync(d, { recursive: true, force: true })
+  }, 30_000)
 })

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -161,8 +161,66 @@ describe('verify — verifyEvidence (실제 게이트 + 증거 기록)', () => {
     expect(fs.existsSync(path.join(d, REPORT_PATH_REL))).toBe(true)
     // scripts 파싱 실패 → 외부 게이트 전부 skip(추측 PASS 금지)
     expect(report.gates.find((g) => g.id === 'typecheck')?.status).toBe('skip')
+    expect(report.gates.find((g) => g.id === 'lint')?.status).toBe('skip')
     expect(report.gates.find((g) => g.id === 'test')?.status).toBe('skip')
     expect(report.gates.find((g) => g.id === 'build')?.status).toBe('skip')
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})
+
+// Goal: verify lint 게이트 — receipt(verify 게이트 소비)가 eslint 거짓완료(#381 류)를 못 잡던 갭 봉합.
+// 패턴은 typecheck/test/build 와 동일(scripts.lint 있으면 실행→실종료코드, 없으면 skip — 거짓 PASS 금지).
+describe('verify — lint 게이트 (#381 거짓완료 클래스 포획)', () => {
+  it('lint 스크립트 + eslint 에러 → lint 게이트 fail(실종료코드) → 종합 status FAIL', () => {
+    const d = tmp()
+    // 실제 종료코드 1로 끝나는 lint 스탠드인(node 스크립트 — eslint 미설치 의존 회피, 종료코드만 관건).
+    fs.writeFileSync(path.join(d, 'lint-fail.js'), 'process.exit(1)\n', 'utf-8')
+    fs.writeFileSync(
+      path.join(d, 'package.json'),
+      JSON.stringify({ name: 'tp', version: '0.0.0', scripts: { lint: 'node lint-fail.js' } }),
+      'utf-8'
+    )
+    const { report } = verifyEvidence(d)
+    const lintGate = report.gates.find((g) => g.id === 'lint')
+    expect(lintGate?.status).toBe('fail')
+    expect(lintGate?.exitCode).toBe(1)
+    expect(lintGate?.skipped).toBe(false)
+    expect(report.status).toBe('FAIL')
+    fs.rmSync(d, { recursive: true, force: true })
+  }, 30_000)
+
+  it('lint 스크립트 없는 프로젝트 → lint 게이트 skip(fail 아님 — 비-lint 프로젝트 회귀 0)', () => {
+    const d = tmp()
+    fs.writeFileSync(path.join(d, 'package.json'), JSON.stringify({ name: 'tp', version: '0.0.0' }), 'utf-8')
+    const { report } = verifyEvidence(d)
+    const lintGate = report.gates.find((g) => g.id === 'lint')
+    expect(lintGate?.status).toBe('skip')
+    expect(lintGate?.skipped).toBe(true)
+    // skip 은 fail 이 아니다 — 비-lint 프로젝트에서 lint 때문에 FAIL 나면 안 됨.
+    expect(report.status).not.toBe('FAIL')
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('lint 스크립트 통과(종료코드 0) → lint 게이트 pass', () => {
+    const d = tmp()
+    fs.writeFileSync(path.join(d, 'lint-ok.js'), 'process.exit(0)\n', 'utf-8')
+    fs.writeFileSync(
+      path.join(d, 'package.json'),
+      JSON.stringify({ name: 'tp', version: '0.0.0', scripts: { lint: 'node lint-ok.js' } }),
+      'utf-8'
+    )
+    const { report } = verifyEvidence(d)
+    expect(report.gates.find((g) => g.id === 'lint')?.status).toBe('pass')
+    fs.rmSync(d, { recursive: true, force: true })
+  }, 30_000)
+
+  it('게이트 집합 = typecheck/lint/test/build/secure 5종(추가만 — 기존 4종 불변)', () => {
+    const d = tmp()
+    fs.writeFileSync(path.join(d, 'package.json'), JSON.stringify({ name: 'tp', version: '0.0.0' }), 'utf-8')
+    const { report } = verifyEvidence(d)
+    const ids = report.gates.map((g) => g.id)
+    expect(ids).toEqual(['typecheck', 'lint', 'test', 'build', 'secure'])
+    expect(report.summary.total).toBe(5)
     fs.rmSync(d, { recursive: true, force: true })
   })
 })


### PR DESCRIPTION
## 무엇을

`vhk verify` 게이트(typecheck/test/build/secure **4종**)에 **lint 게이트**를 추가했습니다 → **5종**.

## 왜 (#381 동기)

receipt(`vhk receipt`)는 verify 게이트를 소비해 거짓완료를 잡는데, 현재 typecheck/test/build/secure 4종만 봐서 **eslint 실패(#381 류)를 못 잡습니다**. lint 게이트를 추가하면:
- receipt 가 그 거짓완료 클래스도 **red 로 자동 포획** → decision=block.
- verify 가 CI gate(tsc→eslint→build)와 **정합**.

## 어떻게

- `runGates`: typecheck **바로 뒤**(정적검사 묶음)에 lint 게이트 추가. `scripts.lint` 있으면 `pm run lint` 실행→실종료코드로 pass/fail, **없으면 skip**(비-lint 프로젝트 fail 0). typecheck/test/build 와 동일 패턴.
- `GateResult.id` 유니온 + `runScriptGate` 시그니처에 `'lint'` 동기.
- `review.ts` `impliedGates`: 게이트 풀세트 분기 + `린트|lint|eslint|biome` 키워드.
- **`receipt.ts` 무수정** — 수집부(`collectReceipt`)가 게이트 id 에 일반적이라 lint fail 이 `failedGateIds`·`red` 에 자동 합류.

## 수용 기준 (테스트)

1. ✅ lint 스크립트 + 에러 → lint 게이트 fail → status FAIL → receipt evidence red=true → decision=block.
2. ✅ lint 스크립트 없음 → lint skip(fail 0, 회귀 0).
3. ✅ lint 통과 → 게이트 pass.
4. ✅ 게이트 집합 = `[typecheck, lint, test, build, secure]` 5종 단언. GA: 기존 4게이트 불변(추가만).

## 게이트 결과

- `pnpm build` ✓ · `pnpm lint` exit 0 ✓ · `pnpm test:run` **1991 pass** ✓ · `secure scan` CRITICAL:0 ✓
- E2E(dist): 실패 lint repo → `verify --json` → FAIL, `lint=fail`, total=5.

## 남은 위험

- verify 가 lint 만큼 느려짐(consumer 에 lint 스크립트 있을 때만). 비-lint 프로젝트는 skip 이라 영향 0.
- lint 스크립트 보유 repo 는 이제 lint 통과가 verify PASS 조건에 포함됨(의도된 동작).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 검증 프로세스에 린트(lint) 게이트 추가. 이제 코드 정적 분석이 필수 검증 단계에 포함됩니다.

* **Documentation**
  * 검증 단계 설명 업데이트. 게이트 실행 명령어 및 결과 저장 경로 명시.

* **Tests**
  * 린트 게이트 관련 통합 및 단위 테스트 추가. 검증 체크리스트에 린트 항목 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->