### PR TITLE
feat(mission): glob 미지원 forbidden 문법 거짓 안전 → caution 정직화 (Goal 87 방향 2-1)

### DIFF
--- a/docs/log/2026-06-25-glob-honest-forbidden.md
+++ b/docs/log/2026-06-25-glob-honest-forbidden.md
@@ -1,0 +1,39 @@
+# 2026-06-25 — glob 미지원 forbidden 문법 거짓 안전 → caution (방향 2-1)
+
+## 결함 요약
+
+`mission.json`의 `forbidden` 배열에 `!`, `{}`, `[]`, 후행 `/`를 포함한 glob 패턴을 쓰면
+`globToRegExp`가 해당 패턴을 잘못 처리해 **파일이 실제로는 금지 경로인데도 매칭 실패**로 조용히 통과했다.
+
+- `!src/a.ts` — negation glob. globToRegExp가 `!`를 리터럴로 escape해 `\!src\/a\.ts`가 됨 → 경로와 절대 매칭 안 됨.
+- `src/{a,b}.ts` — 중괄호 확장. escape돼 리터럴 `\{a\,b\}` 매칭 → 실제 `src/a.ts` 통과.
+- `src/[ab].ts` — 문자 클래스. escape돼 리터럴 `\[ab\]` 매칭 → `src/a.ts` 통과.
+- `src/` — 후행 `/`. 경로는 `/`로 끝나지 않으므로 절대 매칭 안 됨.
+
+결과: forbidden인데 위반 0 → receipt에서 forbidden 검증이 완료된 것처럼 보였다 = **거짓 안전**.
+
+## 수정 접근 (방향 2-1 — 정직화, 차단 격상 없음)
+
+1. `detectUnsupportedGlob(g: string): string | null` 순수 함수 추가 (mission.ts)
+   - 검출: `!` 어느 위치든 / `{` / `[` / 후행 `/` → 비null(미지원 표시).
+   - `?`는 `[^/]`로 변환돼 **지원되므로** 검출 안 함.
+
+2. `MissionCheckResult`에 `unsupportedForbiddenPatterns: string[]` 추가.
+3. `ReceiptIntentEvidence`에 `unsupportedForbiddenCount?: number` 옵셔널 추가 (GA 동결).
+4. `decideReceipt` caution 분기에 `unsupportedForbidden` 조건 추가 — block 분기 절대 불변.
+5. `collectIntent` (receipt.ts 경계)에서 `unsupportedForbiddenCount` 전파.
+6. `receiptReasons` + `renderReceiptMarkdown` ⑤ intent 행에 사유/비고 표기.
+7. `ko.ts` receipt 섹션에 `unsupportedForbiddenGlob` 키 추가.
+8. `missionCheck` CLI에서 미지원 패턴 경고 출력 + "✓ 통과" 모순 방지.
+
+## 불변식 유지 확인 (tsx 직접 실행)
+
+- 8/8 detectUnsupportedGlob 케이스 PASS
+- checkMission: violations=0, unsupportedForbiddenPatterns=1 (src/{a,b}.ts)
+- decideReceipt unsupportedForbiddenCount=1 → caution (block 아님)
+- decideReceipt missionKnown=false, unsupportedForbiddenCount=5 → pass (하위호환)
+
+## 참조
+
+- Goal 87 방향 2-1 (방향 B 설계)
+- critic: L-1(중간 ! 검출·"✓ 통과" 모순), L-2(? 지원됨 예외), L-3(toBe 단언) 반영

--- a/src/commands/mission.ts
+++ b/src/commands/mission.ts
@@ -64,19 +64,17 @@ export function globToRegExp(glob: string): RegExp {
   return new RegExp('^' + re + '$')
 }
 
