### PR TITLE
feat: vhk win 성공기록(N3) + reinforce evolve 확장(N2) — 복리 척추 ⓒ

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -79,6 +79,7 @@ Cursor에게 한국어로 말해도 됩니다.
 | 실패+교훈 기록 | `vhk memory add "테스트 미커버" --type failure --why "..." --lesson "회귀 가드 먼저"` | "이 실수 기억해" |
 | 성공 기록 | `vhk memory add "롤백 빨랐다" --type success --why "백업 먼저"` | "이 성공 기억해" |
 | 교훈만 빠르게 | `vhk learn "PowerShell 은 && 미지원"` | "교훈 남겨" |
+| 성공만 빠르게 | `vhk win "worktree 병렬로 충돌 0 머지"` | "성공 남겨" |
 | 목록 | `vhk memory list [--type failure] [--all]` | "기억 보여줘" |
 | 보관(선순환) | `vhk memory archive <번호>` | "이거 보관해" |
 | 삭제 / 해결 / 보관해제 | `vhk memory remove <번호>` · `vhk memory resolve <번호>` · `vhk memory unarchive <번호>` | "이 기억 지워/해결/복원" |
@@ -199,6 +200,7 @@ vhk doctor
 | `vhk goal` | Goal 단계별 미션 관리 |
 | `vhk blocker` | 블로커 기록 (3건 누적 시 HARD_STOP) |
 | `vhk learn` | 교훈 기록 → memory v2 단일 SoT |
+| `vhk win` | 성공 기록 → memory successes (reinforce evolve 입력) |
 | `vhk resume` | .vhk/HARD_STOP 해제 (`--confirm` 필요) |
 | `vhk pattern` | 반복 패턴 감지·목록 (`pattern detect` · `pattern list` · `pattern dismiss`) |
 | `vhk evolve` | 패턴 → 룰 후보 제안·반영·undo |

--- a/docs/log/2026-07-01-win-reinforce-overnight.md
+++ b/docs/log/2026-07-01-win-reinforce-overnight.md
@@ -1,0 +1,22 @@
+# 2026-07-01 — vhk win(N3) + 밤샘 무인 결함루프 + N7 머지
+
+## 세션 흐름 (append-only)
+
+### 1. 밤샘 무인 결함루프 (overnight-autoloop 스킬)
+- **의도**: vhk 대상·both·cap10 무인 결함 감사→수정→검증+적대리뷰→PR(머지0).
+- **엔진 부정합**: `autoloop.workflow.js`가 yohan-mcp(python)+control-tower(next) 전용 하드코딩(`master`·npm). vhk=main·pnpm → 사본 패치(scratchpad): `master→main`, verifyCmd `ts`=`pnpm build; test:run`.
+- **★버그**: Workflow `args`를 JSON 문자열/객체 어느 쪽으로 넘겨도 스크립트 `args` 글로벌에 안 실림(하네스 직렬화) → **2회 오실행**(기본 레포로 조용히 폴백). 완료 리포트 보고서야 발각(vhk 대신 yohan-mcp/control-tower에 6 PR). **해결 = 스크립트에 REPOS/SCOPE/CAP 하드코딩**. 3회차 vhk 확정(transcript `대상 레포:` grep 조기검증). 교훈 → 기억 `workflow-args-json-object`.
+- **결과**: vhk 실결함 2건 → **#432**(readMission 스키마 검증 누락→손상 mission.json 크래시)·**#433**(review goals/ 빈 경우 exit1 오인). 둘 다 적대리뷰+전체 테스트 통과, 머지0. 부산물 ecosystem 6 PR(#18·19 yohan-mcp / #14~17 control-tower)=A(열어둠).
+- 리포트: `docs/audits/overnight-2026-07-01.md`(오실행)·`overnight-2026-07-01-vhk.md`(정본).
+
+### 2. 머지 (사람 게이트)
+- **#431**(N7 receipt-log)·**#432**·**#433** 머지(main `189db50`). #431·432 `--auto`(green 즉시), #433 auto-merge 설정 꺼져 분류기 차단 → 사용자 `!` 직접 머지.
+
+### 3. N3 `vhk win` 성공기록 (이 커밋)
+- **왜**: 자가진화 격차 ⓒ — 성공패턴이 버려짐(pattern.ts 감지만). `vhk learn`(실패/교훈)의 **성공 쌍둥이**로 `vhk win` 신설 → memory v2 `successes`에 append → pattern reinforce 입력 → evolve reinforce 후보(N2)로 복리. ✅/❌ 대칭 완성의 입력면.
+- **구현**: `memory.ts recordSuccess()`(loadForMutation 실패 시 null=빈 v2로 안 덮음, learn과 동일 계약) · `agent.ts win()` · 등록 6지점(index import+alias+command · cli-args KNOWN+FREEFORM · command-registry · ko.winTitle · COMMANDS.md). freeform이라 nlp-router 불요(learn과 동일).
+- **검증**: TDD(tests/win.test.ts RED→GREEN). typecheck 무에러 · 전체 2101 tests green(commands-doc 드리프트 가드가 COMMANDS.md 누락 잡음→보강).
+
+## 다음
+- **N2** reinforce evolve 확장(`evolve.ts generateCandidates` reinforce 분기) = 척추 본체. win이 그 입력면.
+- ecosystem 6 PR = 열어둠(그 레포 작업 때).

