### PR TITLE
feat(receipt): mission checksum 스냅샷 + baseSha 무결성 — 위조 방어 2층 (Goal 87 방향 3-③·3-④)

### DIFF
--- a/docs/log/2026-06-25-receipt-integrity.md
+++ b/docs/log/2026-06-25-receipt-integrity.md
@@ -1,0 +1,47 @@
+# 2026-06-25 — receipt 위조 방어: mission checksum 스냅샷 + baseSha 무결성 (방향 3-③·3-④)
+
+> append-only dev log. Goal 87 의도 검증 방향 3(위조·미설정 차단)의 두 조각을 한 PR에 순차 구현.
+> 브랜치 `feat/receipt-integrity` · 베이스 main(#398 머지 후 — unsupportedForbiddenCount/decideReceipt 반영본).
+
+## 무엇을·왜 (위조 방어 0 → checksum + baseSha 무결성)
+
+receipt 는 "AI 의 됐어요"를 기계증거로 대조하는데, 그 증거 자체가 위조·오타로 무력화되는 두 구멍이 있었다.
+
+### 3-③ mission checksum 스냅샷 (사후 위조 탐지)
+- 구멍: receipt 발행 *후* `.vhk/mission.json`(목표·forbidden)을 완화로 사후 위조해도, 그 영수증이
+  *어떤 계약으로* 판정했는지 증명할 길이 없었다. → 같은 mission 의 두 영수증을 구분 못 함.
+- 수정: `ReceiptIntentEvidence.missionChecksum?: string`(옵셔널, GA 동결) 추가 — `collectIntent`에서
+  Node 내장 `crypto.createHash('sha256')`로 mission.json **raw 내용**(BOM·양끝공백 정규화) 해시 앞 16자.
+  - raw 파일을 해시(파싱 결과 아님) → objective/scope/forbidden 한 글자만 바뀌어도 checksum 변화.
+  - **decision 영향 0** — 순수 사후 감사용. `decideReceipt` 손대지 않음(단조성 불변식 ②·③ 불변).
+  - `.md` 출력에 1줄 표시(mission 있을 때만 — 없으면 출력 변화 0 = 하위호환).
+
+### 3-④ baseSha 무결성 검증 (거짓 stale 방지)
+- 구멍: baseSha(`.base-sha` 파일 또는 `--since` 인자)가 위조·오타·다른 레포 SHA·비커밋 객체여도
+  그대로 사용 → `baseSha ≠ HEAD`가 무조건 참 = **거짓 stale(block)**, intent 의 `git diff <baseSha>`도
+  엉뚱한 기준으로 돌아감.
+- 수정: `verifyBaseSha(cwd, sha)` 추가 — receipt.ts 가 이미 쓰는 `gitOut`(safeExecFile 통로, **execSync 신규 0**)으로
+  `git rev-parse --verify <sha>^{commit}` 실행. 커밋으로 역참조 가능할 때만 통과, 아니면 throw→false.
+  - `collectReceipt`에서 baseSha 계산 직후 검증 — 무효면 null 처리(stale 미상=caution, **block 아님**) + 경고 출력.
+  - `^{commit}` 핵심: blob/tree/태그가 아니라 커밋인지까지 확인(SHA 존재만으로 통과 금지).
+
+## 검증
+
+- `pnpm build` green · `pnpm typecheck` green · `pnpm lint` green(영구 규칙 ESLint 3종 통과 — execSync 신규 0·빈 catch 0·any 0).
+- 순수 로직 테스트(vitest): decideReceipt 18 + render 3 + checksum-decision 2 전부 green.
+- git 스폰 경로(`collectIntent` checksum · `verifyBaseSha` · `collectReceipt` baseSha): 로컬 vitest forks
+  워커가 child-process 스폰에서 크래시(환경 이슈 — [[vhk-local-vitest-forks]], 기존 collectIntent 테스트도 동일 크래시 재현).
+  → tsx 단독 하니스로 **실 git 레포 대조 13/13 green**. 전체 `pnpm test:run`: 954 pass · **assertion 실패 0** · 92 worker-crash(전부 환경). CI(forks)가 진실원.
+- 적대검증(verifyBaseSha): `--hard`(flag-like)→false(인젝션 0), `HEAD; rm -rf x`(no-shell)→false, 빈문자/공백→false,
+  `HEAD`·단축SHA·이미 `^{commit}` 붙은 값→true. 거짓 *pass* 방향 우회 없음(모두 caution 방향으로만 보수적).
+
+## 테스트 설계 함정 (스스로 잡음)
+- 초안: "무효 baseSha → decision ≠ block" 단언. 실패. 원인은 코드 아님 — bare 임시 레포가 `collectReceipt`
+  실행 중 `.vhk/reports`·ledger 를 써서 **dirty=true**가 독립적으로 block 을 만듦(diag 로 확인).
+- 교정: decision(오염 가능)이 아니라 3-④ 직접 출력(`base.sha=null`·`staleKnown=false`·`stale=false`)만 단언.
+
+## 파일
+- `src/lib/receipt.ts` — `ReceiptIntentEvidence.missionChecksum?`(why 블록주석) + render checksum 1줄.
+- `src/commands/receipt.ts` — `missionChecksum()` 헬퍼 + `verifyBaseSha()` + `collectReceipt` baseSha 검증·경고.
+- `src/i18n/ko.ts` — `receipt.invalidBaseSha(sha)` 추가만(기존 키 불변).
+- `tests/receipt.test.ts` — 3-③·3-④ describe 블록 추가.

--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
 import { join } from 'node:path'
 import chalk from 'chalk'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
@@ -16,7 +17,7 @@ import { fileCoverageByFile, COVERAGE_CORRUPT } from '../lib/coverage-parse.js'
 import { diffCoverage } from '../lib/diff-coverage.js'
 import { parsePorcelainLines } from '../lib/git-porcelain.js'
 import { porcelainPath, isSelfTrackedPath } from '../lib/self-tracked.js'
-import { readMission, checkMission } from './mission.js'
+import { readMission, checkMission, MISSION_PATH_REL } from './mission.js'
 import {
   buildReceipt,
   renderReceiptMarkdown,
@@ -53,6 +54,28 @@ export function readBaseSha(cwd: string): string | null {
   } catch {
     // 읽기 실패는 "미기록"으로 정직 처리(거짓 stale 금지).
     return null
+  }
+}
+
+/**
+ * 방향 3-④: baseSha 무결성 검증 — 그 SHA 가 실제 레포의 커밋 객체인지 git 에 묻는다.
+ *
+ * 왜: baseSha(.base-sha 파일 또는 --since 인자)는 사람·외부 입력이라 위조·오타·다른 레포 SHA·
+ *   비커밋 객체(blob/tree)일 수 있다. 검증 없이 그대로 쓰면 "baseSha ≠ HEAD"가 무조건 참이 되어
+ *   **거짓 stale(block)** 을 만들고, intent 의 `git diff <baseSha>` 도 엉뚱한 기준으로 돌아간다.
+ *   `git rev-parse --verify <sha>^{commit}` 는 해당 객체를 커밋으로 역참조 가능할 때만 0 으로 끝나고
+ *   아니면 throw → 무효로 판정한다(존재하지 않거나 커밋이 아니면 false).
+ *
+ * @returns 유효한 커밋이면 true. 무효(미존재·비커밋·git 실패)면 false → 호출부가 baseSha 를 null 처리.
+ */
+export function verifyBaseSha(cwd: string, sha: string): boolean {
+  try {
+    // ^{commit}: blob/tree/태그가 아니라 커밋으로 역참조 가능한지까지 본다(SHA 존재만으로 통과 금지).
+    gitOut(['rev-parse', '--verify', `${sha}^{commit}`], cwd)
+    return true
+  } catch {
+    // throw = 미존재/비커밋/레포 아님 → 무효. 거짓 stale 방지로 호출부가 baseSha 를 버린다.
+    return false
   }
 }
 
@@ -115,6 +138,25 @@ export function collectDiffCover(cwd: string): ReceiptDiffCover {
  * check` 는 self-tracked 를 제외 안 하므로 결과가 미세하게 다를 수 있다 — 의도된 차이.)
  * mission.json 없으면 undefined → decision·출력 영향 0(하위호환).
  */
+/**
+ * 방향 3-③: mission.json 내용의 sha256 스냅샷(앞 16자). 사후 위조 탐지용 — decision 영향 0.
+ *
+ * 왜 raw 파일을 해시하나: readMission 의 파싱 결과가 아니라 디스크의 실제 바이트를 본다 →
+ * objective/scope/forbidden 어느 한 글자라도 바뀌면 checksum 이 달라진다. BOM·양끝 공백은 stripBom+trim
+ * 으로 정규화(무의미한 차이로 checksum 이 흔들리지 않게) — 의미 있는 내용 변화만 반영. 16자 절단:
+ * 사후 대조엔 충돌확률 무시 가능하고 영수증 가독성↑. 읽기 실패 → undefined(거짓 checksum 금지, 정직).
+ */
+function missionChecksum(cwd: string): string | undefined {
+  try {
+    const raw = stripBom(readFileSync(join(cwd, MISSION_PATH_REL), 'utf-8')).trim()
+    if (!raw) return undefined
+    return createHash('sha256').update(raw, 'utf-8').digest('hex').slice(0, 16)
+  } catch {
+    // 읽기 실패는 checksum 부재로 정직 처리 — intent 본체(forbidden/scope)는 readMission 으로 이미 수집됨.
+    return undefined
+  }
+}
+
 export function collectIntent(cwd: string, baseSha?: string | null): ReceiptIntentEvidence | undefined {
   const mission = readMission(cwd)
   if (!mission) return undefined
@@ -144,6 +186,7 @@ export function collectIntent(cwd: string, baseSha?: string | null): ReceiptInte
     forbiddenHits: result.violations.length,
     scopeWarnings: result.warnings.length,
     unsupportedForbiddenCount: result.unsupportedForbiddenPatterns.length,
+    missionChecksum: missionChecksum(cwd),
   }
 }
 
@@ -163,7 +206,13 @@ export function collectReceipt(cwd: string, baseShaOverride?: string | null): Re
   const dirty = commit?.dirty ?? false
 
   // ③ stale — 작업시작 기준선 SHA ≠ 현재 HEAD. 기준선/HEAD 미상이면 stale 미상(거짓 block 금지).
-  const baseSha = baseShaOverride !== undefined ? baseShaOverride : readBaseSha(cwd)
+  // 방향 3-④: 기준선 SHA 가 실제 커밋인지 먼저 검증 — 위조·오타·다른 레포 SHA·비커밋 객체면 무효
+  //   처리해 거짓 stale(block)·엉뚱한 diff 기준을 막는다(무효 → null → stale 미상=caution, block 아님).
+  const rawBaseSha = baseShaOverride !== undefined ? baseShaOverride : readBaseSha(cwd)
+  const baseSha = rawBaseSha !== null && !verifyBaseSha(cwd, rawBaseSha) ? null : rawBaseSha
+  if (rawBaseSha !== null && baseSha === null) {
+    console.error(chalk.yellow(`  ⚠️  ${ko.receipt.invalidBaseSha(rawBaseSha)}`))
+  }
   const staleKnown = baseSha !== null && headSha !== null
   const stale = staleKnown ? baseSha !== headSha : false
 

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -273,6 +273,9 @@ export const ko = {
     // Goal 87 방향 2-1: glob 미지원 문법 경고 — 거짓 안전을 caution 으로 드러냄.
     unsupportedForbiddenGlob: (n: number) =>
       `forbidden 패턴 ${n}개에 미지원 glob 문법(!, {}, [], 후행 /) — 해당 forbidden 검증 무효. 지원: *, **, ?`,
+    // Goal 87 방향 3-④: 작업시작 기준선 SHA 가 실제 커밋이 아님(위조·오타·다른 레포) — 무효 처리(거짓 stale 방지).
+    invalidBaseSha: (sha: string) =>
+      `작업시작 기준선 SHA(${sha})가 이 레포의 커밋이 아닙니다 — 무효 처리(stale 판정 제외). vhk receipt --mark-start 로 다시 고정하세요.`,
   },
   worktree: {
     checkTitle: '🌳 Worktree env 점검',

--- a/src/lib/receipt.ts
+++ b/src/lib/receipt.ts
@@ -57,6 +57,12 @@ export interface ReceiptIntentEvidence {
    * undefined·0은 무시. GA 동결 — 옵셔널로만 추가(기존 시그니처 불변).
    */
   unsupportedForbiddenCount?: number
+  // 방향 3-③: 영수증 발행 시점 mission.json 내용의 sha256 스냅샷(앞 16자).
+  // 왜: receipt 는 발행 후 mission.json 이 사후 위조(목표·forbidden 완화)돼도 그 영수증의 판정 근거가
+  //   무엇이었는지 증명할 길이 없었다. checksum 을 박아두면 "이 영수증은 *그때의* 계약으로 판정했다"가
+  //   사후 검증 가능해진다(같은 mission 의 두 영수증 checksum 이 다르면 사이에 계약이 바뀐 것).
+  // decision 에는 절대 반영 안 함 — 순수 사후 감사용(단조성 불변식 ②·③ 불변). GA 동결 — 옵셔널 추가만.
+  missionChecksum?: string
 }
 
 /** 영수증 입력 — 4대 기계증거 + (옵션) 의도 대조(commands/receipt.ts 가 git/verify/diff-cover/mission 에서 수집). */
@@ -273,6 +279,11 @@ export function renderReceiptMarkdown(r: Receipt): string {
     lines.push(`| ⑤ intent(의도 대조) | ${intentCell} | ${intentNote} |`)
   }
   lines.push('')
+  // 방향 3-③: mission checksum 1줄(사후 위조 탐지용). mission 있을 때만 — 없으면 출력 변화 0(하위호환).
+  if (e.intent?.missionKnown && e.intent.missionChecksum) {
+    lines.push(`- mission checksum: \`${e.intent.missionChecksum}\` (발행 시점 .vhk/mission.json 내용 해시 — 사후 위조 탐지용)`)
+    lines.push('')
+  }
   lines.push('**사유:**')
   for (const reason of r.reasons) lines.push(`- ${reason}`)
   lines.push('')