-/**
- * glob 패턴이 globToRegExp 로 지원되지 않는 문법을 포함하는지 검출. 포함하면 패턴 문자열(비null) 반환.
- *
- * 검출 규칙:
- * - `!` — 어느 위치에든 포함 시 미지원(negation glob 은 globToRegExp 가 처리 안 함).
- * - `{` — 중괄호 확장({a,b}) 미지원. `.+^${}()|[]\\` escape 목록에 `{` 가 있어 리터럴로 처리됨.
- * - `[` — 문자 클래스([abc]·[!abc]) 미지원. escape 처리돼 리터럴 `[` 로만 매칭됨.
- * - 후행 `/` — 디렉터리 한정 glob. globToRegExp 가 trailing slash 를 그대로 re 에 붙여
- *   "경로가 /로 끝나야 매칭" 조건을 만들므로 파일 경로와 절대 매칭 안 됨.
- *
- * why: `?` 는 `[^/]` 로 변환돼 **지원됨** → 검출 대상 아님(L-2).
- *      `*`·`**` 도 지원. [abc]·[!abc] 는 escape돼 리터럴로 처리되므로 둘 다 미지원 경고 대상.
- */
+// glob 패턴이 globToRegExp 로 지원되지 않는 문법을 포함하는지 검출. 포함하면 패턴 문자열(비null) 반환.
+//
+// 검출 규칙:
+// - `!` — 어느 위치에든 포함 시 미지원(negation glob 은 globToRegExp 가 처리 안 함).
+// - `{` — 중괄호 확장({a,b}) 미지원. `.+^${}()|[]\\` escape 목록에 `{` 가 있어 리터럴로 처리됨.
+// - `[` — 문자 클래스([abc]·[!abc]) 미지원. escape 처리돼 리터럴 `[` 로만 매칭됨.
+// - 후행 `/` — 디렉터리 한정 glob. globToRegExp 가 trailing slash 를 그대로 re 에 붙여
+//   "경로가 /로 끝나야 매칭" 조건을 만들므로 파일 경로와 절대 매칭 안 됨.
+//
+// why: `?` 는 `[^/]` 로 변환돼 지원됨 → 검출 대상 아님(L-2).
+//      `*`·`**` 도 지원. [abc]·[!abc] 는 escape돼 리터럴로 처리되므로 둘 다 미지원 경고 대상.
 export function detectUnsupportedGlob(g: string): string | null {
   if (g.includes('!')) return g
   if (g.includes('{')) return g

--- a/src/commands/mission.ts
+++ b/src/commands/mission.ts
@@ -8,6 +8,7 @@ import { readJsonFile } from '../lib/read-json.js'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
 import { printNextStep } from '../lib/next-step.js'
 import { isInteractive } from '../lib/interactive.js'
+import { ko } from '../i18n/ko.js'
 
 /**
  * Goal 17: vhk mission — Mission Contract (Trust Loop scope/intent 층).
@@ -36,6 +37,7 @@ export interface MissionCheckResult {
   violations: { file: string; pattern: string }[]
   warnings: { file: string }[]
   disclaimer: string
+  unsupportedForbiddenPatterns: string[]
 }
 
 /** glob → RegExp. `**`=경로 전체(슬래시 포함), `*`=세그먼트 내, `?`=한 글자. 외부 의존 0. */
@@ -62,6 +64,27 @@ export function globToRegExp(glob: string): RegExp {
   return new RegExp('^' + re + '$')
 }
 
+/**
+ * glob 패턴이 globToRegExp 로 지원되지 않는 문법을 포함하는지 검출. 포함하면 패턴 문자열(비null) 반환.
+ *
+ * 검출 규칙:
+ * - `!` — 어느 위치에든 포함 시 미지원(negation glob 은 globToRegExp 가 처리 안 함).
+ * - `{` — 중괄호 확장({a,b}) 미지원. `.+^${}()|[]\\` escape 목록에 `{` 가 있어 리터럴로 처리됨.
+ * - `[` — 문자 클래스([abc]·[!abc]) 미지원. escape 처리돼 리터럴 `[` 로만 매칭됨.
+ * - 후행 `/` — 디렉터리 한정 glob. globToRegExp 가 trailing slash 를 그대로 re 에 붙여
+ *   "경로가 /로 끝나야 매칭" 조건을 만들므로 파일 경로와 절대 매칭 안 됨.
+ *
+ * why: `?` 는 `[^/]` 로 변환돼 **지원됨** → 검출 대상 아님(L-2).
+ *      `*`·`**` 도 지원. [abc]·[!abc] 는 escape돼 리터럴로 처리되므로 둘 다 미지원 경고 대상.
+ */
+export function detectUnsupportedGlob(g: string): string | null {
+  if (g.includes('!')) return g
+  if (g.includes('{')) return g
+  if (g.includes('[')) return g
+  if (g.endsWith('/')) return g
+  return null
+}
+
 /** 경로가 glob 목록 중 하나라도 매칭하는지. 경로 구분자는 posix(/)로 정규화. */
 function matchesAny(file: string, globs: string[]): string | null {
   const norm = file.replace(/\\/g, '/')
@@ -78,6 +101,7 @@ function matchesAny(file: string, globs: string[]): string | null {
 export function checkMission(changedFiles: string[], mission: Mission): MissionCheckResult {
   const violations: MissionCheckResult['violations'] = []
   const warnings: MissionCheckResult['warnings'] = []
+  const unsupportedForbiddenPatterns = mission.forbidden.filter((g) => detectUnsupportedGlob(g) !== null)
   for (const file of changedFiles) {
     const forbiddenHit = matchesAny(file, mission.forbidden)
     if (forbiddenHit) {
@@ -88,7 +112,7 @@ export function checkMission(changedFiles: string[], mission: Mission): MissionC
       warnings.push({ file })
     }
   }
-  return { violations, warnings, disclaimer: MISSION_DISCLAIMER }
+  return { violations, warnings, disclaimer: MISSION_DISCLAIMER, unsupportedForbiddenPatterns }
 }
 
 /** .vhk/mission.json 읽기 (BOM-safe). 없거나 손상이면 null. */
@@ -213,7 +237,12 @@ export async function missionCheck(): Promise<void> {
     console.log(chalk.yellow.bold(`\n  ⚠️  scope 밖 변경 ${result.warnings.length}건 (경고)`))
     for (const w of result.warnings) console.log(chalk.yellow(`   ? ${w.file}`))
   }
-  if (result.violations.length === 0 && result.warnings.length === 0) {
+  if (result.unsupportedForbiddenPatterns.length > 0) {
+    console.log(chalk.yellow.bold(`\n  ⚠️  ${ko.receipt.unsupportedForbiddenGlob(result.unsupportedForbiddenPatterns.length)}`))
+    for (const p of result.unsupportedForbiddenPatterns) console.log(chalk.yellow(`   ? ${p}`))
+  }
+  // 미지원 패턴이 있으면 "✓ 통과"와 "⚠️ 미지원" 모순 메시지를 동시 출력하지 않는다(critic L-1).
+  if (result.violations.length === 0 && result.warnings.length === 0 && result.unsupportedForbiddenPatterns.length === 0) {
     console.log(chalk.green('\n  ✓ 변경이 계약(scope/forbidden) 안입니다.'))
   }
   console.log(chalk.yellow(`\n  ${result.disclaimer}`))

--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -138,8 +138,13 @@ export function collectIntent(cwd: string, baseSha?: string | null): ReceiptInte
     // git 실패 → 변경 목록 미상. 빈 목록(위반 0)으로 둔다 — 거짓 block 금지(정직). 다른 증거가 보완.
   }
   const changed = [...files].filter((f) => !isSelfTrackedPath(f))
-  const { violations, warnings } = checkMission(changed, mission)
-  return { missionKnown: true, forbiddenHits: violations.length, scopeWarnings: warnings.length }
+  const result = checkMission(changed, mission)
+  return {
+    missionKnown: true,
+    forbiddenHits: result.violations.length,
+    scopeWarnings: result.warnings.length,
+    unsupportedForbiddenCount: result.unsupportedForbiddenPatterns.length,
+  }
 }
 
 /**

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -270,6 +270,9 @@ export const ko = {
     nextBlockMessage: '🔴 기계증거가 "됐어요"와 모순 — 아직 완료 아님. 막힌 증거(red/dirty/stale)부터 고치세요:',
     nextCautionMessage: '🟡 실차단은 없으나 약신호 있음(수동 확인 권장). 보강 후 다시 떼세요:',
     nextPassMessage: '🟢 게으른 거짓완료 징후 없음(미묘한 오류는 못 잡음). 완료 처리하려면:',
+    // Goal 87 방향 2-1: glob 미지원 문법 경고 — 거짓 안전을 caution 으로 드러냄.
+    unsupportedForbiddenGlob: (n: number) =>
+      `forbidden 패턴 ${n}개에 미지원 glob 문법(!, {}, [], 후행 /) — 해당 forbidden 검증 무효. 지원: *, **, ?`,
   },
   worktree: {
     checkTitle: '🌳 Worktree env 점검',

--- a/src/lib/receipt.ts
+++ b/src/lib/receipt.ts
@@ -52,6 +52,11 @@ export interface ReceiptIntentEvidence {
   forbiddenHits: number
   /** scope 밖 변경 파일 수(>0 → caution — advisory). */
   scopeWarnings: number
+  /**
+   * 금지 패턴 중 glob 미지원 문법 개수. >0이면 forbidden 검증이 무효일 수 있음 → caution(advisory).
+   * undefined·0은 무시. GA 동결 — 옵셔널로만 추가(기존 시그니처 불변).
+   */
+  unsupportedForbiddenCount?: number
 }
 
 /** 영수증 입력 — 4대 기계증거 + (옵션) 의도 대조(commands/receipt.ts 가 git/verify/diff-cover/mission 에서 수집). */
@@ -96,7 +101,9 @@ export function decideReceipt(e: ReceiptEvidence): ReceiptDecision {
   // 약신호(soft) — 차단은 아니나 "안심"도 금지 → caution. (단조성: pass 로 못 내려감)
   const hasUncoveredChange = e.diffCover.measured && e.diffCover.totalUncovered > 0
   const scopeWarned = intentKnown && e.intent!.scopeWarnings > 0
-  if (e.gates.hasSoftWarning || !e.staleKnown || hasUncoveredChange || scopeWarned) return 'caution'
+  // intentKnown이 false면 단락평가로 e.intent! 접근 안 됨 — 이 순서 필수(GA 동결, 단조성 불변식 ②·③ 유지).
+  const unsupportedForbidden = intentKnown && (e.intent!.unsupportedForbiddenCount ?? 0) > 0
+  if (e.gates.hasSoftWarning || !e.staleKnown || hasUncoveredChange || scopeWarned || unsupportedForbidden) return 'caution'
 
   return 'pass'
 }
@@ -122,6 +129,10 @@ export function receiptReasons(e: ReceiptEvidence): string[] {
   }
   if (e.intent?.missionKnown && e.intent.scopeWarnings > 0)
     reasons.push(`scope 밖 변경 ${e.intent.scopeWarnings}건 — 시킨 범위 밖일 수 있음(advisory, 차단 안 함)`)
+  if (e.intent?.missionKnown && (e.intent.unsupportedForbiddenCount ?? 0) > 0)
+    reasons.push(
+      `forbidden 패턴 ${e.intent.unsupportedForbiddenCount}개가 glob 미지원 문법 포함 — forbidden 검증이 무효할 수 있음(!, {}, [], 후행 / — caution)`
+    )
   if (reasons.length === 0) reasons.push('전 게이트 green · clean · 신선 · 변경라인 풀커버')
   return reasons
 }
