### PR TITLE
feat(lint): 영구 코딩 규칙 3종 ESLint 코드화 — 의도 검증의 영구 층 자동 집행

### DIFF
--- a/docs/log/2026-06-25-eslint-permanent-rules.md
+++ b/docs/log/2026-06-25-eslint-permanent-rules.md
@@ -1,0 +1,38 @@
+# 2026-06-25 — Phase 1: 영구 코딩 규칙을 ESLint 로 코드화 (의도 검증 방향 1)
+
+> append-only dev log. Goal 87(의도 대조)이 **작업별 계약(mission.json)** 을 검증한 데 이어,
+> **프로젝트 영구 규칙(RULES.md)** 을 자동 집행에 합류시키는 작업. 진입점 plan: 의도 검증 강화 방향 1.
+
+## 한 줄 결론
+
+RULES.md 코딩 규칙 중 문서로만 있던 3가지(execSync 신규 금지·빈 catch 금지·명시 any 금지)를 `eslint.config.js` 규칙으로 코드화했다. 이제 `verify` 의 lint 게이트(#381)를 타고 `receipt` 가 위반을 `block` 으로 **자동 흡수**한다 — "AI 가 시킨 것"의 **영구 층**을 자동 검증 루프에 합류.
+
+## 무엇을 (eslint.config.js 3규칙 추가)
+
+| 규칙 | 구현 | 근거 |
+|---|---|---|
+| R1 execSync 신규 금지 | `no-restricted-syntax` — `CallExpression[callee.name='execSync']` + `MemberExpression[property.name='execSync']` | RULES.md:31/64. `safeExecFile` 은 `execFileSync` 사용(exec.ts)이라 **통로는 안 막힘** — execSync 만 차단 |
+| R2 빈 catch 금지 | `no-empty: ['error', { allowEmptyCatch: false }]` | RULES.md:27. 주석으로 사유 밝힌 catch 는 통과(말없이 삼킴만 차단) |
+| R3 명시 any 금지 | `@typescript-eslint/no-explicit-any: 'error'` | RULES.md:26. tsc strict 는 implicit 만, 명시 `: any`/`as any` 는 여기서 |
+
+receipt 합류는 #381 로 이미 배선됨(lint fail → `gates.red` → `decideReceipt` block) → **신규 합류 코드 0줄**.
+
+## 검증 (구현 전 적대 검증 포함)
+
+1. **위반 0 실측**: `eslint src` EXIT=0 — 3규칙 적용 후에도 기존 코드 깨끗.
+2. **규칙 작동 negative test**: src 에 위반 3개 심은 probe → `no-empty`·`no-explicit-any`·`no-restricted-syntax` 각 1건 검출 후 probe 삭제. "config 오류로 무시돼서 0"이 아님을 확인.
+3. **R1 통로 안전**: `safeExecFile` 이 `execFileSync` 사용(execSync 아님) → R1 에 안 걸림.
+4. **단위(T1.3)**: `tests/eslint-rules.test.ts` — Linter API 로 8케이스 고정(검출 + 설계결정: 주석 catch 통과·execFileSync 허용·깨끗한 코드 0). 로컬 vitest forks crash 라 tsx 로 8케이스 직접 검증 PASS([[vhk-local-vitest-forks]] → CI 진실원).
+5. `tsc --noEmit` 0 · `pnpm build` 성공.
+
+## 설계 결정 (정직)
+
+- **console.log(R4) 제외**: 986건 중 952건이 `src/commands/` 정상 CLI 출력 → 전체 금지 불가. 경로별 차등은 임의 예외 필요 → Phase 3 별도 트랙으로 분리(레버리지 대비 위험).
+- **빈 catch 정책**: 주석으로 사유 밝힌 무시는 허용 — RULES.md "빈 catch 금지" 정신(에러 은폐 방지)과 정합. 기존 3건(cloud·evolve)이 그 형태라 위반 0.
+- **드리프트 봉인 1차**: 테스트가 eslint.config.js 에 3규칙 존재를 확인. 더 강한 RULES.md↔ESLint 일치는 Phase 2(T2b).
+
+## 잔여 (후속)
+
+- **Phase 2** (병렬): T2a receipt 합류 E2E(규칙 위반 → lint fail → receipt block) · T2b RULES.md↔ESLint 일치 봉인.
+- **Phase 3**: console.log 경로별 정책(별도 트랙, 후순위).
+- 의도 검증 방향 2(glob 정직화)·3(위조·미설정)·4(objective LLM)는 사용자 추후 결정.

--- a/docs/log/2026-06-25-eslint-permanent-rules.md
+++ b/docs/log/2026-06-25-eslint-permanent-rules.md
@@ -36,3 +36,9 @@ receipt 합류는 #381 로 이미 배선됨(lint fail → `gates.red` → `decid
 - **Phase 2** (병렬): T2a receipt 합류 E2E(규칙 위반 → lint fail → receipt block) · T2b RULES.md↔ESLint 일치 봉인.
 - **Phase 3**: console.log 경로별 정책(별도 트랙, 후순위).
 - 의도 검증 방향 2(glob 정직화)·3(위조·미설정)·4(objective LLM)는 사용자 추후 결정.
+
+## 리뷰 반영 (CodeRabbit · #395 · 2026-06-25)
+
+정합 테스트(`tests/eslint-rules.test.ts`)가 약했던 2건(🟡 Functional Correctness) 강화:
+- **① flat config 전체 병합**: `eslintConfig[0]`만 보던 것을 배열 전체 `rules` 병합으로 — 규칙이 다른 config 항목에 있어도 정확.
+- **② 존재 확인 → config 실제 값으로 동작 검증**: `toBeDefined()`만으로는 `no-empty`가 `allowEmptyCatch:true`로 **약화돼도 통과**하던 것을, config 의 실제 규칙 값을 lint 에 주입해 검증 → 약화·selector 삭제 시 동작 테스트가 직접 빨강(강한 드리프트 봉인). tsx 로 config 병합·8케이스 재검증 PASS(병합 규칙 10개·3규칙 정의 확인).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,5 +27,23 @@ export default tseslint.config({
     '@typescript-eslint/no-base-to-string': 'error',
     // Promise reject 는 Error 로(문자열 reject 는 스택 없는 디버깅 지옥).
     '@typescript-eslint/prefer-promise-reject-errors': 'error',
+
+    // ── 영구 코딩 규칙 코드화 (RULES.md → 자동 집행 → verify lint 게이트 → receipt block #381) ──
+    // RULES.md: `execSync` 신규 사용 금지 → `safeExecFile` 사용. execFileSync(safeExecFile 내부 통로)는 허용 — execSync 만 차단.
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: "CallExpression[callee.name='execSync']",
+        message: 'execSync 신규 사용 금지 → safeExecFile 사용 (RULES.md 코딩 규칙)',
+      },
+      {
+        selector: "MemberExpression[property.name='execSync']",
+        message: 'execSync 신규 사용 금지 → safeExecFile 사용 (RULES.md 코딩 규칙)',
+      },
+    ],
+    // RULES.md: try-catch 필수, 빈 catch 금지. 주석으로 무시 사유를 밝힌 catch 는 통과(no-empty 기본).
+    'no-empty': ['error', { allowEmptyCatch: false }],
+    // RULES.md: TypeScript strict (any 금지) — tsc strict 는 implicit any 만, 명시 `: any`/`as any` 는 여기서 차단.
+    '@typescript-eslint/no-explicit-any': 'error',
   },
 })

