### PR TITLE
feat: vhk watch — 무인 세션 정지 감시 (트랙 A 수준2)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -204,6 +204,7 @@ vhk doctor
 | `vhk blocker` | 블로커 기록 (3건 누적 시 HARD_STOP) |
 | `vhk learn` | 교훈 기록 → memory v2 단일 SoT |
 | `vhk win` | 성공 기록 → memory successes (reinforce evolve 입력) |
+| `vhk watch` | 무인 세션 정지 감시 — 세션 로그 idle 초과 시 텔레그램·콘솔 알림 (`--idle-min` `--interval` `--window` `--once`) |
 | `vhk resume` | .vhk/HARD_STOP 해제 (`--confirm` 필요) |
 | `vhk pattern` | 반복 패턴 감지·목록 (`pattern detect` · `pattern list` · `pattern dismiss`) |
 | `vhk evolve` | 패턴 → 룰 후보 제안·반영·undo |

--- a/docs/troubleshooting/TS-005-rmsync-file-exit127.md
+++ b/docs/troubleshooting/TS-005-rmsync-file-exit127.md
@@ -1,9 +1,11 @@
 # TS-005 — rmSync(파일)이 silent exit 127 (이 Node 환경)
 
-> 출처: #353 resume exit 127 런타임 디버깅(2026-06-23).
+> 출처: #353 resume exit 127 런타임 디버깅(2026-06-23). 확장: 노트북 재현(2026-07-02).
 
 ## 증상
 `rmSync(파일경로, …)` 가 이 환경(Windows/Node)에서 **에러도 stderr 도 없이 exit 127** 로 프로세스를 즉시 죽인다. `unlinkSync` 는 정상 동작.
