### PR TITLE
feat(evolve): reinforce 성공패턴을 룰 후보로 활용 (N2)

### DIFF
--- a/.vhk/ledger.jsonl
+++ b/.vhk/ledger.jsonl
@@ -1,1 +1,2 @@
 {"version":"2.6.0","date":"2026-06-22","status":"PASS","sha":"827c56f7a015b730b7d132ea86e179f8bd59f320","shortSha":"827c56f","dirty":true}
+{"version":"2.7.0","date":"2026-07-01","status":"PASS","sha":"692b4ecd9fea7865fba174ba6530fd0cd5174988","shortSha":"692b4ec","dirty":true}

--- a/docs/log/2026-07-01-n2-evolve-reinforce.md
+++ b/docs/log/2026-07-01-n2-evolve-reinforce.md
@@ -1,0 +1,32 @@
+# 2026-07-01 — N2: reinforce 성공패턴 evolve 후보 활용 + vhk 자기 도그푸딩
+
+> append-only. 추가만, 수정·삭제 금지.
+
+## 한 일 (N2 — 복리 척추 1/2)
+`pattern.ts`가 감지만 하고 `evolve.ts`가 버리던 **reinforce(성공) 패턴**을 룰 후보로 살림. avoid(❌) 단방향이던 자산을 ✅/❌ 양방향으로 대칭화.
+
+### 변경
+- `src/commands/evolve.ts`
+  - `generateCandidates`: 필터 `kind === 'avoid'` → `status === 'active'` (avoid+reinforce 모두). patternId가 kind 포함(`sigOf`)이라 dedupeKey 충돌 0.
+  - `buildDraft`: kind 분기. reinforce → `- ✅ 권장: 태그 '…' 패턴 재사용 (근거: N건 성공, …)`. avoid는 기존 "사전 점검 필수" 유지.
+  - `evolveSuggest` "후보 없음" 분기: `activeAvoid` → `activePatterns`(reinforce 포함 정직화).
+- `tests/evolve.test.ts`: 옛 동작 박제 테스트(`reinforce 패턴 제외`) → 새 동작으로 교체 + buildDraft reinforce + dedupeKey 충돌 없음 테스트 추가.
+
+### 철칙 부합
+결정론 빈도 카운팅(LLM 0). RULES.md 반영은 여전히 `evolve apply` 사람 승인 게이트. apply 자동화는 안 함(ⓓ 철칙 위반).
+
+### TDD
+RED(2 fail 정확한 이유) → GREEN(52 pass) → 전체 `vhk verify` PASS.
+
+## vhk 자기 도그푸딩 (이 작업으로 vhk를 vhk로 검증)
+"VHK 작업 때 vhk 쓰나?" 질문 계기 — 그동안 raw git/vitest만 씀(도그푸딩 구멍) → 만회.
+
+- **버전 스큐 발견**: 글로벌 `vhk` = 2.6.0(stale, pnpm bin), 로컬 dist = 2.7.0. → 이 브랜치 코드 검증하려면 `node dist/index.js`로 돌려야 함(글로벌은 옛 코드 테스트). **반복 위험 — 도그푸딩 시 항상 로컬 dist 확인.**
+- `vhk mission set/check`: N2 범위 계약(scope=evolve.ts·test) 저장·검증 ✓. glob 한정(objective 의미 미검증) 정직 고지 확인 — ⓑ intent 격차 실물.
+- `vhk verify`: 5게이트(tsc/lint/test:run/build/secure) PASS. 수동 build+test의 상위집합 = 도구가 더 촘촘.
+- `vhk receipt`: 미커밋 상태 🔴 BLOCK 정상 발화("dirty" + "작업시작 미기록"). 거짓완료 탐지기 라이브 작동 증명.
+  - 📝 습관 갭(도구 버그 아님): N2 시작 때 `vhk receipt --mark-start`로 기준선 고정했어야 → stale 판정 가능. 다음부터 작업 시작 시 mark-start.
+
+## 다음
+- N2 커밋(수동 — vhk save 안 씀, main push 차단·정크커밋 위험) → PR → CI green → 머지.
+- **N7 receipt-log 영속** (복리 척추 2/2) = 다음.

