### PR TITLE
fix(review): 빈 goals 에서 exit 1 → 경고 후 스킵(exit 0)

### DIFF
--- a/docs/log/2026-07-01-review-empty-goals-exit0.md
+++ b/docs/log/2026-07-01-review-empty-goals-exit0.md
@@ -1,0 +1,26 @@
+# 2026-07-01 — vhk review: 빈 goals exit 1 → 스킵(exit 0) 정정
+
+## 결론
+`vhk review` 가 goal 이 하나도 없는 저장소에서 경고만 내면 될 것을 `process.exitCode=1`
+로 종료하던 결함(gh#271)을 정정. 경고 후 exit 0(스킵)으로 변경.
+
+## 원인
+review 는 새 증거를 만들지 않는 읽기전용 교차검증인데, `goals.length===0`(선택 기능
+미사용)만으로 '실패'로 간주해 exit 1 을 냈다. 외부 Focus Feed 가드가 이 exit 1 에
+반응해 project-failure incident 레지스트리를 오염(incident 생성은 vhk 밖 외부 도구
+소관 — src/ 에 incident 코드 없음).
+
+## 수정
+- `src/commands/review.ts` — 빈 goals 분기에서 `process.exitCode=1` 제거, 경고 +
+  `printNextStep(vhk goal init)` 후 return(exit 0 스킵). #157 exit code 정책(강한
+  모순이 아닌 상태엔 exit 1 금지)과 일관. verify.ts(같은 읽기전용 검증)가 빈 goals 에서
+  실패하지 않는 것과도 일치.
+- `tests/review.test.ts` — 빈-goals 회귀 테스트 추가(경고 후 exit 0 + 새 증거 미생성).
+
+## 게이트
+- `pnpm build` 성공 · `pnpm test:run` 2094 pass(189 files).
+
+## 교훈
+읽기전용 검증 명령의 exit code 는 "새 증거를 만드는가"가 아니라 "강한 모순이
+있는가"로 결정해야 한다. 선택 기능 미사용은 실패가 아니라 스킵. exit code 가 외부
+가드의 incident 트리거로 소비되는 계약이면 non-failure 상태에 exit 1 을 내면 안 됨.

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -316,8 +316,15 @@ export async function review(opts: { id?: string; strict?: boolean } = {}): Prom
   const cwd = process.cwd()
   const goals = listGoals(GOALS_DIR)
   if (goals.length === 0) {
-    console.error(chalk.yellow('  ⚠️  goals/ 에 goal 이 없습니다. vhk goal init 으로 시작하세요.'))
-    process.exitCode = 1
+    // review 는 새 증거를 안 만드는 읽기전용 교차검증 — goal(선택 기능) 미사용은 '실패'가 아니라
+    // '검증 대상 없음(스킵)'. #157 exit code 정책과 동일하게 강한 모순이 아닌 상태에 exit 1 을 내지 않는다.
+    // (exit 1 은 외부 가드가 project-failure 로 오인해 incident 레지스트리를 오염시킴 — gh#271.)
+    console.error(chalk.yellow('  ⚠️  goals/ 에 goal 이 없어 검증 대상이 없습니다(스킵). vhk goal init 으로 시작하세요.'))
+    printNextStep({
+      message: 'goal 을 만들면 review 가 완료 주장을 교차검증합니다:',
+      command: 'vhk goal init',
+      cursorHint: 'goal 만들어줘',
+    })
     return
   }
 

--- a/tests/review.test.ts
+++ b/tests/review.test.ts
@@ -331,6 +331,19 @@ ${checks.map((c) => `- [x] ${c}`).join('\n')}
     fs.rmSync(d, { recursive: true, force: true })
   })
 
+  it('goals/ 비어 있으면 경고 후 스킵(exit 0) — 선택 기능 미사용을 실패로 오인 금지 (gh#271)', async () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-review-'))
+    // goal 을 하나도 seed 하지 않음 → listGoals=[] 경로.
+    process.chdir(d)
+    process.exitCode = 0
+    await review({})
+    // 읽기전용 review 는 새 증거를 안 만들고, goal 미사용만으로 exit 1(실패) 을 내지 않는다.
+    expect(process.exitCode).toBe(0)
+    expect(fs.existsSync(path.join(d, '.vhk', 'reports', 'latest.json'))).toBe(false)
+    process.chdir(origCwd)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
   it('latest.json 없으면 안내 + exit 1 + 새 증거 미생성', async () => {
     const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-review-'))
     seedGoal(d, 9, 'IN_PROGRESS', ['테스트 통과'])


### PR DESCRIPTION
## 결함 요약
`vhk review` 는 goal(선택 기능) 을 하나도 안 쓴 프로젝트에서 `goals.length === 0` 이면 `process.exitCode = 1` 을 냈다. review 는 새 증거를 만들지 않는 읽기전용 교차검증이므로 goal 미사용은 '실패'가 아니라 '검증 대상 없음'인데, exit 1 을 외부 Focus Feed 가드가 project-failure incident 로 오인해 incident 레지스트리를 오염시켰다(gh#271).

## 수정
- `src/commands/review.ts`: 빈 goals 일 때 exit 1 → 경고 후 `printNextStep`(`vhk goal init`) 안내 + exit 0 스킵으로 정정.
- 근거: #157 exit code 정책(강한 모순이 아닌 상태엔 exit 1 금지), 그리고 같은 읽기전용 검증인 `verify.ts` 가 빈 goals 에서 실패하지 않는 것과의 일관성.
- `tests/review.test.ts`: 빈-goals 회귀 테스트 추가.

## 검증 결과
- `pnpm build`: 성공
- `pnpm test:run`: 189 파일 / 2094 테스트 전부 pass

## 머지 금지: 사람 검토 대기

🤖 Generated with Claude Code
