### PR TITLE
feat(receipt): 의도 대조 — mission(scope/forbidden)을 receipt 5번째 증거로 (Goal 87 PR1)

### DIFF
--- a/docs/log/2026-06-25-goal-87-receipt-intent.md
+++ b/docs/log/2026-06-25-goal-87-receipt-intent.md
@@ -1,0 +1,42 @@
+# 2026-06-25 — Goal 87 PR1: receipt 의도 대조(intent) — 의도 장갑의 손바닥 잇기
+
+> append-only dev log. RFC 0056 T1(receipt) 위에 **의도(mission) 검증 면**을 자동 루프에 합류시킨 작업.
+> 진입점 기획: [2026-06-23 intent-glove-plan](2026-06-23-intent-glove-plan.md) · goal [87](../../goals/87-mission-verify-intent-check.md).
+
+## 한 줄 결론
+
+`vhk receipt` 가 `.vhk/mission.json`(scope/forbidden) 이 있으면 변경 파일을 자동 대조해 **forbidden 위반 → block · scope 밖 → caution** 을 decision 에 반영한다(5번째 증거 `intent`). 이전엔 receipt/verify 가 기계적 done(tsc·test·dirty·stale)만 보고 "시킨 범위(의도)를 지켰나"는 안 봤다 — 의도 장갑의 검증 면이 자동 루프에서 빠져 있던 구멍을 메웠다.
+
+## 무엇을 / 어떻게 (옵션 A — receipt 5번째 증거)
+
+선택지 A(receipt 에 `intent` 증거 추가) 채택 — 진입점 기획의 권장안. 이유: `checkMission` 이 이미 순수 함수라 글루만 필요하고, **latest.json 을 안 건드려** mission.ts:16 의 "별도 네임스페이스(latest.json 불변)" 격리 결정을 존중(옵션 B 는 이 격리를 깸).
+
+- **`src/lib/receipt.ts` (순수)**
+  - `ReceiptIntentEvidence { missionKnown, forbiddenHits, scopeWarnings }` 신설 + `ReceiptEvidence.intent?`(옵셔널 — `staleKnown` 패턴과 동형).
+  - `decideReceipt`: 실차단에 `forbidden 위반(missionKnown && forbiddenHits>0)` 추가(red·dirty·stale 동급 — 변경 파일이 금지 glob 매치 = 결정론 사실). `scopeWarnings>0` 은 caution(advisory).
+  - `receiptReasons`·`renderReceiptMarkdown` 에 의도 사유/⑤ intent 표행 추가(mission 없으면 행 자체가 없음).
+  - 상단 불변식 주석 ① 갱신("실차단 3종"→"red·dirty·stale·forbidden 위반").
+- **`src/commands/receipt.ts` (경계)**
+  - `collectIntent(cwd)` — mission.json 있으면 `git status --porcelain -uall` → `parsePorcelainLines` → `filterSelfTrackedLines`(Goal 85 자기파일 제외 — dirty 와 **동일 기준**) → `porcelainPath` → `checkMission`. mission 없으면 `undefined`.
+  - `collectReceipt` 가 `intent` 를 evidence 에 배선. (수동 `vhk mission check` 는 self-tracked 제외를 안 하므로 미세 차이 — 의도된 차이. receipt 자신이 남기는 .vhk/events 가 scope 경고를 만드는 자기참조 노이즈 방지.)
+
+## 불변식 (수용 기준 충족)
+
+- **하위호환**: mission.json 없으면 `intent=undefined` → decision·출력 변화 0.
+- **단조성**: intent 는 block/caution 방향으로만 추가 — pass 격상 분기 없음(폭포 구조 유지).
+- **과확장 0**: missionKnown 이어도 위반·경고 0 이면 pass(노이즈 유발 안 함).
+- **GA**: 기존 시그니처 추가만(옵셔널 필드) — breaking 0. 신규 명령 0(등록 4지점 무영향).
+- **latest.json 불변**: receipt 격리 경로만 사용 — mission 결과를 latest.json 에 안 박음.
+
+## 검증
+
+- `tsc --noEmit` EXIT=0 (strict 타입 안전) · `pnpm build` 성공(esbuild + DTS).
+- **순수 판정 로직 12 assert 직접 검증 PASS**(tsx 로 `src/lib/receipt.ts` 동적 import — forbidden→block·scope→caution·하위호환·missionKnown=false 영향0·과확장0·단조성·실차단 우선·렌더 행·렌더 하위호환).
+- **vitest 로컬은 worker 환경 crash**(Node25 + vitest4 forks on Windows, import 단계 0ms). **내 변경 무관 — stash 후 원본도 동일 crash 확인**(baseline). [[vhk-local-vitest-forks]] — CI(Linux)가 진실원.
+- 추가한 `tests/receipt.test.ts` 통합 테스트(collectIntent: forbidden→block·scope→caution·하위호환·자기참조 회귀 4건)는 CI 에서 검증. `makeMissionRepo` 가 mission.json 을 커밋해 변경목록에서 빼는 함정 처리(안 그러면 mission.json 자체가 scope 밖으로 잡힘).
+
+## 잔여 (후속 PR)
+
+- **PR2**: `review` 가 forbidden 위반을 거짓완료 신호에 합류(confidence cap/경고 1줄).
+- **PR3(선택)**: receipt `.md` 에 "의도 대조" 전용 섹션(scope/forbidden 상세).
+- objective(목표 달성) 판정은 범위 밖 — 결정론(scope/forbidden)만. LLM judge 는 Goal 73.

--- a/docs/log/2026-06-25-goal-87-receipt-intent.md
+++ b/docs/log/2026-06-25-goal-87-receipt-intent.md
@@ -40,3 +40,8 @@
 - **PR2**: `review` 가 forbidden 위반을 거짓완료 신호에 합류(confidence cap/경고 1줄).
 - **PR3(선택)**: receipt `.md` 에 "의도 대조" 전용 섹션(scope/forbidden 상세).
 - objective(목표 달성) 판정은 범위 밖 — 결정론(scope/forbidden)만. LLM judge 는 Goal 73.
