### PR TITLE
fix(check): vhk check <미인식> silent fallback 제거 — evals 안내·미인식 exit 1 (#405)

### DIFF
--- a/docs/log/2026-06-27-405-check-evals-fallback.md
+++ b/docs/log/2026-06-27-405-check-evals-fallback.md
@@ -1,0 +1,36 @@
+# 2026-06-27 — #405 `vhk check evals` silent fallback 제거
+
+## 증상 (이슈 #405)
+`vhk check evals` 실행 시 'evals' 인자가 무시되고 RULES.md 규칙점검(checkRules)으로 조용히 빠짐(silent fallback).
+golden-set.md(#403)는 `vhk check evals`를 골든셋 채점기로 명시하지만 채점기 본체는 로드맵 goal G-B 예정(미구현)
+→ 사용자가 "골든셋 채점이 돌았다"고 오해할 위험.
+
+## 'evals'가 삼켜지던 위치 (근거)
+이중으로 삼켜짐:
+1. **NL 라우터 가로채기** — `src/lib/cli-args.ts` `detectNaturalLanguageInput`(line 193·200): `routeNaturalLanguage('check evals')`가
+   nlp-router 의 bare `check` 키워드 규칙(`src/lib/nlp-router.ts:344` `/규칙.*(점검|위반)|린트|check|위반/`)에 매칭 →
+   문장 전체('check evals')를 자연어로 판정해 반환. (commander 까지 못 감)
+2. **dispatch 무인자 호출** — `src/lib/nlp-run.ts:74-75` `case 'check': return check()` → `check()`를 인자 없이 호출 → 'evals' 소실 → `checkRules()`.
+   (설령 NL 을 거치지 않아도 `src/index.ts`의 commander `check` 정의에 위치인자가 없어 'evals' 는 excess arg 로 무시됨.)
+
+## 고친 방법 (가장 단순한 해법 — check 위치인자 처리)
+- `src/index.ts` — commander `check` 에 `.argument('[target]')` 추가, action 을 `(target, opts) => check(opts, target)` 로.
+- `src/commands/check.ts` — `check(opts, target?)`: target 있으면 `checkSubcommand(target)` 로 분기.
+  - `evals` → 골든셋 채점기 미구현(goal G-B) **정보성 안내**(exit 0) + `docs/evals/golden-set.md` 참조 + printNextStep.
+  - 그 외 → "알 수 없는 인자 'X' — vhk check 는 RULES.md 규칙 점검" **정직한 안내 + exit 1**(#346: 조용한 성공 위장 차단).
+  - 출력은 logger SoT(`log.*`, Goal 51) 사용 — 신규 raw `console.log(chalk)` 부채 0.
+- `src/lib/cli-args.ts` — `POSITIONAL_ARG_COMMANDS={check,점검,린트}` 추가 → `detectNaturalLanguageInput` 이 `vhk check <arg>` 를
+  NL 로 가로채지 않고 commander 위치인자로 위임(FREEFORM_ARG_COMMANDS 와 동일 패턴). 한글 별칭 포함.
+- `src/i18n/ko.ts` — `check.evalsTitle·evalsHint·unknownTarget(fn)·unknownHint` 메시지 추가.
+- `tests/check.test.ts` — 라우팅 가드(`check/점검/린트 evals`→null) + 회귀(`규칙 점검` NL 유지) + evals 안내(exit 0)·미인식 안내(exit 1) 테스트 추가.
+
+## 게이트
+- `pnpm build` ✅(tsc DTS 타입 통과) · `pnpm exec tsc --noEmit` ✅ · `pnpm lint`(eslint) ✅
+- 정적 게이트 ✅: check-no-raw-json-parse PASS · check-no-stray PASS · no-raw-output 신규 hit 0(기존 checkRules baseline 만).
+- 실 CLI 검증(dist): `vhk check evals`·`vhk 점검 evals` → G-B 안내·exit 0(NL 배너 없음=commander 처리 확인) / `vhk check bogus` → exit 1 /
+  회귀 `vhk 규칙 점검`(NL)→규칙점검 · `vhk check`(무인자)→규칙점검 · `vhk check --goal 999`→goal 게이트.
+- 로컬 vitest forks/threads 불안정(TS-004): check.test.ts 단독 실행도 exit 127 — 단, 무수정 `cli-args.test.ts`·`goal.test.ts` 도 동일 127,
+  `cost.test.ts` 는 `process.chdir() not supported in workers` 로만 실패 → 환경 한계 확인. **전체 회귀는 CI(forks 정상)가 진실원.**
+
+## 다음
+- 골든셋 채점기 본체는 로드맵 goal G-B 에서 구현(이 PR 은 silent fallback 제거 + 안내까지). CI green 후 머지 판단.

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import fs from 'node:fs'
 import { parseRules, type RuleViolation } from '../lib/rules-parser.js'
 import { ko } from '../i18n/ko.js'
+import { log } from '../utils/logger.js'
 import { printNextStep } from '../lib/next-step.js'
 import { goalCheck } from './goal.js'
 
@@ -10,12 +11,42 @@ export interface CheckOptions {
   goal?: string
 }
 
-export async function check(opts: CheckOptions = {}) {
+export async function check(opts: CheckOptions = {}, target?: string) {
+  // #405: `vhk check <target>` 위치인자 처리 — 'evals'(골든셋 채점기, 미구현) 등 미인식 서브명령이
+  // RULES.md 규칙점검으로 조용히 빠지던(silent fallback) 동작을 막고 명시적으로 안내한다.
+  const sub = target?.trim()
+  if (sub) {
+    return checkSubcommand(sub)
+  }
   // --goal <id> 지정 시 goal-aware 게이트로 우회 (RULES.md 점검 대신).
   if (opts.goal !== undefined) {
     return goalCheck({ id: opts.goal })
   }
   return checkRules()
+}
+
+/**
+ * #405: `vhk check <target>` 의 서브명령 안내. silent fallback 금지.
+ *  - 'evals' = 골든셋 채점기용 예약어(본체 미구현, 로드맵 goal G-B) → 정보성 안내(exit 0).
+ *  - 그 외   = 알 수 없는 인자 → 정직한 안내 + exit 1(#346: 조용한 성공 위장 차단).
+ */
+function checkSubcommand(sub: string) {
+  if (sub === 'evals') {
+    log.plain('')
+    log.bold(ko.check.evalsTitle)
+    log.dim(`  ${ko.check.evalsHint}`)
+    printNextStep({
+      message: '지금은 인자 없는 `vhk check` 가 RULES.md 규칙을 점검해요.',
+      command: 'vhk check',
+      cursorHint: '규칙 점검 돌려줘',
+    })
+    return
+  }
+  log.plain('')
+  log.warn(ko.check.unknownTarget(sub))
+  log.dim(`  ${ko.check.unknownHint}`)
+  log.plain('')
+  process.exitCode = 1
 }
 
 async function checkRules() {

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -217,6 +217,12 @@ export const ko = {
     noAutoRules: '⚠️ 자동으로 검사할 규칙이 없어요.',
     allPassed: '🎉 규칙을 모두 지켰어요!',
     summary: '📊 점검 결과:',
+    // #405: 'evals' 는 골든셋 채점기용 예약 서브명령 — 본체는 로드맵 goal G-B 에서 구현(현재 미구현).
+    evalsTitle: '🚧 골든셋 채점기는 아직 미구현이에요 (로드맵 goal G-B).',
+    evalsHint: '채점 기준은 docs/evals/golden-set.md 에 있어요 — 자동 채점은 goal G-B 에서 구현 예정이에요.',
+    // #405: 미인식 인자는 규칙점검으로 조용히 빠지지(silent fallback) 않고 정직하게 안내.
+    unknownTarget: (arg: string) => `알 수 없는 인자 '${arg}' — vhk check 는 RULES.md 규칙 점검 명령이에요.`,
+    unknownHint: '인자 없이 `vhk check` 로 실행하면 규칙을 점검해요.',
   },
   doctor: {
     title: '🩺 개발 환경 점검',

--- a/src/index.ts
+++ b/src/index.ts
@@ -273,9 +273,10 @@ program
   .command('check')
   .alias('점검')
   .alias('린트')
+  .argument('[target]', "예약 서브명령 'evals'(골든셋 채점기, goal G-B 예정) — 미구현/미인식은 안내 (#405)")
   .option('--goal <id>', 'goal id 지정 시 scripts/check-goal-<id>.sh 게이트 실행')
   .description('RULES.md 규칙 점검 — 코드 위반 검사 (또는 --goal <id> 로 goal 게이트)')
-  .action(async (opts: { goal?: string }) => { await check(opts) })
+  .action(async (target: string | undefined, opts: { goal?: string }) => { await check(opts, target) })
 
 const secureCmd = program
   .command('secure')

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -91,6 +91,17 @@ const FREEFORM_ARG_COMMANDS = new Set([
 ])
 
 /**
+ * 위치인자(예약 서브명령 등)를 명령 스스로 처리하는 leaf 명령 → NL 가로채기 금지.
+ * #405: `vhk check evals` 의 'evals' 가 NL 라우터의 bare 'check' 키워드(nlp-router 규칙)에 삼켜져
+ * check() 가 인자 없이 실행되는 silent fallback 을 막는다 → commander 위치인자로 위임해
+ * check() 가 직접 인식/안내(evals 미구현 안내·미인식 인자 에러)하게 한다.
+ * (영문 + 한글 별칭 모두 — KNOWN_COMMAND_TOKENS ⊆ 실제 명령/별칭 을 registry-drift 가 강제하므로 실재 토큰만.)
+ */
+const POSITIONAL_ARG_COMMANDS = new Set([
+  'check', '점검', '린트',
+])
+
+/**
  * 서브커맨드를 갖는 컨테이너 명령 → 실제 서브커맨드 이름 목록.
  * `goal check` · `ref add` · `memory list` 처럼 rest[1] 이 실제 서브커맨드면
  * commander 가 직접 처리한다(자연어 라우터가 가로채지 못하게 — R1: 명령어 매칭 우선).
@@ -182,6 +193,9 @@ export function detectNaturalLanguageInput(argv: string[]): string | null {
 
   // #147: 자유형식 본문 명령(learn/blocker)은 본문에 NLP 키워드가 있어도 가로채지 않는다.
   if (firstIsKnown && FREEFORM_ARG_COMMANDS.has(first)) return null
+
+  // #405: 위치인자 처리 명령(check)은 NL 가로채기 금지 → commander 가 'evals' 등 위치인자를 받게.
+  if (firstIsKnown && POSITIONAL_ARG_COMMANDS.has(first)) return null
 
   // vhk save / vhk 검증
   if (firstIsKnown && rest.length === 1) return null

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { parseRules } from '../src/lib/rules-parser.js'
+import { check } from '../src/commands/check.js'
+import { detectNaturalLanguageInput } from '../src/lib/cli-args.js'
+import { setSink } from '../src/utils/logger.js'
 
 describe('vhk check', () => {
   it('RULES.md 없으면 빈 규칙 배열 반환', () => {
@@ -61,5 +64,63 @@ describe('vhk check', () => {
     expect(structure!.check(tmp)).toEqual([])
 
     fs.rmSync(tmp, { recursive: true })
+  })
+})
+
+// #405: `vhk check <미인식>` 이 RULES.md 규칙점검으로 silent fallback 하지 않고 명시적으로 안내.
+describe('vhk check <서브명령> — silent fallback 차단 (#405)', () => {
+  it('vhk check evals → NL 라우터가 가로채지 않고 commander 위치인자로 위임 (null)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'check', 'evals'])).toBeNull()
+  })
+
+  it('vhk 점검 evals → 한글 별칭도 동일 (null)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '점검', 'evals'])).toBeNull()
+  })
+
+  it('vhk 린트 evals → 한글 별칭도 동일 (null)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '린트', 'evals'])).toBeNull()
+  })
+
+  // 회귀: 인자 없는 자연어 규칙점검은 여전히 NL 로 흐른다(check 키워드 → check 명령).
+  it('회귀: vhk 규칙 점검(자연어) → 여전히 자연어 라우팅', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '규칙', '점검'])).toBe('규칙 점검')
+  })
+
+  describe('서브명령 안내 출력', () => {
+    let captured: string[] = []
+    let restoreSink: (() => void) | undefined
+    let prevExitCode: typeof process.exitCode
+
+    afterEach(() => {
+      restoreSink?.()
+      restoreSink = undefined
+      captured = []
+      process.exitCode = prevExitCode
+    })
+
+    function run(target: string): Promise<void> {
+      captured = []
+      prevExitCode = process.exitCode
+      restoreSink = setSink((line) => captured.push(line))
+      return check({}, target)
+    }
+
+    it("evals → 골든셋 채점기 미구현(goal G-B) 안내, 규칙점검으로 안 샘", async () => {
+      await run('evals')
+      const out = captured.join('\n')
+      expect(out).toMatch(/G-B/)
+      expect(out).toMatch(/golden-set\.md/)
+      // 규칙점검(checkRules)으로 흘렀다면 나올 문구가 없어야 한다 = silent fallback 아님.
+      expect(out).not.toMatch(/규칙 .*개 통과|프로젝트 규칙 점검/)
+      expect(process.exitCode ?? 0).toBe(0)
+    })
+
+    it("미인식 인자 → 정직한 안내 + exit 1 (조용한 성공 위장 차단)", async () => {
+      await run('bogus-sub')
+      const out = captured.join('\n')
+      expect(out).toMatch(/bogus-sub/)
+      expect(out).toMatch(/RULES\.md|규칙/)
+      expect(process.exitCode).toBe(1)
+    })
   })
 })


### PR DESCRIPTION
## 무엇을 / 왜

`vhk check evals` 실행 시 'evals' 인자가 무시되고 RULES.md 규칙점검으로 **조용히 빠지던(silent fallback)** 동작을 제거한다. golden-set.md(#403)는 `vhk check evals`를 골든셋 채점기로 명시하지만 채점기 본체는 로드맵 goal **G-B** 예정(미구현) → 사용자가 "골든셋 채점이 돌았다"고 오해할 위험이 있었다.

## 'evals'가 삼켜지던 위치 (근거 라인)

이중으로 삼켜짐:
1. **NL 라우터 가로채기** — `src/lib/cli-args.ts` `detectNaturalLanguageInput`(L193·L200): `routeNaturalLanguage('check evals')`가 nlp-router 의 bare `check` 키워드 규칙(`src/lib/nlp-router.ts:344` `/규칙.*(점검|위반)|린트|check|위반/`)에 매칭 → 문장 전체를 자연어로 판정 → commander 까지 도달 못 함.
2. **dispatch 무인자 호출** — `src/lib/nlp-run.ts:74-75` `case 'check': return check()` → 인자 없이 호출 → 'evals' 소실 → `checkRules()`.
   (NL 을 거치지 않더라도 commander `check` 정의에 위치인자가 없어 excess arg 로 무시됨.)

## 어떻게 고쳤나 (가장 단순한 해법: check 위치인자 처리)

- **`src/index.ts`** — commander `check` 에 `.argument('[target]')` 추가, action `(target, opts) => check(opts, target)`.
- **`src/commands/check.ts`** — `check(opts, target?)` → target 있으면 `checkSubcommand`:
  - `evals` → 골든셋 채점기 미구현(goal G-B) **정보성 안내**(exit 0) + `docs/evals/golden-set.md` 참조.
  - 그 외 → "알 수 없는 인자 'X' — vhk check 는 RULES.md 규칙 점검" **정직한 안내 + exit 1**(#346).
  - 출력은 logger SoT(`log.*`, Goal 51) — 신규 raw `console.log(chalk)` 부채 0.
- **`src/lib/cli-args.ts`** — `POSITIONAL_ARG_COMMANDS={check,점검,린트}` → `vhk check <arg>` 를 NL 로 가로채지 않고 commander 위임(FREEFORM 패턴과 동일). 한글 별칭 포함.
- **`src/i18n/ko.ts`** — `check.evalsTitle·evalsHint·unknownTarget(fn)·unknownHint`.
- **`tests/check.test.ts`** — 라우팅 가드(`check/점검/린트 evals`→null) + 회귀(`규칙 점검` NL 유지) + evals 안내(exit 0)·미인식(exit 1).

## 게이트

- `pnpm build` ✅ · `tsc --noEmit` ✅ · `pnpm lint` ✅ · check-no-raw-json-parse ✅ · check-no-stray ✅ · no-raw-output 신규 hit 0.
- 실 CLI(dist) 검증: `vhk check evals`/`vhk 점검 evals` → G-B 안내·exit 0(NL 배너 없음=commander 처리 확인) · `vhk check bogus` → exit 1 · 회귀 `vhk 규칙 점검`(NL)·`vhk check`(무인자)·`vhk check --goal 999` 정상.
- 로컬 vitest forks/threads 불안정(TS-004): check.test.ts 단독도 exit 127 — 단 무수정 `cli-args.test.ts`·`goal.test.ts` 도 동일 127 → 환경 한계. **전체 회귀는 CI 가 진실원.**

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * `vhk check <target>` 형태의 위치 인자를 지원해, 하위 명령별로 동작이 분기됩니다.
  * `evals` 입력 시 안내 메시지와 다음 단계 안내가 표시됩니다.

* **버그 수정**
  * 잘못된 입력이 자연어 처리로 잘못 해석되던 문제를 줄여, `check` 계열 명령은 위치 인자를 그대로 처리합니다.
  * 인식할 수 없는 대상은 경고와 함께 실패 상태로 종료됩니다.

* **문서/안내**
  * `check` 관련 안내 문구가 더 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->