+
+**확장(2026-07-02, 노트북 · Node v24.13.0)**: 파일뿐 아니라 **디렉토리 `rmSync(dir,{recursive,force})` 도 동일 재현** — `node -e` 한 줄로 결정적, Claude Code 샌드박스 해제 여부 무관. 이 때문에 tmp+rmSync cleanup 패턴을 쓰는 **vitest 테스트의 워커가 즉사**("Worker exited unexpectedly", 이 머신에서 기존 스위트 실행 불가 — CI 로 검증). 우회 = unlink+rmdir 재귀(`tests/watch.test.ts` `rmTree()` 참조).
 
 ## 발견 경로
 `vhk resume --confirm` 이 `▶️ HARD_STOP 해제` 출력 후 exit 127, HARD_STOP 미해제(#353). 정적 분석 실패 → tsx 격리 디버깅:
@@ -17,8 +19,8 @@
 ## 조치
 - ✅ **clearHardStop**(state-files.ts:115): `rmSync` → `unlinkSync` (#353 — resume 해제 복구).
 - ⚠️ **파일 rmSync 잔여(후속 점검)**: `atomic-write.ts:24` `rmSync(tmp,{force})`(atomicWriteFile 실패 cleanup — 평소 미실행이나 탈 시 exit 127 위험) · `mission.ts:234` `rmSync(p)`(mission clear). 둘 다 `unlinkSync` 권장.
-- ❓ **디렉토리 rmSync**(backup.ts:148·migrate.ts:87, `{recursive,force}`): rmdir 계열이라 별개일 수 있음 — 미검증, 후속 확인.
+- ⚠️ **디렉토리 rmSync**(backup.ts:148·migrate.ts:87, `{recursive,force}`): 2026-07-02 노트북에서 **재현 확인** — 별개 아님. 해당 경로 밟는 머신에선 exit 127 위험 → unlink+rmdir 재귀 교체 후속 권장.
 
 ## 패턴 (회귀 방지)
-- **파일 삭제 = `unlinkSync`**(존재 불확실하면 `existsSync` 가드). 디렉토리 = `rmSync(dir,{recursive})` (검증 후).
-- 신규 `rmSync(<파일>)` 금지.
+- **파일 삭제 = `unlinkSync`**(존재 불확실하면 `existsSync` 가드). **디렉토리 = unlink+rmdir 재귀**(2026-07-02 확장 재현으로 rmSync 디렉토리도 금지 대상 — `tests/watch.test.ts` `rmTree()` 패턴).
+- 신규 `rmSync` 금지(파일·디렉토리 모두).

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,0 +1,265 @@
+/**
+ * vhk watch — 무인 세션 정지 감시 (수준 2: 감지 + 알림).
+ *
+ * 배경(2026-07-01 밤샘루프 사건): 무인 자율 루프가 새벽에 조용히 탈선/정지해도
+ * 아침까지 아무도 모름(8.5h 무감지). 감시자는 에이전트가 아닌 경량 폴러여야 한다 —
+ * Claude Code 세션 로그(~/.claude/projects/<proj>/<session>.jsonl)의 mtime 을 폴링해
+ * idle 초과 시 텔레그램+콘솔로 1회 알리고, 활동 재개 시 recovered 후 재무장한다.
+ * "완료"와 "멈춤"은 로그만으론 구분 불가 — 둘 다 사람이 확인할 신호이므로 함께 알린다.
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import chalk from 'chalk'
+import { ko } from '../i18n/ko.js'
+
+export interface SessionInfo {
+  file: string
+  project: string
+  sessionId: string
+  mtimeMs: number
+}
+
+export interface TrackedSession {
+  lastMtimeMs: number
+  alerted: boolean
+}
+
+/** file 경로 → 추적 상태 */
+export type WatchState = Map<string, TrackedSession>
+
+export interface WatchEvent {
+  kind: 'stalled' | 'recovered'
+  session: SessionInfo
+  idleMs: number
+}
+
+const MIN_MS = 60_000
+const DEFAULT_IDLE_MIN = 15
+const DEFAULT_INTERVAL_SEC = 60
+const DEFAULT_ACTIVE_WINDOW_MIN = 30
+
+export function defaultProjectsDir(): string {
+  return path.join(os.homedir(), '.claude', 'projects')
+}
+
+/**
+ * 메인 세션 jsonl 만 스캔 — projects/<proj>/<session>.jsonl (깊이 고정 2).
+ * 하위폴더(subagents/·workflows/ 등)의 에이전트 로그는 메인 세션이 아니므로 제외.
+ */
+export function scanSessions(projectsDir: string): SessionInfo[] {
+  let projDirs: fs.Dirent[]
+  try {
+    projDirs = fs.readdirSync(projectsDir, { withFileTypes: true }).filter((d) => d.isDirectory())
+  } catch {
+    return []
+  }
+  const sessions: SessionInfo[] = []
+  for (const proj of projDirs) {
+    const dir = path.join(projectsDir, proj.name)
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const e of entries) {
+      if (!e.isFile() || !e.name.endsWith('.jsonl')) continue
+      const file = path.join(dir, e.name)
+      let mtimeMs: number
+      try {
+        mtimeMs = fs.statSync(file).mtimeMs
+      } catch {
+        continue
+      }
+      sessions.push({ file, project: proj.name, sessionId: e.name.replace(/\.jsonl$/, ''), mtimeMs })
+    }
+  }
+  return sessions
+}
+
+/**
+ * 결정적 분류 — 스캔 결과 × 추적 상태(제자리 갱신) → 이벤트.
+ * - 미추적 + 활성 윈도우 내 → 등록만(이벤트 없음). 윈도우 밖 옛 세션은 소음이라 무시.
+ * - 추적 중 + mtime 전진 → 갱신, alerted 였으면 recovered + 재무장.
+ * - 추적 중 + idle 초과 + 미알림 → stalled 1회 (재알림 금지).
+ */
+export function classify(
+  sessions: SessionInfo[],
+  state: WatchState,
+  nowMs: number,
+  idleMs: number,
+  activeWindowMs: number,
+): WatchEvent[] {
+  const events: WatchEvent[] = []
+  for (const s of sessions) {
+    const tracked = state.get(s.file)
+    if (!tracked) {
+      if (nowMs - s.mtimeMs <= activeWindowMs) {
+        state.set(s.file, { lastMtimeMs: s.mtimeMs, alerted: false })
+      }
+      continue
+    }
+    if (s.mtimeMs > tracked.lastMtimeMs) {
+      const wasAlerted = tracked.alerted
+      tracked.lastMtimeMs = s.mtimeMs
+      tracked.alerted = false
+      if (wasAlerted) events.push({ kind: 'recovered', session: s, idleMs: 0 })
+      continue
+    }
+    const idle = nowMs - tracked.lastMtimeMs
+    if (idle >= idleMs && !tracked.alerted) {
+      tracked.alerted = true
+      events.push({ kind: 'stalled', session: s, idleMs: idle })
+    }
+  }
+  return events
+}
+
+export interface Notifier {
+  name: string
+  send(text: string): Promise<boolean>
+}
+
+/**
+ * 텔레그램 알리미 — env VHK_TG_TOKEN + VHK_TG_CHAT_ID 필요(미설정 시 null = 콘솔 전용).
+ * 발송 실패는 throw 하지 않고 false — 알림 채널이 죽어도 감시 루프는 살아야 한다.
+ */
+export function createTelegramNotifier(fetchFn: typeof fetch = fetch): Notifier | null {
+  const token = process.env.VHK_TG_TOKEN
+  const chatId = process.env.VHK_TG_CHAT_ID
+  if (!token || !chatId) return null
+  return {
+    name: 'telegram',
+    async send(text: string): Promise<boolean> {
+      try {
+        const res = await fetchFn(`https://api.telegram.org/bot${token}/sendMessage`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ chat_id: chatId, text }),
+        })
+        return res.ok
+      } catch {
+        return false
+      }
+    },
+  }
+}
+
+function fmtIdleMin(idleMs: number): number {
+  return Math.round(idleMs / MIN_MS)
+}
+
+function eventText(ev: WatchEvent): string {
+  const id8 = ev.session.sessionId.slice(0, 8)
+  if (ev.kind === 'stalled') {
+    return [
+      '⚠️ [vhk watch] 세션 정지 감지',
+      `프로젝트: ${ev.session.project}`,
+      `세션: ${id8}`,
+      `마지막 활동: ${fmtIdleMin(ev.idleMs)}분 전 (완료 또는 멈춤 — 확인 필요)`,
+      `호스트: ${os.hostname()}`,
+    ].join('\n')
+  }
+  return [
+    '✅ [vhk watch] 세션 활동 재개',
+    `프로젝트: ${ev.session.project}`,
+    `세션: ${id8}`,
+    `호스트: ${os.hostname()}`,
+  ].join('\n')
+}
+
+/** fail-fast 숫자 파서 — 밤샘루프 사건 교훈: 잘못된 입력으로 조용히 기본값 폴백 금지. */
+function parsePositive(name: string, raw: string | undefined, fallback: number): number {
+  if (raw === undefined) return fallback
+  const n = Number(raw)
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`--${name} 값이 잘못됨: "${raw}" (양수 필요)`)
+  }
+  return n
+}
+
+export interface WatchOptions {
+  idleMin?: string
+  interval?: string
+  window?: string
+  once?: boolean
+  projectsDir?: string
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms))
+}
+
+export async function watch(opts: WatchOptions = {}): Promise<void> {
+  console.log(chalk.bold(`\n${ko.watch.title}\n`))
+
+  let idleMin: number
+  let intervalSec: number
+  let windowMin: number
+  try {
+    idleMin = parsePositive('idle-min', opts.idleMin, DEFAULT_IDLE_MIN)
+    intervalSec = parsePositive('interval', opts.interval, DEFAULT_INTERVAL_SEC)
+    windowMin = parsePositive('window', opts.window, DEFAULT_ACTIVE_WINDOW_MIN)
+  } catch (e) {
+    console.log(chalk.red(`  ❌ ${e instanceof Error ? e.message : String(e)}`))
+    process.exitCode = 1
+    return
+  }
+  const idleMs = idleMin * MIN_MS
+  const windowMs = windowMin * MIN_MS
+  const projectsDir = opts.projectsDir ?? defaultProjectsDir()
+
+  const notifier = createTelegramNotifier()
+  if (notifier) {
+    console.log(chalk.dim(`  알림 채널: 텔레그램 (VHK_TG_TOKEN·VHK_TG_CHAT_ID 설정됨)`))
+  } else {
+    console.log(chalk.yellow('  ⚠️ 텔레그램 미설정 (VHK_TG_TOKEN·VHK_TG_CHAT_ID) — 콘솔 알림만 동작'))
+  }
+  console.log(chalk.dim(`  감시 대상: ${projectsDir}`))
+  console.log(chalk.dim(`  기준: idle ${idleMin}분 · 폴링 ${intervalSec}초 · 활성 윈도우 ${windowMin}분\n`))
+
+  const state: WatchState = new Map()
+
+  const tick = async (): Promise<void> => {
+    const now = Date.now()
+    const sessions = scanSessions(projectsDir)
+    const events = classify(sessions, state, now, idleMs, windowMs)
+    for (const ev of events) {
+      const text = eventText(ev)
+      if (ev.kind === 'stalled') console.log(chalk.red(`  ${text.replace(/\n/g, '\n  ')}`))
+      else console.log(chalk.green(`  ${text.replace(/\n/g, '\n  ')}`))
+      if (notifier) {
+        const ok = await notifier.send(text)
+        if (!ok) console.log(chalk.yellow('  ⚠️ 텔레그램 발송 실패 (감시는 계속)'))
+      }
+    }
+  }
+
+  if (opts.once) {
+    // 1회 점검 모드: 등록 즉시 판정까지 (이미 idle 인 활성 세션도 이번 호출에서 드러나야 함)
+    const now = Date.now()
+    const sessions = scanSessions(projectsDir)
+    classify(sessions, state, now, idleMs, windowMs)
+    const events = classify(sessions, state, now, idleMs, windowMs)
+    console.log(chalk.dim(`  활성 세션(윈도우 ${windowMin}분 내): ${state.size}개 / 전체 ${sessions.length}개`))
+    for (const [file, t] of state) {
+      const s = sessions.find((x) => x.file === file)
+      if (!s) continue
+      const idle = fmtIdleMin(now - t.lastMtimeMs)
+      const mark = t.alerted ? chalk.red(`정지 ${idle}분`) : chalk.green(`활동 ${idle}분 전`)
+      console.log(`  - ${s.project} / ${s.sessionId.slice(0, 8)} · ${mark}`)
+    }
+    for (const ev of events.filter((e) => e.kind === 'stalled')) {
+      if (notifier) await notifier.send(eventText(ev))
+    }
+    return
+  }
+
+  console.log(chalk.dim('  감시 시작 — 종료는 Ctrl+C\n'))
+  // 첫 tick 은 등록만 일어난다(이벤트는 다음 tick 부터). 상주 폴링 루프.
+  for (;;) {
+    await tick()
+    await sleep(intervalSec * 1000)
+  }
+}

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -570,6 +570,9 @@ export const ko = {
     driftFound: (n: number) =>
       `드리프트 의심 ${n}건 — check-goal 게이트에 goal 고유 검증이 있는데 status: NOT_STARTED:`,
   },