+
+## 리뷰 반영 (CodeRabbit · #394 · 2026-06-25)
+
+- **커밋된 위반 누락 차단 (🟡 정확성)**: `collectIntent` 가 `git status`(미커밋)만 봐서 **금지 파일을 고친 뒤 곧장 커밋하면** `forbiddenHits=0` 으로 위반을 놓치던 우회 구멍 → `baseSha`(작업시작 기준선)가 있으면 `git diff --name-only <baseSha>` + untracked 로 **커밋된 변경까지** 대조한다. (CodeRabbit 이 추천한 `diffUnified0`=`git diff HEAD` 는 커밋된 건 빠지므로 부정확 → `git diff <baseSha>` 채택.) self-tracked 제외는 porcelain 전용 `filterSelfTrackedLines` 대신 경로 기반 `isSelfTrackedPath` 로 통일. 기준선 없으면 status 폴백(이 경우는 receipt 의 stale③ 이 보완). 새 테스트로 "baseSha 기준 검출 vs status 폴백 미검출" 대조 고정.
+- **테스트 누수 (🔵 trivial)**: 임시 git 레포 정리를 `afterEach` 일괄로 — 단언 실패로 인라인 `rmSync` 가 건너뛰어도 누수 0.

--- a/goals/87-mission-verify-intent-check.md
+++ b/goals/87-mission-verify-intent-check.md
@@ -3,7 +3,7 @@ vhk_format: 1
 type: goal
 id: 87
 title: 의도 대조 — receipt/review가 mission(시킨 것)을 검증에 반영 (의도 장갑 손바닥) — P0
-status: NOT_STARTED
+status: IN_PROGRESS
 priority: P0
 created: 2026-06-23
 leads_to: "AI가 시킨 대로(scope/forbidden) 했나"를 자동 판정 — 경쟁사 못 하는 해자(남들은 의도를 모름) 실현
@@ -50,11 +50,11 @@ leads_to: "AI가 시킨 대로(scope/forbidden) 했나"를 자동 판정 — 경
 - **latest.json 스키마 불변** (격리 결정 존중 — 옵션 A).
 - GA: 기존 verify/mission/receipt 시그니처 추가만(옵셔널 필드). breaking 0.
 
