### PR TITLE
feat: vhk loop --tick — 자가진화 조율자 (N1, ⓐ)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -158,6 +158,7 @@ vhk doctor
 | `vhk status` | 프로젝트 상태 대시보드 |
 | `vhk stats` | 통계 대시보드 — 패스율/차단율/진화 적용율 (읽기 전용) |
 | `vhk stats --trend` | receipt-log 시계열 추세 — 거짓완료 판정 추이 (읽기 전용) |
+| `vhk loop` | 자가진화 조율 1틱 — 닫힌 것/다음 한 수 (읽기 전용, 집행 0) |
 | `vhk diff` | Git 변경사항 한국어 요약 |
 | `vhk diff-cover` | 이번 변경이 테스트로 커버됐는지 측정 (자문형) |
 | `vhk mcp` | MCP 서버 시작 (stdio) |

--- a/docs/log/2026-07-01-n1-loop-tick.md
+++ b/docs/log/2026-07-01-n1-loop-tick.md
@@ -14,5 +14,12 @@
 - **스모크가 통합회귀 포획**: 유닛 전부 green이었으나 `vhk loop` 실행 시 NL 라우터가 가로챔("모르겠어요") → KNOWN_COMMAND_TOKENS 누락 확인(stats/status는 등록됨) → `loop`/`틱` 추가 후 실동작 확인. (교훈 parallel-agent-ci-gate: 유닛 green ≠ 통합.)
 - 전체 2120 green · typecheck 무에러 · build 성공.
 
+## 적대리뷰 반영 (Workflow 3다이멘션: 9발견 → 5반증·3확정·1유보)
+- **[med] 집행0 계약 위반**: `collectState`의 `readMemory`가 v1→v2 마이그레이션 시 `persistOnRead`로 디스크 write → "읽기 전용·집행0" 불변식 위반. → **`loadForMutation`(비영속 로더)로 교체** (손상/미래스키마면 ok=false→빈 패턴).
+- **[low] 추세 잡음**: total=2(각 1건) 델타로 거짓 "추세 악화" 승격 → collectState에 **절반당 최소 3표본 가드**(미달 시 trendDelta null).
+- **[low] --tick no-op**: 데드옵션 오해소지 → 설명 "문서화된 no-op 별칭"으로 명확화(`vhk loop --tick` 문법 유효성 위해 옵션 유지).
+- **[UNCERTAIN 반영] 블로커 관측성**: 임계(3) 미만 블로커 1~2건이 카드에서 증발(0건 오독) → `watch` 필드 추가(다음수는 아니나 숨기지 않음).
+- 회귀가드 테스트 2종. 전체 2122 green. 5반증=크래시·수치오계산 0.
+
 ## 다음
 - N4 objective 토큰 교집합(ⓑ) → N5 evolve digest(ⓓ).

