### PR TITLE
fix(mcp): ship 핸들러 sync→async (이벤트루프 블로킹 제거)

### DIFF
--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -1,4 +1,9 @@
-import { execFileSync } from 'node:child_process'
+import { execFileSync, execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+// execFile(callback) → Promise. Node 가 exec/execFile 에 한해 custom promisify 를 제공해
+// 실패(reject) 시에도 err.stdout/err.stderr 가 보존된다(아래 비동기 에러 파싱이 sync 와 동일하게 동작).
+const execFileAsync = promisify(execFile)
 
 // Windows에서 pnpm/npm/npx/yarn/vhk는 .cmd shim. execFileSync는 native 바이너리만 찾으므로 .cmd 확장자 부여.
 // #150: 'vhk' 추가 — 전역 설치 시 vhk.cmd 만 노출돼 MCP 가 bare 'vhk' spawn 시 ENOENT 였음.
@@ -98,6 +103,51 @@ export function safeExecFile(
     const stderr = e.stderr ? e.stderr.toString().trim() : ''
     let msg = e.message ?? String(err)
     if (isTimeoutError(e, timeout)) {
+      msg = `명령 시간 초과 (timeout ${timeout}ms): ${cmd} ${args.join(' ')}`.trim()
+    }
+    return { ok: false, err: msg, out: stdout.trim(), stderr: stderr || undefined }
+  }
+}
+
+// safeExecFile 의 비동기(non-blocking) 쌍둥이. 동작 의미(ExecResult 모양·env 병합·timeout·
+// cwd·trimOutput·Windows .cmd shim 해석·실패 시 stdout/stderr 보존)는 sync 와 동일하게 유지하되,
+// execFileSync 가 이벤트루프를 막는 것을 promisified execFile 로 해소한다(장시간 build/test 가
+// MCP stdio 서버의 다른 요청을 블로킹하지 않게 — server.ts ship 핸들러용).
+// 외부 의존성(execa 등) 추가 없이 node:child_process 내장 API 만 사용 — 공개 CLI 의존성 표면 보존.
+export async function safeExecFileAsync(
+  cmd: string,
+  args: string[],
+  opts: SafeExecOptions = {}
+): Promise<ExecResult> {
+  const { bin, argv } = resolveCmd(cmd, args)
+  const env = opts.env ? { ...process.env, ...opts.env } : undefined
+  const timeout = resolveTimeout(opts.timeoutMs, DEFAULT_EXEC_TIMEOUT_MS)
+  try {
+    const { stdout } = await execFileAsync(bin, argv, {
+      encoding: 'utf-8',
+      env,
+      ...(opts.cwd ? { cwd: opts.cwd } : {}),
+      ...(timeout ? { timeout, killSignal: 'SIGTERM' as const } : {}),
+    })
+    const out = stdout.toString()
+    // trimOutput !== false → trim(기본). false 면 raw 보존(porcelain 선행 공백 등).
+    return { ok: true, out: opts.trimOutput === false ? out : out.trim() }
+  } catch (err) {
+    // non-zero exit / timeout kill: stdout/stderr 는 err.stdout/err.stderr 에 보존됨(sync 와 동일).
+    const e = err as {
+      stdout?: Buffer | string
+      stderr?: Buffer | string
+      message?: string
+      killed?: boolean
+      signal?: string
+      code?: string
+    }
+    const stdout = e.stdout ? e.stdout.toString() : ''
+    const stderr = e.stderr ? e.stderr.toString().trim() : ''
+    let msg = e.message ?? String(err)
+    // sync(spawnSync) 는 timeout 시 code='ETIMEDOUT' 를 주지만, async execFile 은 killSignal 로
+    // 죽여 killed=true + signal 로 신호한다 → 둘 다 timeout 으로 라벨(메시지 파리티). ok=false 는 동일.
+    if (timeout && (e.code === 'ETIMEDOUT' || (e.killed === true && (e.signal === 'SIGTERM' || e.signal === 'SIGKILL')))) {
       msg = `명령 시간 초과 (timeout ${timeout}ms): ${cmd} ${args.join(' ')}`.trim()
     }
     return { ok: false, err: msg, out: stdout.trim(), stderr: stderr || undefined }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod'
 import { existsSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs'
-import { safeExecFile, NETWORK_EXEC_TIMEOUT_MS } from '../lib/exec.js'
+import { safeExecFile, safeExecFileAsync, NETWORK_EXEC_TIMEOUT_MS } from '../lib/exec.js'
 import * as gitSession from '../lib/git-session.js'
 import { isGitRepo } from '../lib/git-repo.js'
 import { parseEnvKeys } from '../commands/env.js'
@@ -357,14 +357,16 @@ export function createVhkMcpServer(): McpServer {
   })
 
   // ─── ship ───────────────────────────────────────────────
-  // TODO(v0.6.1): execa로 비동기 전환 — ship 장시간 블로킹 방지
+  // 빌드·테스트는 장시간 작업 → 비동기(safeExecFileAsync)로 실행해 MCP stdio 이벤트루프
+  // 블로킹을 제거한다(과거 execFileSync 는 응답 동안 다른 요청을 막았음). 동작 의미(ok 판정·
+  // 출력·종료코드)는 동일.
   server.registerTool('ship', { description: '배포 체크리스트 실행 (빌드 + 테스트 + 버전 + git 상태)' }, async () => {
     const checks: string[] = []
 
-    const build = safeExecFile('pnpm', ['build'])
+    const build = await safeExecFileAsync('pnpm', ['build'])
     checks.push(build.ok ? '✅ 빌드 성공' : '❌ 빌드 실패')
 
-    const test = safeExecFile('pnpm', ['test', '--run'])
+    const test = await safeExecFileAsync('pnpm', ['test', '--run'])
     checks.push(test.ok ? '✅ 테스트 통과' : '❌ 테스트 실패')
 
     if (existsSync('package.json')) {

--- a/tests/exec.test.ts
+++ b/tests/exec.test.ts
@@ -103,6 +103,34 @@ describe('lib/exec', () => {
     expect(NETWORK_EXEC_TIMEOUT_MS).toBeLessThan(DEFAULT_EXEC_TIMEOUT_MS)
   })
 
+  it('safeExecFileAsync: 성공 시 ok=true와 trim된 out 반환 (sync 파리티)', async () => {
+    const { safeExecFileAsync } = await import('../src/lib/exec.js')
+    const result = await safeExecFileAsync('node', ['--version'])
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.out).toMatch(/^v\d+\.\d+\.\d+/)
+    }
+  })
+
+  it('safeExecFileAsync: 실패 시 ok=false와 err 메시지 반환', async () => {
+    const { safeExecFileAsync } = await import('../src/lib/exec.js')
+    const result = await safeExecFileAsync('this-binary-does-not-exist-vhk-xyz', [])
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.err).toBeTruthy()
+    }
+  })
+
+  it('safeExecFileAsync: timeoutMs 초과 시 ok=false + 시간 초과 메시지 (이벤트루프 비블로킹)', async () => {
+    const { safeExecFileAsync } = await import('../src/lib/exec.js')
+    // async execFile 은 killSignal 로 죽이므로 killed/signal 기반 timeout 라벨이 동작해야 함.
+    const result = await safeExecFileAsync('node', ['-e', 'setInterval(() => {}, 1000)'], { timeoutMs: 200 })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.err).toMatch(/시간 초과|timeout/i)
+    }
+  })
+
   it('safeExecFileStream: timeoutMs 초과 시 ok=false + 시간 초과 메시지', async () => {
     const { safeExecFileStream } = await import('../src/lib/exec.js')
     const result = safeExecFileStream('node', ['-e', 'setInterval(() => {}, 1000)'], { timeoutMs: 200 })


### PR DESCRIPTION
딥스캔 P2(server.ts:360 TODO). ship의 동기 `safeExecFile`(pnpm build/test)이 MCP 응답을 블로킹하던 것 → 비동기 전환.

**전제 정정:** 발굴이 'execa 이미 deps' 라 했으나 **실제 execa는 deps/lock/node_modules 어디에도 없음**. 공개 플래그십에 신규 런타임 의존성 추가는 부적절 → 의존성 추가 0으로 Node 내장 `node:child_process.execFile`(promisified) `safeExecFileAsync` 신설(기존 exec.ts 패턴 일치). ExecResult 의미·Windows .cmd shim·timeout 라벨 전부 보존.

검증: tsc OK + exec.test.ts 14/14(async 파리티 3 신규). 풀스위트는 Windows+vitest Worker pre-existing flaky라 미실행(교훈).

🤖 Generated with [Claude Code](https://claude.com/claude-code)