### PR TITLE
fix: vhk-auto 스킬 ↔ CLI 명령 드리프트 가드 (#309)

### DIFF
--- a/tests/skill-command-drift.test.ts
+++ b/tests/skill-command-drift.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { program } from '../src/index.js'
+
+// 스킬 ↔ CLI 드리프트 가드 (VHK-023 / #309).
+// 증상이었던 것: vhk-auto 스킬이 옛/미구현 명령(`vhk loop-brief`·`vhk remind`)을 가리켜
+//   오토파일럿 앵커 단계가 unknown command 로 깨졌다(2.6.0). 명령은 이후(#273·#282, 2.7.0)
+//   실제로 추가돼 스킬은 지금 정합하지만, "스킬이 부르는 명령이 실재하나"를 기계로 잡는 가드가
+//   없어 재발 위험이 남아 있었다. 이 테스트가 그 구멍을 막는다 — 진실원은 commander 실등록 표면.
+//
+// 한계(정직): 이 가드는 레포의 정본 스킬(.claude/skills/*/SKILL.md)만 본다. 원래 2.6.0 사고는
+//   사용자의 전역 사본(~/.claude/skills/, 버전관리 밖)이었다 — 거기까진 여기서 가드 못 한다.
+
+const SKILLS_DIR = '.claude/skills'
+
+// 스킬이 의도적으로 가리키는 '아직 없는' 명령(미구현·미래 비전). 실재 명령이 아니라 화이트리스트.
+//  - auto: 2단계 `vhk auto`(외부 발송·이슈 등록 자동화) 비전 + 스킬 트리거 문구. 1단계 MVP 엔 미구현.
+const KNOWN_UNIMPLEMENTED = new Set(['auto'])
+
+/** commander 에 실제 등록된 top-level 명령 + 별칭 = 진짜 `vhk --help` 표면. */
+function liveCommandSurface(): Set<string> {
+  const names = new Set<string>()
+  for (const c of program.commands) {
+    names.add(c.name())
+    for (const a of c.aliases()) names.add(a)
+  }
+  return names
+}
+
+/**
+ * SKILL.md 본문에서 `vhk <token>` 의 첫 토큰을 추출.
+ * `\s+` 덕에 `.vhk/loop-brief.md` 경로나 스킬명 `vhk-auto`(공백 없음)는 잡히지 않는다.
+ */
+function extractVhkCommands(content: string): string[] {
+  const out: string[] = []
+  const re = /\bvhk\s+([a-z][a-z-]+)/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(content)) !== null) out.push(m[1])
+  return out
+}
+
+/** 실재하지도, 화이트리스트에도 없는 참조 명령만 반환(중복 제거·등장 순서 유지). */
+function unknownCommands(content: string, surface: Set<string>): string[] {
+  return [...new Set(extractVhkCommands(content))].filter(
+    (cmd) => !surface.has(cmd) && !KNOWN_UNIMPLEMENTED.has(cmd),
+  )
+}
+
+function listSkillFiles(): { name: string; path: string }[] {
+  if (!existsSync(SKILLS_DIR)) return []
+  return readdirSync(SKILLS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => ({ name: d.name, path: join(SKILLS_DIR, d.name, 'SKILL.md') }))
+    .filter((s) => existsSync(s.path))
+}
+
+describe('스킬 ↔ CLI 드리프트 가드 (VHK-023 / #309)', () => {
+  const surface = liveCommandSurface()
+  const skills = listSkillFiles()
+
+  it('스킬 파일을 실제로 찾는다 (글롭이 깨져 침묵 통과하는 것 방지)', () => {
+    const names = skills.map((s) => s.name)
+    expect(names, '.claude/skills/vhk-auto/SKILL.md 를 못 찾음 — 경로·체크아웃 확인').toContain(
+      'vhk-auto',
+    )
+  })
+
+  it('모든 SKILL.md 의 `vhk <명령>` 참조가 실재 명령이다', () => {
+    for (const skill of skills) {
+      const content = readFileSync(skill.path, 'utf-8')
+      const unknown = unknownCommands(content, surface)
+      expect(
+        unknown,
+        `${skill.path} 가 실재하지 않는 명령 참조: ${unknown.join(', ')} — 스킬을 실재 명령으로 고치거나(권장) 미구현 비전이면 KNOWN_UNIMPLEMENTED 갱신`,
+      ).toEqual([])
+    }
+  })
+
+  // 메타(테스트의 테스트): 가드가 원래 버그 클래스를 진짜로 잡는지. 가짜 명령엔 반드시 실패해야 함.
+  it('가드가 실재하지 않는 명령을 실제로 잡는다', () => {
+    expect(unknownCommands('run `vhk loop-brief-nope` then `vhk ghostcmd`', surface)).toEqual([
+      'loop-brief-nope',
+      'ghostcmd',
+    ])
+    // 회귀 포인트: 한때 부재였던 loop-brief·remind 가 지금은 실재 → 통과해야 함.
+    expect(unknownCommands('`vhk loop-brief` and `vhk remind`', surface)).toEqual([])
+  })
+})

