### PR TITLE
fix: recap 비-TTY 비대화형 폴백 — 헤드리스 AI 실행 지원 (#288)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -13,6 +13,8 @@ Cursor에게 한국어로 말해도 됩니다.
 | 규칙 동기화 | `vhk 규칙` | "규칙 동기화해" |
 | 보안 스캔 | `vhk 보안 scan` | "보안 스캔 돌려" |
 
+> 🤖 **헤드리스/AI 실행:** `vhk recap`(오늘 정리)은 비-TTY(파이프·AI 에이전트 셸)에서도 동작합니다 — `--summary` · `--next` · `--decisions` · `--blockers` 로 내용을 넘기거나 `--yes` 로 기본값을 씁니다. 미지정 항목은 "미입력"으로 기록되고, ADR/트러블슈팅 문서 **생성**은 대화형(터미널)에서만 진행돼요(비-TTY 에서는 후보만 보고). (#288)
+
 > `vhk sync` 대상(7): `.cursorrules` · `.windsurfrules` · `.github/copilot-instructions.md` · `.agents/rules/vhk-rules.md` · `AGENTS.md` · `GEMINI.md`(Gemini CLI) · `.clinerules/vhk-rules.md`(Cline) + `CLAUDE.md`(하이브리드). 모두 RULES.md 단일소스에서 생성.
 
 | 빌드+테스트 | `pnpm build; pnpm test --run` | "빌드하고 테스트 돌려" |
@@ -142,7 +144,7 @@ vhk doctor
 | `vhk gate` | 아이디어 검증 |
 | `vhk start` | 새 프로젝트 시작 마법사 |
 | `vhk init` | 하네스 파일 생성 |
-| `vhk recap` | 오늘 한 일 정리 + ADR 분리 |
+| `vhk recap` | 오늘 한 일 정리 + ADR 분리 (비-TTY/헤드리스: `--summary/--next/--decisions/--blockers/--yes`) |
 | `vhk sync` | RULES.md → 규칙 파일 동기화 (`--check` = drift 검사만, Goal 63) |
 | `vhk check` | RULES.md 규칙 점검 |
 | `vhk secure` | 보안 스캔 (시크릿 유출 검사) |

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ vhk mcp
 | Goal | `vhk goal init/list/next/check/done/sync/drift` | 단계별 목표, 게이트, 상태 드리프트 관리 |
 | Trust | `vhk verify`, `vhk review`, `vhk receipt`, `vhk preflight`, `vhk testmap`, `vhk mission set/show/check/clear` | 증거 생성, 거짓완료 탐지, 증거 영수증(4대 기계증거 판정), 출고 전 점검, 테스트 매핑, 작업 범위 계약 |
 | 안전 | `vhk blocker`, `vhk resume --confirm`, `vhk mode`, `vhk secure scan` | HARD_STOP, safety mode, 시크릿 스캔 |
-| Git | `vhk status`, `vhk diff`, `vhk save`, `vhk undo`, `vhk restore`, `vhk recap` | 상태/변경 확인, 커밋/푸시, 되돌리기, 세션 로그 |
+| Git | `vhk status`, `vhk diff`, `vhk save`, `vhk undo`, `vhk restore`, `vhk recap` | 상태/변경 확인, 커밋/푸시, 되돌리기, 세션 로그 (`recap` 은 비-TTY/헤드리스 지원 — `--summary/--next/--decisions/--blockers/--yes`) |
 | 환경/품질 | `vhk doctor`, `vhk check`, `vhk env`, `vhk env-check`, `vhk harness`, `vhk audit`, `vhk worktree check/add` | 개발환경, RULES 린트, env, 통합 품질, 보안 감사, worktree 가드 |
 | 배포/패키지 | `vhk ship`, `vhk deploy`, `vhk publish`, `vhk update`, `vhk migrate` | 배포 체크, 배포 실행, npm 릴리스 자동화, 셀프 업데이트, 패키지 매니저 전환 |
 | MCP/클라우드 | `vhk mcp`, `vhk mcp-init`, `vhk cloud push/pull` | MCP stdio 서버, 클라이언트 설정, `.vhk/` secret gist 백업/복원 |

--- a/docs/log/2026-06-28-recap-nontty.md
+++ b/docs/log/2026-06-28-recap-nontty.md
@@ -1,0 +1,30 @@
+# 2026-06-28 — recap 비-TTY 비대화형 폴백 (#288)
+
+> cafe-pos-vhk 도그푸딩(VHK-5). 별도 worktree(fix/recap-nontty-288)에서 1건 PR.
+> 동일 계열 #333(no-args 비-TTY)·#337(undo)와 같은 "대화형 강제·비대화 폴백 부재"의 recap 판.
+
+## 증상 (#288)
+- 비대화형 셸(파이프·AI 에이전트 Bash 도구)에서 `vhk recap` → `ensureInteractive` 가 `⚠️ TTY_REQUIRED` + exit 2 로 중단. 회고 입력이 대화형으로만 가능.
+- 모순: `COMMANDS.md` 는 "오늘 한 일 정리해"를 AI 사용으로 안내하나, 실제론 AI(비-TTY)가 못 돌림. 메인 개발은 AI가 도는데 세션 정리를 AI가 못 해 흐름 단절.
+
+## 수정
+- `src/commands/recap.ts`: 진입부 `ensureInteractive`(exit 2 중단) → `isInteractive({ yes })` 분기로 교체.
+  - 대화형(TTY/VHK_FORCE_INTERACTIVE=1): 기존 4-필드 프롬프트 그대로 — 회귀 0(프롬프트 배열 바이트 동일).
+  - 비대화형(비-TTY/`--yes`): 프롬프트 호출 없이 플래그값(`--summary/--next/--decisions/--blockers`) 또는 기본값으로 회고 구성 → 세션 로그 작성. 미지정 항목은 `_(미입력 — 비대화형 실행)_` 표식(거짓 본문 날조 금지).
+  - 파일 작성 후 비대화형은 조기 종료: ADR/트러블슈팅 **후보는 읽기전용 보고**, 문서 생성·CLAUDE.md 갱신처럼 프롬프트 필요한 경로는 건너뜀(헤드리스 inquirer 금지 규칙 준수 — 6개 prompt 사이트 전부 가드 안쪽).
+- `src/index.ts`: recap 커맨드에 `--summary/--decisions/--next/--blockers/-y,--yes` 옵션 추가. (NL 라우터는 옵션 토큰 있으면 자동 위임 → cli-args 변경 불필요.)
+- `src/i18n/ko.ts`: `recap.notProvided/nonInteractiveNote/detectSkipNonInteractive` 추가.
+- MCP `recap` 툴은 별도 read-only 구현(`gitSession.recapLog`)이라 무영향 — CLI 경로만 변경.
+
+## 테스트
+- `tests/recap.test.ts`: 비-TTY 3케이스 추가(`node:fs`·`doc-suggest`·`troubleshooting`·`hard-stop-guard` 모킹으로 실레포 오염 차단).
+  - 비-TTY: inquirer 미호출 + writeFileSync 호출(로그 생성) + exit≠2.
+  - `--summary/--next` 플래그가 본문에 반영.
+  - 플래그 미지정 시 "미입력" 표식 기록.
+- 빌드된 dist 헤드리스 스모크: `echo "" | env -C <tmp-repo> node dist/index.js recap --summary ... --next ...` → 로그 생성 + **EXIT=0**(과거 exit 2 → 해소 확인).
+
+## 게이트
+- `pnpm build` ✓ (tsup ESM + DTS 풀 타입체크 통과).
+- `tests/recap.test.ts` 단독 6 pass(forks·threads 양쪽). `nlp-router` 86 pass·`interactive` 11 pass. `node scripts/check-commands-doc.mjs --strict` PASS(57 명령 전부 문서화).
+- 로컬 vitest 멀티파일은 forks "Worker exited unexpectedly"·threads "process.chdir not supported"·exit 127(rmSync) 환경성 플래키(TS-004/005, 내 변경 무관) → 단독 실행/CI 가 진실원. mcp-cli-contract 2건 실패는 threads 의 chdir 제약(deploy/publish 파리티, #288 무관).
+- 문서: COMMANDS.md(헤드리스 안내 + 명령표 행)·README(Git 표 행) 동작 일치 갱신.

--- a/src/commands/recap.ts
+++ b/src/commands/recap.ts
@@ -9,12 +9,18 @@ import { createTroubleshootingFile } from '../lib/troubleshooting.js'
 import { ko } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { printSecurityWarnings } from '../lib/check-secure.js'
-import { ensureInteractive } from '../lib/interactive.js'
+import { isInteractive } from '../lib/interactive.js'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
 import { localDate } from '../lib/date.js'
 
 export type RecapOptions = {
   since?: string
+  // #288: 비-TTY(헤드리스 AI·파이프)·--yes 비대화형 회고 입력. 미지정 항목은 기본값/미입력 표식.
+  summary?: string
+  decisions?: string
+  next?: string
+  blockers?: string
+  yes?: boolean
 }
 
 export async function recap(options: RecapOptions = {}) {
@@ -69,33 +75,45 @@ export async function recap(options: RecapOptions = {}) {
   }
 
   console.log('')
-  // VHK-014: 비-TTY 면 프롬프트 크래시 대신 friendly 안내 + exit 1 (위 git 분석은 보여준 뒤).
-  if (!ensureInteractive('회고 입력은 대화형으로만 가능합니다.')) return
+  // #288: 비-TTY(헤드리스 AI·파이프) 또는 --yes 면 프롬프트 대신 플래그값(없으면 미입력 표식)으로
+  // 회고를 구성한다. 과거엔 여기서 ensureInteractive 가 TTY_REQUIRED(exit 2)로 중단해 AI 워크플로가
+  // 끊겼다(COMMANDS.md "오늘 한 일 정리해" 안내와 모순). 대화형 경로는 그대로 — 프롬프트 호출 금지
+  // 규칙은 아래 비-TTY 분기(프롬프트 미호출)에서 지킨다.
+  const interactive = isInteractive({ yes: options.yes })
 
-  const answers = await prompt([
-    {
-      type: 'input',
-      name: 'summary',
-      message: ko.recap.summary,
-    },
-    {
-      type: 'input',
-      name: 'decisions',
-      message: ko.recap.decisions,
-      default: '없음',
-    },
-    {
-      type: 'input',
-      name: 'nextTodo',
-      message: ko.recap.nextTodo,
-    },
-    {
-      type: 'input',
-      name: 'blockers',
-      message: ko.recap.blockers,
-      default: '없음',
-    },
-  ])
+  const answers = interactive
+    ? await prompt<{ summary: string; decisions: string; nextTodo: string; blockers: string }>([
+        {
+          type: 'input',
+          name: 'summary',
+          message: ko.recap.summary,
+        },
+        {
+          type: 'input',
+          name: 'decisions',
+          message: ko.recap.decisions,
+          default: '없음',
+        },
+        {
+          type: 'input',
+          name: 'nextTodo',
+          message: ko.recap.nextTodo,
+        },
+        {
+          type: 'input',
+          name: 'blockers',
+          message: ko.recap.blockers,
+          default: '없음',
+        },
+      ])
+    : {
+        summary: options.summary?.trim() || ko.recap.notProvided,
+        decisions: options.decisions?.trim() || '없음',
+        nextTodo: options.next?.trim() || ko.recap.notProvided,
+        blockers: options.blockers?.trim() || '없음',
+      }
+
+  if (!interactive) console.log(chalk.dim(`  ${ko.recap.nonInteractiveNote}`))
 
   const today = localDate()
   const logDir = path.join(process.cwd(), 'docs', 'log')
@@ -145,6 +163,39 @@ export async function recap(options: RecapOptions = {}) {
   ].join('\n')
 
   fs.writeFileSync(filePath, content, 'utf-8')
+
+  const gitSaveCmd = process.platform === 'win32'
+    ? 'git add .; git commit -m "recap: 세션 기록"'
+    : 'git add . && git commit -m "recap: 세션 기록"'
+
+  // #288: 비대화형(비-TTY/--yes)은 여기서 마무리한다 — ADR/트러블슈팅 후보는 읽기전용으로
+  // 보고하되, 문서 자동 생성·CLAUDE.md 갱신처럼 프롬프트가 필요한 경로는 건너뛴다(헤드리스 inquirer 금지).
+  if (!interactive) {
+    const adrCandidates = detectAdrCandidates(diff)
+    if (adrCandidates.length > 0) {
+      console.log(chalk.cyan.bold(`\n${ko.recap.adrDetected} (${adrCandidates.length}건)`))
+      for (const candidate of adrCandidates) {
+        console.log(chalk.cyan(`  • ${candidate.title}: ${candidate.context}`))
+        candidate.files.forEach(f => console.log(chalk.dim(`    ${f}`)))
+      }
+    }
+    const troubleCommits = detectTroubleshootingCommits(commits)
+    if (troubleCommits.length > 0) {
+      console.log(chalk.yellow.bold(`\n${ko.recap.troubleDetected} (${troubleCommits.length}건)`))
+      troubleCommits.forEach(c => console.log(chalk.dim(`  • ${c.message}`)))
+    }
+    if (adrCandidates.length > 0 || troubleCommits.length > 0) {
+      console.log(chalk.dim(`  ${ko.recap.detectSkipNonInteractive}`))
+    }
+    console.log(chalk.green.bold(`\n${ko.recap.done}`))
+    console.log(chalk.dim(`  📄 ${path.relative(process.cwd(), filePath)}`))
+    printNextStep({
+      message: '오늘 기록 완료! 저장하고 싶으면:',
+      command: gitSaveCmd,
+      cursorHint: '저장해줘',
+    })
+    return
+  }
 
   const adrCandidates = detectAdrCandidates(diff)
   if (adrCandidates.length > 0) {
@@ -269,10 +320,6 @@ export async function recap(options: RecapOptions = {}) {
       }
     }
   }
-
-  const gitSaveCmd = process.platform === 'win32'
-    ? 'git add .; git commit -m "recap: 세션 기록"'
-    : 'git add . && git commit -m "recap: 세션 기록"'
 
   printNextStep({
     message: '오늘 기록 완료! 저장하고 싶으면:',

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -226,6 +226,10 @@ export const ko = {
     createAdr: '왜 그렇게 했는지 기록 문서를 만들까요?',
     troubleDetected: '🔧 버그·오류를 고친 커밋이 보여요!',
     createTroubleshoot: '어떻게 고쳤는지 메모를 남길까요?',
+    // #288: 비-TTY(헤드리스 AI·파이프)·--yes 비대화형 경로 안내.
+    notProvided: '_(미입력 — 비대화형 실행)_',
+    nonInteractiveNote: '비대화형 모드 — 회고 본문은 --summary / --next / --decisions / --blockers 플래그로 채울 수 있어요 (미지정 항목은 "미입력"으로 기록).',
+    detectSkipNonInteractive: '비대화형 모드 — 문서 자동 생성은 대화형(vhk recap)에서만. 위 후보를 참고해 직접 기록하세요.',
   },
   check: {
     title: '🔍 프로젝트 규칙 점검',

--- a/src/index.ts
+++ b/src/index.ts
@@ -257,6 +257,12 @@ program
   .alias('오늘')
   .description('오늘 한 일 정리 + ADR/트러블슈팅 자동 분리')
   .option('--since <date>', '분석 시작일 (YYYY-MM-DD)')
+  // #288: 비-TTY(헤드리스 AI·파이프)에서도 회고를 남길 수 있게 비대화형 입력 경로 제공.
+  .option('--summary <text>', '작업 요약 (비대화형 입력)')
+  .option('--decisions <text>', '결정 사항 (비대화형 입력)')
+  .option('--next <text>', '다음 할 일 (비대화형 입력)')
+  .option('--blockers <text>', '블로커 (비대화형 입력)')
+  .option('-y, --yes', '비대화형 실행 — 프롬프트 없이 플래그·기본값 사용 (TTY 에서도 강제)')
   .action(recap)
 
 // 유틸

--- a/tests/recap.test.ts
+++ b/tests/recap.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 const mockIsGitRepo = vi.fn()
 const mockHasAnyCommits = vi.fn()
 const mockGetSessionDiff = vi.fn()
 const mockGetRecentCommits = vi.fn()
+const mockPrompt = vi.fn()
+const mockWriteFileSync = vi.fn()
 
 vi.mock('../src/lib/git.js', () => ({
   isGitRepo: (...a: unknown[]) => mockIsGitRepo(...a),
@@ -22,14 +24,47 @@ vi.mock('../src/lib/adr.js', () => ({
   createAdrFile: () => '',
 }))
 
-vi.mock('inquirer', () => ({
-  default: { prompt: () => Promise.resolve({}) },
+// #288 비-TTY 테스트가 실 레포에 docs/log 파일을 쓰지 않도록 fs 격리(writeFileSync 만 spy).
+vi.mock('node:fs', () => {
+  const m = {
+    existsSync: () => false,
+    mkdirSync: () => undefined,
+    readdirSync: () => [] as string[],
+    writeFileSync: (...a: unknown[]) => mockWriteFileSync(...a),
+    readFileSync: () => '',
+  }
+  return { default: m, ...m }
+})
+
+vi.mock('../src/lib/doc-suggest.js', () => ({
+  detectTroubleshootingCommits: () => [],
 }))
+
+vi.mock('../src/lib/troubleshooting.js', () => ({
+  createTroubleshootingFile: () => '',
+}))
+
+// HARD_STOP 가드는 state-files/action-ledger 경유로 fs 를 타므로 직접 모킹(차단 아님 = 진행).
+vi.mock('../src/lib/hard-stop-guard.js', () => ({
+  ensureNotHardStopped: () => true,
+}))
+
+vi.mock('inquirer', () => ({
+  default: { prompt: (...a: unknown[]) => mockPrompt(...a) },
+}))
+
+function setTTY(value: boolean | undefined): boolean | undefined {
+  const orig = process.stdin.isTTY
+  Object.defineProperty(process.stdin, 'isTTY', { value, configurable: true })
+  return orig
+}
 
 describe('vhk recap', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockPrompt.mockResolvedValue({})
   })
 
   it('Git 레포가 아니면 안내만 출력하고 종료한다', async () => {
@@ -64,5 +99,74 @@ describe('vhk recap', () => {
     await recap()
     expect(mockGetSessionDiff).toHaveBeenCalled()
     expect(mockGetRecentCommits).toHaveBeenCalled()
+  })
+
+  describe('#288 비-TTY(헤드리스 AI·파이프) 비대화형 경로', () => {
+    let origTTY: boolean | undefined
+    let origExit: typeof process.exitCode
+
+    beforeEach(() => {
+      origTTY = setTTY(false) // 비-TTY 강제
+      origExit = process.exitCode
+      process.exitCode = 0
+      mockIsGitRepo.mockResolvedValue(true)
+      mockHasAnyCommits.mockResolvedValue(true)
+    })
+
+    afterEach(() => {
+      setTTY(origTTY)
+      process.exitCode = origExit
+    })
+
+    it('프롬프트 없이 세션 로그를 쓰고 정상 종료한다 (TTY_REQUIRED exit 2 아님)', async () => {
+      mockGetSessionDiff.mockResolvedValue({
+        filesChanged: 2,
+        insertions: 10,
+        deletions: 1,
+        files: [{ file: 'src/a.ts', status: 'modified' }],
+      })
+      mockGetRecentCommits.mockResolvedValue([{ hash: 'abc1234', message: 'fix: x' }])
+
+      const { recap } = await import('../src/commands/recap.js')
+      await recap({})
+
+      expect(mockPrompt).not.toHaveBeenCalled() // 헤드리스 inquirer 금지 준수
+      expect(mockWriteFileSync).toHaveBeenCalled() // 세션 로그 실제 생성
+      expect(process.exitCode).not.toBe(2) // 과거 TTY_REQUIRED 중단이 사라짐
+    })
+
+    it('--summary/--next 플래그가 회고 본문에 반영된다', async () => {
+      mockGetSessionDiff.mockResolvedValue({
+        filesChanged: 1,
+        insertions: 5,
+        deletions: 0,
+        files: [{ file: 'src/a.ts', status: 'modified' }],
+      })
+      mockGetRecentCommits.mockResolvedValue([])
+
+      const { recap } = await import('../src/commands/recap.js')
+      await recap({ summary: '로그인 화면 구현', next: '테스트 추가' })
+
+      expect(mockPrompt).not.toHaveBeenCalled()
+      const content = mockWriteFileSync.mock.calls[0]?.[1] as string
+      expect(content).toContain('로그인 화면 구현')
+      expect(content).toContain('테스트 추가')
+    })
+
+    it('플래그 미지정 항목은 "미입력" 표식으로 기록(거짓 본문 날조 금지)', async () => {
+      mockGetSessionDiff.mockResolvedValue({
+        filesChanged: 1,
+        insertions: 5,
+        deletions: 0,
+        files: [{ file: 'src/a.ts', status: 'modified' }],
+      })
+      mockGetRecentCommits.mockResolvedValue([])
+
+      const { recap } = await import('../src/commands/recap.js')
+      await recap({}) // 플래그 전무
+
+      const content = mockWriteFileSync.mock.calls[0]?.[1] as string
+      expect(content).toContain('미입력') // summary·nextTodo 가 미입력 표식
+    })
   })
 })


### PR DESCRIPTION
## 무엇 / 왜 (#288)
`vhk recap` 이 비대화형 셸(파이프·AI 에이전트 Bash 도구)에서 `ensureInteractive` 로 `⚠️ TTY_REQUIRED` + **exit 2** 중단 → 헤드리스 AI 가 세션 정리를 못 함. `COMMANDS.md` 의 "오늘 한 일 정리해(AI 사용)" 안내와 **모순**이었다(도그푸딩 VHK-5).

## 고친 내용
- **TTY 가드 → 분기 교체** (`src/commands/recap.ts`): `ensureInteractive`(exit 2 중단) 대신 `isInteractive({ yes })` 로 분기. 비-TTY/`--yes` 면 프롬프트 호출 없이(헤드리스 inquirer 금지 준수) `--summary/--next/--decisions/--blockers` 또는 기본값으로 세션 로그를 쓴다. 미지정 항목은 `_(미입력 — 비대화형 실행)_` 표식 — **거짓 본문 날조 금지**.
- **모든 prompt 사이트 가드 안쪽**: 파일 작성 후 비대화형은 조기 종료. ADR/트러블슈팅 **후보는 읽기전용 보고**, 문서 생성·CLAUDE.md 갱신처럼 프롬프트가 필관리자 6개 경로는 건너뜀.
- **옵션 추가** (`src/index.ts`): `--summary/--decisions/--next/--blockers/-y,--yes`. (NL 라우터는 옵션 토큰 있으면 자동 위임 → cli-args 변경 불필요.)
- **문서 일치**: COMMANDS.md(헤드리스 안내 + 명령표)·README. i18n 메시지 추가.
- **대화형(TTY) 경로는 기존 프롬프트 그대로 — 회귀 0.** MCP `recap` 툴은 별도 read-only 구현이라 무영향.

## 게이트 (로컬 / CI)
- `pnpm build` ✓ (tsup ESM + DTS 풀 타입체크) · `eslint src/commands/recap.ts src/index.ts src/i18n/ko.ts` ✓
- `tests/recap.test.ts` **6 pass**(forks·threads 양쪽, 비-TTY 3케이스 신규) · `nlp-router` 86 · `interactive` 11 pass · `node scripts/check-commands-doc.mjs --strict` PASS(57 명령 전부 문서화)
- **헤드리스 스모크**(빌드된 dist): `echo "" | env -C <tmp-repo> node dist/index.js recap --summary … --next …` → 로그 생성 + **EXIT=0**(과거 exit 2 해소 확인)
- ⚠️ **로컬 vitest 멀티파일 플래키**: forks "Worker exited unexpectedly" / threads "process.chdir not supported" / exit 127(rmSync) — 이 환경 고질(TS-004/005), **내 변경 무관**. 단독 실행·**CI 가 진실원**. (mcp-cli-contract 2건 실패는 threads 의 chdir 제약 — deploy/publish 파리티, #288 무관)

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)