### PR TITLE
feat(receipt): receipt 발행 측정 엔트리를 events 원장에 영속 (N7)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,8 @@
 # LF 고정으로 차단.
 *.mjs text eol=lf
 *.sh text eol=lf
+
+# .vhk/events/*.jsonl = append-only 증거 원장(action-ledger·diff-cover·receipt-log).
+# 멀티PC 양쪽이 각자 append 후 분기 시 라인 단위로 양쪽 줄 보존(충돌 대신 union 머지).
+# diff-cover-log.ts·receipt-log.ts 주석이 가정하던 설정 — 실제 누락분 보강(N7).
+.vhk/events/*.jsonl merge=union

--- a/.vhk/ledger.jsonl
+++ b/.vhk/ledger.jsonl
@@ -1,1 +1,2 @@
 {"version":"2.6.0","date":"2026-06-22","status":"PASS","sha":"827c56f7a015b730b7d132ea86e179f8bd59f320","shortSha":"827c56f","dirty":true}
+{"version":"2.7.0","date":"2026-07-01","status":"PASS","sha":"692b4ecd9fea7865fba174ba6530fd0cd5174988","shortSha":"692b4ec","dirty":true}

--- a/docs/log/2026-07-01-n7-receipt-log.md
+++ b/docs/log/2026-07-01-n7-receipt-log.md
@@ -1,0 +1,26 @@
+# 2026-07-01 — N7: receipt-log 영속 (복리 척추 2/2)
+
+> append-only. 추가만, 수정·삭제 금지.
+
+## 한 일
+`vhk receipt` 발행마다 측정 엔트리 1줄을 `.vhk/events/receipt-log.jsonl`에 append. 콘솔 휘발이던 decision 판정을 영속 → "거짓완료 판정 분포" 추세 토대(N6 `vhk stats --trend`가 소비, #374 evolve 효과측정이 applied 시점과 조인).
+
+### 변경
+- `src/lib/receipt-log.ts` (신규) — `diff-cover-log.ts` 패턴 미러. 순수 `buildReceiptLogEntry(Receipt)` + `readReceiptLog` + `appendReceiptLog`. 측정치만(decision·SHA·red·gateStatus·dirty·stale·diffCoverRatio·forbiddenHits·scopeWarnings) — reasons/honesty 원문·사적 경로 0.
+- `src/commands/receipt.ts` — `writeReceipt` 뒤 best-effort `appendReceiptLog`(try/catch — append 실패가 본 판정/출력 안 막음) + import.
+- `tests/receipt-log.test.ts` (신규) — 10 테스트(매핑·null 처리·라운드트립·손상 skip·append-only).
+
+### 위치·자기참조 봉인
+`.vhk/events/receipt-log.jsonl` — `self-tracked.ts:isSelfTrackedPath`가 `.vhk/events/*.jsonl` prefix 제외 → receipt 가 자기 로그 append 해도 다음 receipt 의 dirty 판정 미오염(#315 동형). append는 dirty 수집(collectReceipt) **뒤**라 자기 발행이 자기 판정에 안 섞임. `.vhk/events/`는 gitignore 아님 → 추적(추세 영속).
+
+### 철칙 부합
+측정전용·읽기 토대. decision 로직 불변(decideReceipt 미변경) — 단조성 불변식 보존. LLM 0.
+
+### TDD + 도그푸딩
+RED(module 없음) → GREEN 10 pass → `vhk verify` 5게이트(tsc/lint/test:run/build/secure) **PASS**. mission scope 준수 ✓. read-only 적대 리뷰(cavecrew-reviewer, 쓰기 없음).
+
+## 발견(기록만)
+- `.gitattributes`에 `events/*.jsonl merge=union` **미설정** — diff-cover-log.ts 주석이 주장하나 실제 없음(기존 latent 갭, N7 무관). 멀티PC append 분기 시 줄 충돌 가능 — 별도 1줄 PR 후보.
+
+## 다음
+- N3(`vhk win` 성공기록) → N11(evolve-nudge Stop hook) → 백로그 계속.

--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -26,6 +26,7 @@ import {
   type ReceiptDiffCover,
   type ReceiptIntentEvidence,
 } from '../lib/receipt.js'
+import { appendReceiptLog, buildReceiptLogEntry } from '../lib/receipt-log.js'
 
 /**
  * Goal 86 (RFC 0056 T1): vhk receipt — 에이전트 "완료" 시점에 4대 기계증거를 영수증 1장으로.
@@ -292,6 +293,14 @@ export async function receipt(opts: ReceiptOptions = {}): Promise<void> {
 
   const r = collectReceipt(cwd, opts.since ?? undefined)
   const { jsonPath, mdPath } = writeReceipt(cwd, r)
+
+  // N7: 측정 엔트리 1줄을 .vhk/events/receipt-log.jsonl 에 append(decision 분포 추세 토대).
+  // best-effort — 원장 append 실패가 본 판정/출력을 절대 막지 않는다(advisory 영속).
+  try {
+    appendReceiptLog(cwd, buildReceiptLogEntry(r))
+  } catch {
+    /* 원장 append 실패 비치명 — receipt 본 판정은 이미 .json/.md 로 기록됨 */
+  }
 
   // --json: 기계 소비용 — 영수증 JSON 만 stdout 으로.
   if (opts.json) {

--- a/src/lib/receipt-log.ts
+++ b/src/lib/receipt-log.ts
@@ -1,0 +1,102 @@
+import { existsSync, readFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { atomicWriteFile } from './atomic-write.js'
+import { stripBom } from './read-json.js'
+import type { Receipt, ReceiptDecision } from './receipt.js'
+import type { ReportStatus } from '../commands/verify.js'
+
+// N7 (RFC0056 측정 토대): vhk receipt 발행마다 decision·기계증거 요약을 영속화.
+// 콘솔 휘발 → "거짓완료 판정 분포" 추세 분석 토대(N6 vhk stats --trend 가 소비, #374 evolve
+// 효과측정이 applied 시점과 조인).
+//
+// 위치(.vhk/events/receipt-log.jsonl): diff-cover-log·evidence-ledger·action-ledger 와 동일한
+//   "추적되는 증거 원장" 패턴. self-tracked.ts 가 .vhk/events/*.jsonl prefix 를 dirty 판정에서
+//   제외하므로(자기참조 봉인, #315 동형), receipt 가 스스로 append 해도 다음 receipt 의 dirty
+//   판정을 오염시키지 않는다. recall-log 처럼 gitignore 하지 않는 이유 — 측정치(decision·SHA·
+//   플래그·커버율)만 담고 사적 경로/reasons 원문은 안 남긴다. 레포 차원 영속 가치(추세)가 있어 추적.
+//
+// best-effort: 로그 실패는 receipt 본 판정/출력을 절대 막지 않는다(commands/receipt.ts 에서 try/catch).
+
+export const RECEIPT_LOG_REL = join('.vhk', 'events', 'receipt-log.jsonl')
+
+export interface ReceiptLogEntry {
+  /** 발행 시각 ISO(receipt.generatedAt). */
+  ts: string
+  /** 기계 판정. */
+  decision: ReceiptDecision
+  /** 발행 시점 HEAD 전체 SHA(비-git/커밋0 → null). */
+  sha: string | null
+  /** 사람용 짧은 SHA(7자). */
+  shortSha: string | null
+  /** 게이트 red(실종료코드 fail). */
+  red: boolean
+  /** verify 종합 상태(PASS/WARN/FAIL). */
+  gateStatus: ReportStatus
+  /** git dirty(자기파일 제외 후). */
+  dirty: boolean
+  /** stale. staleKnown=false(기준선 미기록)면 null — 모름을 false 로 위장하지 않음. */
+  stale: boolean | null
+  /** 변경라인 커버율. diff-cover 미측정 → null. */
+  diffCoverRatio: number | null
+  /** 미검증 추가라인 수. 미측정 → null. 라인 원문은 안 남김. */
+  diffCoverUncovered: number | null
+  /** forbidden 위반 파일 수. mission 부재 → null. */
+  forbiddenHits: number | null
+  /** scope 밖 변경 파일 수. mission 부재 → null. */
+  scopeWarnings: number | null
+}
+
+/**
+ * Receipt → 측정 로그 엔트리(순수, fs/시간 부수효과 0). ts 는 receipt.generatedAt 에서 따옴.
+ * 측정치만 추출 — reasons/honesty 등 원문은 의도적으로 제외(원장 비대화·사적정보 0).
+ */
+export function buildReceiptLogEntry(r: Receipt): ReceiptLogEntry {
+  const e = r.evidence
+  const intentKnown = e.intent?.missionKnown === true
+  return {
+    ts: r.generatedAt,
+    decision: r.decision,
+    sha: r.head.sha,
+    shortSha: r.head.shortSha,
+    red: e.gates.red,
+    gateStatus: e.gates.status,
+    dirty: e.dirty,
+    stale: e.staleKnown ? e.stale : null,
+    diffCoverRatio: e.diffCover.measured ? e.diffCover.ratio : null,
+    diffCoverUncovered: e.diffCover.measured ? e.diffCover.totalUncovered : null,
+    forbiddenHits: intentKnown ? e.intent!.forbiddenHits : null,
+    scopeWarnings: intentKnown ? e.intent!.scopeWarnings : null,
+  }
+}
+
+/**
+ * .vhk/events/receipt-log.jsonl 파싱(JSONL). 파일 없음 → []. 손상 라인 skip. BOM-safe.
+ * 최소 스키마(decision:string, ts:string) 검증 — 형태 안 맞는 줄 무시.
+ */
+export function readReceiptLog(cwd: string): ReceiptLogEntry[] {
+  const p = join(cwd, RECEIPT_LOG_REL)
+  if (!existsSync(p)) return []
+  const out: ReceiptLogEntry[] = []
+  for (const line of stripBom(readFileSync(p, 'utf-8')).split(/\r?\n/)) {
+    const t = line.trim()
+    if (!t) continue
+    try {
+      const e = JSON.parse(t) as ReceiptLogEntry
+      if (e && typeof e.decision === 'string' && typeof e.ts === 'string') out.push(e)
+    } catch {
+      /* 손상 라인 skip — 원장 한 줄 깨졌다고 죽지 않음 */
+    }
+  }
+  return out
+}
+
+/**
+ * 측정 엔트리 1개 append(append-only). 원자적 쓰기(temp→rename — 쓰기 중 kill 에도 손상 방지).
+ */
+export function appendReceiptLog(cwd: string, entry: ReceiptLogEntry): void {
+  const p = join(cwd, RECEIPT_LOG_REL)
+  mkdirSync(join(cwd, '.vhk', 'events'), { recursive: true })
+  const existing = existsSync(p) ? stripBom(readFileSync(p, 'utf-8')).replace(/\n*$/, '') : ''
+  const body = (existing ? existing + '\n' : '') + JSON.stringify(entry) + '\n'
+  atomicWriteFile(p, body)
+}

--- a/tests/receipt-log.test.ts
+++ b/tests/receipt-log.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { buildReceipt, type ReceiptEvidence, type ReceiptMeta } from '../src/lib/receipt.js'
+import {
+  buildReceiptLogEntry,
+  readReceiptLog,
+  appendReceiptLog,
+  RECEIPT_LOG_REL,
+} from '../src/lib/receipt-log.js'
+
+// N7: vhk receipt 발행마다 측정 엔트리를 .vhk/events/receipt-log.jsonl 에 append.
+// diff-cover-log 패턴 미러 — 측정치만(사적 경로·reasons 원문 0), .vhk/events/*.jsonl
+// 이라 self-tracked 제외 자동 상속. 추세(decision 분포)는 N6 stats --trend 가 소비.
+
+function evidence(over: Partial<ReceiptEvidence> = {}): ReceiptEvidence {
+  return {
+    gates: { red: false, status: 'PASS', failedGateIds: [], hasSoftWarning: false },
+    dirty: false,
+    stale: false,
+    staleKnown: true,
+    diffCover: { measured: true, totalAdded: 10, totalUncovered: 2, ratio: 0.8 },
+    ...over,
+  }
+}
+
+function meta(over: Partial<ReceiptMeta> = {}): ReceiptMeta {
+  return {
+    generatedAt: '2026-07-01T12:00:00.000Z',
+    date: '2026-07-01',
+    slug: 'caution',
+    headSha: 'abcdef1234567890',
+    baseSha: 'abcdef1234567890',
+    ...over,
+  }
+}
+
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-rlog-'))
+}
+
+describe('buildReceiptLogEntry', () => {
+  it('영수증의 decision·SHA·플래그를 측정 엔트리로 매핑', () => {
+    const r = buildReceipt(evidence(), meta())
+    const e = buildReceiptLogEntry(r)
+    expect(e.ts).toBe('2026-07-01T12:00:00.000Z')
+    expect(e.decision).toBe(r.decision)
+    expect(e.sha).toBe('abcdef1234567890')
+    expect(e.shortSha).toBe('abcdef1')
+    expect(e.red).toBe(false)
+    expect(e.dirty).toBe(false)
+    expect(e.gateStatus).toBe('PASS')
+  })
+
+  it('staleKnown=false → stale 필드 null (모름을 false 로 위장 안 함)', () => {
+    const r = buildReceipt(evidence({ staleKnown: false, stale: false }), meta({ baseSha: null }))
+    const e = buildReceiptLogEntry(r)
+    expect(e.stale).toBeNull()
+  })
+
+  it('diffCover 미측정 → ratio·uncovered null', () => {
+    const r = buildReceipt(
+      evidence({ diffCover: { measured: false, totalAdded: 0, totalUncovered: 0, ratio: 1 } }),
+      meta()
+    )
+    const e = buildReceiptLogEntry(r)
+    expect(e.diffCoverRatio).toBeNull()
+    expect(e.diffCoverUncovered).toBeNull()
+  })
+
+  it('mission 부재 → forbiddenHits·scopeWarnings null', () => {
+    const r = buildReceipt(evidence(), meta())
+    const e = buildReceiptLogEntry(r)
+    expect(e.forbiddenHits).toBeNull()
+    expect(e.scopeWarnings).toBeNull()
+  })
+
+  it('mission 있으면 forbiddenHits·scopeWarnings 수치 기록', () => {
+    const r = buildReceipt(
+      evidence({ intent: { missionKnown: true, forbiddenHits: 1, scopeWarnings: 2 } }),
+      meta()
+    )
+    const e = buildReceiptLogEntry(r)
+    expect(e.forbiddenHits).toBe(1)
+    expect(e.scopeWarnings).toBe(2)
+  })
+
+  it('측정치만 — reasons·honesty 원문 안 남김', () => {
+    const r = buildReceipt(evidence(), meta())
+    const e = buildReceiptLogEntry(r) as Record<string, unknown>
+    expect(e.reasons).toBeUndefined()
+    expect(JSON.stringify(e)).not.toContain('honesty')
+  })
+})
+
+describe('append/readReceiptLog', () => {
+  it('append 후 read 라운드트립', () => {
+    const d = tmp()
+    const r = buildReceipt(evidence(), meta())
+    appendReceiptLog(d, buildReceiptLogEntry(r))
+    const log = readReceiptLog(d)
+    expect(log).toHaveLength(1)
+    expect(log[0].decision).toBe(r.decision)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('파일 없으면 []', () => {
+    const d = tmp()
+    expect(readReceiptLog(d)).toEqual([])
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('손상 라인 skip (no throw)', () => {
+    const d = tmp()
+    fs.mkdirSync(path.join(d, '.vhk', 'events'), { recursive: true })
+    const r = buildReceipt(evidence(), meta())
+    fs.writeFileSync(
+      path.join(d, RECEIPT_LOG_REL),
+      '{ bad json <<<\n' + JSON.stringify(buildReceiptLogEntry(r)) + '\n',
+      'utf-8'
+    )
+    expect(() => readReceiptLog(d)).not.toThrow()
+    expect(readReceiptLog(d)).toHaveLength(1)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('append-only — 두 번 append 시 2줄', () => {
+    const d = tmp()
+    const r = buildReceipt(evidence(), meta())
+    appendReceiptLog(d, buildReceiptLogEntry(r))
+    appendReceiptLog(d, buildReceiptLogEntry(r))
+    expect(readReceiptLog(d)).toHaveLength(2)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})


### PR DESCRIPTION
## 무엇 (N7 — 복리 척추 2/2)

`vhk receipt` 발행마다 decision·기계증거 요약 1줄을 `.vhk/events/receipt-log.jsonl`에 append. 콘솔 휘발이던 판정을 영속 → **거짓완료 판정 분포 추세** 토대(N6 `vhk stats --trend` 소비, #374 evolve 효과측정이 applied 시점과 조인).

## 변경

- `src/lib/receipt-log.ts` (신규) — `diff-cover-log.ts` 패턴 미러. 순수 `buildReceiptLogEntry(Receipt)` + `readReceiptLog` + `appendReceiptLog`. **측정치만**(decision·SHA·red·gateStatus·dirty·stale·diffCoverRatio·forbiddenHits·scopeWarnings) — reasons/honesty 원문·사적 경로 0.
- `src/commands/receipt.ts` — `writeReceipt` 뒤 best-effort `appendReceiptLog`(try/catch — append 실패가 본 판정/출력 안 막음) + import.
- `.gitattributes` — `.vhk/events/*.jsonl merge=union` 보강. diff-cover-log·receipt-log 주석이 가정하던 멀티PC append 분기 줄 보존 설정 누락분(적대리뷰 지적분 동봉).
- `tests/receipt-log.test.ts` (신규) — 10 테스트.

## 자기참조 봉인 (#315 동형)

`.vhk/events/*.jsonl` → `self-tracked.ts:isSelfTrackedPath`가 dirty 판정에서 제외. append는 dirty 수집(`collectReceipt`) **뒤**라 자기 발행이 자기 판정 무염. `.vhk/events/`는 gitignore 아님 → 추적(추세 영속).

## 철칙 부합

측정전용·읽기 토대. `decideReceipt` 미변경 → 단조성 불변식 보존. LLM 0.

## 검증 (TDD + 도그푸딩)

- RED(module 없음) → GREEN 10 pass.
- `vhk verify` 5게이트(tsc/lint/test:run/build/secure) **PASS**. `vhk mission check` scope 준수 ✓.
- read-only 적대 리뷰(critic 쓰기구멍 회피, cavecrew-reviewer): 6항목 중 5 OK, 1(.gitattributes merge=union 누락) → 본 PR에 반영.

> 부수 커밋 `chore(vhk): evidence ledger`는 `vhk verify`가 증거 2파일만 스코프 커밋(의도·안전). squash 흡수.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