@@ -246,13 +257,19 @@ export function renderReceiptMarkdown(r: Receipt): string {
   // ⑤ intent(의도 대조, Goal 87) — mission.json 있을 때만 행 추가(없으면 출력 변화 0 = 하위호환).
   if (e.intent?.missionKnown) {
     const it = e.intent
-    const intentCell = it.forbiddenHits > 0 ? '❌' : it.scopeWarnings > 0 ? 'ℹ️' : '✅'
-    const intentNote =
-      it.forbiddenHits > 0
-        ? `forbidden 위반 ${it.forbiddenHits}건 — 시킨 범위(의도) 어김`
-        : it.scopeWarnings > 0
-          ? `scope 밖 변경 ${it.scopeWarnings}건 — advisory(차단 안 함)`
-          : 'scope/forbidden 계약 준수'
+    const unsupportedCount = it.unsupportedForbiddenCount ?? 0
+    const intentCell = it.forbiddenHits > 0 ? '❌' : it.scopeWarnings > 0 || unsupportedCount > 0 ? 'ℹ️' : '✅'
+    let intentNote: string
+    if (it.forbiddenHits > 0) {
+      intentNote = `forbidden 위반 ${it.forbiddenHits}건 — 시킨 범위(의도) 어김`
+    } else if (it.scopeWarnings > 0) {
+      intentNote = `scope 밖 변경 ${it.scopeWarnings}건 — advisory(차단 안 함)`
+    } else if (unsupportedCount > 0) {
+      // forbiddenHits=0 이더라도 미지원 문법으로 인해 검증 자체가 무효일 수 있음 — 정직 표기.
+      intentNote = `forbidden 패턴 미지원 문법 — 검증 무효 가능(caution)`
+    } else {
+      intentNote = 'scope/forbidden 계약 준수'
+    }
     lines.push(`| ⑤ intent(의도 대조) | ${intentCell} | ${intentNote} |`)
   }
   lines.push('')

--- a/tests/mission.test.ts
+++ b/tests/mission.test.ts
@@ -11,6 +11,7 @@ import {
   missionSet,
   missionShow,
   missionCheck,
+  detectUnsupportedGlob,
   MISSION_PATH_REL,
   MISSION_DISCLAIMER,
   type Mission,
@@ -35,6 +36,33 @@ describe('mission — globToRegExp', () => {
   it('`*.md` 는 루트 세그먼트만 (디렉터리 안 넘음)', () => {
     expect(globToRegExp('*.md').test('README.md')).toBe(true)
     expect(globToRegExp('*.md').test('docs/x.md')).toBe(false)
+  })
+})
+
+describe('mission — detectUnsupportedGlob (방향 2-1)', () => {
+  it('선두 ! → 비null (negation glob 미지원)', () => {
+    expect(detectUnsupportedGlob('!src/a.ts')).not.toBeNull()
+  })
+  it('중간 ! → 비null (어느 위치든 ! 는 미지원, L-1)', () => {
+    expect(detectUnsupportedGlob('src/a!b.ts')).not.toBeNull()
+  })
+  it('{ 포함 → 비null (중괄호 확장 미지원)', () => {
+    expect(detectUnsupportedGlob('src/{a,b}.ts')).not.toBeNull()
+  })
+  it('[ 포함 → 비null (문자 클래스 미지원, [abc]·[!abc] 둘 다)', () => {
+    expect(detectUnsupportedGlob('src/[ab].ts')).not.toBeNull()
+  })
+  it('후행 / → 비null (디렉터리 glob 미지원)', () => {
+    expect(detectUnsupportedGlob('src/')).not.toBeNull()
+  })
+  it('? 는 지원됨 → null (L-2: globToRegExp 가 [^/] 로 변환)', () => {
+    expect(detectUnsupportedGlob('src/a?.ts')).toBeNull()
+  })
+  it('** 포함 일반 패턴 → null (지원)', () => {
+    expect(detectUnsupportedGlob('src/**/*.ts')).toBeNull()
+  })
+  it('*.md → null (지원)', () => {
+    expect(detectUnsupportedGlob('*.md')).toBeNull()
   })
 })
 
@@ -63,6 +91,15 @@ describe('mission — checkMission (순수)', () => {
   it('disclaimer 항상 존재 ("보장 아님" + 경로 glob 한계)', () => {
     expect(checkMission([], mission([], [])).disclaimer).toBe(MISSION_DISCLAIMER)
     expect(MISSION_DISCLAIMER).toMatch(/경로 glob|의미/)
+  })
+  it('미지원 forbidden 패턴 → unsupportedForbiddenPatterns 수집, 위반은 0 (glob 실패지 파일 매치 아님)', () => {
+    const r = checkMission(['src/a.ts'], mission([], ['src/{a,b}.ts']))
+    expect(r.violations).toHaveLength(0)
+    expect(r.unsupportedForbiddenPatterns).toHaveLength(1)
+  })
+  it('지원 forbidden 패턴만 있으면 unsupportedForbiddenPatterns 빈 배열', () => {
+    const r = checkMission(['src/a.ts'], mission([], ['**/secret*']))
+    expect(r.unsupportedForbiddenPatterns).toHaveLength(0)
   })
 })
 

--- a/tests/receipt.test.ts
+++ b/tests/receipt.test.ts
@@ -278,6 +278,36 @@ describe('decideReceipt — ⑤ intent(의도 대조) 반영', () => {
   })
 })
 
