### PR TITLE
fix: vhk save 커밋 메시지를 변경 파일 기반으로 자동 생성 (#286)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -149,7 +149,7 @@ vhk doctor
 | `vhk cloud` | .vhk 클라우드 백업·복원 (push/pull) |
 | `vhk ship` | 배포 체크리스트 + 회고 |
 | `vhk doctor` | 개발 환경 점검 (+ `--strict` 드리프트 게이트) |
-| `vhk save` | git 저장 (add → commit → push) |
+| `vhk save` | git 저장 (add → commit → push) · 커밋 메시지 미지정 시 변경 파일 기반 자동 생성, `-m "메시지"` 로 직접 지정 |
 | `vhk undo` | 최근 커밋 되돌리기 |
 | `vhk restore` | sync 백업 복원 |
 | `vhk status` | 프로젝트 상태 대시보드 |

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ vhk mcp
 | Goal | `vhk goal init/list/next/check/done/sync/drift` | 단계별 목표, 게이트, 상태 드리프트 관리 |
 | Trust | `vhk verify`, `vhk review`, `vhk receipt`, `vhk preflight`, `vhk testmap`, `vhk mission set/show/check/clear` | 증거 생성, 거짓완료 탐지, 증거 영수증(4대 기계증거 판정), 출고 전 점검, 테스트 매핑, 작업 범위 계약 |
 | 안전 | `vhk blocker`, `vhk resume --confirm`, `vhk mode`, `vhk secure scan` | HARD_STOP, safety mode, 시크릿 스캔 |
-| Git | `vhk status`, `vhk diff`, `vhk save`, `vhk undo`, `vhk restore`, `vhk recap` | 상태/변경 확인, 커밋/푸시, 되돌리기, 세션 로그 |
+| Git | `vhk status`, `vhk diff`, `vhk save`, `vhk undo`, `vhk restore`, `vhk recap` | 상태/변경 확인, 커밋/푸시(커밋 메시지 미지정 시 변경 파일 기반 자동 생성 · `-m "메시지"` 직접 지정), 되돌리기, 세션 로그 |
 | 환경/품질 | `vhk doctor`, `vhk check`, `vhk env`, `vhk env-check`, `vhk harness`, `vhk audit`, `vhk worktree check/add` | 개발환경, RULES 린트, env, 통합 품질, 보안 감사, worktree 가드 |
 | 배포/패키지 | `vhk ship`, `vhk deploy`, `vhk publish`, `vhk update`, `vhk migrate` | 배포 체크, 배포 실행, npm 릴리스 자동화, 셀프 업데이트, 패키지 매니저 전환 |
 | MCP/클라우드 | `vhk mcp`, `vhk mcp-init`, `vhk cloud push/pull` | MCP stdio 서버, 클라이언트 설정, `.vhk/` secret gist 백업/복원 |

--- a/docs/log/2026-06-28-286-save-change-summary-msg.md
+++ b/docs/log/2026-06-28-286-save-change-summary-msg.md
@@ -1,0 +1,38 @@
+# 2026-06-28 — #286 vhk save 커밋 메시지 변경요약 자동 생성
+
+## 증상 (이슈 #286)
+독푸딩(cafe-pos-vhk)에서 `vhk save` 로 만든 14커밋이 전부 `chore: vhk save` 로 동일.
+git 히스토리에서 "어떤 작업인지" 구분 불가 → 정보가치 낮음. 심각도 Low(히스토리 품질).
+기대: 변경 파일/범위 기반 메시지 생성 또는 `-m` 메시지 인자.
+
+## 진단 (정직하게 — 이슈 추정 일부는 이미 해결됨)
+- `-m, --message` 인자는 **이미 존재**(#154, src/index.ts:334). 이슈가 적은 "메시지 인자 없음"은
+  2.6.0 기준 스테일 — 사용자 직접 지정 경로는 이미 동작.
+- 남은 진짜 갭 = **비-TTY/에이전트 fallback**이 하드코딩 `'chore: vhk save'`(save.ts:112).
+  독푸딩 14커밋은 전부 이 경로(비대화형 자동화 + `-m` 미사용)를 탔다 → 리터럴 문자열이 정확히 일치.
+- TTY 프롬프트 기본값은 `formatDefaultCommitMessage()` = `✨ vhk save: <타임스탬프>`(시각마다 달라 "항상 동일"
+  문제는 비-TTY 한정). MCP save(server.ts:158)도 같은 타임스탬프 default.
+
+## 고친 방법 (coherent — 한 값/한 경로)
+- `src/commands/save.ts`
+  - `formatDefaultCommitMessage`(타임스탬프) 제거 → `formatChangeSummaryMessage(lines)` 신규.
+    porcelain 라인에서 경로 추출(rename `old -> new` 은 new 만), `chore: vhk save` 접두 유지하되
+    파일 반영: 1개=경로, N개=`N files: a, b, …` + subject ~72자 상한 초과분은 `+K more`.
+  - `save()`: `autoMessage = formatChangeSummaryMessage(lines)` 1회 계산 → TTY 프롬프트 default 와
+    비-TTY fallback 둘 다 이 값 사용(타임스탬프 default 보다 "변경 반영" 기대에 부합 + 코드경로 단일화).
+  - 우선순위: `--message`(직접) → TTY 프롬프트(기본=요약) → 비-TTY fallback(요약).
+- `src/mcp/server.ts`: 인라인 타임스탬프 default → 동일 helper 재사용(CLI 파리티). `files` 가 이미
+  같은 porcelain 라인 배열이라 무손실 교체. 미사용 `now`/`ts` 제거.
+
+## 회귀 테스트 (tests/save.test.ts)
+- 비-TTY fallback 테스트: 단언을 `'chore: vhk save'` → `'chore: vhk save — file.ts'` 로 갱신(버그를
+  인코딩하던 단언 교정 + 회귀 방지 제목).
+- `formatChangeSummaryMessage` 단위: 단일/다중/rename/대량(+N more·전부나열 안 함)/빈 입력.
+
+## 게이트
+- 로컬 worktree node_modules 없어 `pnpm install --prefer-offline` 선행(exit 0). `pnpm build` 통과 확인.
+- 로컬 vitest forks 불안정(TS-004) 가능 → save.test 단독/표적 실행으로 확인, 불안정 시 CI 가 진실원으로 명시.
+
+## 범위 밖(의도)
+- conventional type(feat/fix) 파일 추론 안 함(불신뢰). i18n 미적용(기존 하드코딩 fallback 과 동일 정책).
+- 역사적 문서(goals/archive·superpowers specs)의 `chore: vhk save` 문구는 손대지 않음.

--- a/docs/log/2026-06-28-286-save-change-summary-msg.md
+++ b/docs/log/2026-06-28-286-save-change-summary-msg.md
@@ -36,3 +36,34 @@ git 히스토리에서 "어떤 작업인지" 구분 불가 → 정보가치 낮�
 ## 범위 밖(의도)
 - conventional type(feat/fix) 파일 추론 안 함(불신뢰). i18n 미적용(기존 하드코딩 fallback 과 동일 정책).
 - 역사적 문서(goals/archive·superpowers specs)의 `chore: vhk save` 문구는 손대지 않음.
+
+## 보강 — G4 적대리뷰 후속 (치명 1건: core.quotePath 한글 경로 깨짐)
+
+### 증상 (실측 재현)
+한글 파일명이 있는 repo 에서 `vhk save` → 커밋 메시지가
+`chore: vhk save — "\355\225\234\352\270\200\355\214\214\354\235\274.ts"` 처럼 8진 이스케이프로 깨짐.
+이전 고정 메시지(`chore: vhk save`)는 경로를 안 넣었으니 **이 PR 이 새로 일으키는 회귀**.
+한국어 사용자에서 즉시 발동.
+
+### 근본 원인
+`src/lib/git-session.ts` 의 `statusPorcelain()` 이 `git status --porcelain` 을 `-c core.quotepath=false`
+없이 실행 → git 기본(quotepath=true)이 비ASCII 경로를 따옴표+8진으로 출력. 이 출력이
+`formatChangeSummaryMessage` 의 입력(`lines`)이라 메시지에 그대로 박힘. (#319 에서 `diffUnified0` 가
+같은 이유로 이미 quotepath=false 를 적용했었음 — 동일 계열 버그.)
+
+### 고친 방법
+- `git-session.ts`: `statusPorcelain` argv 를 `['-c','core.quotepath=false','status','--porcelain']` 로
+  변경(`diffUnified0`/check-records/record-reminder 와 동일 패턴·casing). 공유 SoT 라 save 메시지 +
+  status/MCP 파일 표시가 한 번에 고쳐짐. `trimOutput:false` 유지(check-goal-48 게이트).
+- `git-session.test.ts`: statusPorcelain argv 단언을 quotepath 포함으로 갱신(#319 와 동일하게 argv
+  레벨에서 fix 고정 — 플래그 제거 시 즉시 빨강).
+- `tests/save-quotepath.test.ts`(신규): 실 git repo 에 한글 파일 생성 → statusPorcelain →
+  formatChangeSummaryMessage 메시지에 raw `한글파일.ts` 포함 + `\NNN` 8진/따옴표 없음 고정.
+  chdir 미사용(cwd 명시)으로 TS-004 회피.
+- `src/mcp/server.ts`: save 핸들러 `files` 파싱을 CLI 와 동일 `parsePorcelainLines()` 로 통일
+  (CRLF 정규화 — files 가 메시지가 되므로 파싱 파리티가 정확성에 직결).
+- `formatChangeSummaryMessage`: 72자 상한이 `+N more` 접미사 미포함 근사치임을 주석 명시.
+- README: save 동작(자동 메시지·`-m`) 갱신(헌법 "동작 바뀌면 README 갱신").
+
+### 검증
+- 빌드한 CLI 실측: fix 후 `chore: vhk save — 한글파일.ts`(raw). build·tsc·관련 테스트 PASS 는 PR 본문.

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -44,6 +44,8 @@ export function formatChangeSummaryMessage(lines: string[]): string {
   if (paths.length === 1) return `${prefix} — ${paths[0]}`.replace(/\r?\n/g, ' ')
 
   // subject 상한(~72자 conventional) 안에서 가능한 파일을 나열, 나머지는 '+N more'.
+  // 상한은 근사치 — ' +N more' 접미사는 길이 검사 후 덧붙으므로 최종 길이가 SUBJECT_MAX 를
+  // 접미사 길이만큼 넘을 수 있다(git subject 는 hard limit 아님 → 허용).
   const head = `${prefix} — ${paths.length} files: `
   const shown: string[] = []
   for (const p of paths) {

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -24,13 +24,35 @@ function must(r: ExecResult): string {
   return r.out
 }
 
-export function formatDefaultCommitMessage(date = new Date()): string {
-  const y = date.getFullYear()
-  const m = String(date.getMonth() + 1).padStart(2, '0')
-  const d = String(date.getDate()).padStart(2, '0')
-  const h = String(date.getHours()).padStart(2, '0')
-  const min = String(date.getMinutes()).padStart(2, '0')
-  return `✨ vhk save: ${y}-${m}-${d} ${h}:${min}`
+// #286: 변경 파일 목록(git porcelain 라인)으로 의미있는 커밋 메시지를 만든다.
+// 이전엔 비-TTY/에이전트 저장이 항상 'chore: vhk save' 로 고정돼 git 히스토리에서 작업을
+// 구분할 수 없었다(독푸딩 cafe-pos-vhk 14커밋 전부 동일). 이제 변경 파일/개수를 반영해
+// 저장마다 다른 메시지를 만든다. 사용자가 -m 으로 직접 지정하면 그쪽이 우선.
+const SUBJECT_MAX = 72
+export function formatChangeSummaryMessage(lines: string[]): string {
+  const prefix = 'chore: vhk save'
+  // porcelain v1: "XY path" (코드 2자 + 공백 + 경로). rename 은 "old -> new" → new 만 취함.
+  const paths = lines
+    .map(line => {
+      const name = line.slice(3).trim()
+      const arrow = name.lastIndexOf(' -> ')
+      return (arrow >= 0 ? name.slice(arrow + 4) : name).trim()
+    })
+    .filter(Boolean)
+
+  if (paths.length === 0) return prefix
+  if (paths.length === 1) return `${prefix} — ${paths[0]}`.replace(/\r?\n/g, ' ')
+
+  // subject 상한(~72자 conventional) 안에서 가능한 파일을 나열, 나머지는 '+N more'.
+  const head = `${prefix} — ${paths.length} files: `
+  const shown: string[] = []
+  for (const p of paths) {
+    if (shown.length > 0 && (head + [...shown, p].join(', ')).length > SUBJECT_MAX) break
+    shown.push(p)
+  }
+  const remaining = paths.length - shown.length
+  const list = shown.join(', ') + (remaining > 0 ? ` +${remaining} more` : '')
+  return `${head}${list}`.replace(/\r?\n/g, ' ')
 }
 
 function statusIcon(code: string): string {
@@ -98,8 +120,10 @@ export async function save(opts: SaveOptions = {}): Promise<void> {
     console.log(`   ${statusIcon(code)} ${name}`)
   })
 
-  // #154: --message 제공 시 프롬프트 건너뛰고 그대로 사용(MCP save 파리티). 없으면 기존 흐름
-  // (TTY → 프롬프트 / 비-TTY → 기본 메시지).
+  // 메시지 우선순위(#286 + #154): ① --message(에이전트/사용자 직접) → ② TTY 프롬프트
+  // (기본값 = 변경요약) → ③ 비-TTY fallback(변경요약). 항상 'chore: vhk save' 고정이던
+  // 과거와 달리, 변경 파일을 반영해 매 저장마다 의미있는 메시지를 만든다(히스토리 구분 가능).
+  const autoMessage = formatChangeSummaryMessage(lines)
   const message = opts.message?.trim()
     ? opts.message.trim()
     : await promptOrDefault(
@@ -107,9 +131,9 @@ export async function save(opts: SaveOptions = {}): Promise<void> {
           type: 'input',
           name: 'message',
           message: t('save.commitMessage'),
-          default: formatDefaultCommitMessage(),
+          default: autoMessage,
         }])).message,
-        'chore: vhk save',
+        autoMessage,
       )
 
   const spinner = ora(t('save.saving')).start()

--- a/src/lib/git-session.ts
+++ b/src/lib/git-session.ts
@@ -11,9 +11,16 @@ import { safeExecFile, type ExecResult } from './exec.js'
 //   · cwd 기본 process.cwd() → MCP(인자 생략)·CLI(gitRoot 전달) 파리티.
 //   · porcelain 만 raw 보존(trimOutput:false) — 선행 공백(" M file")이 파싱에 load-bearing.
 
-/** git status --porcelain — 선행 공백 보존(raw). 변경 파일 파싱의 SoT. */
+// #286/#319: core.quotepath=false 로 비ASCII(한글) 경로를 8진 이스케이프 없이 raw UTF-8 로 받는다.
+// Git 기본(quotepath=true)은 `"\355\214\214...ts"`(따옴표+8진)로 출력 → save 의 변경요약 커밋
+// 메시지(formatChangeSummaryMessage)와 status/MCP 의 파일 표시에 깨진 문자열이 박힌다(한국어
+// 사용자에서 즉시 발동). `-c key=val` 은 git 글로벌 옵션이라 서브커맨드(status) 앞에 와야 한다.
+/** git -c core.quotepath=false status --porcelain — 선행 공백 보존(raw). 변경 파일 파싱의 SoT. */
 export function statusPorcelain(cwd: string = process.cwd()): ExecResult {
-  return safeExecFile('git', ['status', '--porcelain'], { cwd, trimOutput: false })
+  return safeExecFile('git', ['-c', 'core.quotepath=false', 'status', '--porcelain'], {
+    cwd,
+    trimOutput: false,
+  })
 }
 
 /** git branch --show-current — 현재 브랜치명. */

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -6,6 +6,7 @@ import { safeExecFile, NETWORK_EXEC_TIMEOUT_MS } from '../lib/exec.js'
 import * as gitSession from '../lib/git-session.js'
 import { isGitRepo } from '../lib/git-repo.js'
 import { parseEnvKeys } from '../commands/env.js'
+import { formatChangeSummaryMessage } from '../commands/save.js'
 import { resolveDeployTarget } from '../commands/deploy.js'
 import { bumpVersion } from '../commands/publish.js'
 import { detectCurrentPM, parseAuditOutputDetailed, runAuditJson } from '../commands/audit.js'
@@ -153,9 +154,8 @@ export function createVhkMcpServer(): McpServer {
         }
       }
 
-      const now = new Date()
-      const ts = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')} ${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`
-      const commitMsg = message?.trim() || `✨ vhk save: ${ts}`
+      // #286: 메시지 미지정 시 변경 파일 기반 요약 생성(CLI save 와 동일 helper — 파리티).
+      const commitMsg = message?.trim() || formatChangeSummaryMessage(files)
 
       // goal 70: 고위험 옵트인 — confirm:true 없으면 commit/push 하지 않고 미리보기만.
       // 에이전트가 사람 승인 없이 원격에 push 하는 것을 차단(undo 와 동일 패턴, HIGH_RISK_MCP_TOOLS).

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -7,6 +7,7 @@ import * as gitSession from '../lib/git-session.js'
 import { isGitRepo } from '../lib/git-repo.js'
 import { parseEnvKeys } from '../commands/env.js'
 import { formatChangeSummaryMessage } from '../commands/save.js'
+import { parsePorcelainLines } from '../lib/git-porcelain.js'
 import { resolveDeployTarget } from '../commands/deploy.js'
 import { bumpVersion } from '../commands/publish.js'
 import { detectCurrentPM, parseAuditOutputDetailed, runAuditJson } from '../commands/audit.js'
@@ -127,8 +128,9 @@ export function createVhkMcpServer(): McpServer {
         return { content: [{ type: 'text', text: '📭 저장할 변경사항이 없습니다.' }] }
       }
 
-      // statusPorcelain 은 raw(후행 개행 포함) → 빈 줄 제거 후 파일 카운트.
-      const files = status.out.split('\n').filter(Boolean)
+      // CLI save 와 동일 파싱(parsePorcelainLines: CRLF 정규화 + 빈 줄 제거) — files 가
+      // formatChangeSummaryMessage 로 들어가 커밋 메시지가 되므로 파싱 파리티가 정확성에 직결.
+      const files = parsePorcelainLines(status.out)
 
       // MCP 모드는 inquirer 프롬프트가 동작하지 않으므로 CLI 의 확인 단계 없이
       // severe(critical/high) 시크릿이 발견되면 commit 자체를 거부한다.

--- a/tests/git-session.test.ts
+++ b/tests/git-session.test.ts
@@ -27,10 +27,11 @@ const lastOpts = () => mockExec.mock.calls.at(-1)?.[2]
 const lastBin = () => mockExec.mock.calls.at(-1)?.[0]
 
 describe('git-session — git argv SoT (같은 질문 = 함수 하나)', () => {
-  it('statusPorcelain → git status --porcelain (raw 보존)', () => {
+  it('statusPorcelain → git -c core.quotepath=false status --porcelain (raw 보존)', () => {
     session.statusPorcelain('/repo')
     expect(lastBin()).toBe('git')
-    expect(lastArgv()).toEqual(['status', '--porcelain'])
+    // #286/#319: quotepath=false 로 한글 경로 8진 이스케이프 차단(커밋 메시지·표시 깨짐 방지).
+    expect(lastArgv()).toEqual(['-c', 'core.quotepath=false', 'status', '--porcelain'])
     // 선행 공백(" M file") 의미있음 → trimOutput:false 강제.
     expect(lastOpts()).toMatchObject({ cwd: '/repo', trimOutput: false })
   })

--- a/tests/save-quotepath.test.ts
+++ b/tests/save-quotepath.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { statusPorcelain } from '../src/lib/git-session.js'
+import { parsePorcelainLines } from '../src/lib/git-porcelain.js'
+import { formatChangeSummaryMessage } from '../src/commands/save.js'
+
+// #286 회귀: 한글(비ASCII) 파일명이 변경요약 커밋 메시지에 git 8진 이스케이프(`\355...`)로
+// 깨져 박히지 않는지 실 git repo 로 고정한다. 원인은 statusPorcelain 이 core.quotepath=false
+// 없이 호출되어 git 기본(quotepath=true)이 비ASCII 경로를 따옴표+8진으로 출력하던 것(#319 계열).
+//
+// 정리(rmSync) 안 함: Windows 에서 .git objects 핸들 점유 중 rmSync(recursive) 가 try/catch 를
+// 우회해 vitest worker 를 통째로 죽인다(TS-004 — "Worker exited unexpectedly"). temp 디렉터리는
+// os.tmpdir() 에 남겨 OS/CI(ephemeral) 가 회수하게 둔다. chdir 도 미사용(cwd 명시 전달).
+describe('#286 한글 경로 커밋 메시지 (core.quotepath)', () => {
+  function newRepo(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'vhk-qp-'))
+    const opt = { cwd: dir, stdio: 'pipe' as const }
+    execFileSync('git', ['init'], opt)
+    execFileSync('git', ['config', 'user.email', 't@t.dev'], opt)
+    execFileSync('git', ['config', 'user.name', 'tester'], opt)
+    // 저장소 설정이 fix 를 가리지 않게 git 기본(quotepath=true) 을 명시 — 그래도 statusPorcelain
+    // 의 `-c core.quotepath=false`(명령 레벨)가 이를 덮어 raw 경로를 내야 한다.
+    execFileSync('git', ['config', 'core.quotepath', 'true'], opt)
+    return dir
+  }
+
+  it('한글 파일명이 8진 이스케이프 없이 raw 경로로 메시지에 들어감', () => {
+    const dir = newRepo()
+    writeFileSync(join(dir, '한글파일.ts'), 'x\n', 'utf-8')
+
+    const res = statusPorcelain(dir)
+    expect(res.ok).toBe(true)
+    const msg = formatChangeSummaryMessage(parsePorcelainLines(res.out))
+
+    expect(msg).toContain('한글파일.ts') // raw UTF-8 경로
+    expect(msg).not.toMatch(/\\\d{3}/) // 8진 이스케이프(\355 등) 없음
+    expect(msg).not.toContain('"') // quotepath 따옴표 래핑 없음
+  })
+
+  it('한글 단일 파일 — fallback 고정문자열로 회귀하지 않고 경로 반영', () => {
+    const dir = newRepo()
+    writeFileSync(join(dir, '메모.txt'), 'y\n', 'utf-8')
+
+    const msg = formatChangeSummaryMessage(parsePorcelainLines(statusPorcelain(dir).out))
+    expect(msg).toBe('chore: vhk save — 메모.txt')
+  })
+})

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { execFileSync } from 'node:child_process'
 import inquirer from 'inquirer'
-import { formatDefaultCommitMessage } from '../src/commands/save.js'
+import { formatChangeSummaryMessage } from '../src/commands/save.js'
 import { t } from '../src/i18n/ko.js'
 
 vi.mock('node:child_process')
@@ -97,7 +97,7 @@ describe('save', () => {
     process.exitCode = exitBefore
   })
 
-  it('비-TTY 면 커밋 메시지 inquirer 없이 기본값(chore: vhk save) 사용', async () => {
+  it('#286: 비-TTY 면 inquirer 없이 변경요약 fallback 메시지로 커밋 (고정 chore: vhk save 아님)', async () => {
     // vitest = 비-TTY (stdin.isTTY undefined). promptOrDefault 가 ask() 미호출 → fallback.
     const ttyBefore = process.stdin.isTTY
     Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
@@ -111,8 +111,8 @@ describe('save', () => {
       await expect(save()).resolves.not.toThrow()
       // inquirer 프롬프트 미호출 (비대화형 = stdin 미접근, MCP 안전)
       expect(vi.mocked(inquirer.prompt)).not.toHaveBeenCalled()
-      // 커밋은 fallback 메시지로 수행 (commit(message, cwd) 시그니처)
-      expect(mockCommit).toHaveBeenCalledWith('chore: vhk save', '/repo')
+      // #286: fallback 도 변경 파일 반영 (' M file.ts' → file.ts). 고정 메시지였던 회귀 방지.
+      expect(mockCommit).toHaveBeenCalledWith('chore: vhk save — file.ts', '/repo')
     } finally {
       Object.defineProperty(process.stdin, 'isTTY', { value: ttyBefore, configurable: true })
     }
@@ -146,9 +146,33 @@ describe('save', () => {
 })
 
 describe('vhk save helpers', () => {
-  it('formatDefaultCommitMessage — vhk save 접두사', () => {
-    const msg = formatDefaultCommitMessage(new Date('2026-05-23T15:30:00'))
-    expect(msg).toBe('✨ vhk save: 2026-05-23 15:30')
+  describe('formatChangeSummaryMessage (#286)', () => {
+    it('단일 파일 — 경로를 메시지에 반영', () => {
+      expect(formatChangeSummaryMessage([' M src/commands/save.ts']))
+        .toBe('chore: vhk save — src/commands/save.ts')
+    })
+
+    it('여러 파일 — 개수 + 목록', () => {
+      expect(formatChangeSummaryMessage([' M a.ts', '?? b.ts', ' D c.ts']))
+        .toBe('chore: vhk save — 3 files: a.ts, b.ts, c.ts')
+    })
+
+    it('rename — "old -> new" 에서 new 경로만 사용', () => {
+      expect(formatChangeSummaryMessage(['R  old.ts -> src/new.ts']))
+        .toBe('chore: vhk save — src/new.ts')
+    })
+
+    it('파일 많으면 subject 상한 내로 자르고 +N more 로 총개수 표기', () => {
+      const many = Array.from({ length: 30 }, (_, i) => ` M src/very/long/path/file-${i}.ts`)
+      const msg = formatChangeSummaryMessage(many)
+      expect(msg.startsWith('chore: vhk save — 30 files: ')).toBe(true)
+      expect(msg).toMatch(/ \+\d+ more$/)
+      expect(msg).not.toContain('file-29.ts') // 일부만 나열(전부 X)
+    })
+
+    it('변경 없음 — prefix 만 (방어)', () => {
+      expect(formatChangeSummaryMessage([])).toBe('chore: vhk save')
+    })
   })
 
   it('t(save.*) — i18n 키 조회', () => {


### PR DESCRIPTION
## 무엇을 / 왜 (#286)

`vhk save` 의 비-TTY/에이전트 fallback 커밋 메시지가 항상 `chore: vhk save` 로 **고정**돼,
git 히스토리에서 "어떤 작업인지" 구분이 불가능했다(독푸딩 cafe-pos-vhk 14커밋 전부 동일).

**스코프 정확히:** `-m, --message` 인자는 **이미 존재**한다(#154, `src/index.ts`). 이슈가 적은
"메시지 인자 없음"은 2.6.0 기준 스테일 — 사용자 직접 지정 경로는 이미 동작했다. 이 PR이 닫는
**유일한 갭은 비-TTY fallback** 이 변경 내용을 반영하지 못하던 것이다.

## 고친 방법 (coherent — 한 값/한 경로)

- `src/commands/save.ts`
  - 타임스탬프 default `formatDefaultCommitMessage` **삭제** → `formatChangeSummaryMessage(lines)` 신규.
    porcelain 라인에서 경로 추출(rename `old -> new` 은 new 만), `chore:` 접두 유지하되 변경 반영:
    1개 = 경로, N개 = `N files: a, b, …` + subject ~72자 상한 초과분은 `+K more`.
  - `save()` 가 `autoMessage` 1회 계산 → **TTY 프롬프트 default 와 비-TTY fallback 둘 다** 사용.
  - 우선순위: `--message`(직접 지정) → TTY 프롬프트(기본=요약) → 비-TTY fallback(요약).
- `src/mcp/server.ts`: 인라인 타임스탬프 default → **동일 helper 재사용**(CLI 파리티). `files` 가
  이미 같은 porcelain 라인 배열이라 무손실 교체. 미사용 `now`/`ts` 제거.
- `tests/save.test.ts`: 버그를 인코딩하던 단언(`'chore: vhk save'`)을 교정 +
  `formatChangeSummaryMessage` 단위(단일/다중/rename/대량 `+N more`/빈 입력).
- `COMMANDS.md`: save 항목에 자동 생성 + `-m` 명시.

`tsc --noEmit` 가 클린 통과 = 삭제한 `formatDefaultCommitMessage` 를 다른 곳에서 import 하지
않음을 증명(스테일 importer 면 타입체크 실패). MCP **tool input schema 는 불변** — default 메시지
*내용*만 바뀜 → GA API 시그니처 breaking 아님.

## 실측 검증 (smoke — 빌드한 CLI 를 비-TTY 로 실행)

```
chore: vhk save — 2 files: a.txt, src/commands/save.ts   # 수정된 추적 파일 → 전체 경로
chore: vhk save — src/commands/save.ts                    # 단일 파일
```
이슈의 정확한 시나리오(비-TTY 자동화)에서 메시지가 변경마다 달라짐을 확인.

## 게이트 (정직)

- `pnpm build` (ESM+DTS) **PASS** · `tsc --noEmit` **PASS(클린)**
- `tests/save.test.ts` **12/12 PASS** · `tests/mcp-server.test.ts` **8/8 PASS**(save 핸들러 직접 검증)
- `mcp-optin`/`mcp-hardstop`: 로컬 worker-fork crash = **TS-004**(`process.chdir`/temp-git/rmSync on Windows).
  내 변경 **이전 baseline(stash) 에서 동일하게 재현**됨 → 환경 탓, 내 변경 무관. 두 파일의 save 테스트는
  메시지를 **직접 지정**하거나(`message:'x'`) commit 전에 차단돼, 새 fallback 경로를 타지 않는다.
  **CI 가 진실원**(로컬 forks flaky).
- **블로커: 없음**

## 범위 밖(의도 — 후속 후보)

- conventional type(feat/fix) 파일 추론 안 함(불신뢰). i18n 미적용(기존 하드코딩 fallback 과 동일 정책).
- vhk 자체 action 원장 `.vhk/events/ai-actions.jsonl` 이 **추적되는** 레포에서는 요약에 함께 노출된다
  (선존: save 가 `git add -A` 로 이미 커밋해 옴 — 회귀 아님). 메시지는 여전히 변하고 실파일도 나열됨.
  vhk-내부 경로 필터링은 #286 범위 밖 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * `vhk save`가 변경된 파일을 바탕으로 커밋 메시지를 자동 생성합니다.
  * 파일이 여러 개면 일부 파일명과 함께 `+N more` 형식으로 요약됩니다.
  * 커밋 메시지는 `-m "메시지"`로 직접 지정할 수 있습니다.

* **버그 수정**
  * 비ASCII(예: 한글) 파일명이 커밋 메시지에 올바르게 표시되도록 개선했습니다.
  * 비대화형 환경에서도 저장 동작이 더 일관되게 작동합니다.

* **문서**
  * 명령 목록과 Git 관련 설명을 새 동작에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->