### PR TITLE
fix: goal done — 파이프 조기종료(EPIPE) 시 DONE 전이 보장 + exit 255 차단 (#287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ### Fixed
 
+- **`vhk goal done` 파이프 조기종료(EPIPE) 시 상태 전이 누락 + exit 255 차단** (#287) — 게이트 통과 후 상태 write(frontmatter→DONE)를 게이트 출력보다 **먼저** 수행. Windows 는 파이프 write 가 동기라, 소비자가 출력 도중 파이프를 닫으면(예: `... | Select-Object -First 3`) `console.log(gate.out)` 이 EPIPE 를 throw 해 스택을 풀고 `atomicWriteFile` 전에 함수를 빠져나가던 게 원인 — 부수효과(상태 전이)를 출력보다 앞세워 출력 소비 여부와 무관하게 전이를 보장. 추가로 CLI 진입점에서 stdout/stderr 의 EPIPE 를 정상 종료(0)로 흡수. 회귀: 게이트 출력 print 가 EPIPE 로 죽어도 DONE 전이 보존.
 - **verify 자기참조 봉인** (Goal 85, #315, #370) — dirty 판정에서 vhk 자기 산출 추적파일(`.vhk/ledger.jsonl`·`.vhk/events/*.jsonl`)을 제외(`src/lib/self-tracked.ts` 단일 SoT). verify 직후 자기 ledger append 때문에 늘 거짓 "낡은 증거(dirty)"로 done/release 게이트를 막던 자기모순 해소. 과확장 0·퇴행 0 테스트 고정.
 - **recall 자유형식 쿼리 NL 라우터 가로채기 차단** (#313, #365) — `recall`/`회상` 쿼리에 트리거 단어(어떻게·보안·롤백 등)가 섞여도 NL 라우터에 가로채이지 않고 commander 로 위임(`FREEFORM_ARG_COMMANDS` 에 추가). 흔한 한국어 쿼리에서 메모리 검색이 무에러로 불능이던 문제 해소.
 - **goal·memory 파괴적 입력 검증 강화** (#317·#318, #367) — `goal check/done --id` 빈/공백 값(`Number('')===0` 으로 goal 0 오염)과 `memory remove/archive` 부분파싱(`parseInt('2zzz')=2`·`'1.5'=1`)을 정수 정규식으로 거부 — 엉뚱한 항목 DONE/삭제 차단.

--- a/docs/log/2026-06-28-287-goal-done-epipe.md
+++ b/docs/log/2026-06-28-287-goal-done-epipe.md
@@ -1,0 +1,32 @@
+# 2026-06-28 — #287 goal done EPIPE 시 상태 전이 누락 + exit 255
+
+## 결론
+`vhk goal done` 의 게이트 통과 후, 상태 write(frontmatter → DONE)를 **게이트 출력보다 먼저** 수행하도록 순서를 바꿨다. 추가로 CLI 진입점에서 stdout/stderr 파이프 조기종료(EPIPE)를 정상 종료(0)로 흡수한다.
+
+## 증상 (출처: cafe-pos-vhk 도그푸딩, VHK-3 · Windows 11 · PowerShell 5.1)
+- `vhk goal done --id 1 2>&1 | Select-Object -First 3` 처럼 소비자가 출력 도중 파이프를 닫으면
+  `goals/1-*.md` 의 `status` 가 DONE 으로 전이되지 않음(NOT_STARTED 잔존).
+- `$LASTEXITCODE = 255`(= −1).
+
+## 원인
+`goalDone` 는 게이트 통과 후 **게이트 출력(`console.log(gate.out)`)을 먼저** 찍고, 그 뒤에서 `atomicWriteFile` 로 상태를 전이했다.
+게이트 출력(빌드·테스트 로그)은 길어 파이프를 넘치게 한다 → 소비자가 일찍 닫으면 그 `console.log` 가 깨진 파이프에 write.
+Windows 는 파이프 write 가 **동기**라 EPIPE 가 **throw** 되어 스택을 풀고 함수를 빠져나간다 → `atomicWriteFile` 미도달 → 전이 누락.
+미처리 EPIPE 는 그대로 프로세스 크래시(비정상 종료코드).
+
+## 고친 것
+1. **src/commands/goal.ts (핵심)** — `goalDone`: 게이트 통과 시 read+update+`atomicWriteFile`(부수효과)를
+   게이트 출력·성공 메시지보다 **먼저** 수행. 출력은 `showGateOutput()` 클로저로 묶어 세 분기(실패/무변경/성공)에서
+   동일하게 재생(사용자가 보는 출력 순서는 그대로). 파이프가 끊겨 이후 `console.log` 가 죽어도 전이는 디스크에 안전.
+2. **src/index.ts (보강)** — isMainModule 안에서 stdout/stderr 의 `error`(EPIPE) → `process.exit(0)`,
+   top-level catch 의 **첫 분기**로 `isEpipeError(err) → exit(0)`(동기 throw EPIPE 가 다시 `console.error` 로
+   같은 끊긴 파이프를 때려 255 가 되던 경로 차단). isMainModule 내부 등록이라 테스트/임포트엔 영향 없음.
+3. **tests/goal.test.ts** — 회귀: 게이트 출력 `console.log` 에서만 EPIPE 를 던지게 모사 → 상태가 DONE 으로 전이됨을 확인.
+
+## 검증 (로컬 vitest forks 는 worker crash flaky — TS-004, CI 가 진실원)
+- `pnpm build` ✓ · `pnpm typecheck` ✓ · `pnpm lint` ✓
+- 회귀 로직 단독 증명(tsx 하니스): 미수정 코드 → `status-DONE=false`(RED, 버그 재현) / 수정 코드 → `status-DONE=true`(GREEN).
+- Fix2 메커니즘 증명: >64KB 출력→조기종료 소비자에서 핸들러 없음=exit 1 / 동일 핸들러 적용=exit 0.
+- 한계(정직): vhk 의 작은 출력 명령은 OS 파이프 버퍼(64KB)를 안 넘겨 in-node EPIPE 가 안 뜨고,
+  PowerShell `Select-Object -First` 는 자식 프로세스를 **외부에서 종료**(종료코드는 PowerShell 소관)한다.
+  → 그 경우에도 **상태 무결성은 Fix1 이 보장**(write 가 출력보다 앞서므로 어떻게 죽든 디스크 상태는 안전).

--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -433,10 +433,17 @@ export async function goalDone(opts: { id?: string }): Promise<void> {
   }
   warnIfBashOnWindows(scriptPath)
   const gate = runGate(scriptPath)
-  console.log(chalk.dim(`  ▶ 게이트 검증: ${gate.runner} ${scriptPath}\n`))
-  if (gate.out) console.log(gate.out)
+  // #287: 게이트 출력(빌드·테스트 로그)은 길어서, stdout 파이프가 조기 종료되면(예: PowerShell
+  //       `... | Select -First N`) 이 write 에서 EPIPE 가 난다. Windows 는 파이프 write 가 동기라
+  //       EPIPE 가 throw 되어 스택을 풀고 나가 버려 — 아래 상태 전이(atomicWriteFile)에 도달하지 못한다.
+  //       그래서 게이트 통과 시 '부수효과(상태 전이)'를 출력보다 먼저 수행한다(출력 소비 여부와 무관하게 전이 보장).
+  const showGateOutput = (): void => {
+    console.log(chalk.dim(`  ▶ 게이트 검증: ${gate.runner} ${scriptPath}\n`))
+    if (gate.out) console.log(gate.out)
+  }
   if (!gate.ok) {
     // Forbidden: 게이트 실패에도 done 으로 마킹 금지. frontmatter 변경 없이 종료.
+    showGateOutput()
     console.log(
       chalk.red(
         `\n  ❌ 게이트 실패 — frontmatter 변경 없이 종료. (Forbidden: 실패 = 보존)`
@@ -450,6 +457,7 @@ export async function goalDone(opts: { id?: string }): Promise<void> {
   const updated = updateFrontmatterStatus(content, 'DONE', { completed: today })
   if (updated === content) {
     // 갱신 결과 무변경 — frontmatter 미인식(손상·마커 누락) 또는 이미 동일 상태. "✅ DONE" 거짓 성공 방지.
+    showGateOutput()
     console.log(
       chalk.yellow(
         `\n  ⚠ frontmatter 갱신 결과 변경 없음 — 이미 DONE(completed: ${today})이거나 frontmatter 형식 미인식. 파일을 확인하세요.`
@@ -458,7 +466,9 @@ export async function goalDone(opts: { id?: string }): Promise<void> {
     process.exitCode = 1
     return
   }
+  // #287: durable write 를 출력보다 먼저 — 파이프가 끊겨(EPIPE) 후속 console.log 가 죽어도 전이는 이미 디스크에 안전.
   atomicWriteFile(target.filePath, updated) // Goal 40: frontmatter 갱신 중 kill 시 goal 파일 손상 방지
+  showGateOutput()
   console.log(chalk.green(`\n  ✅ Goal ${id} → DONE (completed: ${today})`))
   printNextStep({
     message: `Goal ${id} 완료! 다음 goal 로:`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1090,7 +1090,25 @@ const isMainModule =
   !!process.argv[1] &&
   getRealPath(fileURLToPath(import.meta.url)) === getRealPath(process.argv[1])
 
+// #287: stdout/stderr 의 소비자(예: PowerShell `... | Select -First N`)가 출력을 다 읽기 전에
+//       파이프를 닫으면 후속 write 가 EPIPE 를 던진다. 미처리 시 exit 255 로 죽고, 그 throw 가
+//       부수효과(상태 write)보다 먼저 나면 상태 전이까지 누락된다(본 이슈). EPIPE 는 정상 종료(0)로
+//       흡수한다 — 각 커맨드가 부수효과를 출력보다 먼저 수행하므로(goalDone 참조) 파이프가 끊겨도
+//       디스크 상태는 안전하다.
+const isEpipeError = (err: unknown): boolean =>
+  err instanceof Error && (err as NodeJS.ErrnoException).code === 'EPIPE'
+
 if (isMainModule) {
+  // POSIX 는 파이프 write 가 비동기 → EPIPE 가 'error' 이벤트로 온다(여기서 흡수). Windows 는 동기 →
+  // throw 되어 아래 try/catch 로 잡힌다. 양쪽 모두 0 종료. (isMainModule 안에서만 등록 = 테스트 격리.)
+  const swallowEpipe = (stream: NodeJS.WriteStream): void => {
+    stream.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'EPIPE') process.exit(0)
+      throw err
+    })
+  }
+  swallowEpipe(process.stdout)
+  swallowEpipe(process.stderr)
   // VHK-014: parseAsync 를 try/catch 로 감싸 unsettled top-level await 경고 제거 +
   // 비-TTY/EOF 프롬프트 크래시(ERR_USE_AFTER_CLOSE)를 friendly 종료로 처리.
   try {
@@ -1109,6 +1127,11 @@ if (isMainModule) {
       }
     }
   } catch (err) {
+    if (isEpipeError(err)) {
+      // #287: 동기 write(Windows 파이프)에서 throw 된 EPIPE. 여기서 console.error 재시도는 같은
+      //       끊긴 파이프(2>&1)라 또 EPIPE → exit 255 의 원흉. 메시지 없이 정상 종료(0)한다.
+      process.exit(0)
+    }
     if (isPromptAbortError(err)) {
       // #153: 비-TTY 프롬프트 중단도 TTY_REQUIRED 전용 코드(2)로 — generic 실패와 구분.
       console.error(chalk.yellow('\n  ⚠️  TTY_REQUIRED — 대화형 입력이 취소/종료됐습니다 (비대화형 환경 불가).'))

--- a/tests/goal.test.ts
+++ b/tests/goal.test.ts
@@ -968,3 +968,57 @@ describe('#330 goalCheck/goalDone — 비숫자 --id 진짜 원인 지목', () =
     })
   }
 })
+
+// #287: stdout 파이프가 게이트 로그 도중 조기 종료(EPIPE)돼도 status 전이는 보존돼야 한다.
+//        (Windows 는 파이프 write 가 동기 → EPIPE throw 가 스택을 풀어 옛 코드는 write 전 종료.)
+describe('#287 goalDone — 파이프 조기종료(EPIPE) 시에도 상태 전이 보장', () => {
+  let origCwd: string
+  let origExitCode: number | string | undefined
+  beforeEach(() => {
+    origCwd = process.cwd()
+    origExitCode = process.exitCode
+    mockSafeExecFile.mockReset()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    process.chdir(origCwd)
+    process.exitCode = origExitCode
+    vi.restoreAllMocks()
+  })
+
+  it('게이트 출력 print 가 EPIPE 로 죽어도 frontmatter 는 DONE 으로 전이됨', async () => {
+    const dir = tmpProject('epipe-done')
+    makeGoalFile(dir, 4, 'NOT_STARTED')
+    mkdirSync(join(dir, 'scripts'), { recursive: true })
+    writeFileSync(join(dir, 'scripts/check-goal-4.sh'), '#!/usr/bin/env bash\nexit 0\n', 'utf-8')
+    // 게이트 통과시키고, 게이트 출력에 마커를 심어 그 출력 console.log 에서만 EPIPE 를 던지게 한다.
+    // (PowerShell `... | Select -First N` 처럼 소비자가 게이트 로그 도중 파이프를 닫는 상황 모사.)
+    const MARK = '__VHK287_EPIPE_MARK__'
+    mockSafeExecFile.mockReturnValue({ ok: true, out: MARK, err: '' })
+    vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+      if (String(a[0]).includes(MARK)) {
+        throw Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })
+      }
+    })
+    process.chdir(dir)
+    try {
+      const { goalDone } = await import('../src/commands/goal.js')
+      let thrown: unknown = null
+      try {
+        await goalDone({ id: '4' })
+      } catch (e) {
+        // 옛 코드: write 전 throw → 여기로(상태 미전이). 수정 코드: write 후 throw → 여기로(상태 전이됨).
+        thrown = e
+      }
+      // 시뮬레이션이 실제로 EPIPE 를 던졌는지 확인 — 테스트가 헛돌지 않게 가드.
+      expect((thrown as NodeJS.ErrnoException | null)?.code).toBe('EPIPE')
+      // 핵심: 출력이 EPIPE 로 끊겼어도 상태 전이는 디스크에 남아야 한다.
+      const after = readFileSync(join(dir, 'goals/4-test.md'), 'utf-8')
+      expect(after).toContain('status: DONE')
+      expect(after).not.toContain('status: NOT_STARTED')
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## 무엇을 / 왜
`vhk goal done` 이 stdout 파이프 조기종료(EPIPE) 시 **상태 전이(frontmatter→DONE)를 누락**하고 **exit 255** 로 죽던 문제(#287)를 고친다.

- **핵심**: 게이트 통과 시 상태 write(`atomicWriteFile`)를 **게이트 출력보다 먼저** 수행 → 출력 소비 여부와 무관하게 전이 보장.
- **보강**: CLI 진입점에서 stdout/stderr 의 EPIPE 를 정상 종료(0)로 흡수.
- **회귀 테스트**: 게이트 출력 print 가 EPIPE 로 죽어도 DONE 전이가 보존됨을 확인.

## 원인 (Windows 특이)
`goalDone` 는 게이트 통과 후 `console.log(gate.out)`(빌드·테스트 로그=길다)을 **먼저** 찍고 그 뒤에서 `atomicWriteFile` 로 전이했다. Windows 는 파이프 write 가 **동기**라, 소비자가 출력 도중 파이프를 닫으면(`... | Select-Object -First 3`) 그 `console.log` 가 EPIPE 를 **throw** → 스택을 풀고 함수를 빠져나가 → `atomicWriteFile` 미도달 → 전이 누락. 미처리 EPIPE 가 top-level catch 의 `console.error` 로 같은 끊긴 파이프(2>&1)를 다시 때려 255.

## 변경
- `src/commands/goal.ts` — `goalDone`: 게이트 통과 시 read+update+`atomicWriteFile` 를 출력보다 **먼저**. 출력은 `showGateOutput()` 클로저로 묶어 세 분기에서 동일 재생(사용자가 보는 출력 순서는 그대로).
- `src/index.ts` — `isMainModule` 안에서 stdout/stderr `error`(EPIPE)→`exit(0)`, top-level catch **첫 분기**로 `isEpipeError→exit(0)`. 임포트/테스트엔 영향 없음.
- `tests/goal.test.ts` — 회귀(EPIPE 모사 → DONE 전이 보존).
- `CHANGELOG.md` · `docs/log/2026-06-28-287-goal-done-epipe.md`.

## 검증
- 게이트: `pnpm build` ✅ · `pnpm typecheck` ✅ · `pnpm lint` ✅
- **회귀 RED→GREEN(기계증거, tsx 단독 하니스)**: 미수정 코드 → `status-DONE=false`(버그 재현) / 수정 코드 → `status-DONE=true`.
- **Fix2 메커니즘**: >64KB 출력→조기종료 소비자에서 동일 EPIPE 핸들러 없음=exit 1 / 적용=exit 0(5/5).
- ⚠️ **로컬 vitest forks flaky**(worker crash, TS-004) — 같은 환경에서 무관 테스트(`goal-atomic.test.ts`)도 동일 크래시. **CI 가 진실원.** 추가 회귀 1건은 위 tsx 하니스로 단독 검증.

## 한계 (정직)
- vhk 의 작은 출력 명령은 OS 파이프 버퍼(64KB)를 안 넘겨 in-node EPIPE 가 안 뜨고, PowerShell `Select-Object -First` 는 자식 프로세스를 **외부에서 종료**(종료코드는 PowerShell 소관, −1=255)한다. 그 경우에도 **상태 무결성은 핵심 수정(write-before-output)이 보장** — 어떻게 죽든 디스크 상태는 안전.

Closes #287