--- a/docs/log/2026-07-01-win-reinforce-overnight.md
+++ b/docs/log/2026-07-01-win-reinforce-overnight.md
@@ -20,3 +20,12 @@
 ## 다음
 - **N2** reinforce evolve 확장(`evolve.ts generateCandidates` reinforce 분기) = 척추 본체. win이 그 입력면.
 - ecosystem 6 PR = 열어둠(그 레포 작업 때).
+
+### 4. N2 reinforce evolve 확장 (별도 커밋)
+- **왜**: ⓒ 척추 본체. pattern.ts는 이미 `processBucket(successes,'reinforce')`로 성공패턴 감지하나, `evolve.ts:generateCandidates` 필터가 `kind==='avoid'`만 통과 → reinforce 후보를 버림(구 v0). N2가 필터를 열어 성공패턴도 evolve 후보화 → win(N3) 입력이 룰 후보로 복리. ✅/❌ 대칭 완성.
+- **구현**: `generateCandidates` 필터 `avoid|reinforce` · `buildDraft` kind 분기(reinforce=긍정형 "이 접근 계속 권장") · suggest "allSuggested" 판정도 reinforce 포함(activePatterns). dedupeKey=`patternId:rule`는 patternId 유니크라 avoid/reinforce 충돌0. RULES 반영은 apply 사람승인 유지(철칙 불변).
+- **검증**: TDD — 기존 `reinforce 패턴 제외` 테스트를 계약변경(포함)으로 갱신 + buildDraft reinforce 테스트 신규 → RED 확인 후 GREEN. 전체 2102 tests green.
+
+## 다음(갱신)
+- N2·N3 = ⓒ 완결 → 적대리뷰 후 PR·머지.
+- 후속 복리 척추: N5 evolve digest(ⓓ)·N6 stats --trend(ⓔ)·N1 loop tick(ⓐ)·N4 objective 토큰(ⓑ).

--- a/docs/log/2026-07-01-win-reinforce-overnight.md
+++ b/docs/log/2026-07-01-win-reinforce-overnight.md
@@ -26,6 +26,10 @@
 - **구현**: `generateCandidates` 필터 `avoid|reinforce` · `buildDraft` kind 분기(reinforce=긍정형 "이 접근 계속 권장") · suggest "allSuggested" 판정도 reinforce 포함(activePatterns). dedupeKey=`patternId:rule`는 patternId 유니크라 avoid/reinforce 충돌0. RULES 반영은 apply 사람승인 유지(철칙 불변).
 - **검증**: TDD — 기존 `reinforce 패턴 제외` 테스트를 계약변경(포함)으로 갱신 + buildDraft reinforce 테스트 신규 → RED 확인 후 GREEN. 전체 2102 tests green.
 
+### 5. 적대리뷰 반영 (Workflow 다각 리뷰: 6발견 → 5반증·1확정 low)
+- **CONFIRMED(low)**: reinforce `buildDraft`가 `pattern.summary`(내부라벨 `[reinforce]` + "N건 반복") 임베드 → evolve apply→RULES.md→sync 로 "3건 성공…3건 반복" 모순·내부라벨 노출. → **summary 임베드 제거**, `${count}건 성공 사례`로 재조립(정보손실 0 — 태그·count 이미 앞에). 회귀가드 테스트 추가(`[reinforce]`·`반복` 금지).
+- **5건 반증(오탐)**: 등록 완비·recordSuccess null 계약·nlp-router 미추가 정상(learn 형제)·RULES 사람승인 철칙 부합 등. ※ `[avoid]` 프리픽스 누출은 **기존 동작**(N2 무관·범위 밖).
+
 ## 다음(갱신)
