### PR TITLE
feat(inject-bootstrap): ecosystem.mdc template (E1-02)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -158,6 +158,7 @@ vhk doctor
 | `vhk diff-cover` | 이번 변경이 테스트로 커버됐는지 측정 (자문형) |
 | `vhk mcp` | MCP 서버 시작 (stdio) |
 | `vhk mcp-init` | Cursor·Claude Desktop MCP 설정 생성 |
+| `vhk inject-bootstrap` | Cursor ecosystem 규칙 설치 (`.cursor/rules/ecosystem.mdc`) |
 | `vhk deploy` | 프로덕션 배포 (자동 감지) |
 | `vhk env` | .env → .env.example 동기화 |
 | `vhk env-check` | 필수 환경변수 누락 검사 |

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -18,6 +18,7 @@ import { printSecurityWarnings } from '../lib/check-secure.js'
 import { log } from '../utils/logger.js'
 import { writeFile, fileExists } from '../utils/file.js'
 import { generateCoreRulesContent } from '../lib/core-rules.js'
+import { generateEcosystemMdcContent } from '../lib/inject-bootstrap.js'
 import { VISION_TEMPLATE } from '../templates/vision.js'
 import { fetchPrdFromNotion } from '../notion/fetch-prd.js'
 import type { PrdContent } from '../types/prd.js'
@@ -360,6 +361,7 @@ export function generateFiles(
     '.vhkignore': VHK_IGNORE_TEMPLATE(),
     // core-ruleset 마커블록 상속 — YOHAN_BRAIN_ROOT 있으면 라이브, 없으면 번들 스냅샷
     '.agents/CORE-RULES.md': generateCoreRulesContent(null),
+    '.cursor/rules/ecosystem.mdc': generateEcosystemMdcContent(),
   }
 }
 

--- a/src/commands/inject-bootstrap.ts
+++ b/src/commands/inject-bootstrap.ts
@@ -1,0 +1,55 @@
+import chalk from 'chalk'
+import { injectBootstrap } from '../lib/inject-bootstrap.js'
+import { ko } from '../i18n/ko.js'
+import { log } from '../utils/logger.js'
+import { printNextStep } from '../lib/next-step.js'
+import { prompt } from '../lib/prompt.js'
+import { isInteractive } from '../lib/interactive.js'
+
+export type InjectBootstrapCommandOptions = {
+  yes?: boolean
+  force?: boolean
+}
+
+export async function injectBootstrapCommand(
+  options: InjectBootstrapCommandOptions = {}
+): Promise<void> {
+  const cwd = process.cwd()
+  const force = options.force === true
+
+  if (!force && !options.yes && isInteractive(options)) {
+    const { proceed } = await prompt<{ proceed: boolean }>([{
+      type: 'confirm',
+      name: 'proceed',
+      message: ko.injectBootstrap.confirm,
+      default: true,
+    }])
+    if (!proceed) {
+      log.warn(ko.injectBootstrap.cancelled)
+      return
+    }
+  }
+
+  const result = injectBootstrap(cwd, { yes: options.yes || force, force })
+
+  switch (result) {
+    case 'created':
+      log.success(ko.injectBootstrap.created)
+      break
+    case 'updated':
+      log.success(ko.injectBootstrap.updated)
+      break
+    case 'unchanged':
+      log.info(ko.injectBootstrap.unchanged)
+      break
+    case 'skipped':
+      log.warn(ko.injectBootstrap.skipped)
+      console.log(chalk.dim(`  ${ko.injectBootstrap.retryHint}`))
+      return
+  }
+
+  printNextStep({
+    message: ko.injectBootstrap.nextHint,
+    cursorHint: 'ecosystem.mdc 설치됨 — Cursor cross-repo 작업 시 contract obey',
+  })
+}

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -114,6 +114,16 @@ export const ko = {
     nextHintMessage: '프로젝트 시작 준비 끝! 이제 개발을 시작하세요.',
     nextHintCursor: 'docs/PRD.md 보고 개발 시작해줘',
   },