--- a/tests/eslint-rules.test.ts
+++ b/tests/eslint-rules.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { Linter } from 'eslint'
+import tseslint from 'typescript-eslint'
+import eslintConfig from '../eslint.config.js'
+
+// 영구 코딩 규칙(RULES.md → eslint.config.js → verify lint 게이트 → receipt block #381)이
+// 실제로 위반을 잡는지 fixture 로 고정한다. 검증 대상 3규칙은 모두 type-aware 불필요(문법 기반)
+// 이라 Linter API(타입 정보 없이)로 단위 검증할 수 있다.
+//   R1 no-restricted-syntax(execSync) · R2 no-empty(빈 catch) · R3 no-explicit-any(명시 any)
+// 설계 결정도 회귀로 못박는다: 주석으로 사유를 밝힌 catch 는 통과 · execFileSync(safeExecFile 통로)는 허용.
+
+// 동작 검증용 규칙(명시) — eslint.config.js 의 값과 동일하게 유지. config 존재 여부는 아래 정합 테스트가 봉인.
+const PERMANENT_RULES: Linter.RulesRecord = {
+  'no-restricted-syntax': [
+    'error',
+    { selector: "CallExpression[callee.name='execSync']", message: 'execSync 금지' },
+    { selector: "MemberExpression[property.name='execSync']", message: 'execSync 금지' },
+  ],
+  'no-empty': ['error', { allowEmptyCatch: false }],
+  '@typescript-eslint/no-explicit-any': 'error',
+}
+
+function lint(code: string): Linter.LintMessage[] {
+  const linter = new Linter()
+  return linter.verify(code, {
+    languageOptions: {
+      parser: tseslint.parser as unknown as Linter.Parser,
+      parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+    },
+    // @typescript-eslint 플러그인 등록(no-explicit-any 제공). 타입 마찰만 회피.
+    plugins: { '@typescript-eslint': tseslint.plugin as unknown as Linter.Plugin },
+    rules: PERMANENT_RULES,
+  })
+}
+
+function hits(code: string, ruleId: string): number {
+  return lint(code).filter((m) => m.ruleId === ruleId).length
+}
+
+describe('영구 코딩 규칙 — ESLint 코드화 (RULES.md 자동 집행)', () => {
+  describe('R1: execSync 신규 금지 (no-restricted-syntax)', () => {
+    it('execSync 직접 호출을 잡는다', () => {
+      expect(hits("import { execSync } from 'node:child_process'\nexecSync('echo')", 'no-restricted-syntax')).toBeGreaterThan(0)
+    })
+
+    it('child_process.execSync 멤버 호출도 잡는다', () => {
+      expect(hits("import cp from 'node:child_process'\ncp.execSync('echo')", 'no-restricted-syntax')).toBeGreaterThan(0)
+    })
+
+    it('execFileSync(safeExecFile 통로)는 허용한다 — 통로 자체를 막지 않음', () => {
+      expect(hits("import { execFileSync } from 'node:child_process'\nexecFileSync('git', ['status'])", 'no-restricted-syntax')).toBe(0)
+    })
+  })
+
+  describe('R2: 빈 catch 금지 (no-empty)', () => {
+    it('완전 빈 catch 를 잡는다', () => {
+      expect(hits('try { doThing() } catch {}', 'no-empty')).toBeGreaterThan(0)
+    })
+
+    it('주석으로 사유를 밝힌 catch 는 통과 — "에러를 말없이 삼킴"만 차단', () => {
+      expect(hits('try { doThing() } catch { /* 무시 사유 명시 */ }', 'no-empty')).toBe(0)
+    })
+  })
+
+  describe('R3: 명시 any 금지 (no-explicit-any)', () => {
+    it('명시 any 타입 표기를 잡는다', () => {
+      expect(hits('const x: any = 1', '@typescript-eslint/no-explicit-any')).toBeGreaterThan(0)
+    })
+
+    it('as any 단언도 잡는다', () => {
+      expect(hits('const x = (1 as any)', '@typescript-eslint/no-explicit-any')).toBeGreaterThan(0)
+    })
+  })
+
+  describe('config 정합 — 규칙이 eslint.config.js 에 실제 켜져 있다 (드리프트 1차 봉인)', () => {
+    const flat = (Array.isArray(eslintConfig) ? eslintConfig[0] : eslintConfig) as {
+      rules?: Record<string, unknown>
+    }
+    const cfgRules = flat.rules ?? {}
+
+    it('세 영구 규칙이 모두 eslint.config.js 에 정의돼 있다', () => {
+      expect(cfgRules['no-restricted-syntax']).toBeDefined()
+      expect(cfgRules['no-empty']).toBeDefined()
+      expect(cfgRules['@typescript-eslint/no-explicit-any']).toBeDefined()
+    })
+
+    it('깨끗한 코드는 위반 0', () => {
+      expect(lint('export const x: number = 1\n')).toHaveLength(0)
+    })
+  })
+})

