### PR TITLE
chore(release): v2.9.0 — vhk watch 무인 세션 감시

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ## [Unreleased]
 
+## [2.9.0] - 2026-07-02
+
+### Added
+
+- **`vhk watch` — 무인 세션 정지 감시 (트랙 A 수준 2: 감지+알림)** (#441) — 2026-07-01 밤샘루프 무감지 사건(8.5h) 재발 방지. Claude Code 세션 로그(`~/.claude/projects/<proj>/<session>.jsonl`) mtime 폴링 → idle 초과(기본 15분) 시 **stalled 1회 알림**(재알림 금지)·활동 재개 시 recovered+재무장. 알림은 텔레그램(`VHK_TG_TOKEN`·`VHK_TG_CHAT_ID`, 미설정 시 콘솔 전용을 시작 배너에 명시, 발송 실패는 삼키고 감시 루프 생존). 완료/멈춤은 로그만으론 구분 불가 — 둘 다 확인 신호로 정직하게 알림. 감시자는 에이전트가 아닌 경량 폴러(공멸 방지). 옵션 오입력은 fail-fast(silent 기본값 폴백 금지 — 사건 교훈). 하위폴더(서브에이전트·워크플로) 로그 제외, 메인 세션만 depth 2 스캔. 한글별칭 `감시`, `--once` 1회 점검 모드, `--idle-min`/`--interval`/`--window`.
+
+### Docs
+
+- **TS-005 확장 — 디렉토리 `rmSync` 도 silent exit 127 재현 확정** (#441) — 노트북(Windows·Node v24.13.0)에서 파일·디렉토리 모두 `node -e` 한 줄로 결정적 재현(샌드박스 무관). tmp+rmSync cleanup 패턴이 vitest 워커를 즉사시켜 이 머신에서 스위트 실행 불가였던 근본 원인. 회귀 방지 패턴을 "신규 rmSync 금지(파일·디렉토리 모두), cleanup 은 unlink+rmdir 재귀(`tests/watch.test.ts` `rmTree()`)"로 갱신.
+
 ## [2.8.0] - 2026-07-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,8 +148,8 @@ tags: [process, constitution]
 > 세션 종료: 마지막 갱신·버전·Phase·다음 할 일 갱신. (위 🔒 구역은 절대 건드리지 마.)
 > ⚠️ 아래 `**버전:**` 줄은 CI(version-sync.test.ts)가 강제 — 형식 `**버전:** vX.Y.Z` 유지, 릴리즈마다 package.json 따라 갱신.
 
-**마지막 갱신:** 2026-07-01
-- **버전:** v2.8.0 — 사실 확인은 package.json·CHANGELOG
+**마지막 갱신:** 2026-07-02
+- **버전:** v2.9.0 — 사실 확인은 package.json·CHANGELOG
 - **테스트:** ~2139 pass(로컬) · **MCP tools:** 35 — 사실값은 package.json·CHANGELOG
 - **Phase:** **[2026-07-01] 자가진화 복리 척추 완성 스프린트** — 병렬 실행 계획(vhk-goal-shimmying-moore) 실행: 밤샘 무인루프(vhk 실결함 2건 #432·#433)·**복리 척추 5개 전 항목 머지** — N3+N2(#434 `vhk win`+reinforce evolve, ⓒ)·N6(#435 `stats --trend`, ⓔ)·N1(#436 `loop --tick`, ⓐ)·N4(#437 objective 토큰 교집합, ⓑ)·N5(#438 `evolve digest`, ⓓ). 각 TDD + 다각 적대리뷰(반증·Workflow) + CI green. **폐회로**: win→reinforce→evolve digest→apply(사람)→RULES→receipt(objective 대조)→receipt-log→`stats --trend`→`loop --tick`. **이전**: 서브에이전트 정책 ADR-007·critic 쓰기구멍(memory 필드 확정). 상세 docs/state·docs/log·CHANGELOG.
 - **블로커:** 없음

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ---
 id: vhk-readme
 date: 2026-06-08
-tags: [vhk, cli, readme, v2.8.0, mcp, proof, ai-coding]
+tags: [vhk, cli, readme, v2.9.0, mcp, proof, ai-coding]
 ---
 
 # VHK - Vibe Harness Kit
 
-> **v2.8.0** - AI 코딩 세션을 **목표, 증거, 기억, 규칙**으로 묶는 한국어 CLI.
+> **v2.9.0** - AI 코딩 세션을 **목표, 증거, 기억, 규칙**으로 묶는 한국어 CLI.
 >
 > Cursor, Claude Code, Claude Desktop, Windsurf, Copilot, Antigravity, Gemini, Cline 사이를 옮겨도 같은 규칙과 맥락, 같은 검증 루프를 유지합니다.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "packageManager": "pnpm@11.2.2",
   "description": "VHK — AI 코딩 세션을 목표·증거·기억·규칙으로 묶는 한국어 CLI. 규칙 동기화, MCP 35 tools, verify/review/preflight 게이트.",
   "bin": {


### PR DESCRIPTION
package.json 2.8.0→2.9.0 + CHANGELOG(watch #441, TS-005 확장). 머지 후 태그는 자동 처리, npm 발행은 사용자 2FA(실터미널 `npm publish --ignore-scripts`, main에서만).

🤖 Generated with [Claude Code](https://claude.com/claude-code)