+  injectBootstrap: {
+    confirm: '.cursor/rules/ecosystem.mdc (Cursor ecosystem 규칙)을 설치할까요?',
+    cancelled: '취소했어요.',
+    created: '.cursor/rules/ecosystem.mdc 생성 완료',
+    updated: '.cursor/rules/ecosystem.mdc 갱신 완료',
+    unchanged: 'ecosystem.mdc 가 이미 최신입니다.',
+    skipped: '기존 ecosystem.mdc 가 vhk 템플릿이 아닙니다 — 건너뜀',
+    retryHint: '덮어쓰려면: vhk inject-bootstrap --force',
+    nextHint: 'Cursor ecosystem 규칙 설치 완료',
+  },
   gate: {
     title: '💡 아이디어 검증',
     welcome: '새 아이디어를 검증합니다. 질문에 답해주세요.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { status } from './commands/status.js'
 import { stats } from './commands/stats.js'
 import { startMcpServer, getMcpToolCount } from './mcp/server.js'
 import { mcpInit } from './commands/mcp-init.js'
+import { injectBootstrapCommand } from './commands/inject-bootstrap.js'
 import { deploy } from './commands/deploy.js'
 import { env, envCheck } from './commands/env.js'
 import { publish } from './commands/publish.js'
@@ -388,6 +389,16 @@ program
   .description('Cursor·Claude Desktop MCP 연동 설정 자동 생성 (.cursor/mcp.json)')
   .action(async () => {
     await mcpInit()
+  })
+
+program
+  .command('inject-bootstrap')
+  .alias('생태계규칙')
+  .option('--yes', '확인 없이 실행')
+  .option('--force', '기존 ecosystem.mdc 덮어쓰기')
+  .description('Cursor ecosystem 규칙 설치 (.cursor/rules/ecosystem.mdc)')
+  .action(async (opts: { yes?: boolean; force?: boolean }) => {
+    await injectBootstrapCommand(opts)
   })
 
 program

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -25,6 +25,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'diff-cover', '커버리지',
   'mcp',
   'mcp-init', 'mcp설정',
+  'inject-bootstrap', '생태계규칙',
   'deploy', '배포',
   'env', '환경변수',
   'env-check', '환경변수점검',

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -74,6 +74,7 @@ export const TOP_LEVEL_COMMANDS: ReadonlyArray<{ name: string; desc: string }> =
   { name: 'diff-cover', desc: '이번 변경이 테스트로 커버됐는지 측정 (자문형)' },
   { name: 'mcp', desc: 'MCP 서버 시작 (stdio)' },
   { name: 'mcp-init', desc: 'Cursor·Claude Desktop MCP 설정 생성' },
+  { name: 'inject-bootstrap', desc: 'Cursor ecosystem 규칙 (.cursor/rules/ecosystem.mdc)' },
   { name: 'deploy', desc: '프로덕션 배포 (자동 감지)' },
   { name: 'env', desc: '.env → .env.example 동기화' },
   { name: 'env-check', desc: '필수 환경변수 누락 검사' },

--- a/src/lib/inject-bootstrap.ts
+++ b/src/lib/inject-bootstrap.ts
@@ -1,0 +1,43 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { ECOSYSTEM_MDC_TEMPLATE, ECOSYSTEM_MDC_VERSION } from '../templates/ecosystem-mdc.js'
+import { writeFile, fileExists } from '../utils/file.js'
+
+export const ECOSYSTEM_MDC_REL = '.cursor/rules/ecosystem.mdc'
+
+export type InjectBootstrapResult = 'created' | 'updated' | 'unchanged' | 'skipped'
+
+export type InjectBootstrapOptions = {
+  yes?: boolean
+  force?: boolean
+}
+
+function isCurrentTemplate(content: string): boolean {
+  return (
+    content.includes(`ECOSYSTEM-MDC:START v${ECOSYSTEM_MDC_VERSION}`)
+    && content.includes('ECOSYSTEM-MDC:END')
+  )
+}
+
+export function generateEcosystemMdcContent(): string {
+  return ECOSYSTEM_MDC_TEMPLATE()
+}
+
+export function injectBootstrap(
+  cwd: string,
+  options: InjectBootstrapOptions = {}
+): InjectBootstrapResult {
+  const fullPath = path.join(cwd, ECOSYSTEM_MDC_REL)
+  const next = generateEcosystemMdcContent()
+
+  if (fileExists(fullPath)) {
+    const current = fs.readFileSync(fullPath, 'utf-8')
+    if (isCurrentTemplate(current)) return 'unchanged'
+    if (!options.force && !options.yes) return 'skipped'
+  }
+
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true })
+  const existed = fileExists(fullPath)
+  writeFile(fullPath, next)
+  return existed ? 'updated' : 'created'
+}