--- a/docs/log/2026-07-01-n1-loop-tick.md
+++ b/docs/log/2026-07-01-n1-loop-tick.md
@@ -1,0 +1,18 @@
+# 2026-07-01 — N1 vhk loop --tick (ⓐ 복리 척추 조율자)
+
+## 무엇·왜
+- ⓐ: 자가진화 루프의 "다음 한 수를 누가 부르는가"가 전부 사람이던 갭 해소. `vhk loop` = 폐회로 상태를 읽어 **닫힌 것 / 다음 한 수 1장** 합성(읽기 전용, 집행 0). ⓔ(N6 추세)를 소비.
+
+## 구현
+- `commands/loop.ts`: `computeLoopTick(state)` 순수함수 — 결정적 우선순위 사다리(HARD_STOP > 블로커 임계 > 진화 대기 > 추세 악화 > 미제안 패턴 > 정상). `collectState` = 디스크 읽기(isHardStopActive·countActiveBlockers·evolve queue pending·generateCandidates 미제안수·computeReceiptTrend 델타·selectActiveId). `loopTick` 핸들러 렌더.
+- **집행 0**: 결정경로에 LLM 없음, 수정·커밋·발송 없음 — "닫힌 것/다음 한 수"만 출력. 미제안수는 generateCandidates 재사용(단일 진실원).
+- 정직성: trendDelta null(표본<2)이면 추세 신호 생략(모름을 정상으로 위장 안 함).
+- 등록: index(command+한글별칭 '틱'+--tick option)·command-registry·**cli-args KNOWN**·ko.loop·COMMANDS.md.
+
+## 검증
+- TDD: loop-tick.test.ts 11케이스(우선순위 6단·닫힌신호·null추세·KNOWN 가드).
+- **스모크가 통합회귀 포획**: 유닛 전부 green이었으나 `vhk loop` 실행 시 NL 라우터가 가로챔("모르겠어요") → KNOWN_COMMAND_TOKENS 누락 확인(stats/status는 등록됨) → `loop`/`틱` 추가 후 실동작 확인. (교훈 parallel-agent-ci-gate: 유닛 green ≠ 통합.)
+- 전체 2120 green · typecheck 무에러 · build 성공.
+
+## 다음
+- N4 objective 토큰 교집합(ⓑ) → N5 evolve digest(ⓓ).

--- a/src/commands/loop.ts
+++ b/src/commands/loop.ts
@@ -11,7 +11,7 @@ import {
 } from '../lib/state-files.js'
 import { readQueue, generateCandidates } from './evolve.js'
 import type { PatternEntryV19 } from './pattern.js'
-import { readMemory } from './memory.js'
+import { loadForMutation } from './memory.js'
 import { readReceiptLog } from '../lib/receipt-log.js'
 import { computeReceiptTrend } from './stats.js'
 import { selectActiveId } from './goal.js'
