### PR TITLE
docs(state): measure-first 데이터 분석 보존 (종료 세션 미커밋분)

### DIFF
--- a/docs/state/data-needs-analysis.md
+++ b/docs/state/data-needs-analysis.md
@@ -1,0 +1,70 @@
+# VHK 데이터 분석 — 3각도 (현재 데이터 / 수집 설계 / 분석별 입력)
+
+> 작성: 2026-06-22 도그푸딩 후. 사용자 요청: ① 지금 있는 데이터로 가능한 분석 ② VHK가 수집해야 할 분석용 데이터 ③ 각 분석에 필요한 입력 데이터 명세 — **3개 전부**.
+> SoT 보조: 결정별 needs = research-backlog §📥. 이 문서 = 데이터 관점 상세.
+
+---
+
+## Part 1 — 지금 실재하는 데이터 + 당장 가능한 분석
+
+### 실데이터 인벤토리 (2026-06-22 직접 측정)
+| 데이터셋 | 위치 | 현재량 | 필드 | 지금 가능한 분석 | 한계 |
+|---|---|---|---|---|---|
+| **recall-log** | `.vhk/recall-log.jsonl` | 토이 21 / 본체 6 | ts·source·query·hitIds·topScore | 적중율·topScore 분포·콜드 쿼리 군집 | **queryType 없음**(lexical/paraphrase) |
+| **memory** | `.vhk/memory.json` | 토이 23(d14·f4·s5·p0) | id·content·tags·createdAt·status | 버킷·태그 분포·회상 풀 크기 | 본체 영속 불안정 |
+| **eval 라벨** | `.vhk/eval/recall-eval.json` | 14 | query·expectIds | **Recall@5·MRR**(=71%) | queryType 없음·내 라벨 |
+| **ledger** | `.vhk/ledger.jsonl` | 토이 5 / 본체 1 | version·date·status·sha·dirty | PASS율·이력 추세 | **dirty 항상 true**(#315) → 신선도 분석 오염 |
+| **reports/latest** | `.vhk/reports/` | 1(최신만) | gates·summary·nextActions·commit | 게이트별 통과/실패 | latest만(이력은 ledger) |
+| **ai-actions** | `.vhk/events/` | 본체 16 / 토이 0 | action·blocked | 차단율 | 표본 빈약 |
+| **diff-cover 결과** | **없음 (콘솔만)** | 14회 측정 | — | — | **★미영속 — 파일로 안 남김. 분석하려면 재실행/수기추출** |
+| **버그 코퍼스** | GitHub #313~#347 | 35건 | severity·label·surface·body | 심각도·표면·근본 군집 | gh api 페이지네이션 필요 |
+
+### 실제로 돌려본 분석 (지금 데이터로 — 증명)
+- **recall 적중율** = 81%(17/21). topScore min 1.84·median 5.09·max 10.04. **콜드 4개가 전부 의미격차 쿼리**("2D 그리드…이웃 타일", "건물 못 짓는 곳", "사람이 늘어나는 속도", "시민 만족도"). → 실패모드=어휘불일치 재확인. 단 **적중율(81%) ≠ Recall@5(71%)** — 적중율은 "아무 기억이나 떴나", Recall@5는 "정답 기억이 떴나". 적중율은 낙관 편향.
+- **버그 분포**(부분, gh list 25건): high 3·med 11·low 11. 표면별·근본원인별 군집 가능.
+
+**→ 지금 당장 분석 가능:** 버그 군집 · recall 적중/topScore · Recall@5 · PASS율.
+**→ 지금 못 함:** diff-cover 추세(미영속) · 차단율(표본 빈약) · 자율성·진화(데이터 0).
+
+---
+
+## Part 2 — VHK가 수집해야 할 분석용 데이터 포인트 (텔레메트리 설계)
+
+> VHK가 자기개선/제품분석을 하려면 무엇을 이벤트로 남겨야 하나. **로컬 우선·시크릿 0·옵트인**(SOUL 가드 + 프라이버시 테마).
+
+| 이벤트 스트림 | 필드 | 답하는 분석 질문 | 현재 |
+|---|---|---|---|
+| **command-usage** | cmd·args해시·exitCode·durationMs·ts | 어떤 명령이 자주/느리/실패하나(채택·마찰) | ❌ 없음 |
+| **recall-event** | query·hitIds·topScore·**queryType**·ts | 회상 품질·ML 필요성 | 있음(queryType 추가 필요) |
+| **gate-result** | gate·pass·durationMs·ts | 게이트별 통과율·flaky | ledger에 일부 |
+| **diff-cover-result** | branch·file·added·uncoveredLine·**uncoveredBranch**·ts | 미검증 변경 추세 | ❌ **미영속(콘솔만)** |
+| **autonomy-run** | runId·goal·completed·interventions·hardStop·reviewRejected·ticks | 자율성 신뢰(D2 트리거) | ❌ 스키마 없음 |
+| **evolve-event** | suggId·applied·rejectReason·ts | 진화 채택률·효과 | ❌ 없음 |
+| **guard-event** | action·guard·triggered·bypassed·ts | 안전 집행률(HARD_STOP 우회 탐지) | ai-actions 일부 |
+| **error-event** | cmd·errorType·nonTty·ts | 크래시·견고성(이번 #337류) | ❌ 없음 |
+| **false-completion** | claim·evidence·verdict·ts | 거짓완료 적발(RFC0056 정체성) | ❌ 없음 |
+
+**우선 신설 3개:** ① diff-cover-result 영속(가장 쉬움·즉효) ② autonomy-run(D2 막는 핵심) ③ command-usage(채택 분석 토대).
+
+---
+
+## Part 3 — 분석별 입력 데이터 명세 (스키마·필드·표본)
+
+| 분석 | 입력 데이터셋 | 정확한 스키마 | 최소 표본 | 산출 | 선결 |
+|---|---|---|---|---|---|
+| **Recall@5 kill-gate** | recall-log + eval | `eval{query, expectIds[], queryType:'lexical'\|'paraphrase'}` | ≥30 라벨, paraphrase 비율 고정(예 40%) | Recall@5·MRR·유형별 분해 | queryType 필드 추가 + 오너 라벨 |
+| **diff-cov 승격** | diff-cover-result | `{date,file,added,uncoveredLine,uncoveredBranch,classify:'real'\|'trivial'}` | ≥5 diff/며칠 | 과반>0 여부 + 라인vs분기 격차 | **결과 영속** + branch 측정 |
+| **자율성 D2** | autonomy-run | `{runId,goal,completed:bool,interventions:int,hardStop:bool,reviewRejected:bool,ticks:int}` | 임계 정의 후 ≥N | 완주율·실패유형 | **스키마·임계 정의(미존재)** |
+| **진화 효과** | evolve-event + gate-result | `{suggId,applied,rejectReason}` + 전후 위반수 | 며칠 | 채택률 + 사후 위반감소 | 측정 스키마 정의 |
+| **차단율** | guard-event/ai-actions | `{action,guard,triggered,bypassed}` | 운영량↑ | 차단율·우회율 | 표본 + #335~338 우회 수정 |
+| **명령 채택/마찰** | command-usage | `{cmd,exitCode,durationMs}` | 며칠 | 빈도·실패·느린 명령 | command-usage 신설 |
+
+### 데이터 파이프 선결 (이거 먼저 안 하면 위 전부 무의미)
+1. **(c) 영속·프라이버시** — 본체 memory.json 영속 보장 + recall-log gitignore(#331). 안 새고 안 증발하게.
+2. **(a) 스키마 정의** — autonomy-run · evolve-event(측정대상 부재).
+3. **스키마 보강** — recall에 `queryType` · diff-cover에 `branch`+영속 (세션 발견 결함 반영).
+4. **(b) 오너 며칠 실사용** — 표본 누적. **사람만**.
+
+---
+
+_부록: 이 세션 도그푸딩이 (a)(b) 방법을 증명했고 스키마 결함(구성취약·라인커버한계·미영속)도 드러냄. 남은 건 본체에 파이프 깔기._

--- a/docs/state/research-backlog.md
+++ b/docs/state/research-backlog.md
@@ -103,4 +103,34 @@
 
 ---
 
+## 📥 VHK가 필요로 하는 데이터 (수집 명세 · 2026-06-22 도그푸딩 후 정제)
+
+> 도그푸딩으로 **방법은 검증**됐으나(토이 프로젝트), **확정 데이터는 오너 실사용**이 선결. 아래는 "어떤 분석에 어떤 데이터가, 어떤 형태로, 얼마나 필요한가"의 명세.
+
+### 0. 데이터 갭 3종 (먼저 분류)
+- **(a) 스키마 미정의** — 측정 대상 자체가 없음 → **정의가 선결**: 자율성 완주율·진화 효과.
+- **(b) 수집 부족** — 스키마 있고 도구 작동하나 표본 0~소량: recall 실쿼리·diff 실작업·ai-actions.
+- **(c) 영속 차단** — vhk **본체 레포 memory.json 미영속**(in-memory 재마이그레이션) + recall-log gitignore 누락 → **데이터가 안 쌓이거나 증발/노출**. **이거 먼저 안 고치면 (b) 수집이 무의미**.
+
+### 1. 결정별 필요 데이터
+| 막힌 결정 | 필요 데이터 | 스키마/필드 | 표본 | 수집법 | 현재 | 갭 |
+|---|---|---|---|---|---|---|
+| **Recall@5 ML 도입**(RFC0049) | 오너 실쿼리 + 정답라벨 **+ 쿼리유형** | `recall-log{query,hitIds,topScore,ts}` + `eval{query,expectIds}` **+ 신규 `queryType: lexical\|paraphrase`** | ≥30 라벨, 패러프레이즈 비율 고정 | 며칠 `vhk recall` 실사용 → `memory eval --init` | 토이 60→71%(구성취약) | b + **스키마에 queryType 추가**(세션 발견: 구성이 verdict 좌우) |
+| **diff-cov 게이트 승격**(RFC0050) | 실작업 diff별 미검증 라인 **+ 분기커버** | PR별 `{date,files,added,uncoveredLine,uncoveredBranch,classify}` | ≥5 diff, 며칠 분산 | 본체 작업 PR마다 `test --coverage`→`diff-cover` | 토이 3/10(라인만) | b + **branch-cov 추가**(세션: 라인커버는 단일줄 분기 과소계상) |
+| **자율성→실행력 D2**(RFC0054) | vhk-auto 1회전 결과 | `autonomy-run{runId,goal,completed,interventions,hardStop,reviewRejected,ticks}` | ≥N회(임계 미정) | /vhk-auto 실구동 로그 | **0(스키마 없음)** | **a — 스키마·임계 정의가 1순위** |
+| **"진화 먼저" 전제**(RFC0054§4) | evolve 채택률 + 사후 위반감소 | `evolve-log{suggId,applied,rejectReason}` + 전후 `check` 위반수 | 며칠 누적 | evolve 실사용 + 위반 추세 | **0(측정 없음)** | a + b |
+| **JIT 경고 임계 튜닝** | 위험행동별 경보/오경보 | recall-log 재사용 + `{action,alerted,wasFalseAlarm}` | 위험행동 다수 | recall 데이터 파이프 공유 | 0 | b(Recall과 동일 파이프) |
+| **AI 차단율**(goal61) | guarded 행동 결과 | `ai-actions.jsonl{action,blocked}` | 더 많은 운영량 | 평소 운영 누적 | 8줄(0/8) | b(표본 빈약) |
+| **거짓완료 탐지**(RFC0056 receipt) | 거짓완료 사건 1건+ | `{claim,evidence,verdict:false-complete}` | 90일 1건 적발 | receipt MVP + 실작업 | 0/8 | a(receipt 미구현) + b |
+
+### 2. 한 줄 요약 — 지금 "데이터분석"을 막는 진짜 순서
+1. **(c) 영속 고치기** — 본체 memory.json 미영속 + recall-log gitignore. 안 고치면 뭘 쌓아도 샌다.
+2. **(a) 스키마 2개 정의** — 자율성 완주율·진화 효과(측정 대상이 아예 없음).
+3. **스키마 보강 2개** — recall에 `queryType`, diff-cov에 `branch` (세션이 발견한 결함 반영).
+4. **(b) 오너 실사용 며칠** — recall·diff·ai-actions 표본 누적. **이건 사람만**.
+
+→ **핵심: 데이터분석 이전에 "데이터가 쌓이고·정의되고·안 새는" 파이프부터.** 토이 도그푸딩이 (a)(b) 방법은 증명했고, 결함(구성취약·라인커버한계·영속버그)도 드러냄. 남은 건 본체에 파이프 깔고 오너가 며칠 굴리는 것.
+
+---
+
 _갱신 규칙: 테마가 해소되면 취소선 + 해소 근거(PR·측정값) 1줄. 새 미해결 질문은 종류·우선순위 달아 추가._


### PR DESCRIPTION
종료 확인된 measure-first 세션의 미커밋 분석 유실 방지. data-needs-analysis.md(데이터 인벤토리·Recall@5 71%·수집설계 3각도) + research-backlog.md(+30 데이터 needs). 문서 전용·코드 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)