+  watch: {
+    title: '👁️  무인 세션 정지 감시',
+  },
   agent: {
     blockerTitle: '🛑 Blocker 기록',
     learnTitle: '🧠 Learning 기록',

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,7 @@ async function guardCliDefer(
 import { cloudPush, cloudPull } from './commands/cloud.js'
 import { goalCheck, goalDone, goalDrift, goalInit, goalList, goalNext, goalPeek, goalSync } from './commands/goal.js'
 import { blocker, learn, resume, win } from './commands/agent.js'
+import { watch } from './commands/watch.js'
 import { patternDetect, patternList, patternDismiss } from './commands/pattern.js'
 import { evolveSuggest, evolveList, evolveApply, evolveReject, evolveUndo, evolveNegatives, evolveDigest } from './commands/evolve.js'
 import { runSeo, seoInit, seoSubmit, seoCheck, seoReport, seoAutomate } from './commands/seo/index.js'
@@ -177,6 +178,7 @@ const KO_ALIASES: Record<string, string> = {
   blocker: '블로커',
   learn: '교훈',
   win: '성공',
+  watch: '감시',
   resume: '재개',
   pattern: '패턴',
   evolve: '진화',
@@ -884,6 +886,19 @@ program
   .alias('성공')
   .description('성공 기록 → memory successes (learn 의 성공 쌍둥이 — reinforce evolve 입력)')
   .action(async (content: string[]) => { await win(content.join(' ')) })
+
+program
+  // 트랙 A(신뢰): 2026-07-01 밤샘루프 무감지 사건 재발 방지 — 경량 폴러(에이전트 아님).
+  .command('watch')
+  .alias('감시')
+  .description('무인 세션 정지 감시 — 세션 로그 idle 초과 시 텔레그램·콘솔 알림 (수준 2)')
+  .option('--idle-min <min>', 'idle 판정 기준 분 (기본 15)')
+  .option('--interval <sec>', '폴링 주기 초 (기본 60)')
+  .option('--window <min>', '감시 편입 활성 윈도우 분 (기본 30)')
+  .option('--once', '1회 점검 후 종료 (상태 확인용)')
+  .action(async (opts: { idleMin?: string; interval?: string; window?: string; once?: boolean }) => {
+    await watch(opts)
+  })
 
 program
   .command('resume')

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -56,6 +56,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   'blocker', '블로커',
   'learn', '교훈',
   'win', '성공',
+  'watch', '감시',
   'resume', '재개',
   'mode', '모드',
   'verify', '사전점검',

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -114,6 +114,7 @@ export const TOP_LEVEL_COMMANDS: ReadonlyArray<{ name: string; desc: string }> =
   { name: 'blocker', desc: '블로커 기록 (3건 누적 시 HARD_STOP)' },
   { name: 'learn', desc: '교훈 기록 → memory v2 단일 SoT' },
   { name: 'win', desc: '성공 기록 → memory successes (reinforce 입력)' },
+  { name: 'watch', desc: '무인 세션 정지 감시 — idle 초과 시 텔레그램·콘솔 알림' },
   { name: 'resume', desc: '.vhk/HARD_STOP 해제 (--confirm 필요)' },
   { name: 'pattern', desc: '반복 패턴 감지·목록 (avoid/reinforce)' },
   { name: 'evolve', desc: '패턴 → 룰 후보 제안·반영·undo' },

--- a/tests/watch.test.ts
+++ b/tests/watch.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  scanSessions,
+  classify,
+  createTelegramNotifier,
+  type SessionInfo,
+  type WatchState,
+} from '../src/commands/watch.js'
+import { KNOWN_COMMAND_TOKENS } from '../src/lib/cli-args.js'
+
+// 트랙 A(신뢰) 첫 볼트: vhk watch — 무인 세션 정지 감시.
+// 2026-07-01 밤샘루프 사건(오실행·8.5h 무감지) 재발 방지. 세션 jsonl mtime 폴링 →
+// idle 초과 시 stalled 1회 알림, 회복 시 recovered + 재무장.
+
+const MIN = 60_000
+
+function tmpProjects(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-watch-'))
+}
+
+// TS-005: 이 환경(Windows/Node)서 rmSync 가 silent exit 127 로 워커를 죽임(파일·디렉토리 모두 재현, 2026-07-02).
+// unlinkSync/rmdirSync 는 정상 — cleanup 은 이 우회 헬퍼로만.
+function rmTree(dir: string): void {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name)
+    if (e.isDirectory()) rmTree(p)
+    else fs.unlinkSync(p)
+  }
+  fs.rmdirSync(dir)
+}
+
+function makeSession(root: string, proj: string, id: string, mtimeMs: number): string {
+  const dir = path.join(root, proj)
+  fs.mkdirSync(dir, { recursive: true })
+  const file = path.join(dir, `${id}.jsonl`)
+  fs.writeFileSync(file, '{"type":"user"}\n')
+  fs.utimesSync(file, new Date(mtimeMs), new Date(mtimeMs))
+  return file
+}
+
+function info(file: string, project: string, sessionId: string, mtimeMs: number): SessionInfo {
+  return { file, project, sessionId, mtimeMs }
+}
+
+describe('scanSessions', () => {
+  it('projects/<proj>/<id>.jsonl 만 잡고 하위폴더(서브에이전트·워크플로)는 제외', () => {
+    const root = tmpProjects()
+    const now = Date.now()
+    makeSession(root, 'proj-a', 'aaa', now - MIN)
+    makeSession(root, 'proj-b', 'bbb', now - 2 * MIN)
+    // 하위폴더 로그 — 메인 세션 아님, 제외돼야 함
+    const subDir = path.join(root, 'proj-a', 'subagents', 'workflows')
+    fs.mkdirSync(subDir, { recursive: true })
+    fs.writeFileSync(path.join(subDir, 'agent-x.jsonl'), '{}\n')
+    const sessions = scanSessions(root)
+    expect(sessions).toHaveLength(2)
+    const ids = sessions.map((s) => s.sessionId).sort()
+    expect(ids).toEqual(['aaa', 'bbb'])
+    const a = sessions.find((s) => s.sessionId === 'aaa')!
+    expect(a.project).toBe('proj-a')
+    rmTree(root)
+  })
+
+  it('projects 디렉토리가 없으면 빈 배열 (크래시 금지)', () => {
+    expect(scanSessions(path.join(os.tmpdir(), 'vhk-watch-none-존재안함'))).toEqual([])
+  })
+})
+
+describe('classify', () => {
+  const IDLE = 15 * MIN
+  const WINDOW = 30 * MIN
+
+  it('활성 윈도우 내 신규 세션 → 등록만, 이벤트 없음', () => {
+    const now = Date.now()
+    const state: WatchState = new Map()
+    const events = classify([info('/f/a.jsonl', 'p', 'a', now - MIN)], state, now, IDLE, WINDOW)
+    expect(events).toEqual([])
+    expect(state.size).toBe(1)
+  })
+
+  it('활성 윈도우 밖의 미추적 세션 → 등록하지 않음 (옛 세션 소음 차단)', () => {
+    const now = Date.now()
+    const state: WatchState = new Map()
+    classify([info('/f/old.jsonl', 'p', 'old', now - WINDOW - MIN)], state, now, IDLE, WINDOW)
+    expect(state.size).toBe(0)
+  })
+
+  it('추적 중 세션이 idle 초과 → stalled 1회, 같은 상태 재분류 시 중복 알림 없음', () => {
+    const now0 = Date.now()
+    const state: WatchState = new Map()
+    const s = info('/f/a.jsonl', 'p', 'a', now0 - MIN)
+    classify([s], state, now0, IDLE, WINDOW) // 등록
+    const later = now0 + IDLE + MIN
+    const events1 = classify([s], state, later, IDLE, WINDOW)
+    expect(events1).toHaveLength(1)
+    expect(events1[0].kind).toBe('stalled')
+    expect(events1[0].idleMs).toBeGreaterThanOrEqual(IDLE)
+    const events2 = classify([s], state, later + MIN, IDLE, WINDOW)
+    expect(events2).toEqual([]) // 재알림 금지
+  })
+
+  it('stalled 후 mtime 전진 → recovered + 재무장 (다시 idle 되면 다시 stalled)', () => {
+    const now0 = Date.now()
+    const state: WatchState = new Map()
+    const s0 = info('/f/a.jsonl', 'p', 'a', now0 - MIN)
+    classify([s0], state, now0, IDLE, WINDOW)
+    const t1 = now0 + IDLE + MIN
+    classify([s0], state, t1, IDLE, WINDOW) // stalled
+    // 활동 재개 — mtime 전진
+    const s1 = info('/f/a.jsonl', 'p', 'a', t1 + MIN)
+    const recovered = classify([s1], state, t1 + 2 * MIN, IDLE, WINDOW)
+    expect(recovered).toHaveLength(1)
+    expect(recovered[0].kind).toBe('recovered')
+    // 재무장 확인 — 다시 idle 초과 시 다시 stalled
+    const t2 = t1 + MIN + IDLE + 2 * MIN
+    const stalledAgain = classify([s1], state, t2, IDLE, WINDOW)
+    expect(stalledAgain).toHaveLength(1)
+    expect(stalledAgain[0].kind).toBe('stalled')
+  })
+
+  it('추적 중 세션은 활성 윈도우 밖이어도 계속 판정 (idle 감시가 목적)', () => {
+    const now0 = Date.now()
+    const state: WatchState = new Map()
+    const s = info('/f/a.jsonl', 'p', 'a', now0 - MIN)
+    classify([s], state, now0, IDLE, WINDOW)
+    const muchLater = now0 + WINDOW + IDLE + MIN
+    const events = classify([s], state, muchLater, IDLE, WINDOW)
+    expect(events).toHaveLength(1)
+    expect(events[0].kind).toBe('stalled')
+  })
+})
+
+describe('createTelegramNotifier', () => {
+  it('env 미설정이면 null (콘솔 전용 모드)', () => {
+    const prevToken = process.env.VHK_TG_TOKEN
+    const prevChat = process.env.VHK_TG_CHAT_ID
+    delete process.env.VHK_TG_TOKEN
+    delete process.env.VHK_TG_CHAT_ID
+    expect(createTelegramNotifier()).toBeNull()
+    if (prevToken !== undefined) process.env.VHK_TG_TOKEN = prevToken
+    if (prevChat !== undefined) process.env.VHK_TG_CHAT_ID = prevChat
+  })
+
+  it('env 설정 시 sendMessage API 호출 (fetch 주입)', async () => {
+    process.env.VHK_TG_TOKEN = 'tok123'
+    process.env.VHK_TG_CHAT_ID = 'chat456'
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true } as Response)
+    const notifier = createTelegramNotifier(fetchFn as unknown as typeof fetch)
+    expect(notifier).not.toBeNull()
+    const ok = await notifier!.send('테스트 알림')
+    expect(ok).toBe(true)
+    expect(fetchFn).toHaveBeenCalledOnce()
+    const [url, init] = fetchFn.mock.calls[0]
+    expect(String(url)).toContain('bot' + 'tok123')
+    expect(String(url)).toContain('sendMessage')
+    const body = JSON.parse((init as RequestInit).body as string)
+    expect(body.chat_id).toBe('chat456')
+    expect(body.text).toContain('테스트 알림')
+    delete process.env.VHK_TG_TOKEN
+    delete process.env.VHK_TG_CHAT_ID
+  })
+
+  it('fetch 실패해도 throw 하지 않고 false (감시 루프 생존)', async () => {
+    process.env.VHK_TG_TOKEN = 'tok123'
+    process.env.VHK_TG_CHAT_ID = 'chat456'
+    const fetchFn = vi.fn().mockRejectedValue(new Error('network down'))
+    const notifier = createTelegramNotifier(fetchFn as unknown as typeof fetch)
+    await expect(notifier!.send('x')).resolves.toBe(false)
+    delete process.env.VHK_TG_TOKEN
+    delete process.env.VHK_TG_CHAT_ID
+  })
+})
+
+describe('watch 명령 등록', () => {
+  it('영문·한글 별칭이 KNOWN_COMMAND_TOKENS 에 등록됨 (NL 라우터 가드)', () => {
+    expect(KNOWN_COMMAND_TOKENS.has('watch')).toBe(true)
+    expect(KNOWN_COMMAND_TOKENS.has('감시')).toBe(true)
+  })
+})