--- a/tests/receipt.test.ts
+++ b/tests/receipt.test.ts
@@ -11,7 +11,7 @@ import {
   type ReceiptDecision,
   HONESTY_LINE,
 } from '../src/lib/receipt.js'
-import { collectReceipt, collectIntent } from '../src/commands/receipt.js'
+import { collectReceipt, collectIntent, verifyBaseSha } from '../src/commands/receipt.js'
 
 // Goal 86 (RFC 0056 T1): vhk receipt — 4대 기계증거 → 영수증 1장.
 // 핵심 불변식(테스트로 고정):
@@ -436,4 +436,158 @@ describe('collectIntent(경계) — mission.json ↔ 변경 파일', () => {
     expect(intent?.scopeWarnings).toBe(0)
     expect(intent?.forbiddenHits).toBe(0)
   })
+
+  // 방향 3-③: mission checksum 스냅샷(사후 위조 탐지). decision 영향 0 — 순수 사후 감사용.
+  it('mission 있으면 missionChecksum 존재 + 16자 hex', () => {
+    const d = makeMissionRepo({ forbidden: ['secret/**'], scope: [] })
+    const intent = collectIntent(d)
+    expect(intent?.missionChecksum).toBeDefined()
+    expect(intent?.missionChecksum).toMatch(/^[0-9a-f]{16}$/)
+  })
+
+  it('mission.json 내용이 바뀌면 checksum 도 달라진다(사후 위조 탐지)', () => {
+    const d = makeMissionRepo({ forbidden: ['secret/**'], scope: [] })
+    const before = collectIntent(d)?.missionChecksum
+    // forbidden 을 완화(위조 시나리오) → 내용 변화 → checksum 변화.
+    fs.writeFileSync(
+      path.join(d, '.vhk', 'mission.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        objective: 'test',
+        scope: [],
+        forbidden: [],
+        createdAt: '2026-06-25T00:00:00.000Z',
+        updatedAt: '2026-06-25T00:00:00.000Z',
+      }),
+      'utf-8'
+    )
+    const after = collectIntent(d)?.missionChecksum
+    expect(before).toBeDefined()
+    expect(after).toBeDefined()
+    expect(after).not.toBe(before)
+  })
+
+  it('하위호환 — mission 없으면 missionChecksum 자체가 없다(undefined intent)', () => {
+    const d = makeMissionRepo(null)
+    expect(collectIntent(d)).toBeUndefined()
+  })
+})
+
+// 방향 3-③: checksum 은 decision 에 절대 반영 안 됨(순수 사후 감사) — 단조성 불변식 ②·③ 불변.
+describe('decideReceipt — missionChecksum 은 decision 무영향(3-③)', () => {
+  it('checksum 유무가 decision 을 바꾸지 않는다(clean→pass 유지)', () => {
+    const withSum = cleanEvidence()
+    withSum.intent = { missionKnown: true, forbiddenHits: 0, scopeWarnings: 0, missionChecksum: 'deadbeefdeadbeef' }
+    const without = cleanEvidence()
+    without.intent = { missionKnown: true, forbiddenHits: 0, scopeWarnings: 0 }
+    expect(decideReceipt(withSum)).toBe('pass')
+    expect(decideReceipt(without)).toBe('pass')
+    expect(decideReceipt(withSum)).toBe(decideReceipt(without))
+  })
+
+  it('forbidden 위반 + checksum 있어도 여전히 block(checksum 이 격상시키지 못함)', () => {
+    const e = cleanEvidence()
+    e.intent = { missionKnown: true, forbiddenHits: 1, scopeWarnings: 0, missionChecksum: 'abcdef0123456789' }
+    expect(decideReceipt(e)).toBe('block')
+  })
+})
+
+describe('renderReceiptMarkdown — mission checksum 1줄(3-③)', () => {
+  function md(intent: ReceiptEvidence['intent']) {
+    const e = cleanEvidence()
+    e.intent = intent
+    return renderReceiptMarkdown(
+      buildReceipt(e, {
+        generatedAt: '2026-06-25T00:00:00.000Z',
+        date: '2026-06-25',
+        slug: 's',
+        headSha: 'abc1234def',
+        baseSha: 'abc1234def',
+      })
+    )
+  }
+
+  it('checksum 있으면 mission checksum 줄을 표시', () => {
+    const out = md({ missionKnown: true, forbiddenHits: 0, scopeWarnings: 0, missionChecksum: 'deadbeefdeadbeef' })
+    expect(out).toContain('mission checksum')
+    expect(out).toContain('deadbeefdeadbeef')
+  })
+
+  it('checksum 없으면(mission 있어도) checksum 줄 없음', () => {
+    const out = md({ missionKnown: true, forbiddenHits: 0, scopeWarnings: 0 })
+    expect(out).not.toContain('mission checksum')
+  })
+
+  it('하위호환 — mission 부재(intent undefined)면 checksum 줄 없음', () => {
+    const out = md(undefined)
+    expect(out).not.toContain('mission checksum')
+  })
+})
+
+// 방향 3-④: baseSha 무결성 — 위조·오타·비커밋 SHA 를 무효 처리(거짓 stale 방지).
+describe('verifyBaseSha / collectReceipt — baseSha 무결성(3-④)', () => {
+  const tmpDirs: string[] = []
+  afterEach(() => {
+    for (const d of tmpDirs) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true })
+      } catch {
+        /* 정리 실패 무시 */
+      }
+    }
+    tmpDirs.length = 0
+  })
+
+  // 커밋 2개 + 빌드/테스트 게이트 없는 임시 git 레포 — baseSha 검증만 본다.
+  function makeRepo(): { dir: string; head: string } {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-receipt-basesha-'))
+    tmpDirs.push(d)
+    const g = (args: string[]): void => {
+      execFileSync('git', args, { cwd: d, stdio: 'pipe' })
+    }
+    g(['init'])
+    g(['config', 'user.email', 't@t'])
+    g(['config', 'user.name', 't'])
+    fs.writeFileSync(path.join(d, 'README.md'), 'seed\n', 'utf-8')
+    g(['add', '.'])
+    g(['commit', '-m', 'seed'])
+    const head = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: d, encoding: 'utf-8' }).trim()
+    return { dir: d, head }
+  }
+
+  it('verifyBaseSha — 실제 HEAD 커밋이면 true', () => {
+    const { dir, head } = makeRepo()
+    expect(verifyBaseSha(dir, head)).toBe(true)
+  })
+
+  it('verifyBaseSha — 존재하지 않는 SHA 면 false(위조·오타)', () => {
+    const { dir } = makeRepo()
+    expect(verifyBaseSha(dir, '0000000000000000000000000000000000000000')).toBe(false)
+    expect(verifyBaseSha(dir, 'not-a-sha')).toBe(false)
+  })
+
+  it('verifyBaseSha — 커밋이 아닌 객체(tree)면 false(^{commit} 역참조 실패)', () => {
+    const { dir, head } = makeRepo()
+    // HEAD 의 tree SHA — 존재하는 객체지만 커밋이 아님. ^{commit} 으로 못 풀어야 정상.
+    const treeSha = execFileSync('git', ['rev-parse', `${head}^{tree}`], { cwd: dir, encoding: 'utf-8' }).trim()
+    expect(verifyBaseSha(dir, treeSha)).toBe(false)
+  })
+
+  // 무효 baseSha → 무효 처리(stale 미상). decision 은 임시 레포의 dirty/게이트로 오염될 수 있어
+  // 단언하지 않는다 — 3-④의 직접 출력(base.sha null·staleKnown false·stale false)만 본다.
+  it('collectReceipt — 무효 baseSha(--since 위조) → base.sha null · staleKnown false · stale false', () => {
+    const { dir } = makeRepo()
+    const r = collectReceipt(dir, '0000000000000000000000000000000000000000')
+    expect(r.base.sha).toBeNull()
+    expect(r.evidence.staleKnown).toBe(false)
+    expect(r.evidence.stale).toBe(false) // 무효 baseSha 는 거짓 stale 을 만들지 않는다.
+  }, 30_000)
+
+  it('collectReceipt — 유효 baseSha(=HEAD) → base.sha 보존 · staleKnown true · stale=false', () => {
+    const { dir, head } = makeRepo()
+    const r = collectReceipt(dir, head)
+    expect(r.base.sha).toBe(head)
+    expect(r.evidence.staleKnown).toBe(true)
+    expect(r.evidence.stale).toBe(false)
+  }, 30_000)
 })