-## Completion Check (작은 단위 — 미착수)
-- [ ] `ReceiptEvidence.intent?` 필드 + `commands/receipt.ts` 수집기가 mission.json 있을 때 `checkMission` 호출
-- [ ] 순수 `decideReceipt`가 forbidden→block · scope→caution 반영 (단조성 유지)
-- [ ] 하위호환 테스트 — mission.json 없으면 기존과 동일(decision·출력 불변)
-- [ ] 과확장 0 테스트 — scope 안 변경은 caution 유발 안 함
+## Completion Check (PR1 완료 · PR2/게이트 잔여)
+- [x] `ReceiptEvidence.intent?` 필드 + `commands/receipt.ts` 수집기가 mission.json 있을 때 `checkMission` 호출 (PR1, #394 예정)
+- [x] 순수 `decideReceipt`가 forbidden→block · scope→caution 반영 (단조성 유지) (PR1)
+- [x] 하위호환 테스트 — mission.json 없으면 기존과 동일(decision·출력 불변) (PR1)
+- [x] 과확장 0 테스트 — scope 안 변경은 caution 유발 안 함 (PR1)
 - [ ] review가 forbidden 위반을 거짓완료 신호로 합류 (PR2)
 - [ ] 공통 게이트(_meta), check-goal-87.mjs (vhk goal sync 자동생성)
 

--- a/goals/README.md
+++ b/goals/README.md
@@ -2,7 +2,7 @@
 
 # goals/ 인덱스
 
-> 총 7 goal — IN_PROGRESS 3 · NOT_STARTED 3 · DONE 1
+> 총 7 goal — IN_PROGRESS 4 · NOT_STARTED 2 · DONE 1
 > 공통 게이트 = [_meta.md](_meta.md) · 카드 형식/상태 의미는 각 파일 frontmatter 참조.
 
 | # | 제목 | 상태 | 우선순위 | 다음 연결 |
@@ -13,4 +13,4 @@
 | 79 | verify 로컬 환경의존 테스트 분리 — 선조사 후 범위 재조정(확실한 것만) — P0 | 🔄 IN_PROGRESS | P0 | 로컬 verify 신뢰 — 선조사로 회귀 0 확인, 확실한 조치만 적용 |
 | 85 | receipt/verify dirty 판정에서 자기 산출 추적파일 제외 (#315 자기참조 봉인) — P0 | ✅ DONE | P0 | receipt가 자기 ledger 때문에 늘 block되는 자기모순 제거 (RFC 0056 T1 선결) |
 | 86 | vhk receipt MVP — 4대 기계증거를 영수증 1장으로 (RFC 0056 T1) — P0 | 🔄 IN_PROGRESS | P0 | 에이전트 "됐어요"를 기계증거 영수증으로 — 거짓완료 탐지 90일 쐐기 |
-| 87 | 의도 대조 — receipt/review가 mission(시킨 것)을 검증에 반영 (의도 장갑 손바닥) — P0 | ⬜ NOT_STARTED | P0 | "AI가 시킨 대로(scope/forbidden) 했나"를 자동 판정 — 경쟁사 못 하는 해자(남들은 의도를 모름) 실현 |
+| 87 | 의도 대조 — receipt/review가 mission(시킨 것)을 검증에 반영 (의도 장갑 손바닥) — P0 | 🔄 IN_PROGRESS | P0 | "AI가 시킨 대로(scope/forbidden) 했나"를 자동 판정 — 경쟁사 못 하는 해자(남들은 의도를 모름) 실현 |

--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -15,7 +15,7 @@ import { addedLinesByFile } from '../lib/diff-hunks.js'
 import { fileCoverageByFile, COVERAGE_CORRUPT } from '../lib/coverage-parse.js'
 import { diffCoverage } from '../lib/diff-coverage.js'
 import { parsePorcelainLines } from '../lib/git-porcelain.js'
-import { filterSelfTrackedLines, porcelainPath } from '../lib/self-tracked.js'
+import { porcelainPath, isSelfTrackedPath } from '../lib/self-tracked.js'
 import { readMission, checkMission } from './mission.js'
 import {
   buildReceipt,
@@ -103,22 +103,41 @@ export function collectDiffCover(cwd: string): ReceiptDiffCover {
 /**
  * ⑤ intent(의도 대조, Goal 87) 수집 — .vhk/mission.json 있으면 변경 파일을 scope/forbidden 과 대조.
  *
- * 변경 파일은 dirty(②)와 **동일 기준**으로 자기 산출 추적파일을 제외한다(Goal 85 filterSelfTrackedLines):
- * receipt 자신이 남기는 .vhk/events·ledger 가 scope 경고를 만드는 자기참조 노이즈를 막기 위함.
- * (수동 `vhk mission check` 는 self-tracked 를 제외 안 하므로 결과가 미세하게 다를 수 있다 — 의도된 차이.)
+ * 변경 파일 범위:
+ *  - baseSha(작업시작 기준선)가 있으면 `git diff --name-only <baseSha>` (baseSha..working tree) +
+ *    untracked 신규 — **커밋된 변경까지 포함**한다. 그래야 금지 파일을 고친 뒤 곧장 커밋해 status 에서
+ *    숨겨도(forbiddenHits=0 위장) 의도 위반을 놓치지 않는다(CodeRabbit #394 지적 — 거짓완료 우회 차단).
+ *  - 기준선 미기록이면 미커밋 변경(status -uall)만 본다. 이 경우 커밋된 변경은 receipt 의 stale(③)이
+ *    "증거 낡음"으로 잡는다(가능하면 vhk receipt --mark-start 로 기준선을 박는 게 정확).
+ *
+ * dirty(②)와 **동일 기준**으로 vhk 자기 산출 추적파일(isSelfTrackedPath)을 제외한다 — receipt 자신이
+ * 남기는 .vhk/events·ledger 가 scope 경고를 만드는 자기참조 노이즈 방지(Goal 85). (수동 `vhk mission
+ * check` 는 self-tracked 를 제외 안 하므로 결과가 미세하게 다를 수 있다 — 의도된 차이.)
  * mission.json 없으면 undefined → decision·출력 영향 0(하위호환).
  */
-export function collectIntent(cwd: string): ReceiptIntentEvidence | undefined {
+export function collectIntent(cwd: string, baseSha?: string | null): ReceiptIntentEvidence | undefined {
   const mission = readMission(cwd)
   if (!mission) return undefined
-  let changed: string[] = []
+  const files = new Set<string>()
   try {
-    // -uall: 미추적 파일을 개별 경로로 펴서 glob 매칭 정확도 확보(getCommitInfo 와 동일 이유).
-    const lines = parsePorcelainLines(gitOut(['status', '--porcelain', '--untracked-files=all'], cwd))
-    changed = filterSelfTrackedLines(lines).map(porcelainPath)
+    if (baseSha) {
+      // baseSha..working tree — 커밋된 변경까지 포함. diff 는 tracked 만이므로 untracked 는 ls-files 로 보충.
+      const diffNames = gitOut(['diff', '--name-only', baseSha], cwd)
+      const untracked = gitOut(['ls-files', '--others', '--exclude-standard'], cwd)
+      for (const f of `${diffNames}\n${untracked}`.split('\n')) {
+        const t = f.trim()
+        if (t) files.add(t)
+      }
+    } else {
+      // -uall: 미추적 파일을 개별 경로로 펴서 glob 매칭 정확도 확보(getCommitInfo 와 동일 이유).
+      for (const line of parsePorcelainLines(gitOut(['status', '--porcelain', '--untracked-files=all'], cwd))) {
+        files.add(porcelainPath(line))
+      }
+    }
   } catch {
-    // git status 실패 → 변경 목록 미상. 빈 목록(위반 0)으로 둔다 — 거짓 block 금지(정직).
+    // git 실패 → 변경 목록 미상. 빈 목록(위반 0)으로 둔다 — 거짓 block 금지(정직). 다른 증거가 보완.
   }
+  const changed = [...files].filter((f) => !isSelfTrackedPath(f))
   const { violations, warnings } = checkMission(changed, mission)
   return { missionKnown: true, forbiddenHits: violations.length, scopeWarnings: warnings.length }
 }
@@ -146,8 +165,8 @@ export function collectReceipt(cwd: string, baseShaOverride?: string | null): Re
   // ④ diff-cover — advisory(약신호).
   const diffCover = collectDiffCover(cwd)
 
-  // ⑤ intent — mission.json 있으면 scope/forbidden 대조(Goal 87). 없으면 undefined(decision·출력 영향 0).
-  const intent = collectIntent(cwd)
+  // ⑤ intent — mission.json 있으면 scope/forbidden 대조(Goal 87). baseSha 전달 → 커밋된 변경도 포함.
+  const intent = collectIntent(cwd, baseSha)
 
   return buildReceipt(
     {

--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -8,18 +8,22 @@ import { atomicWriteFile } from '../lib/atomic-write.js'
 import { localDate } from '../lib/date.js'
 import { stripBom } from '../lib/read-json.js'
 import { ko } from '../i18n/ko.js'
-import { getCommitInfo } from '../lib/git-repo.js'
+import { getCommitInfo, gitOut } from '../lib/git-repo.js'
 import { verifyEvidence } from './verify.js'
 import { diffUnified0 } from '../lib/git-session.js'
 import { addedLinesByFile } from '../lib/diff-hunks.js'
 import { fileCoverageByFile, COVERAGE_CORRUPT } from '../lib/coverage-parse.js'
 import { diffCoverage } from '../lib/diff-coverage.js'
+import { parsePorcelainLines } from '../lib/git-porcelain.js'
+import { filterSelfTrackedLines, porcelainPath } from '../lib/self-tracked.js'
+import { readMission, checkMission } from './mission.js'
 import {
   buildReceipt,
   renderReceiptMarkdown,
   type Receipt,
   type ReceiptDecision,
   type ReceiptDiffCover,
+  type ReceiptIntentEvidence,
 } from '../lib/receipt.js'
 
 /**
@@ -97,6 +101,29 @@ export function collectDiffCover(cwd: string): ReceiptDiffCover {
 }
 
 /**
+ * ⑤ intent(의도 대조, Goal 87) 수집 — .vhk/mission.json 있으면 변경 파일을 scope/forbidden 과 대조.
+ *
+ * 변경 파일은 dirty(②)와 **동일 기준**으로 자기 산출 추적파일을 제외한다(Goal 85 filterSelfTrackedLines):
+ * receipt 자신이 남기는 .vhk/events·ledger 가 scope 경고를 만드는 자기참조 노이즈를 막기 위함.
+ * (수동 `vhk mission check` 는 self-tracked 를 제외 안 하므로 결과가 미세하게 다를 수 있다 — 의도된 차이.)
+ * mission.json 없으면 undefined → decision·출력 영향 0(하위호환).
+ */
+export function collectIntent(cwd: string): ReceiptIntentEvidence | undefined {
+  const mission = readMission(cwd)
+  if (!mission) return undefined
+  let changed: string[] = []
+  try {
+    // -uall: 미추적 파일을 개별 경로로 펴서 glob 매칭 정확도 확보(getCommitInfo 와 동일 이유).
+    const lines = parsePorcelainLines(gitOut(['status', '--porcelain', '--untracked-files=all'], cwd))
+    changed = filterSelfTrackedLines(lines).map(porcelainPath)
+  } catch {
+    // git status 실패 → 변경 목록 미상. 빈 목록(위반 0)으로 둔다 — 거짓 block 금지(정직).
+  }
+  const { violations, warnings } = checkMission(changed, mission)
+  return { missionKnown: true, forbiddenHits: violations.length, scopeWarnings: warnings.length }
+}
+
+/**
  * 4대 기계증거를 수집해 영수증 객체를 만든다(경계). LLM 0.
  * @param baseShaOverride --since <sha> 로 명시 기준선 지정 시. 없으면 .base-sha 파일.
  */
@@ -119,6 +146,9 @@ export function collectReceipt(cwd: string, baseShaOverride?: string | null): Re
   // ④ diff-cover — advisory(약신호).
   const diffCover = collectDiffCover(cwd)
 
+  // ⑤ intent — mission.json 있으면 scope/forbidden 대조(Goal 87). 없으면 undefined(decision·출력 영향 0).
+  const intent = collectIntent(cwd)
+
   return buildReceipt(
     {
       gates: { red: failedGateIds.length > 0, status: report.status, failedGateIds, hasSoftWarning },
@@ -126,6 +156,7 @@ export function collectReceipt(cwd: string, baseShaOverride?: string | null): Re
       stale,
       staleKnown,
       diffCover,
+      intent,
     },
     {
       generatedAt: new Date().toISOString(),

--- a/src/lib/receipt.ts
+++ b/src/lib/receipt.ts
@@ -5,9 +5,10 @@
 // .json/.md 영수증을 만든다. fs/git 수집은 commands/receipt.ts(경계)가 담당한다(테스트 용이).
 //
 // ★핵심 불변식(테스트로 고정 — tests/receipt.test.ts):
-//   ① decision 은 기계증거만으로(LLM 추론 0). 실차단 3종(red·dirty·stale) 중 하나라도면 block.
+//   ① decision 은 기계증거만으로(LLM 추론 0). 실차단(red·dirty·stale·forbidden 위반) 중 하나라도면 block.
+//      (Goal 87: forbidden=변경 파일이 mission 금지 glob 매치 = 결정론 사실 → red/dirty/stale 와 동급 차단.)
 //   ② 단조성: caution → pass 격상 절대 금지. 부정 신호가 늘면 결과가 좋아질 수 없다(pass→caution→block).
-//   ③ ④ diff-cover 는 advisory(약신호) — decision 을 block 으로 격하시키지 못한다(차단은 3종만).
+//   ③ ④ diff-cover·scope 경고는 advisory(약신호) — decision 을 block 으로 격하시키지 못한다(차단은 위 4종만).
 //
 // ★정직 경계(RFC 0056 §11 ①): diff-cover 의 covered 는 "테스트 실행 도달"이지 "정확성"이 아니다.
 //   그러므로 영수증이 잡는 것은 **게으른 거짓완료**(빌드 깨짐·미커밋·stale)에 한정되고, "almost
@@ -39,7 +40,21 @@ export interface ReceiptDiffCover {
   ratio: number
 }
 
-/** 영수증 입력 — 4대 기계증거(commands/receipt.ts 가 git/verify/diff-cover 에서 수집). */
+/**
+ * ⑤ intent(의도 대조) 증거 — Goal 87. mission.json(scope/forbidden) ↔ 변경 파일을 글로브로 대조.
+ * forbidden 위반은 변경 파일이 금지 경로에 매치되는 **결정론 사실**(LLM 0)이라 red/dirty/stale 와
+ * 동급 실차단(block). scope 밖 변경은 advisory(caution). mission 없으면 이 증거 자체가 부재(영향 0).
+ */
+export interface ReceiptIntentEvidence {
+  /** mission.json 이 있어 의도 대조를 수행했는가. false 면 decision 영향 0(missionKnown 패턴은 staleKnown 과 동형). */
+  missionKnown: boolean
+  /** forbidden glob 위반 파일 수(>0 → 실차단 block — 결정론). */
+  forbiddenHits: number
+  /** scope 밖 변경 파일 수(>0 → caution — advisory). */
+  scopeWarnings: number
+}
+
+/** 영수증 입력 — 4대 기계증거 + (옵션) 의도 대조(commands/receipt.ts 가 git/verify/diff-cover/mission 에서 수집). */
 export interface ReceiptEvidence {
   /** ① tsc/test/build 실종료코드 게이트. */
   gates: ReceiptGateEvidence
@@ -51,6 +66,8 @@ export interface ReceiptEvidence {
   staleKnown: boolean
   /** ④ 변경라인 diff-cover(advisory). */
   diffCover: ReceiptDiffCover
+  /** ⑤ intent(의도 대조, Goal 87) — mission.json 있을 때만. 부재 → decision·출력 영향 0(하위호환). */
+  intent?: ReceiptIntentEvidence
 }
 
 /** 산출 .md 하단 고정 1줄 — 정직성(능력 경계)을 제품에 박는다(RFC 0056 §6·§11). */
@@ -58,23 +75,28 @@ export const HONESTY_LINE =
   '이 영수증은 게으른 거짓완료(빌드 깨짐·미커밋·낡은 증거)를 잡지, 미묘한 오류(그럴듯하게 틀린 코드)는 못 잡는다. 판정은 기계증거(종료코드·dirty·SHA) 기반이며 LLM 추론이 아니다.'
 
 /**
- * 4대 기계증거 → decision. **순수 함수, LLM 0.**
+ * 4대 기계증거 + (옵션) 의도 대조 → decision. **순수 함수, LLM 0.**
  *
- * 실차단 3종(red·dirty·stale) 중 하나라도면 block(불변식 ①). 그게 아니고 약신호(soft 게이트·
- * stale 미상·diff-cover 미커버)가 있으면 caution. 전부 clean·확인됐을 때만 pass.
+ * 실차단(red·dirty·stale·forbidden 위반) 중 하나라도면 block(불변식 ①). 그게 아니고 약신호(soft
+ * 게이트·stale 미상·diff-cover 미커버·scope 밖 변경)가 있으면 caution. 전부 clean·확인됐을 때만 pass.
  *
  * 단조성(불변식 ②): 부정 신호가 늘수록 block ← caution ← pass 한 방향으로만 간다. caution 을
  * pass 로 격상시키는 분기는 존재하지 않는다(아래는 "block? → caution? → pass" 폭포라 역행 불가).
  *
- * ④ diff-cover 는 caution 까지만 올린다(advisory, 불변식 ③) — block 분기에 절대 들어가지 않는다.
+ * ④ diff-cover·scope 경고는 caution 까지만 올린다(advisory, 불변식 ③) — block 분기에 절대 안 들어간다.
+ * ⑤ intent 는 missionKnown=false(mission 부재)면 forbiddenHits/scopeWarnings 를 무시 → 영향 0(하위호환).
  */
 export function decideReceipt(e: ReceiptEvidence): ReceiptDecision {
-  // 실차단 3종 — diff-cover 는 여기에 없다(advisory 라 block 격하 불가).
-  if (e.gates.red || e.dirty || (e.staleKnown && e.stale)) return 'block'
+  const intentKnown = e.intent?.missionKnown === true
+  const forbiddenViolated = intentKnown && e.intent!.forbiddenHits > 0
+
+  // 실차단 — diff-cover·scope 는 여기에 없다(advisory 라 block 격하 불가). forbidden 위반은 결정론 차단.
+  if (e.gates.red || e.dirty || (e.staleKnown && e.stale) || forbiddenViolated) return 'block'
 
   // 약신호(soft) — 차단은 아니나 "안심"도 금지 → caution. (단조성: pass 로 못 내려감)
   const hasUncoveredChange = e.diffCover.measured && e.diffCover.totalUncovered > 0
-  if (e.gates.hasSoftWarning || !e.staleKnown || hasUncoveredChange) return 'caution'
+  const scopeWarned = intentKnown && e.intent!.scopeWarnings > 0
+  if (e.gates.hasSoftWarning || !e.staleKnown || hasUncoveredChange || scopeWarned) return 'caution'
 
   return 'pass'
 }
@@ -88,6 +110,8 @@ export function receiptReasons(e: ReceiptEvidence): string[] {
   }
   if (e.dirty) reasons.push('working tree 가 dirty — 미커밋/untracked 변경 있음(자기파일 제외 후에도)')
   if (e.staleKnown && e.stale) reasons.push('작업 시작 SHA ≠ 현재 HEAD — 증거가 낡았을 수 있음(stale)')
+  if (e.intent?.missionKnown && e.intent.forbiddenHits > 0)
+    reasons.push(`의도 위반 — forbidden(금지 경로) 변경 ${e.intent.forbiddenHits}건: mission 계약을 어김 — block`)
   if (!e.staleKnown) reasons.push('작업 시작 기준선 미기록 — stale 판정 불가(vhk receipt --mark-start 로 기준선 고정 가능)')
   if (e.gates.hasSoftWarning) reasons.push('일부 게이트 skip/warn — 결과 불완전(수동 확인 권장)')
   if (e.diffCover.measured && e.diffCover.totalUncovered > 0) {
@@ -96,6 +120,8 @@ export function receiptReasons(e: ReceiptEvidence): string[] {
       `변경라인 미검증 ${e.diffCover.totalUncovered}/${e.diffCover.totalAdded} (커버 ${pct}%) — advisory(약신호, 차단 안 함)`
     )
   }
+  if (e.intent?.missionKnown && e.intent.scopeWarnings > 0)
+    reasons.push(`scope 밖 변경 ${e.intent.scopeWarnings}건 — 시킨 범위 밖일 수 있음(advisory, 차단 안 함)`)
   if (reasons.length === 0) reasons.push('전 게이트 green · clean · 신선 · 변경라인 풀커버')
   return reasons
 }
@@ -217,6 +243,18 @@ export function renderReceiptMarkdown(r: Receipt): string {
   lines.push(`| ③ stale(작업시작 SHA≠HEAD) | ${staleCell} | ${staleNote} |`)
   // ④ 는 advisory — 체크표시는 정보용이지 decision 에 영향 없음(표 비고에 명시).
   lines.push(`| ④ diff-cover(advisory) | ${dc.measured && dc.totalUncovered === 0 ? '✅' : 'ℹ️'} | ${dcNote} |`)
+  // ⑤ intent(의도 대조, Goal 87) — mission.json 있을 때만 행 추가(없으면 출력 변화 0 = 하위호환).
+  if (e.intent?.missionKnown) {
+    const it = e.intent
+    const intentCell = it.forbiddenHits > 0 ? '❌' : it.scopeWarnings > 0 ? 'ℹ️' : '✅'
+    const intentNote =
+      it.forbiddenHits > 0
+        ? `forbidden 위반 ${it.forbiddenHits}건 — 시킨 범위(의도) 어김`
+        : it.scopeWarnings > 0
+          ? `scope 밖 변경 ${it.scopeWarnings}건 — advisory(차단 안 함)`
+          : 'scope/forbidden 계약 준수'
+    lines.push(`| ⑤ intent(의도 대조) | ${intentCell} | ${intentNote} |`)
+  }
   lines.push('')
   lines.push('**사유:**')
   for (const reason of r.reasons) lines.push(`- ${reason}`)

--- a/tests/receipt.test.ts
+++ b/tests/receipt.test.ts
@@ -11,7 +11,7 @@ import {
   type ReceiptDecision,
   HONESTY_LINE,
 } from '../src/lib/receipt.js'
-import { collectReceipt } from '../src/commands/receipt.js'
+import { collectReceipt, collectIntent } from '../src/commands/receipt.js'
 
 // Goal 86 (RFC 0056 T1): vhk receipt — 4대 기계증거 → 영수증 1장.
 // 핵심 불변식(테스트로 고정):
@@ -223,4 +223,164 @@ describe('lint 게이트 → receipt block 합류 (#381 거짓완료 포획)', (
     expect(r.decision).toBe('block')
     fs.rmSync(d, { recursive: true, force: true })
   }, 30_000)
+})
+
+// Goal 87: ⑤ intent(의도 대조) — mission(scope/forbidden) ↔ 변경 파일.
+//  forbidden 위반 = 결정론 실차단(block, red/dirty/stale 동급) · scope 밖 = advisory(caution).
+//  mission.json 없으면 동작·decision·출력 변화 0(하위호환). 단조성·과확장 0 유지.
+describe('decideReceipt — ⑤ intent(의도 대조) 반영', () => {
+  it('forbidden 위반(missionKnown) → block (red/dirty/stale 동급 실차단)', () => {
+    const e = cleanEvidence()
+    e.intent = { missionKnown: true, forbiddenHits: 1, scopeWarnings: 0 }
+    expect(decideReceipt(e)).toBe('block')
+  })
+
+  it('scope 밖 변경만(forbidden 0, missionKnown) → caution (block 아님 — advisory)', () => {
+    const e = cleanEvidence()
+    e.intent = { missionKnown: true, forbiddenHits: 0, scopeWarnings: 3 }
+    expect(decideReceipt(e)).toBe('caution')
+  })
+
+  it('하위호환 — intent 부재(undefined)면 기존과 동일(clean→pass)', () => {
+    const e = cleanEvidence()
+    expect(e.intent).toBeUndefined()
+    expect(decideReceipt(e)).toBe('pass')
+  })
+
+  it('missionKnown=false 면 forbiddenHits 가 있어도 무시 → 영향 0(clean→pass)', () => {
+    const e = cleanEvidence()
+    // mission 없을 때의 방어값: 숫자가 채워져도 missionKnown=false 면 decision 에 반영 안 됨.
+    e.intent = { missionKnown: false, forbiddenHits: 5, scopeWarnings: 5 }
+    expect(decideReceipt(e)).toBe('pass')
+  })
+
+  it('과확장 0 — missionKnown 이어도 위반·경고 0 이면 caution 유발 안 함(clean→pass)', () => {
+    const e = cleanEvidence()
+    e.intent = { missionKnown: true, forbiddenHits: 0, scopeWarnings: 0 }
+    expect(decideReceipt(e)).toBe('pass')
+  })
+
+  it('단조성 — clean 에 forbidden 위반을 더해도 절대 pass 로 격상 안 됨(→block)', () => {
+    const order: Record<ReceiptDecision, number> = { pass: 0, caution: 1, block: 2 }
+    const base = cleanEvidence()
+    const baseRank = order[decideReceipt(base)] // pass
+    const violated = cleanEvidence()
+    violated.intent = { missionKnown: true, forbiddenHits: 2, scopeWarnings: 0 }
+    expect(order[decideReceipt(violated)]).toBeGreaterThanOrEqual(baseRank)
+    expect(decideReceipt(violated)).toBe('block')
+  })
+
+  it('실차단 우선 — diff-cover 풀커버여도 forbidden 위반이면 block', () => {
+    const e = cleanEvidence()
+    e.diffCover = { measured: true, totalAdded: 10, totalUncovered: 0, ratio: 1 }
+    e.intent = { missionKnown: true, forbiddenHits: 1, scopeWarnings: 0 }
+    expect(decideReceipt(e)).toBe('block')
+  })
+})
+
+describe('renderReceiptMarkdown — ⑤ intent 행', () => {
+  function receiptWithIntent(intent: ReceiptEvidence['intent']) {
+    const e = cleanEvidence()
+    e.intent = intent
+    return renderReceiptMarkdown(
+      buildReceipt(e, {
+        generatedAt: '2026-06-25T00:00:00.000Z',
+        date: '2026-06-25',
+        slug: 's',
+        headSha: 'abc1234def',
+        baseSha: 'abc1234def',
+      })
+    )
+  }
+
+  it('forbidden 위반 → ⑤ intent 행 + "의도" 표기 + 판정 BLOCK', () => {
+    const md = receiptWithIntent({ missionKnown: true, forbiddenHits: 1, scopeWarnings: 0 })
+    expect(md).toContain('intent')
+    expect(md).toMatch(/의도|forbidden/)
+    expect(md).toContain('BLOCK')
+  })
+
+  it('하위호환 — mission 부재(intent undefined)면 ⑤ intent 행 자체가 없다(출력 변화 0)', () => {
+    const md = receiptWithIntent(undefined)
+    expect(md).not.toContain('⑤')
+    expect(md).not.toContain('intent')
+  })
+})
+
+describe('collectIntent(경계) — mission.json ↔ 변경 파일', () => {
+  // 커밋 1개 박은 임시 git 레포 + 선택적 mission.json. verify 게이트는 안 돌림(intent 수집만 — 빠름).
+  function makeMissionRepo(mission: { forbidden: string[]; scope: string[] } | null): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-receipt-intent-'))
+    const g = (args: string[]): void => {
+      execFileSync('git', args, { cwd: d, stdio: 'pipe' })
+    }
+    g(['init'])
+    g(['config', 'user.email', 't@t'])
+    g(['config', 'user.name', 't'])
+    fs.writeFileSync(path.join(d, 'README.md'), 'seed\n', 'utf-8')
+    g(['add', '.'])
+    g(['commit', '-m', 'seed'])
+    if (mission) {
+      fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+      fs.writeFileSync(
+        path.join(d, '.vhk', 'mission.json'),
+        JSON.stringify({
+          schemaVersion: 1,
+          objective: 'test',
+          scope: mission.scope,
+          forbidden: mission.forbidden,
+          createdAt: '2026-06-25T00:00:00.000Z',
+          updatedAt: '2026-06-25T00:00:00.000Z',
+        }),
+        'utf-8'
+      )
+      // mission.json 을 커밋해 "변경 파일"에서 뺀다 — 안 그러면 mission.json 자체가 scope 밖 변경으로
+      // 잡혀 검증 대상(secret/stray/self-tracked)만 보려는 의도를 흐린다.
+      g(['add', '.'])
+      g(['commit', '-m', 'mission'])
+    }
+    return d
+  }
+
+  it('forbidden 매치 변경 → forbiddenHits>0 → decideReceipt block (수용기준)', () => {
+    const d = makeMissionRepo({ forbidden: ['secret/**'], scope: [] })
+    fs.mkdirSync(path.join(d, 'secret'), { recursive: true })
+    fs.writeFileSync(path.join(d, 'secret', 'key.txt'), 'x', 'utf-8')
+    const intent = collectIntent(d)
+    expect(intent?.missionKnown).toBe(true)
+    expect(intent?.forbiddenHits).toBeGreaterThan(0)
+    const e = cleanEvidence()
+    e.intent = intent
+    expect(decideReceipt(e)).toBe('block')
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('scope 밖 변경 → scopeWarnings>0 · forbiddenHits=0 → caution', () => {
+    const d = makeMissionRepo({ forbidden: [], scope: ['allowed/**'] })
+    fs.writeFileSync(path.join(d, 'stray.txt'), 'x', 'utf-8')
+    const intent = collectIntent(d)
+    expect(intent?.forbiddenHits).toBe(0)
+    expect(intent?.scopeWarnings).toBeGreaterThan(0)
+    const e = cleanEvidence()
+    e.intent = intent
+    expect(decideReceipt(e)).toBe('caution')
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('하위호환 — mission.json 없으면 collectIntent undefined(변경이 있어도)', () => {
+    const d = makeMissionRepo(null)
+    fs.writeFileSync(path.join(d, 'whatever.txt'), 'x', 'utf-8')
+    expect(collectIntent(d)).toBeUndefined()
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('자기참조 회귀 — .vhk/events/*.jsonl 변경은 scope 경고를 유발 안 함(dirty 와 동일 제외)', () => {
+    const d = makeMissionRepo({ forbidden: [], scope: ['src/**'] })
+    fs.mkdirSync(path.join(d, '.vhk', 'events'), { recursive: true })
+    fs.writeFileSync(path.join(d, '.vhk', 'events', 'ai-actions.jsonl'), '{}\n', 'utf-8')
+    const intent = collectIntent(d)
+    expect(intent?.scopeWarnings).toBe(0)
+    expect(intent?.forbiddenHits).toBe(0)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
 })

--- a/tests/receipt.test.ts
+++ b/tests/receipt.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
@@ -308,9 +308,23 @@ describe('renderReceiptMarkdown — ⑤ intent 행', () => {
 })
 
 describe('collectIntent(경계) — mission.json ↔ 변경 파일', () => {
+  // 임시 git 레포를 모아 afterEach 에서 일괄 삭제 — 단언 실패로 인라인 rmSync 가 건너뛰어도 누수 0(CodeRabbit #394).
+  const tmpDirs: string[] = []
+  afterEach(() => {
+    for (const d of tmpDirs) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true })
+      } catch {
+        /* 정리 실패는 무시 — 테스트 결과에 영향 없음 */
+      }
+    }
+    tmpDirs.length = 0
+  })
+
   // 커밋 1개 박은 임시 git 레포 + 선택적 mission.json. verify 게이트는 안 돌림(intent 수집만 — 빠름).
   function makeMissionRepo(mission: { forbidden: string[]; scope: string[] } | null): string {
     const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-receipt-intent-'))
+    tmpDirs.push(d)
     const g = (args: string[]): void => {
       execFileSync('git', args, { cwd: d, stdio: 'pipe' })
     }
@@ -352,7 +366,19 @@ describe('collectIntent(경계) — mission.json ↔ 변경 파일', () => {
     const e = cleanEvidence()
     e.intent = intent
     expect(decideReceipt(e)).toBe('block')
-    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('커밋된 forbidden 위반도 잡는다 — baseSha 기준(커밋해 숨기기 차단, CodeRabbit #394)', () => {
+    const d = makeMissionRepo({ forbidden: ['secret/**'], scope: [] })
+    const base = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: d, encoding: 'utf-8' }).trim()
+    fs.mkdirSync(path.join(d, 'secret'), { recursive: true })
+    fs.writeFileSync(path.join(d, 'secret', 'key.txt'), 'leak', 'utf-8')
+    execFileSync('git', ['add', '.'], { cwd: d, stdio: 'pipe' })
+    execFileSync('git', ['commit', '-m', 'leak'], { cwd: d, stdio: 'pipe' })
+    // 커밋 후 working tree 는 clean — status(미커밋)만 보면 놓친다. baseSha 기준이면 커밋된 위반을 잡는다.
+    expect(collectIntent(d, base)?.forbiddenHits).toBeGreaterThan(0)
+    // 대조: 기준선 없으면 status 폴백 → 미커밋 0 이라 forbiddenHits=0 (이 경우 receipt stale 이 보완).
+    expect(collectIntent(d)?.forbiddenHits).toBe(0)
   })
 
   it('scope 밖 변경 → scopeWarnings>0 · forbiddenHits=0 → caution', () => {
@@ -364,14 +390,12 @@ describe('collectIntent(경계) — mission.json ↔ 변경 파일', () => {
     const e = cleanEvidence()
     e.intent = intent
     expect(decideReceipt(e)).toBe('caution')
-    fs.rmSync(d, { recursive: true, force: true })
   })
 
   it('하위호환 — mission.json 없으면 collectIntent undefined(변경이 있어도)', () => {
     const d = makeMissionRepo(null)
     fs.writeFileSync(path.join(d, 'whatever.txt'), 'x', 'utf-8')
     expect(collectIntent(d)).toBeUndefined()
-    fs.rmSync(d, { recursive: true, force: true })
   })
 
   it('자기참조 회귀 — .vhk/events/*.jsonl 변경은 scope 경고를 유발 안 함(dirty 와 동일 제외)', () => {
@@ -381,6 +405,5 @@ describe('collectIntent(경계) — mission.json ↔ 변경 파일', () => {
     const intent = collectIntent(d)
     expect(intent?.scopeWarnings).toBe(0)
     expect(intent?.forbiddenHits).toBe(0)
-    fs.rmSync(d, { recursive: true, force: true })
   })
 })


### PR DESCRIPTION
## 무엇

`vhk receipt` 가 `.vhk/mission.json`(scope/forbidden)이 있으면 변경 파일을 자동 대조해 **의도(시킨 범위)를 지켰는지**를 영수증 판정에 반영합니다. 이전엔 receipt/verify 가 기계적 done(tsc·test·dirty·stale)만 보고 "시킨 범위·금지(mission)를 어겼나"는 안 봤습니다 — **의도 장갑의 검증 면이 자동 루프에서 빠져 있던 구멍**을 메웁니다.

- **forbidden 위반 → `block`** (변경 파일이 금지 glob 매치 = 결정론 사실, red/dirty/stale 동급 실차단)
- **scope 밖 변경 → `caution`** (advisory)
- **mission.json 없으면 동작·decision·출력 변화 0** (하위호환)

## 어떻게 (옵션 A — receipt 5번째 증거)

`checkMission` 이 이미 순수 함수라 글루만 추가. **latest.json 을 안 건드려** mission.ts 의 "별도 네임스페이스(latest.json 불변)" 격리 결정을 존중(옵션 B 는 이 격리를 깸).

- `src/lib/receipt.ts` (순수): `ReceiptIntentEvidence` + `ReceiptEvidence.intent?`(옵셔널) + `decideReceipt`(forbidden→block·scope→caution) + reasons + md ⑤행
- `src/commands/receipt.ts` (경계): `collectIntent()` — dirty(②)와 **동일 기준**으로 자기 산출 추적파일 제외(Goal 85) → 자기참조 노이즈 방지
- `tests/receipt.test.ts`: forbidden/scope/하위호환/과확장0/단조성/자기참조 회귀

## 불변식 (수용 기준)

- **하위호환**: mission 없으면 `intent=undefined` → 기존과 동일
- **단조성**: intent 는 block/caution 방향으로만 — pass 격상 분기 없음
- **과확장 0**: missionKnown 이어도 위반·경고 0 이면 pass
- **GA**: 옵셔널 필드 추가만 — breaking 0, 신규 명령 0
- **latest.json 불변**: receipt 격리 경로만 사용

## 검증

- `tsc --noEmit` 0 · `pnpm build` 성공 · **순수 판정 로직 12 assert 직접 검증 PASS**(tsx)
- ⚠️ 로컬 vitest 는 환경 worker crash(Node25+vitest4 forks on Windows, import 단계) — **내 변경 무관**(stash 후 원본도 동일 crash 확인). **CI(Linux)가 통합 테스트 진실원** — 머지 전 CI green 확인 필요.

## 잔여 (후속 PR)

- **PR2**: `review` 가 forbidden 위반을 거짓완료 신호에 합류
- **PR3(선택)**: receipt `.md` 에 "의도 대조" 전용 섹션

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 변경 사항과 미션 문서를 함께 확인해, 금지 항목 위반은 차단하고 범위 밖 변경은 주의로 표시하는 영수증 판단이 추가되었습니다.
  * 영수증 출력에 의도 대조 결과가 새 항목으로 표시됩니다.

* **버그 수정**
  * 미션 문서가 없거나 확인 중 오류가 나도 불필요하게 차단되지 않도록 동작이 개선되었습니다.
  * 기존 판정 기준은 유지하면서 새 검사 결과만 보강했습니다.

* **테스트**
  * 차단, 주의, 하위호환, 출력 형식, 수집 동작에 대한 검증이 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->