### PR TITLE
feat: vhk evolve digest — 후보 묶음 초안 (N5, ⓓ)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -117,6 +117,7 @@ Cursor에게 한국어로 말해도 됩니다.
 | 룰 후보 제안 | `vhk evolve suggest` | "규칙 제안해" |
 | 부정 예시 후보 수집 | `vhk evolve negatives` | "실패에서 하지 말 것 뽑아줘" |
 | 후보 목록 / 반영 / 기각 / 되돌리기 | `vhk evolve list` · `vhk evolve apply <id>` · `vhk evolve reject <id>` · `vhk evolve undo` | "규칙 반영해" |
+| 후보 묶음 초안(신뢰도별·읽기전용) | `vhk evolve digest` | "후보 묶어서 초안 보여줘" |
 
 ## SEO·수익 대시보드 (seo — Goals 21~26)
 

--- a/docs/log/2026-07-01-n5-evolve-digest.md
+++ b/docs/log/2026-07-01-n5-evolve-digest.md
@@ -13,5 +13,13 @@
 - **스모크가 CONTAINER 드리프트 포획**: `vhk evolve digest` 실행 시 "서브커맨드 아님"(command-registry allowlist 누락) → 추가 후 실동작. (N1 KNOWN 교훈과 동형 — 통합 스모크 필수.)
 - 전체 2138 green · typecheck 무에러.
 
+## 적대리뷰 반영 (Workflow 3다이멘션: 6발견 → 4반증·1확정·1유보. 철칙 위반 0)
+- **[확정 med→low] digest 한글 별칭 누락**: 형제 6개(제안/부정예시/목록/반영/기각/되돌리기)는 `.alias()` 있는데 digest만 없음 → CLAUDE.md "한글 별칭 필수" 위반 + 드리프트 가드 미포착. → **`.alias('묶음')` 추가**(형제 대칭).
+- **[유보 low] tie-break 사전순**: 동률 시 `localeCompare`가 e10을 e2보다 앞에 → `{numeric:true}`로 숫자순 수정 + 회귀가드 테스트.
+- **철칙 검증 통과**: 자동 apply 0·RULES 미변경·읽기전용(loadForMutation 비영속) 전부 확인.
+
+### 🔧 선재 버그 발견 (N5 무관·별도 후속)
+- **evolve 한글 서브별칭 전부 CLI 차단**: CONTAINER 가드(`cli-args.ts:259`)가 command-registry 영문 allowlist만 검사 → `vhk evolve 제안`·`묶음` 등 **모든** 한글 서브별칭이 "서브커맨드 아님"으로 거부(스모크 확인). 형제도 동일하게 죽어있는 선재 결함. digest 추가와 무관하나 발견 기록 — 후속 수정 시 전 컨테이너(goal·evolve·seo) allowlist에 한글 별칭 합류 필요(광범위 영향이라 별도 PR).
+
 ## 다음
-- **복리 척추 5개(N2·N7·N6·N1·N4) 완성 + N5(ⓓ) 마감.** 후속 후보: N11 evolve-nudge hook·measure-first(Recall@5)·v2.8.0 발행.
+- **복리 척추 5개(N2·N7·N6·N1·N4) 완성 + N5(ⓓ) 마감.** 후속 후보: ⚠️evolve 한글 서브별칭 가드 수정(선재)·N11 evolve-nudge hook·measure-first(Recall@5)·v2.8.0 발행.

--- a/docs/log/2026-07-01-n5-evolve-digest.md
+++ b/docs/log/2026-07-01-n5-evolve-digest.md
@@ -1,0 +1,17 @@
+# 2026-07-01 — N5 vhk evolve digest (ⓓ)
+
+## 무엇·왜
+- ⓓ: evolve apply 수동 → **자동 apply 배제(철칙)**. 대신 pending 룰 후보를 **신뢰도별 묶음 초안**으로 출력해 사람 PR 검토 비용↓. RULES.md 미변경.
+
+## 구현
+- `evolve.ts`: `buildDigest(pending, patterns)` 순수 — patternId→pattern.count 조인으로 **신뢰도(5+=high·3~4=med·<3=low)** 부여, 빈도 내림차순(동률 id 오름차순). `evolveDigest` 핸들러 = readQueue + loadForMutation(비영속·읽기전용, loop 계약 동일) → 신뢰도 그룹 렌더.
+- **철칙**: 자동 apply 0, RULES 미변경 — digest 는 PR 초안 복사용. 반영은 `evolve apply` 사람 승인.
+- 등록: index evolve **서브명령** `digest` + command-registry **CONTAINER allowlist**(digest) + ko evolve.digest* + COMMANDS.
+
+## 검증
+- TDD: evolve-digest.test.ts 5(신뢰도 매핑·경계 5/4/2·패턴미상 0·정렬·빈입력).
+- **스모크가 CONTAINER 드리프트 포획**: `vhk evolve digest` 실행 시 "서브커맨드 아님"(command-registry allowlist 누락) → 추가 후 실동작. (N1 KNOWN 교훈과 동형 — 통합 스모크 필수.)
+- 전체 2138 green · typecheck 무에러.
+
+## 다음
+- **복리 척추 5개(N2·N7·N6·N1·N4) 완성 + N5(ⓓ) 마감.** 후속 후보: N11 evolve-nudge hook·measure-first(Recall@5)·v2.8.0 발행.