### PR DESCRIPTION
## 결론

receipt 증거 자체를 위조·오타로 무력화하던 **두 구멍**을 한 PR에 순차로 막는다. 둘 다 GA 동결 준수(옵셔널 추가만), `decideReceipt` 불변(단조성 유지), `latest.json` 불변.

## 무엇을·왜

### 3-③ mission checksum 스냅샷 (사후 위조 탐지)
- **구멍**: receipt 발행 *후* `.vhk/mission.json`(목표·forbidden)을 완화로 사후 위조해도, 그 영수증이 *어떤 계약으로* 판정했는지 증명할 길이 없었다.
- **수정**: `ReceiptIntentEvidence.missionChecksum?`(옵셔널) — `collectIntent`가 Node 내장 `crypto.createHash('sha256')`로 mission.json **raw 내용** 해시(앞 16자). raw 파일 기준이라 objective/scope/forbidden 한 글자만 바뀌어도 checksum 변화. **decision 영향 0**(순수 사후 감사용). `.md` 1줄 표시(mission 있을 때만).

### 3-④ baseSha 무결성 검증 (거짓 stale 방지)
- **구멍**: baseSha(`.base-sha` 또는 `--since`)가 위조·오타·다른 레포 SHA·비커밋 객체여도 그대로 써서 `baseSha ≠ HEAD`가 무조건 참 = **거짓 stale(block)**, intent 의 `git diff <baseSha>`도 엉뚱한 기준.
- **수정**: `verifyBaseSha` — receipt.ts 가 이미 쓰는 `gitOut`(=`safeExecFile`, **execSync 신규 0**)으로 `git rev-parse --verify <sha>^{commit}`. 커밋으로 역참조 가능할 때만 통과. 무효면 `collectReceipt`가 null 처리(stale 미상=caution, **block 아님**) + 경고. `^{commit}`로 blob/tree/태그 배제.