--- a/src/templates/ecosystem-mdc.ts
+++ b/src/templates/ecosystem-mdc.ts
@@ -1,0 +1,26 @@
+export const ECOSYSTEM_MDC_VERSION = '1'
+
+const START = `<!-- ECOSYSTEM-MDC:START v${ECOSYSTEM_MDC_VERSION} (vhk template — 직접 편집 금지) -->`
+const END = '<!-- ECOSYSTEM-MDC:END -->'
+
+export function ECOSYSTEM_MDC_TEMPLATE(): string {
+  return [
+    '---',
+    'description: Yohan ecosystem boundaries (Cursor-only)',
+    'alwaysApply: true',
+    '---',
+    '',
+    '# Ecosystem (Cursor-only)',
+    '',
+    START,
+    '',
+    '1. **Claude Code = primary** — handoff, release-gate, epic architecture, vhk-auto는 Claude-only (yohan-cc-skills).',
+    '2. **Cursor = secondary** — Composer batch/repeat 보조; 코딩·반복 작업용.',
+    '3. **Cross-repo / harness** — 이 레포 `AGENTS.md` 먼저; 전역 계약·tier는 **yohan-brain** `memory/core/ecosystem-contract.yaml` + `memory/core/inheritance-registry.yaml` (status=active면 obey). 로컬에 brain 없으면 MCP digest 또는 brain clone 경로 사용.',
+    '4. **Concurrency** — same repo + same branch에 에이전트 2개 금지; parallel은 worktree (`vhk worktree` / Cursor `--worktree`).',
+    '5. **Derived files** — `AGENTS.md`·`.cursorrules` 손수 편집 금지 → `RULES.md` 수정 후 `vhk sync`. `.cursor/agents/`에 `.claude/agents/` 중복 금지.',
+    '',
+    END,
+    '',
+  ].join('\n')
+}

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -25,6 +25,14 @@ const EXPECTED_FILES = [
 ]
 
 describe('vhk init', () => {
+  it('generateFiles — ecosystem.mdc 템플릿 포함 (E1-02)', () => {
+    const files = generateFiles('my-app', '설명', ['Node.js'])
+    const mdc = files['.cursor/rules/ecosystem.mdc']
+    expect(mdc).toContain('ECOSYSTEM-MDC:START')
+    expect(mdc).toContain('memory/core/inheritance-registry.yaml')
+    expect(mdc).toContain('AGENTS.md')
+  })
+
   it('템플릿 파일이 생성된다', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-test-'))
     const files = generateFiles('my-app', '테스트 프로젝트', ['Node.js', 'TypeScript'])

--- a/tests/inject-bootstrap.test.ts
+++ b/tests/inject-bootstrap.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  ECOSYSTEM_MDC_REL,
+  generateEcosystemMdcContent,
+  injectBootstrap,
+} from '../src/lib/inject-bootstrap.js'
+import { ECOSYSTEM_MDC_VERSION } from '../src/templates/ecosystem-mdc.js'
+
+describe('inject-bootstrap (E1-02)', () => {
+  it('generateEcosystemMdcContent — contract v1.1 5줄 + 마커', () => {
+    const content = generateEcosystemMdcContent()
+    expect(content).toContain(`ECOSYSTEM-MDC:START v${ECOSYSTEM_MDC_VERSION}`)
+    expect(content).toContain('alwaysApply: true')
+    expect(content).toContain('AGENTS.md')
+    expect(content).toContain('memory/core/ecosystem-contract.yaml')
+    expect(content).toContain('memory/core/inheritance-registry.yaml')
+    expect(content).toContain('vhk sync')
+    expect(content).toContain('vhk worktree')
+  })
+
+  it('injectBootstrap — created → unchanged on second run', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-inject-'))
+    try {
+      expect(injectBootstrap(tmp, { yes: true })).toBe('created')
+      const filePath = path.join(tmp, ECOSYSTEM_MDC_REL)
+      expect(fs.existsSync(filePath)).toBe(true)
+      expect(injectBootstrap(tmp, { yes: true })).toBe('unchanged')
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('injectBootstrap — custom file skipped without force', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-inject-skip-'))
+    try {
+      const filePath = path.join(tmp, ECOSYSTEM_MDC_REL)
+      fs.mkdirSync(path.dirname(filePath), { recursive: true })
+      fs.writeFileSync(filePath, '# custom\n', 'utf-8')
+      expect(injectBootstrap(tmp)).toBe('skipped')
+      expect(fs.readFileSync(filePath, 'utf-8')).toBe('# custom\n')
+      expect(injectBootstrap(tmp, { force: true })).toBe('updated')
+      expect(fs.readFileSync(filePath, 'utf-8')).toContain('ECOSYSTEM-MDC:START')
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Cursor-only .cursor/rules/ecosystem.mdc v1.1 (contract-aligned)
- New command: hk inject-bootstrap (--force for custom overwrite)
- hk init includes ecosystem.mdc

## Test plan
- [x] vitest inject-bootstrap.test.ts (3)
- [x] vitest init.test.ts ecosystem assertion
- [x] npm run build

## Depends
- private-rules-repository v0.2.2 PR (tier S inject-ecosystem-mdc)

Made with [Cursor](https://cursor.com)