--- a/docs/log/2026-07-01-n5-evolve-digest.md
+++ b/docs/log/2026-07-01-n5-evolve-digest.md
@@ -21,5 +21,8 @@
 ### 🔧 선재 버그 발견 (N5 무관·별도 후속)
 - **evolve 한글 서브별칭 전부 CLI 차단**: CONTAINER 가드(`cli-args.ts:259`)가 command-registry 영문 allowlist만 검사 → `vhk evolve 제안`·`묶음` 등 **모든** 한글 서브별칭이 "서브커맨드 아님"으로 거부(스모크 확인). 형제도 동일하게 죽어있는 선재 결함. digest 추가와 무관하나 발견 기록 — 후속 수정 시 전 컨테이너(goal·evolve·seo) allowlist에 한글 별칭 합류 필요(광범위 영향이라 별도 PR).
 
+### 🔧 CI 회귀 포획 (로컬 게이트에 lint 누락)
+- 리뷰수정 push 후 **CI gate+test 전 매트릭스 fail** — 로컬은 typecheck+test만 돌려 green이었으나 CI gate=lint 포함. `buildDigest` confidence 삼항에 불필요 타입단언(`as DigestEntry['confidence']`) → eslint no-unnecessary-type-assertion. 단순 제거하면 tsc가 삼항을 `string`으로 넓혀 실패(eslint↔tsc 충돌) → **map 콜백 반환타입 `(it): DigestEntry` 명시**로 문맥타입 부여(단언 불필요·narrow 유지). 교훈: 로컬 게이트에 `pnpm lint` 필수(typecheck≠lint).
+
 ## 다음
 - **복리 척추 5개(N2·N7·N6·N1·N4) 완성 + N5(ⓓ) 마감.** 후속 후보: ⚠️evolve 한글 서브별칭 가드 수정(선재)·N11 evolve-nudge hook·measure-first(Recall@5)·v2.8.0 발행.