--- a/tests/skill-command-drift.test.ts
+++ b/tests/skill-command-drift.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync, readdirSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
+import type { Command } from 'commander'
 import { program } from '../src/index.js'
 
 // 스킬 ↔ CLI 드리프트 가드 (VHK-023 / #309).
@@ -8,6 +9,13 @@ import { program } from '../src/index.js'
 //   오토파일럿 앵커 단계가 unknown command 로 깨졌다(2.6.0). 명령은 이후(#273·#282, 2.7.0)
 //   실제로 추가돼 스킬은 지금 정합하지만, "스킬이 부르는 명령이 실재하나"를 기계로 잡는 가드가
 //   없어 재발 위험이 남아 있었다. 이 테스트가 그 구멍을 막는다 — 진실원은 commander 실등록 표면.
+//
+// why 추출을 "인라인 코드스팬(백틱) 안"으로 한정한다(CodeRabbit #417 Major 대응):
+//   마크다운에서 명령은 항상 `vhk x` 처럼 백틱으로 감싼다. 반면 "vhk 레포 전용"·"vhk 헌법"은
+//   제품명을 명사로 쓴 *산문*이다. 백틱 유무가 명령 호출 ↔ 산문을 가르는 유일하게 신뢰할 신호다.
+//   그래서 토큰을 \p{L}(한글 포함)로 넓혀 별칭 참조(`vhk 리마인드`)까지 잡으면서도, 백틱 밖
+//   한글 산문(vhk 레포)을 오탐하지 않는다. 컨테이너(goal·mission 등)는 서브토큰(next·check)까지
+//   검증한다 — 서브 rename/삭제도 #309 와 똑같이 앵커를 깨므로(G4).
 //
 // 한계(정직): 이 가드는 레포의 정본 스킬(.claude/skills/*/SKILL.md)만 본다. 원래 2.6.0 사고는
 //   사용자의 전역 사본(~/.claude/skills/, 버전관리 밖)이었다 — 거기까진 여기서 가드 못 한다.
@@ -18,33 +26,49 @@ const SKILLS_DIR = '.claude/skills'
 //  - auto: 2단계 `vhk auto`(외부 발송·이슈 등록 자동화) 비전 + 스킬 트리거 문구. 1단계 MVP 엔 미구현.
 const KNOWN_UNIMPLEMENTED = new Set(['auto'])
 