--- a/tests/eslint-rules.test.ts
+++ b/tests/eslint-rules.test.ts
@@ -9,16 +9,22 @@ import eslintConfig from '../eslint.config.js'
 //   R1 no-restricted-syntax(execSync) · R2 no-empty(빈 catch) · R3 no-explicit-any(명시 any)
 // 설계 결정도 회귀로 못박는다: 주석으로 사유를 밝힌 catch 는 통과 · execFileSync(safeExecFile 통로)는 허용.
 
-// 동작 검증용 규칙(명시) — eslint.config.js 의 값과 동일하게 유지. config 존재 여부는 아래 정합 테스트가 봉인.
-const PERMANENT_RULES: Linter.RulesRecord = {
-  'no-restricted-syntax': [
-    'error',
-    { selector: "CallExpression[callee.name='execSync']", message: 'execSync 금지' },
-    { selector: "MemberExpression[property.name='execSync']", message: 'execSync 금지' },
-  ],
-  'no-empty': ['error', { allowEmptyCatch: false }],
-  '@typescript-eslint/no-explicit-any': 'error',
+// flat config 배열 전체에서 rules 병합 — 특정 항목 위치([0])에 의존하지 않음(CodeRabbit #395).
+const configs = Array.isArray(eslintConfig) ? eslintConfig : [eslintConfig]
+const mergedRules: Record<string, unknown> = {}
+for (const c of configs) {
+  const r = (c as { rules?: Record<string, unknown> }).rules
+  if (r) Object.assign(mergedRules, r)
 }
+
+// ★동작 검증은 config 의 **실제 규칙 값**으로 한다(명시 복제값이 아니라). 그래서 config 가 약화되면
+//   (no-empty 가 allowEmptyCatch:true 로 바뀌거나 selector 가 빠지거나 규칙이 삭제되면) 아래 동작
+//   테스트가 직접 빨강이 된다 — 존재만 보는 toBeDefined 보다 강한 드리프트 봉인(CodeRabbit #395).
+const TESTED_RULES = {
+  'no-restricted-syntax': mergedRules['no-restricted-syntax'],
+  'no-empty': mergedRules['no-empty'],
+  '@typescript-eslint/no-explicit-any': mergedRules['@typescript-eslint/no-explicit-any'],
+} as Linter.RulesRecord
 
 function lint(code: string): Linter.LintMessage[] {
   const linter = new Linter()
@@ -29,7 +35,7 @@ function lint(code: string): Linter.LintMessage[] {
     },
     // @typescript-eslint 플러그인 등록(no-explicit-any 제공). 타입 마찰만 회피.
     plugins: { '@typescript-eslint': tseslint.plugin as unknown as Linter.Plugin },
-    rules: PERMANENT_RULES,
+    rules: TESTED_RULES,
   })
 }
 