--- a/src/commands/evolve.ts
+++ b/src/commands/evolve.ts
@@ -48,12 +48,16 @@ export interface EvolveQueueFile {
 
 /**
  * 결정적 한국어 룰 초안 생성 — 같은 입력 → 같은 출력(ML/LLM 없음).
- * 예: "- 태그 'build' 관련 작업 시 사전 점검 필수 (근거: 3건 반복, [avoid] 태그 'build' 3건 반복)"
+ * avoid:     "- 태그 'build' 관련 작업 시 사전 점검 필수 (근거: 3건 반복, [avoid] …)"
+ * reinforce: "- ✅ 권장: 태그 'deploy' 패턴 재사용 (근거: 3건 성공, [reinforce] …)"
+ * N2: 성공패턴(reinforce)도 룰 초안화 — pattern.ts 가 감지만 하고 버리던 ✅ 자산을 살림.
  */
 export function buildDraft(p: PatternEntryV19): string {
   const axisLabel = p.axis === 'tag' ? `태그 '${p.signal}'` : `키워드 '${p.signal}'`
-  const countDesc = `${p.count}건 반복`
-  return `- ${axisLabel} 관련 작업 시 사전 점검 필수 (근거: ${countDesc}, ${p.summary})`
+  if (p.kind === 'reinforce') {
+    return `- ✅ 권장: ${axisLabel} 패턴 재사용 (근거: ${p.count}건 성공, ${p.summary})`
+  }
+  return `- ${axisLabel} 관련 작업 시 사전 점검 필수 (근거: ${p.count}건 반복, ${p.summary})`
 }
 
 /** dedupeKey = `${patternId}:${targetLayer}`. v1 의 `${patternId}:rule` 과 하위호환(targetLayer 기본 'rule'). */
@@ -63,7 +67,8 @@ export function buildDedupeKey(patternId: string, targetLayer: TargetLayer = 'ru
 
 /**
  * 후보 생성 — 순수 함수. 부수효과 없음.
- * v0 규칙: kind==='avoid' AND status==='active' 패턴만 대상.
+ * 규칙: status==='active' 패턴 대상 (N2: avoid + reinforce 모두 — 성공패턴도 룰 자산화).
+ *   patternId 가 kind 를 포함(pattern.ts sigOf)해 avoid/reinforce dedupeKey 충돌 0.
  * A1: 같은 dedupeKey 가 rejected 이면 재제안 억제.
  * A2: 같은 dedupeKey 가 pending/applied 이면 스킵.
  * 결정성: patternId 알파벳 오름차순 정렬.
@@ -80,7 +85,7 @@ export function generateCandidates(
   )
 
   const eligible = patterns
-    .filter((p) => p.kind === 'avoid' && p.status === 'active')
+    .filter((p) => p.status === 'active')
     .sort((a, b) => a.id.localeCompare(b.id))
 
   const result: Omit<EvolveQueueItem, 'id' | 'createdAt'>[] = []
@@ -360,8 +365,9 @@ export async function evolveSuggest(opts: { json?: boolean } = {}): Promise<void
   const newItems = generateCandidates(patterns, queue.items)
 
   if (newItems.length === 0 && !opts.json) {
-    const activeAvoid = patterns.filter(p => p.kind === 'avoid' && p.status === 'active')
-    if (activeAvoid.length === 0) {
+    // N2: avoid + reinforce 모두 후보 대상 → 활성 패턴 전체로 "패턴 없음/모두 제안됨" 구분.
+    const activePatterns = patterns.filter(p => p.status === 'active')
+    if (activePatterns.length === 0) {
       console.log(chalk.yellow('\n📭 ' + t('evolve.noPatterns')))
       return
     }

--- a/tests/evolve.test.ts
+++ b/tests/evolve.test.ts
@@ -93,6 +93,17 @@ describe('buildDraft', () => {
     const draft = buildDraft(p)
     expect(draft).toContain("'auth'")
   })
+
+  it('reinforce 패턴 → ✅ 권장 재사용 초안 (성공 근거)', () => {
+    const p = pat('p4', 'deploy', 3, 'reinforce')
+    const draft = buildDraft(p)
+    expect(draft).toContain("'deploy'")
+    expect(draft).toContain('✅ 권장')
+    expect(draft).toContain('재사용')
+    expect(draft).toContain('3건 성공')
+    // avoid 문구(사전 점검)는 reinforce 초안에 섞이지 않음
+    expect(draft).not.toContain('사전 점검')
+  })
 })
 
 // ── buildDedupeKey ───────────────────────────────────────────────────────────
@@ -115,14 +126,28 @@ describe('generateCandidates', () => {
     expect(result.every((r) => r.status === 'pending')).toBe(true)
   })
 
-  it('reinforce 패턴 제외', () => {
+  it('avoid·reinforce active 패턴 모두 후보 생성 (N2: 성공패턴 활용)', () => {
     const patterns = [
       pat('p1', 'build', 3, 'avoid'),
       pat('p2', 'deploy', 3, 'reinforce'),
     ]
     const result = generateCandidates(patterns, [])
-    expect(result).toHaveLength(1)
-    expect(result[0].patternId).toBe('p1')
+    expect(result).toHaveLength(2)
+    expect(result.map((r) => r.patternId).sort()).toEqual(['p1', 'p2'])
+    // reinforce 후보 초안은 ✅ 권장 형태
+    const reinforce = result.find((r) => r.patternId === 'p2')
+    expect(reinforce?.draft).toContain('✅ 권장')
+  })
+
+  it('avoid·reinforce 동일 signal 이어도 dedupeKey 충돌 없음', () => {
+    // 실제 pattern.ts sigOf 가 kind 를 포함 → patternId 가 kind 별로 달라 충돌 0
+    const patterns = [
+      pat('a1', 'build', 3, 'avoid'),
+      pat('r1', 'build', 3, 'reinforce'),
+    ]
+    const result = generateCandidates(patterns, [])
+    const keys = result.map((r) => r.dedupeKey)
+    expect(new Set(keys).size).toBe(keys.length)
   })
 
   it('archived 패턴 제외', () => {


### PR DESCRIPTION
## 무엇 (N2 — 복리 척추 1/2)

`pattern.ts`가 감지만 하고 `evolve.ts:generateCandidates`가 버리던 **reinforce(성공) 패턴**을 evolve 후보로 살림. avoid(❌) 단방향이던 룰 자산을 ✅/❌ 양방향으로 대칭화.

## 변경

- `generateCandidates`: 필터 `kind === 'avoid'` → `status === 'active'` (avoid+reinforce 모두). `patternId`가 kind 포함(`pattern.ts:sigOf`)이라 avoid/reinforce dedupeKey 충돌 0.
- `buildDraft`: kind 분기. reinforce → `- ✅ 권장: 태그 '…' 패턴 재사용 (근거: N건 성공, …)`. avoid는 기존 "사전 점검 필수" 유지.
- `evolveSuggest` "후보 없음" 분기: `activeAvoid` → `activePatterns` (reinforce 포함 정직화).

## 철칙 부합

결정론 빈도 카운팅(LLM 0). RULES.md 반영은 여전히 `evolve apply` 사람 승인 게이트. apply 자동화는 하지 않음(철칙).

## 검증 (TDD + vhk 도그푸딩)

- RED: 옛 동작 박제 테스트(`reinforce 패턴 제외`) 교체 + buildDraft reinforce + dedupeKey 충돌 없음 테스트 → 2 fail(정확한 이유).
- GREEN: `evolve.test.ts` 52 pass.
- `vhk verify` 5게이트(tsc/lint/test:run/build/secure) **PASS** (로컬 dist 2.7.0 — 글로벌 2.6.0 스큐 주의).
- `vhk mission check` scope 준수 ✓ · `vhk receipt` 미커밋 BLOCK→커밋 후 해소.

## 메모

- 부수 커밋 `chore(vhk): evidence ledger [skip ci]`는 `vhk verify`가 증거 2파일만 스코프 커밋(의도·안전). squash 머지로 흡수.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 활성 상태의 패턴이 더 넓게 반영되어, 추천/주의 문구가 상황에 맞게 생성됩니다.
  * 활성 패턴이 없을 때만 안내를 종료하도록 동작이 개선되었습니다.

* **Bug Fixes**
  * 권장 항목은 “✅ 권장” 형태로, 주의 항목은 “사전 점검 필수” 형태로 더 일관되게 표시됩니다.
  * 같은 신호를 가진 항목도 중복 없이 후보로 처리되도록 개선되었습니다.

* **Tests**
  * 권장/주의 문구와 후보 생성 기준을 검증하는 테스트가 추가·갱신되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->