### PR TITLE
feat: vhk stats --trend — receipt-log 시계열 추세 (N6, ⓔ)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -157,6 +157,7 @@ vhk doctor
 | `vhk restore` | sync 백업 복원 |
 | `vhk status` | 프로젝트 상태 대시보드 |
 | `vhk stats` | 통계 대시보드 — 패스율/차단율/진화 적용율 (읽기 전용) |
+| `vhk stats --trend` | receipt-log 시계열 추세 — 거짓완료 판정 추이 (읽기 전용) |
 | `vhk diff` | Git 변경사항 한국어 요약 |
 | `vhk diff-cover` | 이번 변경이 테스트로 커버됐는지 측정 (자문형) |
 | `vhk mcp` | MCP 서버 시작 (stdio) |

--- a/docs/log/2026-07-01-n6-stats-trend.md
+++ b/docs/log/2026-07-01-n6-stats-trend.md
@@ -13,5 +13,12 @@
 - TDD: `stats-trend.test.ts` 6케이스(빈입력·분포·평균·추세방향·정렬결정성·total1) RED→GREEN.
 - 전체 2108 tests green · typecheck 무에러.
 
+## 적대리뷰 반영 (Workflow 3다이멘션: 9발견 → 5반증·4확정, 블로커 0)
+확정 4건 전부 **정직표기 계약 위반**(이 기능 핵심가치라 전부 수정):
+- **①② 홀수 total 비대칭**: 앞절반 mid개·뒤절반 total-mid개인데 라벨 "절반 N개씩"이 뒤절반(1 많음) 은폐 → `window` 제거, `earlierN/recentN` 명시 + 라벨 "앞 N개 vs 뒤 M개".
+- **③ avgDiffCover 분모 은닉**: n=1 100%도 전체 대표처럼 오인(red/dirty는 count/total 병기하는데 홀로 은닉) → `coverN` 인터페이스 노출 + `(측정 coverN/total)` 병기.
+- **④ COMMANDS.md**: `vhk stats --trend` 행 추가(사용법 SoT).
+- 회귀가드 테스트(earlierN/recentN·coverN·홀수 비대칭) 추가. 전체 2109 green. 5반증=크래시·수치오계산 0.
+
 ## 다음
 - N1 loop --tick(ⓐ) — 추세 소비 조율자. → N4 objective 토큰(ⓑ) → N5 evolve digest(ⓓ).