## 검증
- `pnpm build`·`pnpm typecheck`·`pnpm lint` 전부 green(영구 규칙 ESLint 3종 통과).
- 순수 로직 테스트(vitest): decideReceipt 18 + render 3 + checksum-decision 2 green.
- git 스폰 경로: 로컬 vitest forks 워커가 child-process 스폰에서 크래시(환경 이슈, 기존 테스트도 동일 — assertion 실패 0). tsx 단독 하니스로 **실 git 레포 대조 13/13 green**. CI(forks)가 진실원.
- **적대검증**(verifyBaseSha): `--hard`(flag-like)→false(인젝션 0), `HEAD; rm -rf x`(no-shell)→false, 빈문자/공백→false, `HEAD`·단축SHA·`^{commit}` 중복→true. 거짓 *pass* 방향 우회 없음(보수적으로 caution 방향만).

## 파일
- `src/lib/receipt.ts` — `missionChecksum?` 필드(why 블록주석) + render checksum 1줄
- `src/commands/receipt.ts` — `missionChecksum()` + `verifyBaseSha()` + `collectReceipt` 검증·경고
- `src/i18n/ko.ts` — `receipt.invalidBaseSha` 추가만
- `tests/receipt.test.ts` — 3-③·3-④ describe
- `docs/log/2026-06-25-receipt-integrity.md` — dev log

🤖 Generated with [Claude Code](https://claude.com/claude-code)