### PR TITLE
feat: objective 토큰 교집합 advisory — 의도 대조 (N4, ⓑ)

### DIFF
--- a/docs/log/2026-07-01-n4-objective-overlap.md
+++ b/docs/log/2026-07-01-n4-objective-overlap.md
@@ -1,0 +1,16 @@
+# 2026-07-01 — N4 objective 토큰 교집합 (ⓑ 복리 척추)
+
+## 무엇·왜
+- ⓑ: intent 의미검증 미완 갭. **LLM 결정경로 영구 배제** 전제 하에, mission.objective ↔ (active goal.title + 최근 commit) **결정론 토큰 교집합**을 receipt advisory 신호로. "목표와 실제 작업 어휘가 안 겹침"을 약신호로 조기 포착 → 북극성(의도대로 검증) 기여.
+
+## 구현 (GA-동결 receipt 결정로직 — 옵셔널 추가만)
+- `lib/receipt.ts`: `ReceiptIntentEvidence.objectiveTokenOverlap?: number` 추가. `decideReceipt`에 `objectiveMismatch = intentKnown && overlap === 0` → **caution 분기만**(block 절대 금지). `=== 0` 이라 undefined(미계산) 무영향 = 하위호환·단조성 불변식 ③ 보존. `receiptReasons`에 advisory 1줄.
+- `commands/receipt.ts`: `computeObjectiveOverlap(objective, ref)` 순수(pattern.tokenize 재사용, LLM 0) · `isRealObjective`(placeholder/빈값 = 암묵 opt-out) · `collectObjectiveRef`(goal.frontmatter.title + `git log -1 --format=%s`, 읽기전용·실패무해). collectIntent가 실제 objective일 때만 계산.
+- **opt-in**: 별도 플래그 대신 "실제 objective 를 mission set 으로 채우면 검증"(placeholder면 undefined=영향0). 노이즈 caution 최소화.
+
+## 검증
+- TDD: objective-overlap.test.ts(computeObjectiveOverlap 5·isRealObjective 3) + receipt.test.ts decideReceipt overlap 3케이스(0→caution·>0→pass·undefined→pass, block 절대 안 함).
+- 전체 2133 green · typecheck 무에러. **단조성 불변식**: overlap 0 은 caution 이 상한(다른 실차단 없으면 block 불가).
+
+## 다음
+- N5 evolve digest(ⓓ) — 복리 척추 마지막(사용자 요청분).

--- a/docs/log/2026-07-01-n4-objective-overlap.md
+++ b/docs/log/2026-07-01-n4-objective-overlap.md
@@ -12,5 +12,11 @@
 - TDD: objective-overlap.test.ts(computeObjectiveOverlap 5·isRealObjective 3) + receipt.test.ts decideReceipt overlap 3케이스(0→caution·>0→pass·undefined→pass, block 절대 안 함).
 - 전체 2133 green · typecheck 무에러. **단조성 불변식**: overlap 0 은 caution 이 상한(다른 실차단 없으면 block 불가).
 
+## 적대리뷰 반영 (Workflow 3다이멘션: 7발견 → 3반증·3확정 low·1유보)
+**단조성 위반 0·GA 시그니처 위반 0 — 핵심계약 보존.** 확정 전부 advisory 오탐(차단·역행 없음):
+- **[low] 빈 objTokens → 거짓 caution**: 실제 objective인데 tokenize가 전부 필터(전부 <2자/불용어, 예 "봇 앱")면 0 반환 → 거짓 caution. ref-empty는 가드하면서 비대칭. → `computeObjectiveOverlap`이 objTokens 빈집합이면 **undefined 반환**(미계산, 대칭). UNCERTAIN도 동일 근본이라 함께 해소.
+- **[low] cwd 계약 위반**: `collectObjectiveRef`가 `listGoals('goals')`로 process.cwd() 기준 → 테스트(temp cwd)서 실레포 goal 오염. → `listGoals(join(cwd, 'goals'))`(goal.ts 관례 일치).
+- 회귀가드 테스트(undefined 반환) 갱신. 전체 2133 green. 3반증=단조성·GA·하위호환 전부 불변 확인.
+
 ## 다음
 - N5 evolve digest(ⓓ) — 복리 척추 마지막(사용자 요청분).

--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -170,9 +170,10 @@ export function isRealObjective(objective: string): boolean {
 }
 
 /** objective ↔ ref 결정론 토큰 교집합 수(공통 distinct 토큰). pattern.tokenize 재사용, LLM 0. */