--- a/docs/log/2026-07-01-n6-stats-trend.md
+++ b/docs/log/2026-07-01-n6-stats-trend.md
@@ -1,0 +1,17 @@
+# 2026-07-01 — N6 vhk stats --trend (ⓔ 복리 척추)
+
+## 무엇·왜
+- ⓔ: N7(receipt-log.jsonl 영속, 머지됨)이 쌓은 측정치를 **시계열 추세**로 가시화. ⓐ(loop tick)가 "추세 악화"를 다음 한 수 근거로 쓸 토대.
+- `vhk stats --trend` — receipt-log 읽어 거짓완료 판정(decision) 추이 출력.
+
+## 구현
+- `stats.ts`: `computeReceiptTrend(entries)` 순수함수(fs/시간 부수효과 0) — total·decision분포·red/dirty율·diff-cover 평균·**앞절반 vs 뒷절반 block율 델타**(양수=악화). `stats(opts.trend)` 분기 + `renderTrend`(읽기 전용).
+- 정직성: total<2 → trend null, 측정분 0 → avgDiffCover null (표본부족을 0으로 위장 안 함, RFC0056 정신).
+- 등록: index.ts `.option('--trend')` (신규 명령 아님 → 드리프트 4지점 불요). ko stats.trend* 4키.
+
+## 검증
+- TDD: `stats-trend.test.ts` 6케이스(빈입력·분포·평균·추세방향·정렬결정성·total1) RED→GREEN.
+- 전체 2108 tests green · typecheck 무에러.
+
+## 다음
+- N1 loop --tick(ⓐ) — 추세 소비 조율자. → N4 objective 토큰(ⓑ) → N5 evolve digest(ⓓ).

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -65,9 +65,12 @@ export interface ReceiptTrend {
   dirtyRate: RateStat
   /** measured diff-cover 비율 평균. 측정분 0 이면 null(모름을 0 으로 위장 안 함). */
   avgDiffCover: number | null
-  /** 앞절반 vs 뒷절반 block 비율 비교. total<2 면 null(표본 부족). */
+  /** diff-cover measured 표본 수(분모 정직표기 — n 작을 때 평균 오인 방지). */
+  coverN: number
+  /** 앞절반 vs 뒷절반 block 비율 비교. total<2 면 null. 홀수 total 은 뒤절반이 1 많음 → earlierN/recentN 명시. */
   trend: {
-    window: number
+    earlierN: number
+    recentN: number
     earlierBlockRate: number
     recentBlockRate: number
     /** recent - earlier. 양수=악화(거짓완료 판정 증가), 음수=개선. */
@@ -102,10 +105,19 @@ export function computeReceiptTrend(entries: ReceiptLogEntry[]): ReceiptTrend {
     arr.length === 0 ? 0 : arr.filter((e) => e.decision === 'block').length / arr.length
   let trend: ReceiptTrend['trend'] = null
   if (total >= 2) {
+    // 홀수 total 은 뒤절반이 1 많다(earlierN/recentN 로 정직 노출 — '절반 N개씩' 오표기 방지, 적대리뷰 반영).
     const mid = Math.floor(total / 2)
-    const earlierBlockRate = blockRate(sorted.slice(0, mid))
-    const recentBlockRate = blockRate(sorted.slice(mid))
-    trend = { window: mid, earlierBlockRate, recentBlockRate, delta: recentBlockRate - earlierBlockRate }
+    const earlier = sorted.slice(0, mid)
+    const recent = sorted.slice(mid)
+    const earlierBlockRate = blockRate(earlier)
+    const recentBlockRate = blockRate(recent)
+    trend = {
+      earlierN: earlier.length,
+      recentN: recent.length,
+      earlierBlockRate,
+      recentBlockRate,
+      delta: recentBlockRate - earlierBlockRate,
+    }
   }
   return {
     total,
@@ -113,6 +125,7 @@ export function computeReceiptTrend(entries: ReceiptLogEntry[]): ReceiptTrend {
     redRate: rate(red),
     dirtyRate: rate(dirty),
     avgDiffCover: coverN === 0 ? null : coverSum / coverN,
+    coverN,
     trend,
   }
 }
@@ -197,16 +210,18 @@ function renderTrend(cwd: string): void {
   log.plain(chalk.cyan('📂 dirty') + chalk.white(` ${pct(tr.dirtyRate.rate)}`) + chalk.dim(` (${tr.dirtyRate.count}/${tr.dirtyRate.total})`))
   log.plain(
     chalk.cyan('🎯 diff-cover 평균') +
-      (tr.avgDiffCover === null ? chalk.dim(' 측정 없음') : chalk.white(` ${pct(tr.avgDiffCover)}`)),
+      (tr.avgDiffCover === null
+        ? chalk.dim(' 측정 없음')
+        : chalk.white(` ${pct(tr.avgDiffCover)}`) + chalk.dim(` (측정 ${tr.coverN}/${tr.total})`)),
   )
 
   if (tr.trend) {
-    const { delta, earlierBlockRate, recentBlockRate, window } = tr.trend
+    const { delta, earlierBlockRate, recentBlockRate, earlierN, recentN } = tr.trend
     const arrow = delta > 0 ? '📈 악화' : delta < 0 ? '📉 개선' : '➡️  동일'
     log.plain(
       chalk.cyan('\n📊 block 추세') +
         chalk.white(` ${pct(earlierBlockRate)} → ${pct(recentBlockRate)}`) +
-        chalk.dim(` (${arrow}, 절반 ${window}개씩)`),
+        chalk.dim(` (${arrow}, 앞 ${earlierN}개 vs 뒤 ${recentN}개)`),
     )
   } else {
     log.plain(chalk.dim('\n  추세: 표본 2개 미만 — 발행 더 누적 필요'))

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -5,6 +5,7 @@ import { printNextStep } from '../lib/next-step.js'
 import { readLedger, type LedgerEntry } from '../lib/evidence-ledger.js'
 import { readAiActions, type AiActionEntry } from '../lib/ai-actions-ledger.js'
 import { readQueue, type EvolveQueueItem } from './evolve.js'
+import { readReceiptLog, type ReceiptLogEntry } from '../lib/receipt-log.js'
 
 /**
  * Goal 61: vhk stats — 읽기전용 통계·대시보드 집계.
@@ -57,14 +58,79 @@ export function calcApplyRate(items: EvolveQueueItem[]): RateStat {
   return { count: applied, total, rate: total === 0 ? 0 : applied / total }
 }
 
+export interface ReceiptTrend {
+  total: number
+  byDecision: { block: number; caution: number; pass: number }
+  redRate: RateStat
+  dirtyRate: RateStat
+  /** measured diff-cover 비율 평균. 측정분 0 이면 null(모름을 0 으로 위장 안 함). */
+  avgDiffCover: number | null
+  /** 앞절반 vs 뒷절반 block 비율 비교. total<2 면 null(표본 부족). */
+  trend: {
+    window: number
+    earlierBlockRate: number
+    recentBlockRate: number
+    /** recent - earlier. 양수=악화(거짓완료 판정 증가), 음수=개선. */
+    delta: number
+  } | null
+}
+
+/**
+ * N6(ⓔ): receipt-log 시계열 추세 — 순수 계산(fs/시간 부수효과 0).
+ * 거짓완료 판정(decision==='block') 추세를 ts 정렬 후 앞절반 vs 뒷절반으로 비교.
+ * total<2 면 trend null, 측정분 0 이면 avgDiffCover null — 표본 부족을 0 으로 위장하지 않는다.
+ */
+export function computeReceiptTrend(entries: ReceiptLogEntry[]): ReceiptTrend {
+  const sorted = [...entries].sort((a, b) => a.ts.localeCompare(b.ts))
+  const total = sorted.length
+  const byDecision = { block: 0, caution: 0, pass: 0 }
+  let red = 0
+  let dirty = 0
+  let coverSum = 0
+  let coverN = 0
+  for (const e of sorted) {
+    if (e.decision === 'block' || e.decision === 'caution' || e.decision === 'pass') byDecision[e.decision]++
+    if (e.red) red++
+    if (e.dirty) dirty++
+    if (typeof e.diffCoverRatio === 'number') {
+      coverSum += e.diffCoverRatio
+      coverN++
+    }
+  }
+  const rate = (c: number): RateStat => ({ count: c, total, rate: total === 0 ? 0 : c / total })
+  const blockRate = (arr: ReceiptLogEntry[]): number =>
+    arr.length === 0 ? 0 : arr.filter((e) => e.decision === 'block').length / arr.length
+  let trend: ReceiptTrend['trend'] = null
+  if (total >= 2) {
+    const mid = Math.floor(total / 2)
+    const earlierBlockRate = blockRate(sorted.slice(0, mid))
+    const recentBlockRate = blockRate(sorted.slice(mid))
+    trend = { window: mid, earlierBlockRate, recentBlockRate, delta: recentBlockRate - earlierBlockRate }
+  }
+  return {
+    total,
+    byDecision,
+    redRate: rate(red),
+    dirtyRate: rate(dirty),
+    avgDiffCover: coverN === 0 ? null : coverSum / coverN,
+    trend,
+  }
+}
+
 function pct(rate: number): string {
   return `${(rate * 100).toFixed(1)}%`
 }
 
 // ── 커맨드 핸들러 (읽기 전용 — 파일 쓰기 없음) ──────────────────────────────────
 
-export async function stats(): Promise<void> {
+export async function stats(opts: { trend?: boolean } = {}): Promise<void> {
   const cwd = process.cwd()
+
+  // N6(ⓔ): --trend → receipt-log 시계열 추세(거짓완료 판정 추이). 기본 대시보드와 분리.
+  if (opts.trend) {
+    renderTrend(cwd)
+    return
+  }
 
   // 3소스 읽기 (전부 읽기 전용 — readQueue 는 in-memory v2 변환만, 디스크 미변경)
   const ledger = readLedger(cwd)
@@ -108,4 +174,43 @@ export async function stats(): Promise<void> {
     command: 'vhk verify',
     cursorHint: t('stats.nextCursor'),
   })
+}
+
+// N6(ⓔ): receipt-log 추세 렌더링(읽기 전용). 표본 부족·미측정은 정직 표기(0 위장 금지).
+function renderTrend(cwd: string): void {
+  const tr = computeReceiptTrend(readReceiptLog(cwd))
+
+  log.bold(`\n📈 ${t('stats.trendTitle')}`)
+  log.plain(chalk.gray('─'.repeat(40)))
+
+  if (tr.total === 0) {
+    log.plain(chalk.dim(`  ${t('stats.trendNoData')}`))
+    printNextStep({ message: t('stats.trendNextMessage'), command: 'vhk receipt', cursorHint: t('stats.trendNextCursor') })
+    return
+  }
+
+  log.plain(
+    chalk.cyan(`\n🧾 발행 ${tr.total}`) +
+      chalk.dim(` — ❌ block ${tr.byDecision.block} · ⚠️ caution ${tr.byDecision.caution} · ✅ pass ${tr.byDecision.pass}`),
+  )
+  log.plain(chalk.cyan('🚦 게이트 red') + chalk.white(` ${pct(tr.redRate.rate)}`) + chalk.dim(` (${tr.redRate.count}/${tr.redRate.total})`))
+  log.plain(chalk.cyan('📂 dirty') + chalk.white(` ${pct(tr.dirtyRate.rate)}`) + chalk.dim(` (${tr.dirtyRate.count}/${tr.dirtyRate.total})`))
+  log.plain(
+    chalk.cyan('🎯 diff-cover 평균') +
+      (tr.avgDiffCover === null ? chalk.dim(' 측정 없음') : chalk.white(` ${pct(tr.avgDiffCover)}`)),
+  )
+
+  if (tr.trend) {
+    const { delta, earlierBlockRate, recentBlockRate, window } = tr.trend
+    const arrow = delta > 0 ? '📈 악화' : delta < 0 ? '📉 개선' : '➡️  동일'
+    log.plain(
+      chalk.cyan('\n📊 block 추세') +
+        chalk.white(` ${pct(earlierBlockRate)} → ${pct(recentBlockRate)}`) +
+        chalk.dim(` (${arrow}, 절반 ${window}개씩)`),
+    )
+  } else {
+    log.plain(chalk.dim('\n  추세: 표본 2개 미만 — 발행 더 누적 필요'))
+  }
+
+  printNextStep({ message: t('stats.trendNextMessage'), command: 'vhk receipt', cursorHint: t('stats.trendNextCursor') })
 }

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -7,6 +7,10 @@ export const ko = {
     noActions: '데이터 없음 (action-ledger 미연동 — Goal 55 머지 후 집계)',
     nextMessage: '집계 확인 완료! 증거를 더 쌓으려면 검증을 실행하세요.',
     nextCursor: '검증 실행해줘',
+    trendTitle: 'receipt 추세 (거짓완료 판정 추이)',
+    trendNoData: '측정 데이터 없음 — vhk receipt 를 반복 발행하면 추세가 쌓입니다.',
+    trendNextMessage: '추세는 receipt 발행이 누적될수록 정밀해집니다.',
+    trendNextCursor: 'receipt 발행해줘',
   },
   status: {
     title: '프로젝트 상태',

--- a/src/index.ts
+++ b/src/index.ts
@@ -380,7 +380,8 @@ program
   .command('stats')
   .alias('통계')
   .description('통계 대시보드 — 패스율/차단율/진화 적용율 집계 (읽기 전용)')
-  .action(async () => { await stats() })
+  .option('--trend', 'receipt-log 시계열 추세(거짓완료 판정 추이)')
+  .action(async (opts: { trend?: boolean }) => { await stats({ trend: opts.trend }) })
 
 program
   .command('mcp')

--- a/tests/stats-trend.test.ts
+++ b/tests/stats-trend.test.ts
@@ -54,6 +54,7 @@ describe('computeReceiptTrend', () => {
       entry('2026-07-01T03:00:00Z', 'pass', { diffCoverRatio: null }),
     ])
     expect(tr.avgDiffCover).toBeCloseTo(0.7)
+    expect(tr.coverN).toBe(2)
   })
 
   it('추세 = 앞절반 vs 뒷절반 block 비율 (delta 양수=악화)', () => {
@@ -64,6 +65,8 @@ describe('computeReceiptTrend', () => {
       entry('2026-07-01T04:00:00Z', 'block'),
     ])
     expect(tr.trend).not.toBeNull()
+    expect(tr.trend!.earlierN).toBe(2)
+    expect(tr.trend!.recentN).toBe(2)
     expect(tr.trend!.earlierBlockRate).toBe(0)
     expect(tr.trend!.recentBlockRate).toBe(1)
     expect(tr.trend!.delta).toBe(1)
@@ -78,6 +81,17 @@ describe('computeReceiptTrend', () => {
     ])
     expect(tr.trend!.earlierBlockRate).toBe(0)
     expect(tr.trend!.recentBlockRate).toBe(1)
+  })
+
+  it('홀수 total → 뒤절반이 1 많음 (earlierN<recentN, 적대리뷰 라벨 정직표기 가드)', () => {
+    const tr = computeReceiptTrend([
+      entry('2026-07-01T01:00:00Z', 'pass'),
+      entry('2026-07-01T02:00:00Z', 'block'),
+      entry('2026-07-01T03:00:00Z', 'block'),
+    ])
+    expect(tr.total).toBe(3)
+    expect(tr.trend!.earlierN).toBe(1)
+    expect(tr.trend!.recentN).toBe(2)
   })
 
   it('total 1 → trend null (절반 비교 불가)', () => {

--- a/tests/stats-trend.test.ts
+++ b/tests/stats-trend.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { computeReceiptTrend } from '../src/commands/stats.js'
+import type { ReceiptLogEntry } from '../src/lib/receipt-log.js'
+
+// N6(ⓔ): receipt-log 시계열 추세. 순수 계산 검증.
+
+function entry(
+  ts: string,
+  decision: 'block' | 'caution' | 'pass',
+  extra: Partial<ReceiptLogEntry> = {},
+): ReceiptLogEntry {
+  return {
+    ts,
+    decision,
+    sha: null,
+    shortSha: null,
+    red: decision === 'block',
+    gateStatus: 'PASS',
+    dirty: false,
+    stale: null,
+    diffCoverRatio: null,
+    diffCoverUncovered: null,
+    forbiddenHits: null,
+    scopeWarnings: null,
+    ...extra,
+  }
+}
+
+describe('computeReceiptTrend', () => {
+  it('빈 입력 → total 0, trend·avgDiffCover null (표본 없음을 0 으로 위장 안 함)', () => {
+    const tr = computeReceiptTrend([])
+    expect(tr.total).toBe(0)
+    expect(tr.trend).toBeNull()
+    expect(tr.avgDiffCover).toBeNull()
+  })
+
+  it('decision 분포·red·dirty 집계', () => {
+    const tr = computeReceiptTrend([
+      entry('2026-07-01T01:00:00Z', 'pass'),
+      entry('2026-07-01T02:00:00Z', 'block'),
+      entry('2026-07-01T03:00:00Z', 'caution', { dirty: true }),
+      entry('2026-07-01T04:00:00Z', 'block', { dirty: true }),
+    ])
+    expect(tr.total).toBe(4)
+    expect(tr.byDecision).toEqual({ block: 2, caution: 1, pass: 1 })
+    expect(tr.redRate.count).toBe(2)
+    expect(tr.dirtyRate.count).toBe(2)
+  })
+
+  it('avgDiffCover = measured 평균(null 제외)', () => {
+    const tr = computeReceiptTrend([
+      entry('2026-07-01T01:00:00Z', 'pass', { diffCoverRatio: 0.8 }),
+      entry('2026-07-01T02:00:00Z', 'pass', { diffCoverRatio: 0.6 }),
+      entry('2026-07-01T03:00:00Z', 'pass', { diffCoverRatio: null }),
+    ])
+    expect(tr.avgDiffCover).toBeCloseTo(0.7)
+  })
+
+  it('추세 = 앞절반 vs 뒷절반 block 비율 (delta 양수=악화)', () => {
+    const tr = computeReceiptTrend([
+      entry('2026-07-01T01:00:00Z', 'pass'),
+      entry('2026-07-01T02:00:00Z', 'pass'),
+      entry('2026-07-01T03:00:00Z', 'block'),
+      entry('2026-07-01T04:00:00Z', 'block'),
+    ])
+    expect(tr.trend).not.toBeNull()
+    expect(tr.trend!.earlierBlockRate).toBe(0)
+    expect(tr.trend!.recentBlockRate).toBe(1)
+    expect(tr.trend!.delta).toBe(1)
+  })
+
+  it('ts 순서 무관 — 정렬 후 계산(결정성)', () => {
+    const tr = computeReceiptTrend([
+      entry('2026-07-01T04:00:00Z', 'block'),
+      entry('2026-07-01T01:00:00Z', 'pass'),
+      entry('2026-07-01T03:00:00Z', 'block'),
+      entry('2026-07-01T02:00:00Z', 'pass'),
+    ])
+    expect(tr.trend!.earlierBlockRate).toBe(0)
+    expect(tr.trend!.recentBlockRate).toBe(1)
+  })
+
+  it('total 1 → trend null (절반 비교 불가)', () => {
+    const tr = computeReceiptTrend([entry('2026-07-01T01:00:00Z', 'block')])
+    expect(tr.total).toBe(1)
+    expect(tr.trend).toBeNull()
+  })
+})


### PR DESCRIPTION
## 무엇
`vhk stats --trend` — N7 receipt-log.jsonl 을 읽어 **거짓완료 판정 추세** 가시화(ⓔ 복리 척추). ⓐ loop tick 이 '추세 악화'를 다음 한 수 근거로 소비할 토대.

## 구현
- `computeReceiptTrend` 순수함수(fs/시간 부수효과 0): decision 분포·red/dirty율·diff-cover 평균 + **앞절반 vs 뒷절반 block율 델타**(양수=악화).
- **정직성 계약**: total<2 → trend null · 측정분 0 → avgDiffCover null (표본부족을 0 으로 위장 안 함, RFC0056 정신).
- `stats(opts.trend)` 분기 + renderTrend(읽기 전용). index `.option('--trend')` (신규 명령 아님). ko stats.trend* 4키.

## 검증
- TDD: stats-trend.test.ts 6케이스(빈입력·분포·평균·추세방향·정렬결정성·total1).
- 전체 **2108 tests green** · typecheck 무에러.
- 다각 적대리뷰(진행) 결과 반영 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `vhk stats`에 `--trend` 옵션이 추가되어, receipt-log의 시계열 추세와 비율 요약을 확인할 수 있습니다.
  * 추세 화면에 데이터 없음 안내와 다음 단계 안내 문구가 추가되었습니다.
* **Bug Fixes**
  * 입력 순서와 무관하게 동일한 추세 결과가 나오도록 정렬 기준이 보강되었습니다.
  * 표본이 부족한 경우 추세를 계산하지 않고 적절한 안내를 표시합니다.
* **Tests**
  * 추세 계산, 평균 집계, 절반 비교, 빈 데이터 처리에 대한 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->