@@ -46,6 +46,8 @@ export interface LoopTickMove {
 export interface LoopTickCard {
   /** 닫힌(정상) 신호 목록. */
   closed: string[]
+  /** 임계 미만이라 다음 한 수는 아니나 숨기면 안 되는 미해결 항목(관측성 — 0건 오독 방지). */
+  watch: string[]
   /** 결정적으로 뽑은 단 하나의 다음 한 수. */
   nextMove: LoopTickMove
 }
@@ -61,6 +63,12 @@ export function computeLoopTick(s: LoopTickState): LoopTickCard {
   if (s.evolvePending === 0) closed.push('진화 대기 0')
   if (s.trendDelta !== null && s.trendDelta <= 0) closed.push('추세 비악화')
   if (s.unqueuedPatterns === 0) closed.push('미제안 패턴 0')
+
+  // 임계 미만 블로커는 다음 한 수는 아니지만 카드에서 사라지면 안 됨(0건으로 오독 방지 — 적대리뷰 반영).
+  const watch: string[] = []
+  if (s.activeBlockers > 0 && s.activeBlockers < s.blockerThreshold) {
+    watch.push(`미해결 블로커 ${s.activeBlockers}건 (임계 ${s.blockerThreshold} 미만 — 방치 금지)`)
+  }
 
   let nextMove: LoopTickMove
   if (s.hardStop) {
@@ -78,19 +86,24 @@ export function computeLoopTick(s: LoopTickState): LoopTickCard {
   } else {
     nextMove = { priority: '정상', action: '닫힌 루프 — 다음 goal 선택 또는 측정 누적', command: 'vhk goal peek' }
   }
-  return { closed, nextMove }
+  return { closed, watch, nextMove }
 }
 
 /** 디스크에서 폐회로 상태 수집(읽기 전용). */
 function collectState(cwd: string): LoopTickState {
   const blockersContent = existsSync(BLOCKERS_PATH) ? readFileSync(BLOCKERS_PATH, 'utf-8') : ''
-  const mem = readMemory(cwd)
-  const patterns = mem.patterns as PatternEntryV19[]
+  // 읽기 전용 계약 준수: readMemory 는 v1→v2 마이그레이션 시 디스크 write(persistOnRead)로 집행0 을 어긴다.
+  // loadForMutation 은 in-memory 정규화만(비영속) — 손상/미래스키마면 ok=false → 빈 패턴(적대리뷰 med 반영).
+  const loaded = loadForMutation(cwd)
+  const patterns = (loaded.ok ? loaded.mem.patterns : []) as PatternEntryV19[]
   const queue = readQueue(cwd)
   const evolvePending = queue.items.filter((i) => i.status === 'pending').length
   // 지금 suggest 하면 생길 후보 수 = 미제안 active 패턴(generateCandidates 재사용 — 단일 진실원).
   const unqueuedPatterns = generateCandidates(patterns, queue.items).length
   const trend = computeReceiptTrend(readReceiptLog(cwd)).trend
+  // 최소 표본 가드(measure-first): 절반당 3건 미만이면 델타는 잡음 → null(n=1 대 n=1 거짓 추세악화 방지, 적대리뷰 반영).
+  const TREND_MIN = 3
+  const trendDelta = trend && trend.earlierN >= TREND_MIN && trend.recentN >= TREND_MIN ? trend.delta : null
   const activeGoalId = selectActiveId(listGoals('goals'))
   return {
     hardStop: isHardStopActive(),
@@ -98,7 +111,7 @@ function collectState(cwd: string): LoopTickState {
     blockerThreshold: HARD_STOP_BLOCKER_THRESHOLD,
     evolvePending,
     unqueuedPatterns,
-    trendDelta: trend ? trend.delta : null,
+    trendDelta,
     activeGoalId,
   }
 }
@@ -112,6 +125,9 @@ export async function loopTick(): Promise<void> {
 
   if (card.closed.length > 0) {
     log.plain(chalk.green(`  ✅ ${t('loop.closed')} `) + chalk.dim(card.closed.join(' · ')))
+  }
+  if (card.watch.length > 0) {
+    log.plain(chalk.yellow(`  ⚠️  ${t('loop.watch')} `) + chalk.dim(card.watch.join(' · ')))
   }
   log.plain(
     chalk.cyan(`\n  👉 ${t('loop.nextMove')} `) +

--- a/src/commands/loop.ts
+++ b/src/commands/loop.ts
@@ -1,0 +1,126 @@
+import { existsSync, readFileSync } from 'node:fs'
+import chalk from 'chalk'
+import { log } from '../utils/logger.js'
+import { t } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+import {
+  isHardStopActive,
+  countActiveBlockers,
+  BLOCKERS_PATH,
+  HARD_STOP_BLOCKER_THRESHOLD,
+} from '../lib/state-files.js'
+import { readQueue, generateCandidates } from './evolve.js'
+import type { PatternEntryV19 } from './pattern.js'
+import { readMemory } from './memory.js'
+import { readReceiptLog } from '../lib/receipt-log.js'
+import { computeReceiptTrend } from './stats.js'
+import { selectActiveId } from './goal.js'
+import { listGoals } from '../lib/goal-frontmatter.js'
+
+/**
+ * N1(ⓐ): vhk loop --tick — 읽기 전용 자가진화 조율자.
+ * 폐회로 상태(HARD_STOP·블로커·진화 대기·추세·미제안 패턴·active goal)를 읽어
+ * "닫힌 것 / 다음 한 수" 1장으로 합성한다. 집행 0(수정·커밋·발송 없음) — 결정경로에 LLM 없음.
+ * 다음 한 수는 결정적 우선순위(위험 → 복리 → 정상)로 뽑는다.
+ */
+
+export interface LoopTickState {
+  hardStop: boolean
+  activeBlockers: number
+  blockerThreshold: number
+  /** evolve 큐 pending 후보 수. */
+  evolvePending: number
+  /** 아직 큐에 안 오른 active 패턴 수(avoid+reinforce) = 지금 suggest 하면 생길 후보 수. */
+  unqueuedPatterns: number
+  /** receipt 추세 block율 델타(recent-earlier). 표본<2 → null. 양수=악화. */
+  trendDelta: number | null
+  activeGoalId: number | null
+}
+
+export interface LoopTickMove {
+  priority: string
+  action: string
+  command: string
+}
+
+export interface LoopTickCard {
+  /** 닫힌(정상) 신호 목록. */
+  closed: string[]
+  /** 결정적으로 뽑은 단 하나의 다음 한 수. */
+  nextMove: LoopTickMove
+}
+
+/**
+ * 순수 함수 — 상태 → 카드. fs/시간 부수효과 0, 결정적(같은 상태 → 같은 카드).
+ * 우선순위: HARD_STOP > 블로커 임계 > 진화 대기 > 추세 악화 > 미제안 패턴 > 정상.
+ */
+export function computeLoopTick(s: LoopTickState): LoopTickCard {
+  const closed: string[] = []
+  if (!s.hardStop) closed.push('HARD_STOP 없음')
+  if (s.activeBlockers === 0) closed.push('블로커 0')
+  if (s.evolvePending === 0) closed.push('진화 대기 0')
+  if (s.trendDelta !== null && s.trendDelta <= 0) closed.push('추세 비악화')
+  if (s.unqueuedPatterns === 0) closed.push('미제안 패턴 0')
+
+  let nextMove: LoopTickMove
+  if (s.hardStop) {
+    nextMove = { priority: 'HARD_STOP', action: 'HARD_STOP 활성 — 사유 확인 후 사람이 해제', command: 'vhk resume --confirm' }
+  } else if (s.activeBlockers >= s.blockerThreshold) {
+    nextMove = { priority: '블로커 임계', action: `블로커 ${s.activeBlockers}건(임계 ${s.blockerThreshold}) — 해소 우선`, command: 'vhk blocker' }
+  } else if (s.evolvePending > 0) {
+    nextMove = { priority: '진화 대기', action: `evolve 후보 ${s.evolvePending}건 대기 — 검토·반영(사람 승인)`, command: 'vhk evolve list' }
+  } else if (s.trendDelta !== null && s.trendDelta > 0) {
+    nextMove = { priority: '추세 악화', action: 'block율 상승 — 최근 거짓완료 원인 점검', command: 'vhk stats --trend' }
+  } else if (s.unqueuedPatterns > 0) {
+    nextMove = { priority: '패턴 감지', action: `미제안 패턴 ${s.unqueuedPatterns}건 — 룰 후보 생성`, command: 'vhk evolve suggest' }
+  } else if (s.activeGoalId !== null) {
+    nextMove = { priority: '정상', action: `active goal ${s.activeGoalId} 진행`, command: 'vhk work' }
+  } else {
+    nextMove = { priority: '정상', action: '닫힌 루프 — 다음 goal 선택 또는 측정 누적', command: 'vhk goal peek' }
+  }
+  return { closed, nextMove }
+}
+
+/** 디스크에서 폐회로 상태 수집(읽기 전용). */
+function collectState(cwd: string): LoopTickState {
+  const blockersContent = existsSync(BLOCKERS_PATH) ? readFileSync(BLOCKERS_PATH, 'utf-8') : ''
+  const mem = readMemory(cwd)
+  const patterns = mem.patterns as PatternEntryV19[]
+  const queue = readQueue(cwd)
+  const evolvePending = queue.items.filter((i) => i.status === 'pending').length
+  // 지금 suggest 하면 생길 후보 수 = 미제안 active 패턴(generateCandidates 재사용 — 단일 진실원).
+  const unqueuedPatterns = generateCandidates(patterns, queue.items).length
+  const trend = computeReceiptTrend(readReceiptLog(cwd)).trend
+  const activeGoalId = selectActiveId(listGoals('goals'))
+  return {
+    hardStop: isHardStopActive(),
+    activeBlockers: countActiveBlockers(blockersContent),
+    blockerThreshold: HARD_STOP_BLOCKER_THRESHOLD,
+    evolvePending,
+    unqueuedPatterns,
+    trendDelta: trend ? trend.delta : null,
+    activeGoalId,
+  }
+}
+
+export async function loopTick(): Promise<void> {
+  const cwd = process.cwd()
+  const card = computeLoopTick(collectState(cwd))
+
+  log.bold(`\n🔁 ${t('loop.tickTitle')}`)
+  log.plain(chalk.gray('─'.repeat(40)))
+
+  if (card.closed.length > 0) {
+    log.plain(chalk.green(`  ✅ ${t('loop.closed')} `) + chalk.dim(card.closed.join(' · ')))
+  }
+  log.plain(
+    chalk.cyan(`\n  👉 ${t('loop.nextMove')} `) +
+      chalk.white(`[${card.nextMove.priority}] ${card.nextMove.action}`),
+  )
+
+  printNextStep({
+    message: t('loop.nextMessage'),
+    command: card.nextMove.command,
+    cursorHint: t('loop.nextCursor'),
+  })
+}

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -15,6 +15,7 @@ export const ko = {
   loop: {
     tickTitle: 'loop tick — 자가진화 조율 (읽기 전용)',
     closed: '닫힌 것:',
+    watch: '주의:',
     nextMove: '다음 한 수:',
     nextMessage: '읽기 전용 조율 — 실행은 사람이 결정합니다.',
     nextCursor: '다음 한 수 실행해줘',

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -12,6 +12,13 @@ export const ko = {
     trendNextMessage: '추세는 receipt 발행이 누적될수록 정밀해집니다.',
     trendNextCursor: 'receipt 발행해줘',
   },
+  loop: {
+    tickTitle: 'loop tick — 자가진화 조율 (읽기 전용)',
+    closed: '닫힌 것:',
+    nextMove: '다음 한 수:',
+    nextMessage: '읽기 전용 조율 — 실행은 사람이 결정합니다.',
+    nextCursor: '다음 한 수 실행해줘',
+  },
   status: {
     title: '프로젝트 상태',
     notGitRepo: 'Git 저장소가 아니에요. 먼저 git init을 실행하세요.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { diff } from './commands/diff.js'
 import { diffCover } from './commands/diff-cover.js'
 import { status } from './commands/status.js'
 import { stats } from './commands/stats.js'
+import { loopTick } from './commands/loop.js'
 import { startMcpServer, getMcpToolCount } from './mcp/server.js'
 import { mcpInit } from './commands/mcp-init.js'
 import { injectBootstrapCommand } from './commands/inject-bootstrap.js'
@@ -382,6 +383,13 @@ program
   .description('통계 대시보드 — 패스율/차단율/진화 적용율 집계 (읽기 전용)')
   .option('--trend', 'receipt-log 시계열 추세(거짓완료 판정 추이)')
   .action(async (opts: { trend?: boolean }) => { await stats({ trend: opts.trend }) })
+
+program
+  .command('loop')
+  .alias('틱')
+  .description('자가진화 조율 1틱 — 닫힌 것/다음 한 수 (읽기 전용, 집행 0)')
+  .option('--tick', '1틱 실행 (기본 동작)')
+  .action(async () => { await loopTick() })
 
 program
   .command('mcp')

--- a/src/index.ts
+++ b/src/index.ts
@@ -388,7 +388,7 @@ program
   .command('loop')
   .alias('틱')
   .description('자가진화 조율 1틱 — 닫힌 것/다음 한 수 (읽기 전용, 집행 0)')
-  .option('--tick', '1틱 실행 (기본 동작)')
+  .option('--tick', '명시적 1틱 — vhk loop 기본 동작과 동일(문서화된 no-op 별칭)')
   .action(async () => { await loopTick() })
 
 program

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -21,6 +21,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   // #345: '현황' 은 status 의 별칭이 아니다(status 는 '상태'만) → 유령 KNOWN 토큰. 빼면 NL→status 로 친절 라우팅.
   'status', '상태',
   'stats', '통계',
+  'loop', '틱',
   'diff', '변경', '차이',
   'diff-cover', '커버리지',
   'mcp',

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -117,5 +117,6 @@ export const TOP_LEVEL_COMMANDS: ReadonlyArray<{ name: string; desc: string }> =
   { name: 'resume', desc: '.vhk/HARD_STOP 해제 (--confirm 필요)' },
   { name: 'pattern', desc: '반복 패턴 감지·목록 (avoid/reinforce)' },
   { name: 'evolve', desc: '패턴 → 룰 후보 제안·반영·undo' },
+  { name: 'loop', desc: '자가진화 조율 1틱 — 다음 한 수 (읽기 전용)' },
   { name: 'seo', desc: 'SEO·수익 대시보드 (init: 사이트 등록 + 자격증명 보관)' },
 ]

--- a/tests/loop-tick.test.ts
+++ b/tests/loop-tick.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { computeLoopTick, type LoopTickState } from '../src/commands/loop.js'
+import { KNOWN_COMMAND_TOKENS } from '../src/lib/cli-args.js'
+
+// N1(ⓐ): computeLoopTick 순수함수 — 결정적 우선순위 사다리 검증.
+
+function state(over: Partial<LoopTickState> = {}): LoopTickState {
+  return {
+    hardStop: false,
+    activeBlockers: 0,
+    blockerThreshold: 3,
+    evolvePending: 0,
+    unqueuedPatterns: 0,
+    trendDelta: null,
+    activeGoalId: null,
+    ...over,
+  }
+}
+
+describe('computeLoopTick 우선순위 사다리', () => {
+  it('HARD_STOP 최우선 (블로커·진화보다 위)', () => {
+    const c = computeLoopTick(state({ hardStop: true, activeBlockers: 5, evolvePending: 3 }))
+    expect(c.nextMove.priority).toBe('HARD_STOP')
+    expect(c.nextMove.command).toBe('vhk resume --confirm')
+  })
+
+  it('블로커 임계 > 진화 대기', () => {
+    const c = computeLoopTick(state({ activeBlockers: 3, blockerThreshold: 3, evolvePending: 2 }))
+    expect(c.nextMove.priority).toBe('블로커 임계')
+  })
+
+  it('진화 대기 > 추세 악화', () => {
+    const c = computeLoopTick(state({ evolvePending: 1, trendDelta: 0.5 }))
+    expect(c.nextMove.priority).toBe('진화 대기')
+    expect(c.nextMove.command).toBe('vhk evolve list')
+  })
+
+  it('추세 악화 > 미제안 패턴', () => {
+    const c = computeLoopTick(state({ trendDelta: 0.5, unqueuedPatterns: 2 }))
+    expect(c.nextMove.priority).toBe('추세 악화')
+    expect(c.nextMove.command).toBe('vhk stats --trend')
+  })
+
+  it('미제안 패턴 > 정상', () => {
+    const c = computeLoopTick(state({ unqueuedPatterns: 2, activeGoalId: 5 }))
+    expect(c.nextMove.priority).toBe('패턴 감지')
+    expect(c.nextMove.command).toBe('vhk evolve suggest')
+  })
+
+  it('정상 + active goal → work', () => {
+    const c = computeLoopTick(state({ activeGoalId: 88 }))
+    expect(c.nextMove.priority).toBe('정상')
+    expect(c.nextMove.command).toBe('vhk work')
+    expect(c.nextMove.action).toContain('88')
+  })
+
+  it('정상 + goal 없음 → goal peek', () => {
+    const c = computeLoopTick(state())
+    expect(c.nextMove.command).toBe('vhk goal peek')
+  })
+
+  it('닫힌 신호 집계 (모두 정상 + 추세 비악화)', () => {
+    const c = computeLoopTick(state({ trendDelta: -0.1 }))
+    expect(c.closed).toContain('HARD_STOP 없음')
+    expect(c.closed).toContain('블로커 0')
+    expect(c.closed).toContain('진화 대기 0')
+    expect(c.closed).toContain('추세 비악화')
+    expect(c.closed).toContain('미제안 패턴 0')
+  })
+
+  it('trendDelta 양수(악화) → 추세 비악화 신호 미포함', () => {
+    const c = computeLoopTick(state({ trendDelta: 0.3 }))
+    expect(c.closed).not.toContain('추세 비악화')
+  })
+
+  it('trendDelta null(표본부족) → 추세 신호 미포함 (모름을 정상으로 위장 안 함)', () => {
+    const c = computeLoopTick(state({ trendDelta: null }))
+    expect(c.closed).not.toContain('추세 비악화')
+  })
+})
+
+describe('loop 명령 등록 (NL 라우터 가드)', () => {
+  it('영문·한글 별칭이 KNOWN_COMMAND_TOKENS 에 등록됨 — 없으면 NL 라우터가 가로챔', () => {
+    expect(KNOWN_COMMAND_TOKENS.has('loop')).toBe(true)
+    expect(KNOWN_COMMAND_TOKENS.has('틱')).toBe(true)
+  })
+})

--- a/tests/loop-tick.test.ts
+++ b/tests/loop-tick.test.ts
@@ -59,6 +59,18 @@ describe('computeLoopTick 우선순위 사다리', () => {
     expect(c.nextMove.command).toBe('vhk goal peek')
   })
 
+  it('임계 미만 블로커 → watch 노출 (다음수 정상이어도 숨기지 않음, 적대리뷰 반영)', () => {
+    const c = computeLoopTick(state({ activeBlockers: 2, activeGoalId: 5 }))
+    expect(c.watch.some((w) => w.includes('블로커 2건'))).toBe(true)
+    expect(c.nextMove.priority).toBe('정상')
+  })
+
+  it('임계 이상 블로커 → watch 없음 (다음수로 승격)', () => {
+    const c = computeLoopTick(state({ activeBlockers: 3, blockerThreshold: 3 }))
+    expect(c.watch).toHaveLength(0)
+    expect(c.nextMove.priority).toBe('블로커 임계')
+  })
+
   it('닫힌 신호 집계 (모두 정상 + 추세 비악화)', () => {
     const c = computeLoopTick(state({ trendDelta: -0.1 }))
     expect(c.closed).toContain('HARD_STOP 없음')


### PR DESCRIPTION
## 무엇
`vhk loop` — 폐회로 상태(HARD_STOP·블로커·진화 대기·추세·미제안 패턴·goal)를 읽어 **닫힌 것 / 다음 한 수 1장** 합성. 자가진화 루프의 '다음 한 수를 누가 부르나'(전부 사람)를 자동화(ⓐ). **읽기 전용·집행 0**(수정·커밋·발송 없음, 결정경로에 LLM 없음).

## 구현
- `computeLoopTick(state)` 순수함수 — 결정적 우선순위: HARD_STOP > 블로커 임계 > 진화 대기 > 추세 악화 > 미제안 패턴 > 정상. 미제안수는 generateCandidates 재사용(단일 진실원). ⓔ(N6 추세) 소비.
- 정직성: trendDelta null(표본<2) → 추세 신호 생략(모름을 정상으로 위장 안 함).
- 등록 5지점 + KNOWN_COMMAND_TOKENS.

## 검증
- TDD: loop-tick.test.ts 11케이스(우선순위 6단·닫힌신호·null추세·KNOWN 가드).
- **스모크가 통합회귀 포획**: 유닛 green이었으나 실행 시 NL 라우터 가로채기 → KNOWN 누락 발견·추가 후 `vhk loop`/`틱` 실동작 확인.
- 전체 2120 green · typecheck 무에러.

🤖 Generated with [Claude Code](https://claude.com/claude-code)