### PR TITLE
docs: align receipt '실차단' text with 4-condition code (forbidden 포함)

### DIFF
--- a/docs/log/2026-06-28-receipt-stale-text-drift.md
+++ b/docs/log/2026-06-28-receipt-stale-text-drift.md
@@ -1,0 +1,36 @@
+# 2026-06-28 — vhk receipt "실차단 3종" 텍스트 드리프트 정정 (코드는 4조건 — forbidden 포함)
+
+> append-only. 추가만, 수정·삭제 금지.
+
+## 배경 (드리프트)
+- `decideReceipt`(`src/lib/receipt.ts`)의 block 분기는 실제로 **4조건**: `red || dirty || (staleKnown && stale) || forbiddenViolated`.
+- `forbiddenViolated` 는 goal 87(#406, 이미 DONE·머지)이 추가한 정당한 결정론 차단(변경 파일이 mission 금지 glob 매치 = LLM 0 사실, red/dirty/stale 와 동급).
+- 그런데 옛 "실차단 3종(red·dirty·stale)" 텍스트가 코드 곳곳에 잔존 → 텍스트가 코드보다 적게 말하는(under-claim) 드리프트. **코드가 정답 → 텍스트를 코드에 맞춤.**
+
+## 한 일 — 정정 8곳 (파일:라인 / 옛 → 새)
+1. `src/lib/receipt.ts:19` — `ReceiptDecision` JSDoc: `block: 실차단(red/dirty/stale)` → `…(red/dirty/stale/forbidden)`
+2. `src/i18n/ko.ts:295` — `nextBlockMessage`(사용자대면): `막힌 증거(red/dirty/stale)` → `…(red/dirty/stale/forbidden)`
+3. `src/commands/receipt.ts:121` — 주석: `영수증 본체(실차단 3종)` → `…(실차단 red·dirty·stale·forbidden)`
+4. `scripts/check-goal-86.mjs:65` — 주석: `실차단 3종만 block` → 4조건 명시 + "이 게이트는 기저 3종만 확인, forbidden 은 check-goal-87 소관" 한 줄 추가
+5. `scripts/check-goal-86.mjs:66` — `must()` 레이블: `실차단 3종(red·dirty·stale)만 block` → `기저 실차단(red·dirty·stale) block 분기 존재 — forbidden 은 check-goal-87`. **정규식 불변** (goal 86 검증 범위 = 기저 3종 그대로)
+6. `tests/receipt.test.ts:58` — describe: `실차단 3종(red·dirty·stale) 중 하나라도면 block` → `기저 실차단 3종(red·dirty·stale) 각각 단독이면 block … (forbidden 은 별도 describe)`. **루프 불변** (red/dirty/stale만 순회 — forbidden 은 L232 별도 테스트)
+7. `tests/receipt.test.ts:122` — describe: `차단은 3종만이 결정` → `차단은 실차단이 결정(diff-cover 무관)`
+8. `tests/receipt.test.ts:18` — 파일 헤더 불변식 ① 주석: `dirty/stale/red 중 하나라도면 block` → `실차단(red·dirty·stale·forbidden) 중 하나라도면 block` (source `receipt.ts:8` 불변식 헤더와 일치시킴; 특이 어순이라 grep 1차에서 누락 → CI green 확인 후 적발·합류)
+
+### 일부러 "4종"으로 안 바꾼 곳 (정직)
+- check-goal-86 레이블(5)·test:58(6)은 **실제로 기저 3종만 검증/순회**한다. 정규식·루프를 안 바꾸면서 레이블만 "4종"이라 쓰면 레이블↔코드 새 드리프트가 됨 → "기저 3종 + forbidden 은 별도(check-goal-87)" 로 정직하게 분담 표기.
+
+## 안 건드린 것 (정당)
+- `goals/86-receipt-mvp.md` 수용기준 원문 — DONE goal 기준 사후수정은 "짜맞춤" 오해 → 코드 레이블·테스트·주석만 정정.
+- check-goal-86 정규식 / "red/dirty/stale **동급**" 프레이밍(`check-goal-87.mjs:62`·`receipt.test.ts:229/232/273`·`receipt.ts:8/9/45/46/91/104`) — forbidden 을 동급 4번째로 정확히 표현 중이라 유지.
+- `receipt.ts` ①②③ 증거카테고리 번호(red①·dirty②·stale③·diff-cover④·intent⑤) — 차단조건 개수가 아니라 증거 분류 인덱스 → 유지.
+
+## 게이트 결과
+- ✅ `pnpm build` — exit 0 (src 주석·JSDoc 변경 tsc 통과)
+- ✅ `VHK_GATES_SKIP_DEEP=1 node scripts/check-goal-86.mjs` — typecheck ✓ · lint ✓ · `must()` 전건 ✓ (재작성 레이블 포함; 정규식 불변이라 block 분기 매치 유지)
+- ✅ `tests/receipt.test.ts` 파싱·수집 — transform+import 성공, **48 테스트 전부 collect** (describe 텍스트 변경에 구문오류 0 입증)
+- ⚠️ 전체 vitest 실행 — 로컬 forks "Worker exited unexpectedly" / threads exit 127 (TS-004·TS-005 환경 결함, 단언 실패 아님). 본 변경은 주석·레이블·describe **문자열뿐**(실행 로직 0) → 단언 바이트 동일. **CI 가 진실원** (goal-87-done.md 선례 동일 처리).
+
+## 비고
+- 이 레포는 거짓완료를 기계증거로 잡는 도구 → 텍스트가 코드보다 적게 말하는 under-claim 드리프트도 정직성 위반으로 보고 정정.
+- check-goal-86(기저 3종 block 분기) / check-goal-87(forbidden→block) 검증 분담을 레이블에 명시화.

--- a/scripts/check-goal-86.mjs
+++ b/scripts/check-goal-86.mjs
@@ -62,8 +62,9 @@ must(/export function buildReceipt/.test(core), 'receipt.ts: buildReceipt(.json 
 must(/export function renderReceiptMarkdown/.test(core), 'receipt.ts: renderReceiptMarkdown(.md 붙여넣기)')
 must(/export const HONESTY_LINE/.test(core), 'receipt.ts: 정직성 1줄 SoT')
 must(/게으른 거짓완료/.test(core) && /미묘한 오류/.test(core), 'receipt.ts: 정직성 경계(게으른 거짓완료 vs 미묘한 오류)')
-// 실차단 3종만 block — diff-cover 는 block 분기에 없어야 함(advisory 분리)
-must(/e\.gates\.red \|\| e\.dirty \|\| \(e\.staleKnown && e\.stale\)/.test(core), 'receipt.ts: 실차단 3종(red·dirty·stale)만 block')
+// 실차단(red·dirty·stale·forbidden) block — diff-cover 는 block 분기에 없어야 함(advisory 분리).
+// 이 게이트는 기저 3종(red·dirty·stale) 분기 존재만 확인 — forbidden(Goal 87)은 check-goal-87 게이트 소관.
+must(/e\.gates\.red \|\| e\.dirty \|\| \(e\.staleKnown && e\.stale\)/.test(core), 'receipt.ts: 기저 실차단(red·dirty·stale) block 분기 존재 — forbidden 은 check-goal-87')
 
 // ② 경계(IO) — 기존 자산 재사용 글루코드(신규 발명 최소)
 const cmd = read('src/commands/receipt.ts') ?? ''

--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -118,7 +118,7 @@ export function collectDiffCover(cwd: string): ReceiptDiffCover {
       ratio: r.ratio,
     }
   } catch {
-    // diff-cover 수집 실패는 advisory 부재로 — 영수증 본체(실차단 3종)는 계속 만든다.
+    // diff-cover 수집 실패는 advisory 부재로 — 영수증 본체(실차단 red·dirty·stale·forbidden)는 계속 만든다.
     return empty
   }
 }

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -292,7 +292,7 @@ export const ko = {
     title: '증거 영수증',
     noCommit: 'git 커밋을 찾을 수 없습니다 — 작업시작 기준선을 기록하려면 커밋이 1개 이상 필요합니다.',
     markStartDone: '작업시작 기준선 SHA 기록 완료 (이후 stale 비교 기준):',
-    nextBlockMessage: '🔴 기계증거가 "됐어요"와 모순 — 아직 완료 아님. 막힌 증거(red/dirty/stale)부터 고치세요:',
+    nextBlockMessage: '🔴 기계증거가 "됐어요"와 모순 — 아직 완료 아님. 막힌 증거(red/dirty/stale/forbidden)부터 고치세요:',
     nextCautionMessage: '🟡 실차단은 없으나 약신호 있음(수동 확인 권장). 보강 후 다시 떼세요:',
     nextPassMessage: '🟢 게으른 거짓완료 징후 없음(미묘한 오류는 못 잡음). 완료 처리하려면:',
     // Goal 87 방향 2-1: glob 미지원 문법 경고 — 거짓 안전을 caution 으로 드러냄.

--- a/src/lib/receipt.ts
+++ b/src/lib/receipt.ts
@@ -16,7 +16,7 @@
 
 import type { ReportStatus } from '../commands/verify.js'
 
-/** 영수증 판정 — 기계증거만(LLM 0). block: 실차단(red/dirty/stale). caution: 약신호만. pass: 전부 clean·확인됨. */
+/** 영수증 판정 — 기계증거만(LLM 0). block: 실차단(red/dirty/stale/forbidden). caution: 약신호만. pass: 전부 clean·확인됨. */
 export type ReceiptDecision = 'block' | 'caution' | 'pass'
 
 /** 게이트(verify) 증거 요약 — 실종료코드 출처(자기보고 거부, verify.ts 가 이미 강제). */

--- a/tests/receipt.test.ts
+++ b/tests/receipt.test.ts
@@ -15,7 +15,7 @@ import { collectReceipt, collectIntent, verifyBaseSha } from '../src/commands/re
 
 // Goal 86 (RFC 0056 T1): vhk receipt — 4대 기계증거 → 영수증 1장.
 // 핵심 불변식(테스트로 고정):
-//  ① decision 은 기계증거만으로(LLM 0). dirty/stale/red 중 하나라도면 block.
+//  ① decision 은 기계증거만으로(LLM 0). 실차단(red·dirty·stale·forbidden) 중 하나라도면 block.
 //  ② 단조성: caution → pass 격상 절대 금지(부정 신호가 늘면 결과가 좋아질 수 없다).
 //  ③ ④ diff-cover 는 advisory(약신호) — decision 을 block 으로 격하시키지 못한다.
 
@@ -55,7 +55,7 @@ describe('decideReceipt — 기계증거만(LLM 0)', () => {
     expect(decideReceipt(e)).toBe('block')
   })
 
-  it('실차단 3종(red·dirty·stale) 중 하나라도면 block — 조합 무관', () => {
+  it('기저 실차단 3종(red·dirty·stale) 각각 단독이면 block — 조합 무관 (forbidden 은 별도 describe)', () => {
     for (const key of ['red', 'dirty', 'stale'] as const) {
       const e = cleanEvidence()
       if (key === 'red') e.gates.red = true
@@ -119,7 +119,7 @@ describe('④ diff-cover 는 advisory — decision 을 block 으로 격하 못 �
     expect(d).toBe('caution')
   })
 
-  it('실차단(dirty)에 더해 diff-cover 가 풀커버여도 여전히 block — 차단은 3종만이 결정', () => {
+  it('실차단(dirty)에 더해 diff-cover 가 풀커버여도 여전히 block — 차단은 실차단이 결정(diff-cover 무관)', () => {
     const e = cleanEvidence()
     e.dirty = true
     e.diffCover = { measured: true, totalAdded: 10, totalUncovered: 0, ratio: 1 }


### PR DESCRIPTION
## 무엇 / 왜
`vhk receipt` 의 거짓완료 판정 `decideReceipt`(`src/lib/receipt.ts`)는 실제로 **4조건** 차단:
`red || dirty || (staleKnown && stale) || forbiddenViolated`.

`forbiddenViolated` 는 **goal 87(#406, 이미 DONE·머지)** 이 추가한 정당한 결정론 차단(변경 파일이 mission 금지 glob 매치 = LLM 0 사실). 그런데 옛 **"실차단 3종(red·dirty·stale)"** 텍스트가 코드 곳곳에 잔존 → 코드보다 적게 말하는(under-claim) 드리프트. 이 레포는 거짓완료를 기계증거로 잡는 도구라 텍스트도 정직해야 함 → **텍스트를 코드에 맞춤**(코드가 정답).

## 정정 8곳 (파일:라인 / 옛 → 새)
1. `src/lib/receipt.ts:19` — `ReceiptDecision` JSDoc: `block: 실차단(red/dirty/stale)` → `…(red/dirty/stale/forbidden)`
2. `src/i18n/ko.ts:295` — `nextBlockMessage`(사용자대면): `막힌 증거(red/dirty/stale)` → `…(red/dirty/stale/forbidden)`
3. `src/commands/receipt.ts:121` — 주석: `영수증 본체(실차단 3종)` → `…(실차단 red·dirty·stale·forbidden)`
4. `scripts/check-goal-86.mjs:65` — 주석: `실차단 3종만 block` → 4조건 명시 + "이 게이트는 기저 3종만 확인, forbidden 은 check-goal-87 소관"
5. `scripts/check-goal-86.mjs:66` — `must()` 레이블: `실차단 3종(red·dirty·stale)만 block` → `기저 실차단(red·dirty·stale) block 분기 존재 — forbidden 은 check-goal-87` **(정규식 불변)**
6. `tests/receipt.test.ts:58` — describe: `실차단 3종(red·dirty·stale)…` → `기저 실차단 3종(red·dirty·stale) … (forbidden 은 별도 describe)` **(루프 불변)**
7. `tests/receipt.test.ts:122` — describe: `차단은 3종만이 결정` → `차단은 실차단이 결정(diff-cover 무관)`
8. `tests/receipt.test.ts:18` — 파일 헤더 불변식 ① 주석: `dirty/stale/red 중 하나라도면 block` → `실차단(red·dirty·stale·forbidden) 중 하나라도면 block` (source `receipt.ts:8` 와 일치; 특이 어순이라 grep 1차 누락 → CI green 후 적발·합류)

## 일부러 "4종"으로 안 바꾼 곳 (정직)
check-goal-86 레이블(5)·test:58(6)은 **실제로 기저 3종만 검증/순회**. 정규식·루프를 안 바꾸면서 레이블만 "4종"이라 쓰면 레이블↔코드 새 드리프트가 됨 → "기저 3종 + forbidden 은 check-goal-87 별도" 로 분담 정직 표기. (`test:170` `사유(dirty/stale/red) 표기`·`test:194` 격리 주석도 = 3조건만 다루는 시나리오 레이블이라 그대로 — "실차단/3종" 총칭 주장 아님.)

## 안 건드린 것 (정당)
- `goals/86-receipt-mvp.md` 수용기준 원문 — DONE goal 기준 사후수정 = "짜맞춤" 오해 → 코드 레이블·테스트·주석만 정정
- check-goal-86 정규식 / **"red/dirty/stale 동급"** 프레이밍(`check-goal-87.mjs`·`receipt.test.ts:229/232/273`·`receipt.ts` 등 — forbidden 을 동급 4번째로 정확히 표현 중) / `receipt.ts` ①②③ 증거카테고리 번호(red①·dirty②·stale③·diff-cover④·intent⑤)

## 게이트
- ✅ `pnpm build` — exit 0
- ✅ `VHK_GATES_SKIP_DEEP=1 node scripts/check-goal-86.mjs` — typecheck · lint · `must()` 전건 ✓ (재작성 레이블 포함, 정규식 불변이라 매치 유지)
- ✅ 1차 푸시 **CI 전건 green** (gate · test ubuntu/windows × node 22/24 · dogfood · CodeQL · CodeRabbit) — 로컬 vitest forks/threads 풀 crash 는 TS-004 환경 결함이었음을 CI 가 확정. 8번째 수정은 순수 주석이라 동일.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