### PR DESCRIPTION
## 배경
2026-07-01 밤샘루프 사건 — overnight-autoloop 가 Workflow args 하네스 폴백으로 조용히 오실행(2회)했고, 8.5시간 동안 아무도 몰랐다 (`docs/log/2026-07-01-win-reinforce-overnight.md`). "조용히 잘못 돌기/멈추기"를 사람에게 알리는 장치가 0이었음.

## 무엇
`vhk watch` (별칭 `감시`) — 무인 세션 정지 감시, 수준 2(감지+알림).

- `~/.claude/projects/<proj>/<session>.jsonl` mtime 폴링 (메인 세션만, 하위폴더 서브에이전트 로그 제외)
- idle 초과(기본 15분) → **stalled 1회 알림** (재알림 금지) / 활동 재개 → recovered + 재무장
- 알림: 텔레그램 (`VHK_TG_TOKEN`·`VHK_TG_CHAT_ID`), 미설정 시 시작 배너에 명시하고 콘솔 전용. 발송 실패는 삼키고 감시 루프 생존
- `--once` 1회 점검 모드 / `--idle-min` `--interval` `--window`
- fail-fast: 옵션 오입력 시 즉시 에러 종료 (사건 교훈 — silent 기본값 폴백 금지)
- 감시자는 에이전트가 아닌 경량 폴러 (감시자 공멸 방지 원칙)