-- N2·N3 = ⓒ 완결 → 적대리뷰 후 PR·머지.
+- N2·N3 = ⓒ 완결 → PR·머지.
 - 후속 복리 척추: N5 evolve digest(ⓓ)·N6 stats --trend(ⓔ)·N1 loop tick(ⓐ)·N4 objective 토큰(ⓑ).

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -11,7 +11,7 @@ import {
   BLOCKERS_PATH,
   HARD_STOP_BLOCKER_THRESHOLD,
 } from '../lib/state-files.js'
-import { recordLesson } from './memory.js'
+import { recordLesson, recordSuccess } from './memory.js'
 import { selectActiveId } from './goal.js'
 
 function activeGoalId(): number | undefined {
@@ -70,6 +70,27 @@ export async function learn(lesson: string): Promise<void> {
   }
   console.log(chalk.green(`  ✅ 교훈 기록 → memory failures.lesson (${entry.id})`))
   console.log(chalk.dim('  교훈·결정·실패·성공 모두 vhk memory (단일 SoT). vhk memory list 로 확인.'))
+}
+
+// N3: vhk win — 성공 기록(learn 의 성공 쌍둥이). successes.content → pattern reinforce → evolve 후보.
+export async function win(content: string): Promise<void> {
+  console.log(chalk.bold(`\n${ko.agent.winTitle}\n`))
+  if (!content || !content.trim()) {
+    console.log(chalk.red('  ❌ 성공 내용을 입력해 주세요.'))
+    console.log(chalk.dim('  예: vhk win "worktree 병렬로 충돌 0 머지 성공"'))
+    process.exitCode = 1
+    return
+  }
+  const goalId = activeGoalId()
+  const entry = recordSuccess(process.cwd(), content, goalId)
+  if (!entry) {
+    // memory.json 손상 의심 — 빈 v2 로 덮지 않고 중단(데이터 손실 방지, learn 과 동일 계약).
+    console.log(chalk.red('  ❌ memory.json 손상 의심 — 성공 기록 중단. 원본/백업 확인 후 다시 시도하세요.'))
+    process.exitCode = 1
+    return
+  }
+  console.log(chalk.green(`  ✅ 성공 기록 → memory successes (${entry.id})`))
+  console.log(chalk.dim('  성공 패턴은 vhk pattern detect → vhk evolve 재사용 후보로 복리됩니다.'))
 }
 
 export interface ResumeOptions {

--- a/src/commands/evolve.ts
+++ b/src/commands/evolve.ts
@@ -54,7 +54,9 @@ export function buildDraft(p: PatternEntryV19): string {
   const axisLabel = p.axis === 'tag' ? `태그 '${p.signal}'` : `키워드 '${p.signal}'`
   if (p.kind === 'reinforce') {
     // N2: 성공패턴 → 긍정형 룰(이렇게 하면 됐다 → 계속 권장). avoid(사전 점검)와 대칭.
-    return `- ${axisLabel} 관련 작업 시 이 접근 계속 권장 (근거: ${p.count}건 성공, ${p.summary})`
+    // 적대리뷰(low): p.summary 는 내부 라벨 '[reinforce]' + '건 반복'(성공에 '반복'은 모순)을 담아
+    //   RULES.md 로 새므로 임베드 금지 → signal/count 로 재조립(사용자 노출 문구 정합, 정보손실 0).
+    return `- ${axisLabel} 관련 작업 시 이 접근 계속 권장 (근거: ${p.count}건 성공 사례)`
   }
   const countDesc = `${p.count}건 반복`
   return `- ${axisLabel} 관련 작업 시 사전 점검 필수 (근거: ${countDesc}, ${p.summary})`

--- a/src/commands/evolve.ts
+++ b/src/commands/evolve.ts
@@ -52,6 +52,10 @@ export interface EvolveQueueFile {
  */
 export function buildDraft(p: PatternEntryV19): string {
   const axisLabel = p.axis === 'tag' ? `태그 '${p.signal}'` : `키워드 '${p.signal}'`
+  if (p.kind === 'reinforce') {
+    // N2: 성공패턴 → 긍정형 룰(이렇게 하면 됐다 → 계속 권장). avoid(사전 점검)와 대칭.
+    return `- ${axisLabel} 관련 작업 시 이 접근 계속 권장 (근거: ${p.count}건 성공, ${p.summary})`
+  }
   const countDesc = `${p.count}건 반복`
   return `- ${axisLabel} 관련 작업 시 사전 점검 필수 (근거: ${countDesc}, ${p.summary})`
 }
@@ -63,7 +67,7 @@ export function buildDedupeKey(patternId: string, targetLayer: TargetLayer = 'ru
 
 /**
  * 후보 생성 — 순수 함수. 부수효과 없음.
- * v0 규칙: kind==='avoid' AND status==='active' 패턴만 대상.
+ * 규칙: kind ∈ {avoid, reinforce} AND status==='active' 패턴 대상 (N2: 성공패턴도 복리 — reinforce 후보화).
  * A1: 같은 dedupeKey 가 rejected 이면 재제안 억제.
  * A2: 같은 dedupeKey 가 pending/applied 이면 스킵.
  * 결정성: patternId 알파벳 오름차순 정렬.
@@ -80,7 +84,7 @@ export function generateCandidates(
   )
 
   const eligible = patterns
-    .filter((p) => p.kind === 'avoid' && p.status === 'active')
+    .filter((p) => (p.kind === 'avoid' || p.kind === 'reinforce') && p.status === 'active')
     .sort((a, b) => a.id.localeCompare(b.id))
 
   const result: Omit<EvolveQueueItem, 'id' | 'createdAt'>[] = []
@@ -360,8 +364,8 @@ export async function evolveSuggest(opts: { json?: boolean } = {}): Promise<void
   const newItems = generateCandidates(patterns, queue.items)
 
   if (newItems.length === 0 && !opts.json) {
-    const activeAvoid = patterns.filter(p => p.kind === 'avoid' && p.status === 'active')
-    if (activeAvoid.length === 0) {
+    const activePatterns = patterns.filter(p => (p.kind === 'avoid' || p.kind === 'reinforce') && p.status === 'active')
+    if (activePatterns.length === 0) {
       console.log(chalk.yellow('\n📭 ' + t('evolve.noPatterns')))
       return
     }

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -590,6 +590,28 @@ export function recordLesson(cwd: string, lesson: string, goalId?: number): Fail
   return entry
 }
 
+/**
+ * N3: 성공 기록 — learn(recordLesson) 의 성공 쌍둥이. memory v2 successes 에 append.
+ * successes.content 는 pattern.ts processBucket(reinforce) 입력 → evolve reinforce 후보(N2)로
+ * 복리된다("이렇게 하면 됐다"의 양방향 자산화). loadForMutation 실패 시 null(빈 v2 로 안 덮음).
+ */
+export function recordSuccess(cwd: string, content: string, goalId?: number): SuccessEntry | null {
+  const loaded = loadForMutation(cwd)
+  if (!loaded.ok) return null
+  const mem = loaded.mem
+  const tag = goalId !== undefined ? `goal-${goalId}` : 'no-goal'
+  const entry: SuccessEntry = {
+    id: nextId('success', mem),
+    content: content.trim(),
+    tags: [tag],
+    createdAt: new Date().toISOString(),
+    status: 'active',
+  }
+  mem.successes.push(entry)
+  writeMemory(cwd, mem)
+  return entry
+}
+
 // ── 키워드 회상 (RFC 0049 ① · 순수 JS · 의존성 0) ──
 // N≤수백 full-scan. 임베딩·벡터DB 없음(RFC 0049 Kill-gate: eval Recall@5<0.7 측정 전 ML 금지).
 

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -561,6 +561,7 @@ export const ko = {
   agent: {
     blockerTitle: '🛑 Blocker 기록',
     learnTitle: '🧠 Learning 기록',
+    winTitle: '🏆 성공 기록',
     resumeTitle: '▶️  HARD_STOP 해제',
   },
   work: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ async function guardCliDefer(
 }
 import { cloudPush, cloudPull } from './commands/cloud.js'
 import { goalCheck, goalDone, goalDrift, goalInit, goalList, goalNext, goalPeek, goalSync } from './commands/goal.js'
-import { blocker, learn, resume } from './commands/agent.js'
+import { blocker, learn, resume, win } from './commands/agent.js'
 import { patternDetect, patternList, patternDismiss } from './commands/pattern.js'
 import { evolveSuggest, evolveList, evolveApply, evolveReject, evolveUndo, evolveNegatives } from './commands/evolve.js'
 import { runSeo, seoInit, seoSubmit, seoCheck, seoReport, seoAutomate } from './commands/seo/index.js'
@@ -175,6 +175,7 @@ const KO_ALIASES: Record<string, string> = {
   mission: '미션',
   blocker: '블로커',
   learn: '교훈',
+  win: '성공',
   resume: '재개',
   pattern: '패턴',
   evolve: '진화',
@@ -867,6 +868,13 @@ program
   .alias('교훈')
   .description('교훈 기록 → memory v2 failures.lesson 단일 SoT (v2.0 통합 — vhk memory list 로 확인)')
   .action(async (lesson: string[]) => { await learn(lesson.join(' ')) })
+
+program
+  // N3: variadic — 따옴표 없는 다단어 성공기록도 받는다 (learn 과 대칭).
+  .command('win <content...>')
+  .alias('성공')
+  .description('성공 기록 → memory successes (learn 의 성공 쌍둥이 — reinforce evolve 입력)')
+  .action(async (content: string[]) => { await win(content.join(' ')) })
 
 program
   .command('resume')

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -54,6 +54,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'goal', '목표',
   'blocker', '블로커',
   'learn', '교훈',
+  'win', '성공',
   'resume', '재개',
   'mode', '모드',
   'verify', '사전점검',
@@ -85,6 +86,7 @@ function isOptionToken(token: string): boolean {
  */
 const FREEFORM_ARG_COMMANDS = new Set([
   'learn', '교훈',
+  'win', '성공',
   'blocker', '블로커',
   // #313: recall 은 자유형식 검색 쿼리라 '어떻게·보안·롤백' 등 트리거 단어가 본문에 와도
   // 항상 commander 로 위임돼야 한다(NL 라우터 가로채기 금지 — learn/blocker 와 동일).

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -113,6 +113,7 @@ export const TOP_LEVEL_COMMANDS: ReadonlyArray<{ name: string; desc: string }> =
   { name: 'goal', desc: 'Goal 단계별 미션 관리' },
   { name: 'blocker', desc: '블로커 기록 (3건 누적 시 HARD_STOP)' },
   { name: 'learn', desc: '교훈 기록 → memory v2 단일 SoT' },
+  { name: 'win', desc: '성공 기록 → memory successes (reinforce 입력)' },
   { name: 'resume', desc: '.vhk/HARD_STOP 해제 (--confirm 필요)' },
   { name: 'pattern', desc: '반복 패턴 감지·목록 (avoid/reinforce)' },
   { name: 'evolve', desc: '패턴 → 룰 후보 제안·반영·undo' },

--- a/tests/evolve.test.ts
+++ b/tests/evolve.test.ts
@@ -99,7 +99,11 @@ describe('buildDraft', () => {
     const draft = buildDraft(p)
     expect(draft).toContain("'worktree'")
     expect(draft).toContain('계속 권장')
+    expect(draft).toContain('3건 성공')
     expect(draft).not.toContain('사전 점검 필수')
+    // 적대리뷰(low) 회귀 가드: 내부 라벨·모순 어휘가 RULES.md 로 새지 않도록.
+    expect(draft).not.toContain('[reinforce]')
+    expect(draft).not.toContain('반복')
   })
 })
 

--- a/tests/evolve.test.ts
+++ b/tests/evolve.test.ts
@@ -93,6 +93,14 @@ describe('buildDraft', () => {
     const draft = buildDraft(p)
     expect(draft).toContain("'auth'")
   })
+
+  it('reinforce 패턴 → 긍정형 초안(계속 권장, N2)', () => {
+    const p = pat('p4', 'worktree', 3, 'reinforce')
+    const draft = buildDraft(p)
+    expect(draft).toContain("'worktree'")
+    expect(draft).toContain('계속 권장')
+    expect(draft).not.toContain('사전 점검 필수')
+  })
 })
 
 // ── buildDedupeKey ───────────────────────────────────────────────────────────
@@ -115,14 +123,14 @@ describe('generateCandidates', () => {
     expect(result.every((r) => r.status === 'pending')).toBe(true)
   })
 
-  it('reinforce 패턴 제외', () => {
+  it('reinforce 패턴도 후보 생성 (N2 — 성공패턴 복리, avoid/reinforce 대칭)', () => {
     const patterns = [
       pat('p1', 'build', 3, 'avoid'),
       pat('p2', 'deploy', 3, 'reinforce'),
     ]
     const result = generateCandidates(patterns, [])
-    expect(result).toHaveLength(1)
-    expect(result[0].patternId).toBe('p1')
+    expect(result).toHaveLength(2)
+    expect(result.map((r) => r.patternId).sort()).toEqual(['p1', 'p2'])
   })
 
   it('archived 패턴 제외', () => {

--- a/tests/win.test.ts
+++ b/tests/win.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { recordSuccess, readMemory } from '../src/commands/memory.js'
+import { KNOWN_COMMAND_TOKENS } from '../src/lib/cli-args.js'
+
+// N3: vhk win — learn 의 성공 쌍둥이. memory v2 successes 에 기록.
+// successes.content 는 pattern.ts reinforce 감지 입력 → evolve reinforce 후보(N2)로 복리.
+
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-win-'))
+}
+
+describe('recordSuccess', () => {
+  it('successes 버킷에 content + goal 태그로 기록', () => {
+    const d = tmp()
+    const entry = recordSuccess(d, '  worktree 병렬로 충돌 0 머지  ', 42)
+    expect(entry).not.toBeNull()
+    expect(entry!.content).toBe('worktree 병렬로 충돌 0 머지')
+    expect(entry!.tags).toContain('goal-42')
+    const mem = readMemory(d)
+    expect(mem.successes).toHaveLength(1)
+    expect(mem.successes[0].content).toBe('worktree 병렬로 충돌 0 머지')
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('goalId 없으면 no-goal 태그', () => {
+    const d = tmp()
+    const entry = recordSuccess(d, '검증 게이트 통과')
+    expect(entry!.tags).toContain('no-goal')
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('여러 번 기록 → successes 누적 (append)', () => {
+    const d = tmp()
+    recordSuccess(d, '첫 성공')
+    recordSuccess(d, '둘째 성공')
+    expect(readMemory(d).successes).toHaveLength(2)
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+})
+
+describe('win 명령 등록', () => {
+  it('영문·한글 별칭이 KNOWN_COMMAND_TOKENS 에 등록됨 (NL 라우터 가드)', () => {
+    expect(KNOWN_COMMAND_TOKENS.has('win')).toBe(true)
+    expect(KNOWN_COMMAND_TOKENS.has('성공')).toBe(true)
+  })
+})


### PR DESCRIPTION
## 무엇
자가진화 격차 ⓒ(성공패턴 버려짐) 해소 — ✅/❌ 대칭 완성.

- **N3 `vhk win`**: `learn`의 성공 쌍둥이. memory v2 `successes`에 append. 등록 6지점(index import/alias '성공'/command·cli-args KNOWN/FREEFORM·command-registry·ko.winTitle·COMMANDS.md). freeform이라 nlp-router 불요(learn 형제).
- **N2 reinforce evolve**: `generateCandidates` 필터를 `avoid|reinforce`로 확장 + `buildDraft` kind 분기(reinforce=긍정형 '계속 권장'). win 성공기록 → pattern reinforce → **evolve 룰 후보로 복리**. dedupeKey=`patternId:rule` 유니크라 avoid/reinforce 충돌0. **RULES 실반영은 evolve apply 사람승인 유지(철칙 불변, LLM 자동쓰기 경로 0).**

## 검증
- TDD: `win.test.ts`(RED→GREEN) + `evolve.test.ts` 계약변경(reinforce 제외→포함)·buildDraft reinforce 테스트.
- 전체 게이트: typecheck 무에러 · build 성공 · **2102 tests green**.
- **다각 적대리뷰(Workflow 4다이멘션×반증)**: 6발견 → 5반증 · 1확정(low). 확정건(reinforce 초안이 내부 summary 임베드 → RULES 노출 모순) **수정 반영**(summary 제거·회귀가드 테스트). `[avoid]` 프리픽스 누출은 기존 동작(범위 밖).

## 커밋
- N3(`a8fb349`) · N2(`a25117e`) · 리뷰수정(`83833fc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)