+// Goal 87 방향 2-1: glob 미지원 문법 → 거짓 안전을 caution 으로 드러냄.
+describe('decideReceipt — unsupportedForbiddenCount (방향 2-1)', () => {
+  it('unsupportedForbiddenCount>0 → caution (forbidden 검증 무효 가능 — advisory, block 아님)', () => {
+    const e = cleanEvidence()
+    e.intent = { missionKnown: true, forbiddenHits: 0, scopeWarnings: 0, unsupportedForbiddenCount: 1 }
+    expect(decideReceipt(e)).toBe('caution')
+  })
+
+  it('단조성 — unsupportedForbiddenCount>0 결과 등급 ≥ cleanEvidence() 결과 등급', () => {
+    const order: Record<ReceiptDecision, number> = { pass: 0, caution: 1, block: 2 }
+    const base = cleanEvidence()
+    const baseRank = order[decideReceipt(base)]
+    const e = cleanEvidence()
+    e.intent = { missionKnown: true, forbiddenHits: 0, scopeWarnings: 0, unsupportedForbiddenCount: 1 }
+    expect(order[decideReceipt(e)]).toBeGreaterThanOrEqual(baseRank)
+  })
+
+  it('missionKnown=false + unsupportedForbiddenCount=5 → pass (하위호환, 영향 0)', () => {
+    const e = cleanEvidence()
+    e.intent = { missionKnown: false, forbiddenHits: 0, scopeWarnings: 0, unsupportedForbiddenCount: 5 }
+    expect(decideReceipt(e)).toBe('pass')
+  })
+
+  it('intent 없을 때(undefined) → pass 유지 (하위호환)', () => {
+    const e = cleanEvidence()
+    expect(e.intent).toBeUndefined()
+    expect(decideReceipt(e)).toBe('pass')
+  })
+})
+
 describe('renderReceiptMarkdown — ⑤ intent 행', () => {
   function receiptWithIntent(intent: ReceiptEvidence['intent']) {
     const e = cleanEvidence()


### PR DESCRIPTION
## 요약

`mission.json`의 `forbidden` 패턴에 `!`, `{}`, `[]`, 후행 `/`를 쓰면 `globToRegExp`가 매칭을 못 해
금지 경로인데도 조용히 통과하던 **거짓 안전**을 `caution`으로 드러낸다.

- `detectUnsupportedGlob` 순수 함수 추가 — 미지원 문법 검출 (`?`·`*`·`**`는 지원 → 검출 안 함)
- `MissionCheckResult.unsupportedForbiddenPatterns: string[]` 필드 추가
- `ReceiptIntentEvidence.unsupportedForbiddenCount?: number` 옵셔널 추가 (GA 동결)
- `decideReceipt` caution 분기에 `unsupportedForbidden` 조건 추가 (block 분기 불변)
- `collectIntent`에서 `unsupportedForbiddenCount` 전파
- `receiptReasons`·`renderReceiptMarkdown` ⑤ intent 행 — 미지원 패턴 사유/비고 표기
- `missionCheck` CLI — 미지원 패턴 경고 출력 + `✓ 통과`·`⚠️ 미지원` 동시 출력 모순 방지

## 불변식 유지

- block 분기 절대 불변 (단조성)
- `missionKnown=false` 시 `unsupportedForbiddenCount`가 있어도 decision 영향 0 (하위호환)
- 기존 GA 시그니처 breaking 없음 (옵셔널만 추가)

## 테스트 계획

- [ ] `detectUnsupportedGlob` 8케이스 단위 (tsx로 직접 검증 완료)
- [ ] `checkMission` — 미지원 패턴 → `violations=0, unsupportedForbiddenPatterns=1`
- [ ] `decideReceipt` — `unsupportedForbiddenCount=1` → `caution`, `missionKnown=false` → `pass`
- [ ] CI (pnpm build green 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 미지원 glob 문법(`!`, `{}`, `[]`, 끝나는 `/`)이 포함된 금지 패턴을 감지해 별도로 표시합니다.
  * `mission check` 결과와 영수증에 해당 패턴 수와 목록, 경고 메시지가 추가됩니다.
  * 검사 출력이 한국어 메시지로 개선되었습니다.

* **Bug Fixes**
  * 미지원 패턴이 있을 때도 “통과”와 “미지원”이 동시에 보이는 혼동을 방지했습니다.
  * 미지원 금지 패턴이 있으면 판정이 더 적절하게 주의 상태로 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->