### PR TITLE
fix(memory): learnings.md 재마이그레이션 가드 — 디스크 영속 (#372)

### DIFF
--- a/docs/log/2026-06-28-memory-372-remigration-guard.md
+++ b/docs/log/2026-06-28-memory-372-remigration-guard.md
@@ -1,0 +1,38 @@
+# 2026-06-28 — #372 memory.json 재마이그레이션 가드 (디스크 영속)
+
+## 증상 (이슈 #372)
+vhk 본체 레포에서 `vhk memory list`는 18개를 보여주는데 `.vhk/memory.json`이 디스크에 없음(find 0).
+매 실행 learnings.md(18개 항목)에서 **in-memory 로만** 재마이그레이션 → 영속 0회.
+→ measure-first 자기측정(recall/memory) 데이터가 디스크에 안 쌓임(데이터 파이프 (c) 차단).
+
+## 근본 원인 (이슈 추정과 다름 — 정직하게 기록)
+이슈 "근본 추정"은 `memory.ts:200`(v1 배열 + 잠금 의심 경로)을 지목했으나, **그 경로는 디스크에 v1 배열이
+실재할 때만 발동**한다. 본체 레포엔 memory.json 이 아예 없으므로(missing) 실제 발동 경로는 다름:
+
+- `readMemory()`의 **"파일 없음" 분기**(구 line 208-209): `migrateMemory(null, learnings)` 로 흡수만 하고
+  주석 그대로 "쓰지 않음" → 영구화 0회. 매 read 마다 learnings.md 18개를 in-memory 로 다시 빚음.
+- 대조: v1 배열 분기(line 193~)는 read 에서도 1회 영구화(+.v1.bak) → **계약 일관성** 보장. 누락된 건 missing 분기뿐.
+- 토이 프로젝트엔 learnings.md 가 없어 흡수분 0 → 빈 v2 → 증상 안 보임(memory add 는 mutate 경로라 정상 영속).
+
+## 고친 방법 (최소 변경 — missing 분기를 v1 분기와 동일 정책으로)
+- `src/commands/memory.ts`
+  - `persistOnRead(cwd, v2)` 헬퍼 추출 — write + 잠금 실패 시 메모리상 진행(메시지 byte-identical).
+    v1 배열 분기도 이 헬퍼 사용(중복 제거, 두 read 경로 일관성 보장).
+  - `isEmptyV2(m)` 헬퍼 — 흡수할 게 0이면 빈 memory.json 을 만들지 않게 판정(litter 방지).
+  - **missing 분기**: `migrateMemory(null, learnings)` 결과가 비어있지 않으면 `persistOnRead` 로 1회 영속.
+    learnings 도 v1 도 없어 빈 v2 면 쓰지 않음(memoryMigrate line 512 와 동일 "빈 파일 안 만듦" 정책).
+- 멱등 보장: 1회 영속 후 memory.json 은 v2 → 다음 read 는 isV2 분기로 즉시 반환(learnings 재흡수 0).
+- 안전: memory.json·memory.json.* 는 .gitignore 대상 → read 가 파일 생성해도 git 더럽힘/정크커밋 0.
+
+## 회귀 테스트 (tests/memory.test.ts · readMemory 직접 호출 = chdir 회피)
+- `#372 파일 없음 + learnings → 디스크 v2 영속(1회 write), .v1.bak 없음(신규 생성)`.
+- `#372 두 번째 read 는 재마이그레이션 안 함` — failures 2 유지(4 아님) + `.bak` 미생성(2차 write 0 증거) + 디스크 무변경.
+- `#372 파일·learnings 둘 다 없으면 memory.json 생성 안 함`(빈 파일 litter 방지).
+
+## 게이트
+- 로컬 worktree 에 node_modules 없어 `pnpm install` 선행 후 시도 — 결과는 PR 본문에 정직 기록.
+- 로컬 vitest forks 불안정(TS-004: exit 127·`process.chdir() not supported in workers`) 시 memory.test.ts 단독 실행으로 확인,
+  그래도 불안정하면 **CI 가 진실원**으로 명시.
+
+## 다음
+- CI green 확인 후 머지 판단. 본체 레포에서 `vhk memory list` 1회 실행 시 memory.json 생성되는지 실사용 확인 권장.

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -54,6 +54,11 @@ function emptyV2(): MemoryFileV2 {
   return { schemaVersion: MEMORY_SCHEMA_VERSION, decisions: [], failures: [], successes: [], patterns: [] }
 }
 
+/** 흡수할 항목이 전혀 없는 빈 v2 인가 — read 경로가 빈 memory.json 을 litter 하지 않도록 판정용(#372). */
+function isEmptyV2(m: MemoryFileV2): boolean {
+  return m.decisions.length === 0 && m.failures.length === 0 && m.successes.length === 0 && m.patterns.length === 0
+}
+
 function isV2(raw: unknown): raw is MemoryFileV2 {
   return !!raw && typeof raw === 'object' && (raw as { schemaVersion?: number }).schemaVersion === 2
 }
@@ -176,10 +181,22 @@ function readLearningsRaw(cwd: string): string | undefined {
 }
 
 /**
+ * read 경로 자동 영구화 — 마이그레이션 결과(v2)를 1회 디스크에 쓴다.
+ * 영구화 실패(파일 잠금 등)는 read 커맨드를 죽이지 않는다 — 메모리상 v2 로 진행, 다음 쓰기 때 재시도.
+ */
+function persistOnRead(cwd: string, v2: MemoryFileV2): void {
+  try {
+    writeMemory(cwd, v2)
+  } catch {
+    console.error(chalk.yellow(`   (v2 영구화 보류 — ${MEMORY_PATH_REL} 잠금 의심. 이번엔 메모리상으로만 진행)`))
+  }
+}
+
+/**
  * memory.json 읽기 → 항상 v2.
- * **계약 일관성**: 디스크가 v1 평면배열이면 read 경로(memory list / context / brief 등)에서도 1회 실제
- * 마이그레이션을 영구화(v2 write + .v1.bak) — 어느 명령으로 첫 실행해도 동일 결과.
- * 멱등: 이미 v2 면 no-op(재흡수·재기록 없음). 파일이 아예 없으면 빈 v2 만 반환(쓰지 않음).
+ * **계약 일관성**: 디스크가 v1 평면배열이거나 파일이 없어도 learnings.md 흡수분이 있으면 read 경로
+ * (memory list / context / brief 등)에서 1회 실제 마이그레이션을 영구화 — 어느 명령으로 첫 실행해도 동일 결과.
+ * 멱등: 이미 v2 면 no-op(재흡수·재기록 없음). 파일도 learnings 도 없어 흡수할 게 0이면 빈 v2 반환(쓰지 않음 — litter 방지).
  * **안전**: 파일은 있으나 파싱 불가(손상/부분 write/IO) 면 **절대 덮어쓰지 않고** 경고 후 빈 v2 반환(원본 보존).
  */
 export function readMemory(cwd: string = process.cwd()): MemoryFileV2 {
@@ -191,22 +208,20 @@ export function readMemory(cwd: string = process.cwd()): MemoryFileV2 {
   if (raw.kind === 'parsed') {
     if (isV2(raw.value)) return normalizeV2(raw.value)
     if (Array.isArray(raw.value)) {
-      // v1 평면 배열이 디스크에 **실재**할 때만 1회 영구화(+.v1.bak).
-      // 영구화 실패(파일 잠금 등)는 read 커맨드를 죽이지 않는다 — 메모리상 v2 로 진행, 다음 쓰기 때 재시도.
+      // v1 평면 배열이 디스크에 **실재**할 때 1회 영구화(+.v1.bak).
       const v2 = migrateMemory(raw.value, readLearningsRaw(cwd))
-      try {
-        writeMemory(cwd, v2)
-      } catch {
-        console.error(chalk.yellow(`   (v2 영구화 보류 — ${MEMORY_PATH_REL} 잠금 의심. 이번엔 메모리상으로만 진행)`))
-      }
+      persistOnRead(cwd, v2)
       return v2
     }
     // 파싱되나 v1/v2 아님 (미래 스키마/수동 편집) → 덮어쓰지 않고 빈 v2 반환(원본 보존).
     warnUnrecognized(cwd)
     return emptyV2()
   }
-  // 파일 없음 — 빈 v2(+learnings 흡수). 쓰지 않음.
-  return migrateMemory(null, readLearningsRaw(cwd))
+  // 파일 없음 — learnings.md 흡수분이 있으면 1회 영구화(#372: 매 read 재마이그레이션 → 디스크 영속 0 방지).
+  // 흡수할 게 전혀 없으면(빈 v2) 쓰지 않는다 — 빈 memory.json litter 방지(memoryMigrate 와 동일 정책).
+  const v2 = migrateMemory(null, readLearningsRaw(cwd))
+  if (!isEmptyV2(v2)) persistOnRead(cwd, v2)
+  return v2
 }
 
 type LoadOutcome = { ok: true; mem: MemoryFileV2 } | { ok: false }

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -79,6 +79,45 @@ describe('memory v2 — read/write (fs)', () => {
     expect(fs.existsSync(path.join(d, MEMORY_PATH_REL + '.bak'))).toBe(true)
     fs.rmSync(d, { recursive: true, force: true })
   })
+
+  // #372: memory.json 없음 + learnings.md 있음 경로가 매 read 재마이그레이션(in-memory)만 하고
+  //       디스크 영속을 0회 하던 버그 — 자기측정 데이터(recall/memory)가 디스크에 안 쌓임.
+  it('#372 readMemory: 파일 없음 + learnings → 디스크 v2 영속(1회 write), .v1.bak 없음(신규 생성)', () => {
+    const d = tmp()
+    seedLearnings(d, '- [2026-01-01 goal-1] 교훈 하나.\n- [2026-01-02 goal-2] 교훈 둘.\n')
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL))).toBe(false) // 시작: memory.json 없음
+    const mem = readMemory(d)
+    expect(mem.failures).toHaveLength(2)
+    // 핵심: in-memory 만이 아니라 디스크에 실제 영속돼야 함(#372 수용 기준).
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL))).toBe(true)
+    expect(read(d).failures.map((f) => f.lesson)).toEqual(['교훈 하나.', '교훈 둘.'])
+    // v1 원본 파일이 없었으니 .v1.bak 도 없음(신규 생성).
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL + '.v1.bak'))).toBe(false)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('#372 readMemory: 두 번째 read 는 재마이그레이션 안 함 (failures 2 유지 · .bak 미생성 = write 0)', () => {
+    const d = tmp()
+    seedLearnings(d, '- [2026-01-01 goal-1] 교훈 하나.\n- [2026-01-02 goal-2] 교훈 둘.\n')
+    readMemory(d) // 1차: 파일 없음 → learnings 흡수 후 1회 영속(신규 파일이라 .bak 없음)
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL + '.bak'))).toBe(false)
+    const after1 = read(d)
+    const mem2 = readMemory(d) // 2차: 이미 v2 → no-op(재흡수·재기록 없음)
+    // 재마이그레이션이었다면 failures 가 4(2+2)로 늘거나, 두 번째 write 로 .bak 이 생겼을 것.
+    expect(mem2.failures).toHaveLength(2)
+    expect(read(d)).toEqual(after1) // 디스크 내용 무변경
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL + '.bak'))).toBe(false) // 2차 read 가 write 0 이었다는 증거
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('#372 readMemory: 파일·learnings 둘 다 없으면 memory.json 생성 안 함 (빈 파일 litter 방지)', () => {
+    const d = tmp()
+    const mem = readMemory(d)
+    expect(mem.decisions).toEqual([])
+    expect(mem.failures).toEqual([])
+    expect(fs.existsSync(path.join(d, MEMORY_PATH_REL))).toBe(false) // 흡수할 게 없으면 안 씀
+    fs.rmSync(d, { recursive: true, force: true })
+  })
 })
 
 describe('memory v2 — recordLesson (learn 통합)', () => {


### PR DESCRIPTION
Closes #372

## 증상
vhk 본체 레포에서 `vhk memory list`는 18개를 보여주는데 `.vhk/memory.json`이 디스크에 없음(find 0). 매 실행 learnings.md(18개)에서 **in-memory 로만** 재마이그레이션 → 영속 0회. measure-first 자기측정(recall/memory) 데이터가 디스크에 안 쌓임.

## 근본 원인 (이슈 추정과 다름 — 정직하게)
이슈 "근본 추정"은 `memory.ts:200`(v1 배열 + 잠금 의심)을 지목했지만, **그 경로는 디스크에 v1 배열이 실재할 때만 발동**합니다. 본체 레포엔 memory.json 이 아예 없으므로(missing) 실제 발동 경로는 다릅니다:

- `readMemory()`의 **"파일 없음" 분기**(구 line 208-209)가 `migrateMemory(null, learnings)`로 흡수만 하고 주석 그대로 "쓰지 않음" → 영구화 0회. 매 read 마다 learnings.md 18개를 in-memory 로 다시 빚음.
- 대조: v1 배열 분기는 read 에서도 1회 영구화(+`.v1.bak`)해 **계약 일관성**을 지킴. 누락된 건 missing 분기뿐.
- 토이 프로젝트엔 learnings.md 가 없어 흡수분 0 → 빈 v2 → 증상 안 보임(이슈의 "토이는 정상" 관찰과 일치).

즉 line 200(잠금 의심)은 red herring이고, 진짜 원인은 missing 분기의 무조건 no-write 입니다. line 200 경로는 정상이라 그대로 둡니다(최소 변경).

## 수정 (`src/commands/memory.ts`)
- `persistOnRead(cwd, v2)` 헬퍼 추출 — write + 잠금 실패 시 메모리상 진행(기존 메시지 byte-identical). v1 배열 분기도 이 헬퍼 사용 → 두 read 경로 일관성.
- `isEmptyV2(m)` 헬퍼 — 흡수할 게 0이면 빈 memory.json 을 만들지 않음(litter 방지).
- **missing 분기**: `migrateMemory(null, learnings)` 결과가 비어있지 않으면 `persistOnRead`로 1회 영속. learnings·v1 둘 다 없어 빈 v2 면 쓰지 않음(`memoryMigrate`의 "빈 파일 안 만듦" 정책과 동일).
- 멱등: 1회 영속 후 memory.json 은 v2 → 다음 read 는 isV2 분기로 즉시 반환(learnings 재흡수 0).
- 안전: `.vhk/memory.json`·`memory.json.*`는 `.gitignore` 대상 → read 가 파일 생성해도 git 더럽힘/정크커밋 0.

## 테스트 (`tests/memory.test.ts`, 회귀 3건)
`readMemory(d)` 를 explicit cwd 로 직접 호출(아래 forks 크래시를 유발하는 chdir 미사용):
1. 파일 없음 + learnings → 디스크 v2 영속(1회 write), `.v1.bak` 없음(신규 생성).
2. **두 번째 read 는 재마이그레이션 안 함** — failures 2 유지(4 아님) + `.bak` 미생성(2차 write 0 증거) + 디스크 무변경.
3. 파일·learnings 둘 다 없으면 memory.json 생성 안 함(litter 방지).

## 게이트 결과
- `pnpm build` ✅ (ESM + DTS)
- `pnpm exec tsc --noEmit` ✅ (src + tests 전체 타입)
- `pnpm exec eslint src` ✅ (memory.ts clean)
- **`pnpm test`(vitest) ❌ 로컬 환경 한계** — forks 워커 "Worker exited unexpectedly", threads `exit 127`. 무관한 기존 테스트도 동일(TS-004 기록된 로컬 flaky). **CI(forks 정상)가 진실원.**
- 대신 `tsx`로 위 회귀 3케이스(12개 assert)를 직접 실행 → **ALL PASS**(vitest 풀 우회한 실증). 1c "디스크 영속됨"은 수정 전 코드라면 실패하는 케이스.

⚠️ 로컬 worktree 에 node_modules 가 없어 `pnpm install`(offline cache) 선행 후 게이트 실행했습니다. 빌드/타입/lint 는 정상 동작, vitest 만 이 환경에서 크래시(코드 결함 아님).