## 검증
- TDD 11 tests green (scan 필터·classify 중복방지·recovered 재무장·notifier fetch 주입·등록 가드)
- tsc 무에러 · eslint 무위반 · build 성공
- `--once` 실기동: 활성 세션 2/전체 89 정확 감지
- ⚠️ 전체 스위트는 이 머신에서 실행 불가 (TS-005 확장 — 아래) → **CI 검증 필수**

## TS-005 확장 발견 (문서 갱신 포함)
디렉토리 `rmSync({recursive,force})` 도 exit 127 재현 (노트북·Node v24.13.0, `node -e` 한 줄 결정적). 기존 테스트들의 tmp+rmSync cleanup 이 vitest 워커를 즉사시킴 — 이 머신에서 스위트가 못 도는 근본 원인. 본 PR 테스트는 unlink+rmdir 재귀(`rmTree()`)로 우회, TS-005 문서에 패턴 갱신.

## 후속 (별도)
- 수준 3(안전 원인 한정 자동 재개)은 집 PC 세션 로그로 멈춤 순간 확정 후
- backup.ts:148·migrate.ts:87 의 디렉토리 rmSync → unlink+rmdir 교체 (TS-005 조치란 표기)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `vhk watch`(별칭: `감시`) 명령이 추가되어 무인 세션의 정지/복구 상태를 감시할 수 있습니다.
  * 아이들 시간, 감시 간격, 관찰 창, 1회 실행 옵션을 지원하며, 텔레그램과 콘솔 알림을 보냅니다.
* **Bug Fixes**
  * 세션 로그 감시와 알림 상태 관리가 개선되어 중복 경고를 줄였습니다.
  * 파일/디렉토리 정리 관련 예외 상황에 대한 우회 방식이 강화되었습니다.
* **Documentation**
  * 새 명령과 관련 안내가 명령 카탈로그 및 문제 해결 문서에 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->