-/** commander 에 실제 등록된 top-level 명령 + 별칭 = 진짜 `vhk --help` 표면. */
-function liveCommandSurface(): Set<string> {
-  const names = new Set<string>()
-  for (const c of program.commands) {
-    names.add(c.name())
-    for (const a of c.aliases()) names.add(a)
-  }
-  return names
+// 인라인 코드스팬(한 줄 백틱). \n 제외라 ```펜스 블록```·산문은 매칭에서 빠진다.
+const CODE_SPAN = /`([^`\n]+)`/g
+// 코드스팬 안에서 `vhk <명령> [<서브>]`. \p{L} 로 첫 토큰에 한글 별칭까지 포함(u 플래그 필수).
+//   서브토큰도 같은 문자셋 — 단 `--flag`·`"<인자>"` 는 [\p{L}\d] 시작이 아니라 자연히 빠진다.
+const VHK_INVOCATION = /^vhk\s+([\p{L}\d][\p{L}\d-]*)(?:\s+([\p{L}\d][\p{L}\d-]*))?/u
+
+interface Invocation {
+  command: string
+  sub: string | null
 }
 
-/**
- * SKILL.md 본문에서 `vhk <token>` 의 첫 토큰을 추출.
- * `\s+` 덕에 `.vhk/loop-brief.md` 경로나 스킬명 `vhk-auto`(공백 없음)는 잡히지 않는다.
- */
-function extractVhkCommands(content: string): string[] {
-  const out: string[] = []
-  const re = /\bvhk\s+([a-z][a-z-]+)/g
-  let m: RegExpExecArray | null
-  while ((m = re.exec(content)) !== null) out.push(m[1])
+function extractInvocations(content: string): Invocation[] {
+  const out: Invocation[] = []
+  for (const m of content.matchAll(CODE_SPAN)) {
+    const v = VHK_INVOCATION.exec(m[1].trim())
+    if (v) out.push({ command: v[1], sub: v[2] ?? null })
+  }
   return out
 }
 
-/** 실재하지도, 화이트리스트에도 없는 참조 명령만 반환(중복 제거·등장 순서 유지). */
-function unknownCommands(content: string, surface: Set<string>): string[] {
-  return [...new Set(extractVhkCommands(content))].filter(
-    (cmd) => !surface.has(cmd) && !KNOWN_UNIMPLEMENTED.has(cmd),
-  )
+// 명령 이름 또는 별칭으로 commander 명령 노드를 찾는다(없으면 null) = 진짜 `vhk --help` 표면.
+function findCommand(token: string): Command | null {
+  return program.commands.find((c) => c.name() === token || c.aliases().includes(token)) ?? null
+}
+
+// 실재하지 않는 참조(명령 미존재 OR 컨테이너인데 서브 미존재)를 사람이 읽을 사유 문자열로 반환.
+function driftReasons(content: string): string[] {
+  const reasons: string[] = []
+  for (const { command, sub } of extractInvocations(content)) {
+    if (KNOWN_UNIMPLEMENTED.has(command)) continue
+    const cmd = findCommand(command)
+    if (!cmd) {
+      reasons.push(`vhk ${command} — 그런 명령 없음`)
+      continue
+    }
+    // 컨테이너(서브커맨드 보유)에 서브토큰이 붙었는데 실재 서브가 아니면 드리프트.
+    // leaf 명령의 둘째 토큰은 인자(`vhk blocker "<증상>"`)라 검증 대상 아님.
+    if (sub && cmd.commands.length > 0) {
+      const ok = cmd.commands.some((s) => s.name() === sub || s.aliases().includes(sub))
+      if (!ok) reasons.push(`vhk ${command} ${sub} — '${sub}' 서브커맨드 없음`)
+    }
+  }
+  return [...new Set(reasons)]
 }
 
 function listSkillFiles(): { name: string; path: string }[] {
@@ -56,7 +80,6 @@ function listSkillFiles(): { name: string; path: string }[] {
 }
 
 describe('스킬 ↔ CLI 드리프트 가드 (VHK-023 / #309)', () => {
-  const surface = liveCommandSurface()
   const skills = listSkillFiles()
 
   it('스킬 파일을 실제로 찾는다 (글롭이 깨져 침묵 통과하는 것 방지)', () => {
@@ -66,24 +89,29 @@ describe('스킬 ↔ CLI 드리프트 가드 (VHK-023 / #309)', () => {
     )
   })
 
-  it('모든 SKILL.md 의 `vhk <명령>` 참조가 실재 명령이다', () => {
+  it('모든 SKILL.md 의 `vhk <명령> [<서브>]` 참조가 실재한다', () => {
     for (const skill of skills) {
-      const content = readFileSync(skill.path, 'utf-8')
-      const unknown = unknownCommands(content, surface)
+      const reasons = driftReasons(readFileSync(skill.path, 'utf-8'))
       expect(
-        unknown,
-        `${skill.path} 가 실재하지 않는 명령 참조: ${unknown.join(', ')} — 스킬을 실재 명령으로 고치거나(권장) 미구현 비전이면 KNOWN_UNIMPLEMENTED 갱신`,
+        reasons,
+        `${skill.path} 드리프트: ${reasons.join(' / ')} — 스킬을 실재 명령으로 고치거나(권장) 미구현 비전이면 KNOWN_UNIMPLEMENTED 갱신`,
       ).toEqual([])
     }
   })
 
-  // 메타(테스트의 테스트): 가드가 원래 버그 클래스를 진짜로 잡는지. 가짜 명령엔 반드시 실패해야 함.
-  it('가드가 실재하지 않는 명령을 실제로 잡는다', () => {
-    expect(unknownCommands('run `vhk loop-brief-nope` then `vhk ghostcmd`', surface)).toEqual([
-      'loop-brief-nope',
-      'ghostcmd',
-    ])
-    // 회귀 포인트: 한때 부재였던 loop-brief·remind 가 지금은 실재 → 통과해야 함.
-    expect(unknownCommands('`vhk loop-brief` and `vhk remind`', surface)).toEqual([])
+  // 메타(테스트의 테스트): 가드가 원래 버그 클래스를 진짜로 잡는지. 가짜엔 실패, 실재엔 통과해야.
+  it('가드가 가짜 명령·한글 별칭·가짜 서브는 잡고, 산문·실재 참조는 통과시킨다', () => {
+    // 영문 가짜 명령 → 잡음
+    expect(driftReasons('`vhk ghostcmd`').length).toBeGreaterThan(0)
+    // 한글 가짜 별칭 → 잡음 (CodeRabbit #417 Major 회귀 방지 — 별칭 문자셋 커버)
+    expect(driftReasons('`vhk 없는별칭`').length).toBeGreaterThan(0)
+    // 컨테이너 가짜 서브커맨드 → 잡음 (G4: 서브 드리프트도 #309 동일 버그류)
+    expect(driftReasons('`vhk goal 없는서브`').some((r) => r.includes('없는서브'))).toBe(true)
+    // 백틱 밖 산문("vhk 레포 전용"류)은 명령이 아니므로 무시 — false positive 0
+    expect(driftReasons('머지만 자동 — vhk 레포 전용. 이 스킬은 vhk 헌법 의존.')).toEqual([])
+    // 회귀: 실재 명령·서브·한글 별칭(`리마인드`=remind 별칭)은 전부 통과
+    expect(
+      driftReasons('`vhk loop-brief` `vhk remind` `vhk goal next` `vhk mission check` `vhk 리마인드`'),
+    ).toEqual([])
   })
 })


### PR DESCRIPTION
## 요지 (결론 먼저)

이슈 #309(VHK-023)의 뿌리 = **스킬이 부르는 명령이 실재하는지 아무도 기계로 검증하지 않음**. 그 구멍을 막는 회귀 테스트를 추가했다.

- **원래 증상**: `vhk-auto` 스킬 앵커 단계(step1)가 `vhk loop-brief`·`vhk remind` 를 부르는데 2.6.0 엔 두 명령이 없어 `unknown command` 로 오토파일럿 루프가 깨졌다.
- **현재 상태**: 두 명령은 이후 **실제 명령으로 추가됨** — `loop-brief`(#273), `remind`(#282), v2.7.0. 둘 다 스킬이 읽는 산출 파일(`.vhk/loop-brief.md`·`.vhk/remind.md`)을 그대로 생성한다. 즉 **레포 정본 스킬은 이미 CLI 와 정합** → 스킬 명령을 바꾸지 않았다(`brief`/`work` 로 교체는 용도에 안 맞는 다운그레이드).
- **이 PR이 더하는 것**: 그 정합이 다시 깨지지 않게 하는 드리프트 가드.

## 기계 증거 (실행 확인)

`vhk --help` 표면에 두 명령 실재:

```
loop-brief   루프 1틱 앵커 생성 (.vhk/loop-brief.md) — 의도+goal1+교훈+STOP
remind       치명 규칙 재주입 (.vhk/remind.md) — RULES.md NON-NEGOTIABLE/Forbidden 압축
```

실행(읽기만 한 게 아니라 돌려서 산출 파일 확인):

```
node dist/index.js loop-brief   # exit 0 → .vhk/loop-brief.md (2100B)
node dist/index.js remind       # exit 0 → .vhk/remind.md    (881B)
```

## 추가한 가드 — `tests/skill-command-drift.test.ts`

- `.claude/skills/*/SKILL.md` 본문의 `vhk <명령>` 첫 토큰을 추출 → **commander 실등록 표면**(`program.commands` 이름+별칭)에 있는지 검증. 진실원 = 실제 `vhk --help` 표면(정적 미러가 아님).
- `vhk auto`(2단계 미구현 비전 + 스킬 트리거 문구)만 화이트리스트.
- **메타 테스트(테스트의 테스트)** 포함: 가짜 명령엔 반드시 실패 → 원래 버그 클래스를 진짜 잡는지 보증.
- `vhk-auto`·`auto-merge` 두 스킬 모두 커버(현재 전부 정합 → green). 원래 2.6.0 상태였다면 `loop-brief`/`remind` 미실재로 이 테스트가 **빨강**이 됐을 것.

## 정직한 한계

이 가드는 **레포 정본 스킬**만 본다. 원래 #309 사고는 사용자 **전역 사본**(`~/.claude/skills/`, 버전관리 밖)이었고 거기까진 가드 못 한다 — 레포가 가드할 수 있는 정확한 범위가 이것.

## 게이트

- `pnpm build` ✅ · `pnpm typecheck`(tsc --noEmit) ✅ exit 0
- 신규 테스트 단독 + `command-registry` 동반 실행 ✅ (15 pass)
- 로컬 vitest forks 간헐 flaky(메모리 TS-004) → **CI 가 진실원**
- 변경 범위 = `tests/` 1파일(89줄 추가), src 무변경 → check-records 게이트 비적용(dev log 불요)

Fixes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 스킬 문서에 적힌 명령어가 실제 CLI에서 사용 가능한지 자동으로 검증하는 테스트가 추가되었습니다.
  * 등록되지 않은 명령어 참조를 찾아내도록 해, 문서와 실제 동작 간의 불일치를 더 빨리 발견할 수 있습니다.
  * 일부 예외적인 명령어는 정상 동작으로 인정되도록 검증 범위가 포함되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->