-export function computeObjectiveOverlap(objective: string, ref: string): number {
+export function computeObjectiveOverlap(objective: string, ref: string): number | undefined {
   const objTokens = new Set(tokenize(objective))
-  if (objTokens.size === 0) return 0
+  // 토큰화 불가(전부 <2자/불용어) = 미계산(undefined) — '겹침 0'과 구분, ref-empty 가드와 대칭(적대리뷰 반영).
+  if (objTokens.size === 0) return undefined
   const refTokens = new Set(tokenize(ref))
   let overlap = 0
   for (const tok of objTokens) if (refTokens.has(tok)) overlap++
@@ -183,7 +184,7 @@ export function computeObjectiveOverlap(objective: string, ref: string): number 
 function collectObjectiveRef(cwd: string): string {
   const parts: string[] = []
   try {
-    const goals = listGoals('goals')
+    const goals = listGoals(join(cwd, 'goals'))
     const id = selectActiveId(goals)
     const g = id !== null ? goals.find((x) => x.frontmatter.id === id) : undefined
     if (g?.frontmatter.title) parts.push(g.frontmatter.title)

--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -17,7 +17,10 @@ import { fileCoverageByFile, COVERAGE_CORRUPT } from '../lib/coverage-parse.js'
 import { diffCoverage } from '../lib/diff-coverage.js'
 import { parsePorcelainLines } from '../lib/git-porcelain.js'
 import { porcelainPath, isSelfTrackedPath } from '../lib/self-tracked.js'
-import { readMission, checkMission, MISSION_PATH_REL } from './mission.js'
+import { readMission, checkMission, MISSION_PATH_REL, MISSION_SCAFFOLD_OBJECTIVE } from './mission.js'
+import { tokenize } from './pattern.js'
+import { listGoals } from '../lib/goal-frontmatter.js'
+import { selectActiveId } from './goal.js'
 import {
   buildReceipt,
   renderReceiptMarkdown,
@@ -158,6 +161,44 @@ function missionChecksum(cwd: string): string | undefined {
   }
 }
 
+// ── ⓑ(N4): objective 토큰 교집합 — 결정론(LLM 0)·advisory ────────────────────
+
+/** placeholder/빈 objective 는 검증 대상 아님(스캐폴드 미설정 = 암묵 opt-out). */
+export function isRealObjective(objective: string): boolean {
+  const o = objective.trim()
+  return o.length > 0 && o !== MISSION_SCAFFOLD_OBJECTIVE
+}
+
+/** objective ↔ ref 결정론 토큰 교집합 수(공통 distinct 토큰). pattern.tokenize 재사용, LLM 0. */
+export function computeObjectiveOverlap(objective: string, ref: string): number {
+  const objTokens = new Set(tokenize(objective))
+  if (objTokens.size === 0) return 0
+  const refTokens = new Set(tokenize(ref))
+  let overlap = 0
+  for (const tok of objTokens) if (refTokens.has(tok)) overlap++
+  return overlap
+}
+
+/** overlap 참조 텍스트 = active goal.title + 최근 commit subject(읽기 전용, git/goal 실패 무해). */
+function collectObjectiveRef(cwd: string): string {
+  const parts: string[] = []
+  try {
+    const goals = listGoals('goals')
+    const id = selectActiveId(goals)
+    const g = id !== null ? goals.find((x) => x.frontmatter.id === id) : undefined
+    if (g?.frontmatter.title) parts.push(g.frontmatter.title)
+  } catch {
+    /* goal 미상 — ref 에서 생략(정직, 거짓 0 방지) */
+  }
+  try {
+    const subject = gitOut(['log', '-1', '--format=%s'], cwd).trim()
+    if (subject) parts.push(subject)
+  } catch {
+    /* commit 없음/git 실패 — 생략 */
+  }
+  return parts.join(' ')
+}
+
 export function collectIntent(cwd: string, baseSha?: string | null): ReceiptIntentEvidence | undefined {
   const mission = readMission(cwd)
   if (!mission) return undefined
@@ -182,12 +223,19 @@ export function collectIntent(cwd: string, baseSha?: string | null): ReceiptInte
   }
   const changed = [...files].filter((f) => !isSelfTrackedPath(f))
   const result = checkMission(changed, mission)
+  // ⓑ(N4): objective 가 실제 설정됐을 때만 토큰 교집합 계산(암묵 opt-in). placeholder/빈값 → undefined(영향 0).
+  let objectiveTokenOverlap: number | undefined
+  if (isRealObjective(mission.objective)) {
+    const ref = collectObjectiveRef(cwd)
+    if (ref.trim()) objectiveTokenOverlap = computeObjectiveOverlap(mission.objective, ref)
+  }
   return {
     missionKnown: true,
     forbiddenHits: result.violations.length,
     scopeWarnings: result.warnings.length,
     unsupportedForbiddenCount: result.unsupportedForbiddenPatterns.length,
     missionChecksum: missionChecksum(cwd),
+    objectiveTokenOverlap,
   }
 }
 

--- a/src/lib/receipt.ts
+++ b/src/lib/receipt.ts
@@ -63,6 +63,12 @@ export interface ReceiptIntentEvidence {
   //   사후 검증 가능해진다(같은 mission 의 두 영수증 checksum 이 다르면 사이에 계약이 바뀐 것).
   // decision 에는 절대 반영 안 함 — 순수 사후 감사용(단조성 불변식 ②·③ 불변). GA 동결 — 옵셔널 추가만.
   missionChecksum?: string
+  /**
+   * ⓑ(N4): objective 토큰 교집합 수 — mission.objective ↔ (active goal.title + 최근 commit) 의
+   * 결정론 토큰 공통 개수. **LLM 0**(pattern.tokenize 순수 교집합). undefined=미계산(영향 0·하위호환),
+   * 0=계산했으나 겹침 없음 → caution(advisory, block 절대 금지 — 단조성 불변식 ③ 유지). GA 동결 옵셔널 추가.
+   */
+  objectiveTokenOverlap?: number
 }
 
 /** 영수증 입력 — 4대 기계증거 + (옵션) 의도 대조(commands/receipt.ts 가 git/verify/diff-cover/mission 에서 수집). */
@@ -109,7 +115,9 @@ export function decideReceipt(e: ReceiptEvidence): ReceiptDecision {
   const scopeWarned = intentKnown && e.intent!.scopeWarnings > 0
   // intentKnown이 false면 단락평가로 e.intent! 접근 안 됨 — 이 순서 필수(GA 동결, 단조성 불변식 ②·③ 유지).
   const unsupportedForbidden = intentKnown && (e.intent!.unsupportedForbiddenCount ?? 0) > 0
-  if (e.gates.hasSoftWarning || !e.staleKnown || hasUncoveredChange || scopeWarned || unsupportedForbidden) return 'caution'
+  // ⓑ(N4): objective 토큰 교집합 0 → advisory caution(목표와 실제 작업 어휘 안 겹침 = 약신호). `=== 0` 이라 undefined(미계산) 무영향 → block 절대 안 함.
+  const objectiveMismatch = intentKnown && e.intent!.objectiveTokenOverlap === 0
+  if (e.gates.hasSoftWarning || !e.staleKnown || hasUncoveredChange || scopeWarned || unsupportedForbidden || objectiveMismatch) return 'caution'
 
   return 'pass'
 }
@@ -139,6 +147,8 @@ export function receiptReasons(e: ReceiptEvidence): string[] {
     reasons.push(
       `forbidden 패턴 ${e.intent.unsupportedForbiddenCount}개가 glob 미지원 문법 포함 — forbidden 검증이 무효할 수 있음(!, {}, [], 후행 / — caution)`
     )
+  if (e.intent?.missionKnown && e.intent.objectiveTokenOverlap === 0)
+    reasons.push('objective 토큰 교집합 0 — 목표와 최근 작업(goal·commit) 어휘가 겹치지 않음(advisory, 차단 안 함)')
   if (reasons.length === 0) reasons.push('전 게이트 green · clean · 신선 · 변경라인 풀커버')
   return reasons
 }

--- a/tests/objective-overlap.test.ts
+++ b/tests/objective-overlap.test.ts
@@ -23,8 +23,9 @@ describe('computeObjectiveOverlap (결정론·LLM 0)', () => {
     expect(computeObjectiveOverlap('결제 결제 결제', '결제 처리')).toBe(1)
   })
 
-  it('objective 토큰 없음(빈 문자열) → 0', () => {
-    expect(computeObjectiveOverlap('', '아무 작업이나')).toBe(0)
+  it('토큰화 불가 objective(빈/전부 <2자·불용어) → undefined (미계산, ref-empty 가드와 대칭, 적대리뷰 반영)', () => {
+    expect(computeObjectiveOverlap('', '아무 작업이나')).toBeUndefined()
+    expect(computeObjectiveOverlap('가 나', '가 나 다 작업')).toBeUndefined()
   })
 })
 

--- a/tests/objective-overlap.test.ts
+++ b/tests/objective-overlap.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { computeObjectiveOverlap, isRealObjective } from '../src/commands/receipt.js'
+import { MISSION_SCAFFOLD_OBJECTIVE } from '../src/commands/mission.js'
+
+// N4(ⓑ): objective 토큰 교집합 — 결정론(LLM 0). mission.objective ↔ (goal.title+commit) 어휘 대조.
+
+describe('computeObjectiveOverlap (결정론·LLM 0)', () => {
+  it('공통 distinct 토큰 수 카운트', () => {
+    expect(computeObjectiveOverlap('결제 모듈 리팩터링', '결제 모듈 버그 수정')).toBe(2)
+  })
+
+  it('겹침 없음 → 0 (목표와 작업 어휘 불일치 약신호)', () => {
+    expect(computeObjectiveOverlap('결제 인증 구현', '오타 문서 정리')).toBe(0)
+  })
+
+  it('결정적 — 같은 입력 같은 출력', () => {
+    const a = computeObjectiveOverlap('로그인 인증 흐름', '인증 흐름 개선')
+    const b = computeObjectiveOverlap('로그인 인증 흐름', '인증 흐름 개선')
+    expect(a).toBe(b)
+  })
+
+  it('중복 토큰은 distinct 로만(한 번) 카운트', () => {
+    expect(computeObjectiveOverlap('결제 결제 결제', '결제 처리')).toBe(1)
+  })
+
+  it('objective 토큰 없음(빈 문자열) → 0', () => {
+    expect(computeObjectiveOverlap('', '아무 작업이나')).toBe(0)
+  })
+})
+
+describe('isRealObjective (암묵 opt-in 게이트)', () => {
+  it('placeholder(스캐폴드) → false', () => {
+    expect(isRealObjective(MISSION_SCAFFOLD_OBJECTIVE)).toBe(false)
+  })
+
+  it('빈/공백 → false', () => {
+    expect(isRealObjective('')).toBe(false)
+    expect(isRealObjective('   ')).toBe(false)
+  })
+
+  it('실제 목표 → true (계산 대상)', () => {
+    expect(isRealObjective('결제 모듈 구현')).toBe(true)
+  })
+})

--- a/tests/receipt.test.ts
+++ b/tests/receipt.test.ts
@@ -254,6 +254,25 @@ describe('decideReceipt — ⑤ intent(의도 대조) 반영', () => {
     expect(decideReceipt(e)).toBe('pass')
   })
 
+  it('ⓑ(N4) objective 토큰 교집합 0 → caution (advisory, block 아님)', () => {
+    const e = cleanEvidence()
+    e.intent = { missionKnown: true, forbiddenHits: 0, scopeWarnings: 0, objectiveTokenOverlap: 0 }
+    expect(decideReceipt(e)).toBe('caution')
+    expect(decideReceipt(e)).not.toBe('block')
+  })
+
+  it('ⓑ(N4) objective 교집합 >0 → 영향 없음(clean→pass)', () => {
+    const e = cleanEvidence()
+    e.intent = { missionKnown: true, forbiddenHits: 0, scopeWarnings: 0, objectiveTokenOverlap: 2 }
+    expect(decideReceipt(e)).toBe('pass')
+  })
+
+  it('ⓑ(N4) objectiveTokenOverlap undefined(미계산) → 영향 0(하위호환·pass)', () => {
+    const e = cleanEvidence()
+    e.intent = { missionKnown: true, forbiddenHits: 0, scopeWarnings: 0 }
+    expect(decideReceipt(e)).toBe('pass')
+  })
+
   it('과확장 0 — missionKnown 이어도 위반·경고 0 이면 caution 유발 안 함(clean→pass)', () => {
     const e = cleanEvidence()
     e.intent = { missionKnown: true, forbiddenHits: 0, scopeWarnings: 0 }


### PR DESCRIPTION
## 무엇
mission.objective ↔ (active goal.title + 최근 commit) **결정론 토큰 교집합**을 receipt advisory 로(ⓑ). '목표와 실제 작업 어휘가 안 겹침'을 약신호로 조기 포착. **LLM 0**(pattern.tokenize 순수 교집합).

## 안전 (GA-동결 receipt 결정로직 — 옵셔널 추가만)
- `objectiveTokenOverlap?: number` 옵셔널 필드. `overlap === 0` → **caution 분기만**(block 절대 금지). `=== 0` 이라 undefined(미계산) 무영향 = **하위호환·단조성 불변식 ③ 보존**.
- **opt-in**: 실제 objective 를 mission set 으로 채운 경우만 계산(placeholder/빈값 → undefined). 노이즈 caution 최소화.
- collectObjectiveRef = 읽기 전용(goal frontmatter + git log, 실패 무해).

## 검증
- TDD: objective-overlap.test.ts(순수 8) + receipt.test.ts decideReceipt 3케이스(0→caution·>0→pass·undefined→pass, **block 절대 안 함**).
- 전체 2133 green · typecheck 무에러.

🤖 Generated with [Claude Code](https://claude.com/claude-code)