@@ -37,7 +43,7 @@ function hits(code: string, ruleId: string): number {
   return lint(code).filter((m) => m.ruleId === ruleId).length
 }
 
-describe('영구 코딩 규칙 — ESLint 코드화 (RULES.md 자동 집행)', () => {
+describe('영구 코딩 규칙 — ESLint 코드화 (RULES.md 자동 집행, config 실제 값으로 검증)', () => {
   describe('R1: execSync 신규 금지 (no-restricted-syntax)', () => {
     it('execSync 직접 호출을 잡는다', () => {
       expect(hits("import { execSync } from 'node:child_process'\nexecSync('echo')", 'no-restricted-syntax')).toBeGreaterThan(0)
@@ -52,8 +58,8 @@ describe('영구 코딩 규칙 — ESLint 코드화 (RULES.md 자동 집행)', (
     })
   })
 
-  describe('R2: 빈 catch 금지 (no-empty)', () => {
-    it('완전 빈 catch 를 잡는다', () => {
+  describe('R2: 빈 catch 금지 (no-empty, allowEmptyCatch:false)', () => {
+    it('완전 빈 catch 를 잡는다 — config 가 allowEmptyCatch:true 로 약화되면 이 테스트가 빨강', () => {
       expect(hits('try { doThing() } catch {}', 'no-empty')).toBeGreaterThan(0)
     })
 
@@ -72,16 +78,11 @@ describe('영구 코딩 규칙 — ESLint 코드화 (RULES.md 자동 집행)', (
     })
   })
 
-  describe('config 정합 — 규칙이 eslint.config.js 에 실제 켜져 있다 (드리프트 1차 봉인)', () => {
-    const flat = (Array.isArray(eslintConfig) ? eslintConfig[0] : eslintConfig) as {
-      rules?: Record<string, unknown>
-    }
-    const cfgRules = flat.rules ?? {}
-
-    it('세 영구 규칙이 모두 eslint.config.js 에 정의돼 있다', () => {
-      expect(cfgRules['no-restricted-syntax']).toBeDefined()
-      expect(cfgRules['no-empty']).toBeDefined()
-      expect(cfgRules['@typescript-eslint/no-explicit-any']).toBeDefined()
+  describe('config 정합 — 규칙이 eslint.config.js 에 실제 켜져 있다 (드리프트 봉인)', () => {
+    it('세 영구 규칙이 모두 eslint.config.js 에 정의돼 있다 (삭제 시 위 동작 테스트도 빨강)', () => {
+      expect(mergedRules['no-restricted-syntax']).toBeDefined()
+      expect(mergedRules['no-empty']).toBeDefined()
+      expect(mergedRules['@typescript-eslint/no-explicit-any']).toBeDefined()
     })
 
     it('깨끗한 코드는 위반 0', () => {


### PR DESCRIPTION
## 무엇

Goal 87 PR1이 **작업별 계약(mission.json)** 을 검증한 데 이어, **프로젝트 영구 규칙(RULES.md)** 을 자동 검증에 합류시킵니다. RULES.md 코딩 규칙 중 문서로만 있던 3가지를 ESLint 규칙으로 코드화:

| 규칙 | 구현 | 비고 |
|---|---|---|
| execSync 신규 금지 | `no-restricted-syntax` | `execFileSync`(=`safeExecFile` 통로)는 허용 — execSync만 차단 |
| 빈 catch 금지 | `no-empty` (allowEmptyCatch:false) | 주석으로 사유 밝힌 catch는 통과(말없이 삼킴만 차단) |
| 명시 any 금지 | `@typescript-eslint/no-explicit-any` | tsc strict는 implicit만, 명시 `: any`/`as any`는 여기서 |

receipt 합류는 **#381로 이미 배선**(lint fail → `gates.red` → block) → 새 합류 코드 0줄. 영구 규칙 위반이 이제 `receipt`에서 거짓완료로 자동 표면화됩니다.

## 검증 (구현 전 적대 검증 포함)

- **위반 0 실측**: `eslint src` EXIT=0 (3규칙 적용 후에도 기존 코드 깨끗)
- **규칙 작동 negative test**: src에 위반 3개 심은 probe → 각 규칙 1건 검출 확인 후 삭제("config 오류로 무시돼서 0" 아님을 입증)
- **R1 통로 안전**: `safeExecFile`은 `execFileSync` 사용 → R1에 안 걸림
- **단위(tests/eslint-rules.test.ts)**: Linter API로 8케이스 — 검출 + 설계결정(주석 catch 통과·execFileSync 허용·깨끗한 코드 0)
- `tsc --noEmit` 0 · `pnpm build` 성공
- ⚠️ 로컬 vitest는 환경 worker crash → **CI가 진실원**. tsx로 8케이스 직접 PASS 확인

## 설계 결정 (정직)

- **console.log 제외**: 986건 중 952건이 commands의 정상 CLI 출력 → 전체 금지 불가, 경로별 차등은 임의 예외 필요 → Phase 3 별도 트랙
- **드리프트 봉인 1차**: 테스트가 eslint.config.js에 3규칙 존재 확인. 더 강한 RULES.md↔ESLint 일치는 Phase 2

## 잔여 (후속)

- Phase 2(병렬): receipt 합류 E2E + RULES.md↔ESLint 일치 봉인
- Phase 3: console.log 경로별 정책

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 코드 품질 기준이 강화되어, 빈 `catch`, 명시적 `any`, 일부 안전하지 않은 명령 호출 패턴이 더 엄격하게 차단됩니다.
  * 린트 규칙이 실제로 적용되는지 자동 검증하는 테스트가 추가되어, 규칙 일관성과 안정성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->