### PR TITLE
fix(mission): readMission 스키마 검증 강화 — 손상 mission.json 크래시 차단

### DIFF
--- a/docs/log/2026-07-01-mission-readmission-schema-guard.md
+++ b/docs/log/2026-07-01-mission-readmission-schema-guard.md
@@ -1,0 +1,21 @@
+# 2026-07-01 — readMission 스키마 검증 강화 (손상 mission.json 크래시 차단)
+
+## 결론
+`readMission` 이 `objective` 문자열만 검증하고 `scope`/`forbidden` 배열 여부를 검증하지 않아,
+구조 무효 mission.json(예: `{schemaVersion,objective}` 만 있음)이 downstream `checkMission` 에서
+`mission.forbidden.filter(...)` TypeError 를 일으켰다. `collectIntent` 가 이 호출을 try/catch 밖에서
+하므로 `vhk receipt` 전체가 미처리 예외로 죽고("원장/수집 실패는 본 판정을 막지 않는다" 설계와 모순),
+`vhk mission check` 도 크래시.
+
+## 근본원인
+방어 검증 갭. 레포 전반이 BOM-safe·손상라인 skip·정직 null 로 손상 입력을 흡수하는데
+mission.json 만 objective 만 검증해 무효 객체를 흘림. readMission 문서 계약("없거나 손상이면 null")과 어긋남.
+
+## 수정
+- `src/commands/mission.ts` `readMission`: `Array.isArray(m.scope) && Array.isArray(m.forbidden)` 조건 추가,
+  미충족 시 null 반환(손상 흡수). why 블록주석 보강.
+- `tests/mission.test.ts`: 회귀 3건(scope/forbidden 누락, forbidden 비배열, 크래시 없음) 추가.
+
+## 검증
+- `pnpm build` 성공
+- `pnpm test:run` — 189 files / 2096 tests 전부 pass

--- a/src/commands/mission.ts
+++ b/src/commands/mission.ts
@@ -113,13 +113,21 @@ export function checkMission(changedFiles: string[], mission: Mission): MissionC
   return { violations, warnings, disclaimer: MISSION_DISCLAIMER, unsupportedForbiddenPatterns }
 }
 
-/** .vhk/mission.json 읽기 (BOM-safe). 없거나 손상이면 null. */
+/**
+ * .vhk/mission.json 읽기 (BOM-safe). 없거나 손상이면 null.
+ * why: objective 뿐 아니라 scope/forbidden 이 배열인지도 검증한다. 구조 무효 객체(scope/forbidden
+ * 누락·비배열)를 그대로 흘리면 checkMission 의 `mission.forbidden.filter` 가 TypeError 로 죽어
+ * collectIntent(try/catch 밖 호출) 를 통해 vhk receipt/ mission check 전체가 크래시한다
+ * — "원장/수집 실패는 본 판정을 막지 않는다" 설계와 정면 충돌. 손상은 여기서 null 로 흡수.
+ */
 export function readMission(cwd: string = process.cwd()): Mission | null {
   const p = join(cwd, MISSION_PATH_REL)
   if (!existsSync(p)) return null
   try {
     const m = readJsonFile<Mission>(p)
-    if (m && typeof m.objective === 'string') return m
+    if (m && typeof m.objective === 'string' && Array.isArray(m.scope) && Array.isArray(m.forbidden)) {
+      return m
+    }
     return null
   } catch {
     return null

--- a/tests/mission.test.ts
+++ b/tests/mission.test.ts
@@ -119,6 +119,35 @@ describe('mission — readMission BOM-safe', () => {
     expect(readMission(d)).toBeNull()
     fs.rmSync(d, { recursive: true, force: true })
   })
+
+  // ── 손상 스키마 방어 회귀 — scope/forbidden 누락·비배열이면 null (downstream checkMission 크래시 차단) ──
+  it('objective 만 있고 scope/forbidden 누락 → null (구조 무효 흡수)', () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mission-'))
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    fs.writeFileSync(path.join(d, MISSION_PATH_REL), JSON.stringify({ schemaVersion: 1, objective: 'only obj' }), 'utf-8')
+    expect(readMission(d)).toBeNull()
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+  it('forbidden 이 배열이 아니면 (string) → null', () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mission-'))
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    fs.writeFileSync(
+      path.join(d, MISSION_PATH_REL),
+      JSON.stringify({ schemaVersion: 1, objective: 'o', scope: [], forbidden: '**/*.env' }),
+      'utf-8'
+    )
+    expect(readMission(d)).toBeNull()
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+  it('손상 mission.json → readMission null → collectIntent 크래시 없이 undefined', () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mission-'))
+    fs.mkdirSync(path.join(d, '.vhk'), { recursive: true })
+    fs.writeFileSync(path.join(d, MISSION_PATH_REL), JSON.stringify({ schemaVersion: 1, objective: 'only obj' }), 'utf-8')
+    expect(() => readMission(d)).not.toThrow()
+    // 무효 미션은 null 이므로 checkMission 호출 자체에 도달하지 않음(collectIntent 는 early return undefined)
+    expect(readMission(d)).toBeNull()
+    fs.rmSync(d, { recursive: true, force: true })
+  })
 })
 
 describe('mission — 커맨드 통합', () => {


### PR DESCRIPTION
## 결함 요약
`readMission`(`src/commands/mission.ts`)이 `objective`가 문자열인지만 검증하고 `scope`/`forbidden`이 배열인지는 검증하지 않았습니다. 그 결과 손으로 편집하거나 일부만 있는 `.vhk/mission.json`(예: `{ "schemaVersion": 1, "objective": "x" }`)이 검증을 통과해 downstream으로 흘러갑니다.

- `checkMission`이 `mission.forbidden.filter(...)`를 호출 → `TypeError: Cannot read properties of undefined` throw
- `collectIntent`가 이 호출을 try/catch 밖에서 하므로 `vhk receipt` 전체가 미처리 예외로 크래시 ("원장/수집 실패는 본 판정을 막지 않는다" 설계와 모순)
- `vhk mission check`, `missionShow`(`mission.scope.length`)도 함께 크래시
- readMission 문서 계약("없거나 손상이면 null")과도 어긋남

## 수정
- `readMission`에서 `Array.isArray(m.scope) && Array.isArray(m.forbidden)` 조건을 추가해, 구조가 무효면 `null`을 반환(손상 흡수). why 블록주석 보강.
- 회귀 테스트 3건 추가: scope/forbidden 누락 → null, forbidden 비배열(string) → null, 크래시 없음.

## 검증 결과
- `pnpm build` 성공
- `pnpm test:run` — 189 files / 2096 tests 전부 pass

---
머지 금지: 사람 검토 대기

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 손상되었거나 형식이 맞지 않는 미션 파일을 더 엄격하게 검사해, 필관리자 항목이 모두 올바를 때만 정상적으로 읽히도록 개선했습니다.
  * 일부 값이 누락되거나 타입이 잘못된 경우에도 오류 대신 안전하게 `null`을 반환하도록 처리했습니다.
  * 손상된 입력을 읽을 때 예외가 발생하지 않도록 회귀 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->