--- a/src/commands/evolve.ts
+++ b/src/commands/evolve.ts
@@ -424,14 +424,14 @@ export interface DigestEntry {
 export function buildDigest(pending: EvolveQueueItem[], patterns: PatternEntryV19[]): DigestEntry[] {
   const byId = new Map(patterns.map((p) => [p.id, p]))
   return pending
-    .map((it) => {
+    .map((it): DigestEntry => {
       const count = byId.get(it.patternId)?.count ?? 0
       return {
         id: it.id,
         targetLayer: it.targetLayer ?? 'rule',
         draft: it.draft,
         patternCount: count,
-        confidence: (count >= 5 ? 'high' : count >= 3 ? 'med' : 'low') as DigestEntry['confidence'],
+        confidence: count >= 5 ? 'high' : count >= 3 ? 'med' : 'low',
       }
     })
     .sort((a, b) => b.patternCount - a.patternCount || a.id.localeCompare(b.id, undefined, { numeric: true }))

--- a/src/commands/evolve.ts
+++ b/src/commands/evolve.ts
@@ -408,6 +408,76 @@ export async function evolveSuggest(opts: { json?: boolean } = {}): Promise<void
   })
 }
 
+// ── N5(ⓓ): evolve digest — 후보 묶음 PR 초안(읽기 전용·자동 apply 배제) ─────────────
+
+export interface DigestEntry {
+  id: string
+  targetLayer: TargetLayer
+  draft: string
+  /** 근거 패턴 빈도(pattern.count). 패턴 미상 → 0. */
+  patternCount: number
+  /** 빈도 기반 결정적 신뢰도(5+=high · 3~4=med · <3=low). */
+  confidence: 'high' | 'med' | 'low'
+}
+
+/** pending 후보 + 패턴 → 신뢰도 부여 digest(순수·결정적). 빈도 내림차순, 동률은 id 오름차순. */
+export function buildDigest(pending: EvolveQueueItem[], patterns: PatternEntryV19[]): DigestEntry[] {
+  const byId = new Map(patterns.map((p) => [p.id, p]))
+  return pending
+    .map((it) => {
+      const count = byId.get(it.patternId)?.count ?? 0
+      return {
+        id: it.id,
+        targetLayer: it.targetLayer ?? 'rule',
+        draft: it.draft,
+        patternCount: count,
+        confidence: (count >= 5 ? 'high' : count >= 3 ? 'med' : 'low') as DigestEntry['confidence'],
+      }
+    })
+    .sort((a, b) => b.patternCount - a.patternCount || a.id.localeCompare(b.id))
+}
+
+/**
+ * N5(ⓓ): vhk evolve digest — pending 룰 후보를 신뢰도별 묶음 초안으로 출력(읽기 전용).
+ * RULES.md 미변경·자동 apply 0(철칙 — 반영은 evolve apply 사람 승인). digest = PR 초안 복사용.
+ */
+export async function evolveDigest(): Promise<void> {
+  const cwd = process.cwd()
+  const queue = readQueue(cwd)
+  const pending = queue.items.filter((i) => i.status === 'pending')
+  // 읽기 전용: loadForMutation 은 비영속(persistOnRead write 회피 — loop 과 동일 계약).
+  const loaded = loadForMutation(cwd)
+  const patterns = (loaded.ok ? loaded.mem.patterns : []) as PatternEntryV19[]
+  const digest = buildDigest(pending, patterns)
+
+  console.log(chalk.bold('\n📋 ' + t('evolve.digestTitle')))
+  console.log(chalk.gray('─'.repeat(40)))
+
+  if (digest.length === 0) {
+    console.log(chalk.dim('  ' + t('evolve.digestEmpty')))
+    printNextStep({ message: t('evolve.digestEmpty'), command: 'vhk evolve suggest', cursorHint: '진화 후보 생성해줘' })
+    return
+  }
+
+  const label: Record<DigestEntry['confidence'], string> = { high: '🟢 high', med: '🟡 med', low: '🔵 low' }
+  for (const conf of ['high', 'med', 'low'] as const) {
+    const group = digest.filter((d) => d.confidence === conf)
+    if (group.length === 0) continue
+    console.log(chalk.cyan(`\n${label[conf]} (${group.length})`))
+    for (const d of group) {
+      console.log(`  [${d.id}] ${d.targetLayer} ← 근거 ${d.patternCount}건`)
+      console.log(chalk.dim(`      ${d.draft}`))
+    }
+  }
+
+  printNextStep({
+    message: t('evolve.digestNext', digest.length),
+    command: 'vhk evolve apply <id>',
+    cursorHint: '이 후보 반영해줘',
+    alternative: '초안을 RULES.md PR 로 사람이 검토·반영 (자동 반영 없음)',
+  })
+}
+
 export async function evolveList(opts: { status?: string; json?: boolean } = {}): Promise<void> {
   const cwd = process.cwd()
   const queue = readQueue(cwd)

--- a/src/commands/evolve.ts
+++ b/src/commands/evolve.ts
@@ -420,7 +420,7 @@ export interface DigestEntry {
   confidence: 'high' | 'med' | 'low'
 }
 
-/** pending 후보 + 패턴 → 신뢰도 부여 digest(순수·결정적). 빈도 내림차순, 동률은 id 오름차순. */
+/** pending 후보 + 패턴 → 신뢰도 부여 digest(순수·결정적). 빈도 내림차순, 동률은 id 숫자 오름차순(e2<e10). */
 export function buildDigest(pending: EvolveQueueItem[], patterns: PatternEntryV19[]): DigestEntry[] {
   const byId = new Map(patterns.map((p) => [p.id, p]))
   return pending
@@ -434,7 +434,7 @@ export function buildDigest(pending: EvolveQueueItem[], patterns: PatternEntryV1
         confidence: (count >= 5 ? 'high' : count >= 3 ? 'med' : 'low') as DigestEntry['confidence'],
       }
     })
-    .sort((a, b) => b.patternCount - a.patternCount || a.id.localeCompare(b.id))
+    .sort((a, b) => b.patternCount - a.patternCount || a.id.localeCompare(b.id, undefined, { numeric: true }))
 }
 
 /**

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -607,6 +607,9 @@ export const ko = {
     allSuggested: '모든 패턴이 이미 제안됐거나 reject됐습니다.',
     newCandidates: (n: number) => `신규 후보: ${n}개 추가됨`,
     suggestHint: 'vhk evolve suggest 로 생성하세요.',
+    digestTitle: 'evolve digest — 룰 후보 묶음 초안 (읽기 전용·자동 반영 0)',
+    digestEmpty: 'pending 후보가 없습니다. vhk evolve suggest 로 먼저 생성하세요.',
+    digestNext: (n: number) => `후보 ${n}개 — 신뢰도 높은 것부터 사람이 검토·반영(자동 반영 없음).`,
   },
   seo: {
     init: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,7 +128,7 @@ import { cloudPush, cloudPull } from './commands/cloud.js'
 import { goalCheck, goalDone, goalDrift, goalInit, goalList, goalNext, goalPeek, goalSync } from './commands/goal.js'
 import { blocker, learn, resume, win } from './commands/agent.js'
 import { patternDetect, patternList, patternDismiss } from './commands/pattern.js'
-import { evolveSuggest, evolveList, evolveApply, evolveReject, evolveUndo, evolveNegatives } from './commands/evolve.js'
+import { evolveSuggest, evolveList, evolveApply, evolveReject, evolveUndo, evolveNegatives, evolveDigest } from './commands/evolve.js'
 import { runSeo, seoInit, seoSubmit, seoCheck, seoReport, seoAutomate } from './commands/seo/index.js'
 
 const program = new Command()
@@ -947,6 +947,11 @@ evolveCmd
   .option('--json', 'JSON 출력 (CI/MCP용)')
   .description('진화 후보 목록')
   .action(async (opts: { status?: string; json?: boolean }) => { await evolveList(opts) })
+
+evolveCmd
+  .command('digest')
+  .description('진화 후보 묶음 초안 — 신뢰도별 정렬 (읽기 전용·자동 반영 0, PR 초안용)')
+  .action(async () => { await evolveDigest() })
 
 evolveCmd
   .command('apply <id>')

--- a/src/index.ts
+++ b/src/index.ts
@@ -950,6 +950,7 @@ evolveCmd
 
 evolveCmd
   .command('digest')
+  .alias('묶음')
   .description('진화 후보 묶음 초안 — 신뢰도별 정렬 (읽기 전용·자동 반영 0, PR 초안용)')
   .action(async () => { await evolveDigest() })
 

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -20,7 +20,7 @@ export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
   mode: ['lite', 'standard', 'strict'],
   mission: ['set', 'show', 'check', 'clear'],
   pattern: ['detect', 'list', 'dismiss'],
-  evolve: ['suggest', 'negatives', 'list', 'apply', 'reject', 'undo'],
+  evolve: ['suggest', 'negatives', 'list', 'digest', 'apply', 'reject', 'undo'],
   work: ['handoff'],
   worktree: ['add', 'check'],
   seo: ['init', 'submit', 'check', 'report', 'automate'],

--- a/tests/evolve-digest.test.ts
+++ b/tests/evolve-digest.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { buildDigest, type EvolveQueueItem } from '../src/commands/evolve.js'
+import type { PatternEntryV19 } from '../src/commands/pattern.js'
+
+// N5(ⓓ): buildDigest 순수함수 — pending 후보 + 패턴 → 신뢰도 부여·정렬.
+
+function item(id: string, patternId: string): EvolveQueueItem {
+  return {
+    id,
+    patternId,
+    kind: 'rule',
+    targetLayer: 'rule',
+    status: 'pending',
+    draft: `- 초안 ${id}`,
+    dedupeKey: `${patternId}:rule`,
+    createdAt: '2026-01-01T00:00:00Z',
+  }
+}
+
+function pat(id: string, count: number): PatternEntryV19 {
+  return {
+    id,
+    kind: 'avoid',
+    axis: 'tag',
+    signal: 'x',
+    count,
+    sources: [],
+    summary: 's',
+    createdAt: '2026-01-01T00:00:00Z',
+    status: 'active',
+    tags: [],
+  } as PatternEntryV19
+}
+
+describe('buildDigest (결정론)', () => {
+  it('빈도 → 신뢰도 매핑 (5+=high · 3~4=med · <3=low)', () => {
+    const d = buildDigest(
+      [item('e1', 'p1'), item('e2', 'p2'), item('e3', 'p3')],
+      [pat('p1', 6), pat('p2', 3), pat('p3', 1)],
+    )
+    const byId = Object.fromEntries(d.map((x) => [x.id, x]))
+    expect(byId.e1.confidence).toBe('high')
+    expect(byId.e2.confidence).toBe('med')
+    expect(byId.e3.confidence).toBe('low')
+  })
+
+  it('패턴 미상 → patternCount 0, low', () => {
+    const d = buildDigest([item('e1', 'ghost')], [])
+    expect(d[0].patternCount).toBe(0)
+    expect(d[0].confidence).toBe('low')
+  })
+
+  it('빈도 내림차순 정렬 (동률은 id 오름차순)', () => {
+    const d = buildDigest(
+      [item('e2', 'p2'), item('e1', 'p1'), item('e3', 'p3')],
+      [pat('p1', 5), pat('p2', 5), pat('p3', 9)],
+    )
+    // p3(9) 먼저, 그다음 5동률은 id 오름차순 e1·e2
+    expect(d.map((x) => x.id)).toEqual(['e3', 'e1', 'e2'])
+  })
+
+  it('경계 — count 5 high · 4 med · 2 low', () => {
+    const d = buildDigest(
+      [item('e5', 'p5'), item('e4', 'p4'), item('e2', 'p2')],
+      [pat('p5', 5), pat('p4', 4), pat('p2', 2)],
+    )
+    const byId = Object.fromEntries(d.map((x) => [x.id, x]))
+    expect(byId.e5.confidence).toBe('high')
+    expect(byId.e4.confidence).toBe('med')
+    expect(byId.e2.confidence).toBe('low')
+  })
+
+  it('빈 입력 → 빈 digest', () => {
+    expect(buildDigest([], [])).toEqual([])
+  })
+})

--- a/tests/evolve-digest.test.ts
+++ b/tests/evolve-digest.test.ts
@@ -70,6 +70,14 @@ describe('buildDigest (결정론)', () => {
     expect(byId.e2.confidence).toBe('low')
   })
 
+  it('동률 tie-break 는 id 숫자순 (e2 가 e10 보다 앞 — 적대리뷰 반영)', () => {
+    const d = buildDigest(
+      [item('e10', 'p10'), item('e2', 'p2')],
+      [pat('p10', 3), pat('p2', 3)],
+    )
+    expect(d.map((x) => x.id)).toEqual(['e2', 'e10'])
+  })
+
   it('빈 입력 → 빈 digest', () => {
     expect(buildDigest([], [])).toEqual([])
   })


### PR DESCRIPTION
## 무엇
`vhk evolve digest` — pending 룰 후보를 **신뢰도별(빈도 기반) 묶음 초안**으로 출력. evolve apply 수동성의 관리비용↓(사람 PR 검토용). **읽기 전용 · 자동 apply 배제(철칙) · RULES 미변경.**

## 구현
- `buildDigest(pending, patterns)` 순수 — patternId→count 조인으로 신뢰도(5+=high·3~4=med·<3=low), 빈도 내림차순.
- `evolveDigest` = readQueue + loadForMutation(비영속·읽기전용) → 그룹 렌더. digest = PR 초안 복사용.
- 등록: evolve 서브명령 + command-registry CONTAINER allowlist + ko + COMMANDS.

## 검증
- TDD: evolve-digest.test.ts 5(신뢰도 매핑·경계·정렬·패턴미상·빈입력).
- **스모크가 CONTAINER 드리프트 포획**(서브커맨드 allowlist 누락) → 추가 후 실동작.
- 전체 2138 green · typecheck 무에러.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `vhk evolve digest` 명령이 추가되어, 후보 묶음을 신뢰도별로 읽기 전용으로 확인할 수 있습니다.
  * 후보가 있으면 다음 실행 안내와 함께 정리된 목록을 보여주고, 없으면 다음 단계 안내를 표시합니다.
  * `vhk evolve`에 `digest`(묶음) 하위 명령이 추가되었습니다.

* **Documentation**
  * 진화 관련 명령 안내에 `digest` 사용법과 출력 의미가 추가되었습니다.

* **Tests**
  * 후보 묶음 생성 결과의 정렬, 신뢰도 분류, 빈 입력 처리에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->