### PR TITLE
feat: preflight 문서신선도 게이트 추가 (goal 96, #292 G5)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -97,7 +97,7 @@ Cursor에게 한국어로 말해도 됩니다.
 | PR 직전 점검 | `vhk preflight --pr` | "PR 전 점검해" |
 | 테스트 전체 실행 | `vhk preflight --full` | "전체 테스트로 점검해" |
 
-> `preflight` 는 publish/PR 직전 **2FA·shim·worktree env·lint·타입·테스트·git·브랜치 8개**를 한 번에 점검합니다. 치명(🔴: env/lint/타입/테스트) 실패가 1개라도 있으면 `--force` 없이 차단(exit 1). 기본 테스트는 `vitest --changed`(통과분 캐시 스킵), `--full` 로 전체 실행. (읽기 전용 — 자동 수정은 후속)
+> `preflight` 는 publish/PR 직전 **2FA·shim·worktree env·lint·타입·테스트·git·브랜치·문서신선도 9개**를 한 번에 점검합니다. 치명(🔴: env/lint/타입/테스트) 실패가 1개라도 있으면 `--force` 없이 차단(exit 1). 문서신선도(`docs/state/next-task.md` 7일 이상 미갱신)는 경고만, 차단 안 함. 기본 테스트는 `vitest --changed`(통과분 캐시 스킵), `--full` 로 전체 실행. (읽기 전용 — 자동 수정은 후속)
 
 ## worktree 가드 (worktree)
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ vhk blocker "테스트가 같은 원인으로 계속 실패"
 vhk verify     # tsc/lint/test/build/secure 게이트 실행 → .vhk/reports/latest.json
 vhk review     # 최신 증거와 goal 완료조건 교차검증
 vhk receipt    # 4대 기계증거(tsc/test/build 종료코드·git dirty·stale SHA·diff-cover)로 거짓완료 탐지 (LLM 0)
-vhk preflight  # 2FA·shim·env·lint·type·test·git·branch 출고 전 점검
+vhk preflight  # 2FA·shim·env·lint·type·test·git·branch·docs freshness 출고 전 점검
 ```
 
 ### 4. 기억·패턴·자가진화 — 쓸수록 이 개발자에게 최적화

--- a/docs/log/2026-07-04-issue292-g5-doc-freshness.md
+++ b/docs/log/2026-07-04-issue292-g5-doc-freshness.md
@@ -1,0 +1,70 @@
+# 2026-07-04 — 이슈 #292 G5 — 문서 신선도 경고 게이트 (goal 96)
+
+> append-only. 추가만, 수정·삭제 금지.
+
+## 배경
+
+GitHub 이슈 #292 서브태스크 G5. `docs/state/next-task.md` 는 CLAUDE.md 세션종료 의례가
+매 세션 갱신을 요구하는 상태 SoT 문서다. 오래 안 갱신되면 다음 세션이 stale 한 정보로
+시작할 위험이 있다 — 이 신호를 `vhk preflight` 에 읽기전용 경고로 추가했다.
+
+## 사전 조사(Design 단계) 핵심 결론
+
+- 대상 문서: `docs/state/next-task.md` **단독**. `docs/state/blockers.md` 는 append-only
+  특성상 "블로커 없음"이 정상적으로 수십 일 지속 가능해 제외(실측: 2026-07-04 시점 마지막
+  커밋 2026-06-10, 24일+ 경과했는데 현재 상태는 정상인 "블로커 없음" — 같은 7일 임계값을
+  적용하면 상시 거짓경고가 되는 함정을 사전 조사에서 발견).
+- `.vhk/context.md` 는 `.vhk/.gitignore` 로 git 추적 자체가 안 돼 대상 아님.
+- 임계값 7일, severity `'normal'`(항상 경고만, 차단 안 함) — 하드코딩 export 상수로 시작
+  (goal 92 선례를 따라 config/CLI 플래그는 YAGNI 로 기각).
+- mtime 함정 회피 필수: `fs.statSync(...).mtime` 은 `git worktree add` 체크아웃 시각으로
+  리셋되므로 절대 사용 금지 — 반드시 `git log -1 --format=%ct -- <file>` (커밋시각)만 사용.
+
+## 한 일 (TDD RED → GREEN)
+
+1. `tests/preflight.test.ts` 에 `checkDocsFreshness` 신규 describe 블록 작성(RED 확인 —
+   `checkDocsFreshness is not a function`, 9개 테스트 실패).
+2. `src/lib/preflight.ts` 에 `checkDocsFreshness(run, opts)` 구현 — 기존 `checkGitClean`/
+   `checkBranch` 와 동일한 "주입된 `Runner`만 호출" 패턴. `runPreflight()` 반환 배열에
+   9번째 항목으로 배선.
+3. 재실행 → 48개 테스트 전부 GREEN.
+
+## 커버한 케이스
+
+- fresh(3일 전) → pass
+- 정확히 임계값(7일) 경계 → pass(off-by-one 방지, `>` 조건이라 경계 포함)
+- 임계값 초과(10일) → warn(severity `'normal'`, `'critical'` 아님을 명시적으로 assert)
+- git log 실패(`r.ok=false`) → skip
+- 출력 빈 문자열 → skip
+- 출력 파싱 불가(숫자 아님) → skip
+- `thresholdDays` 커스텀 오버라이드(3일로 주면 5일 경과가 warn) 확인
+- `runPreflight()` 통합: 9개 항목 확인 + docs freshness 가 warn(오래된 mock)이어도
+  `summarizePreflight().blocked` 는 여전히 `false`(severity normal 이 실제 배선에서도
+  차단 안 함을 재확인)
+
+NOW/DAY 상수 패턴은 `version-check.test.ts` 를 그대로 차용(고정 NOW + 오프셋 계산으로
+결정론적 테스트, 실제 `Date.now()` 호출 없음).
+
+## 변경 파일
+
+- `src/lib/preflight.ts` — `checkDocsFreshness()`·`DOCS_FRESHNESS_WARN_DAYS`·
+  `DOCS_FRESHNESS_FILE` 신규, `runPreflight()` 배선 1줄 추가.
+- `tests/preflight.test.ts` — 신규 describe 블록 + 기존 `runPreflight` 통합 테스트 갱신
+  (8개 → 9개, mock 응답에 git log 항목 추가).
+- `src/commands/preflight.ts` — **무변경**(배열을 그대로 순회·집계하는 기존 로직이 배열
+  길이·내용과 무관하게 이미 범용으로 동작).
+- `goals/96-docs-freshness-gate.md` + `scripts/check-goal-96.mjs` 신규.
+
+## 게이트
+
+`pnpm exec tsc --noEmit` / `pnpm build` / `pnpm test:run` / `pnpm lint` — 결과는 이 커밋의
+gateStatus 참조(구조화 출력에 실제 실행 결과 기록).
+
+## 교훈
+
+- 문서 신선도처럼 "진짜 문제일 수도, 정상적으로 안 바뀐 걸 수도" 있는 애매한 신호는
+  severity 를 낮게(`'normal'`) 잡고 경고만 하는 게 맞다 — false positive 비용이 lint/
+  typecheck/test 실패보다 훨씬 크다. `blockers.md` 실측 사례(24일+ 지났는데 정상 상태)가
+  이 판단을 실증했다.
+- 상태 관리 파일 신선도를 잴 때 mtime 은 워크트리/CI 체크아웃 환경에서 신뢰할 수 없다
+  (checkout 시각으로 리셋) — git 커밋시각(`%ct`)만 SoT 로 써야 한다.

--- a/goals/96-docs-freshness-gate.md
+++ b/goals/96-docs-freshness-gate.md
@@ -1,0 +1,68 @@
+---
+vhk_format: 1
+type: goal
+id: 96
+title: 문서 신선도 경고 — vhk preflight 에 docs/state/next-task.md 갱신주기 점검 추가 (#292-G5) — P2
+status: DONE
+priority: P2
+created: 2026-07-04
+completed: 2026-07-04
+leads_to: 이슈 #292(문서 신선도) G5 트랙 완료 — next-task.md 가 오래 안 갱신되면 preflight 가 경고(차단 아님)
+---
+
+# Goal 96: 문서 신선도 게이트 (#292-G5)
+
+> 출처: GitHub 이슈 #292 서브태스크 G5. `docs/state/next-task.md` 는 세션 종료 의례(`vhk work
+> handoff`)마다 갱신이 요구되는 상태 SoT 문서 — 오래 갱신 안 되면 "다음 세션이 stale 한 정보로
+> 시작"하는 위험 신호다. 이번 goal 은 이 신호를 `vhk preflight` 에 읽기전용 경고로 추가한다.
+
+## 근거 (사전 조사 — Design 단계 감사)
+
+- `src/lib/preflight.ts:206-215`(`runPreflight()`) — 8개 체크를 배열로 반환하는 기존 오케스트레이션에
+  9번째 항목만 추가하면 배선 끝(`src/commands/preflight.ts` 는 배열을 그대로 순회·집계하므로 무변경).
+- `src/lib/preflight.ts:153-163`(`summarizePreflight()`) — `status==='fail' && severity==='critical'`
+  일 때만 `blocked=true`. `severity: 'normal'` 로 두면 절대 차단 안 됨(경고만).
+- `docs/state/blockers.md` 는 대상에서 **제외** — append-only 라 "블로커 없음"이 정상적으로 수십 일
+  지속 가능(실측: 2026-07-04 시점 마지막 커밋 2026-06-10, 24일+ 경과했는데 현재 상태는 정상인
+  "블로커 없음"). 같은 7일 임계값을 적용하면 상시 거짓경고가 된다.
+- `.vhk/context.md` 는 `.vhk/.gitignore` 로 git 추적 자체가 안 돼 커밋시각 조회 불가 → 대상 아님
+  (이미 별도 SHA 기반 드리프트 체크가 `doctor.ts` 에 비차단 경고로 존재).
+- mtime 함정: `fs.statSync(...).mtime` 은 `git worktree add` 체크아웃 시각으로 리셋되므로 절대
+  사용 불가 — 반드시 `git log -1 --format=%ct -- <file>` (커밋시각) 으로만 판정.
+
+## 동작
+
+`src/lib/preflight.ts` 에 `checkDocsFreshness(run, opts)` 순수 함수 추가 — 기존 `checkGitClean`/
+`checkBranch` 와 동일한 "주입된 `Runner`만 호출" 패턴을 따른다.
+
+- 대상 파일: `docs/state/next-task.md` 단독(`DOCS_FRESHNESS_FILE` export 상수).
+- 임계값: `DOCS_FRESHNESS_WARN_DAYS = 7`(하드코딩 export 상수, YAGNI — config/CLI 플래그 없음).
+- severity: `'normal'`(항상 경고만, 차단 안 함).
+- git 커밋시각 조회 실패/빈 출력/파싱불가 → `status: 'skip'`("판정 불가", 경고도 안 함).
+- `runPreflight()` 반환 배열에 9번째 항목으로 배선(`src/commands/preflight.ts` 무변경).
+
+## Completion Check
+
+- [x] `checkDocsFreshness()` 신규 함수 — fresh/경계값(7일)/초과(warn)/git 실패/빈 출력/파싱불가
+      (전부 skip 또는 pass/warn)/`thresholdDays` 커스텀 오버라이드 단위 테스트 전부 GREEN
+      (`tests/preflight.test.ts`, TDD RED→GREEN 확인).
+- [x] `runPreflight()` 통합 테스트 — 9개 항목 확인 + 정상환경 blocked 아님 + docs freshness
+      가 warn(오래된 mock)이어도 `summarizePreflight().blocked` 는 여전히 `false`(severity
+      normal 이 실제 배선에서도 차단 안 함을 재확인).
+- [x] `src/commands/preflight.ts` 무변경 확인(배열 길이·내용과 무관하게 이미 범용 순회).
+- [x] 공통 게이트(_meta) + `scripts/check-goal-96.mjs`(고유 검증).
+
+## Forbidden Actions (OUT)
+
+- `docs/state/blockers.md` 를 신선도 체크 대상에 포함 금지 — append-only 특성상 상시 오탐(실측
+  확인, 위 근거 참조).
+- `severity: 'critical'` 로 두어 차단(blocked) 시키는 것 금지 — 문서 미갱신은 진짜 문제일 수도,
+  그날 안 바뀐 정상 상태일 수도 있어 false positive 비용이 lint/typecheck/test 실패보다 크다.
+- `fs.statSync(...).mtime` 사용 금지 — 워크트리 checkout 시각으로 리셋되는 함정(실측 확인).
+- 임계값을 CLI 플래그/config 로 노출하는 것 금지(YAGNI, goal 92 선례를 따름) — 필요해지면
+  함수 파라미터(`opts.thresholdDays`)로 이미 열려 있다.
+
+## Mandatory Reading
+
+`src/lib/preflight.ts`(`checkGitClean`/`checkBranch` 선례) · `tests/preflight.test.ts` ·
+`src/commands/preflight.ts`

--- a/goals/README.md
+++ b/goals/README.md
@@ -2,7 +2,7 @@
 
 # goals/ 인덱스
 
-> 총 16 goal — IN_PROGRESS 2 · NOT_STARTED 2 · BLOCKED 1 · DONE 11
+> 총 17 goal — IN_PROGRESS 2 · NOT_STARTED 2 · BLOCKED 1 · DONE 12
 > 공통 게이트 = [_meta.md](_meta.md) · 카드 형식/상태 의미는 각 파일 frontmatter 참조.
 
 | # | 제목 | 상태 | 우선순위 | 다음 연결 |
@@ -23,3 +23,4 @@
 | 93 | ecosystem.mdc 정체성 모순 제거 — "Claude Code = primary" → 실행/트리거 계층 분리 — P2 | ✅ DONE | P2 | RFC 0057(에이전트 불가지론) 실측 감사가 확정한 3항목 중 트랙① 완결 — 트랙②(receipt agent 필드)·트랙③(트리거 격차 문서화)는 별도 goal/트랙에서 병렬 진행 |
 | 94 | agent attribution — receipt/ledger 4대 스키마에 에이전트 감지 필드 추가 — P2 | ✅ DONE | P2 | RFC 0057(기억/복리/에이전트불가지론) 트랙② 완료 — "누가 이 작업을 했는지" 실측 데이터 축적 시작(향후 stats/trend 분석 토대) |
 | 95 | RFC 0057 정식 문서화 + 트리거 격차 명시 — 순수 문서 트랙(트랙③) — P2 | ✅ DONE | P2 | VHK 정체성(에이전트 불가지론 + 자가진화 복리)의 실측 감사 결과를 근거 문서로 고정 — 트랙①(ecosystem.mdc 모순 제거)·트랙②(receipt agent 필드)가 참조할 SoT 확보 |
+| 96 | 문서 신선도 경고 — vhk preflight 에 docs/state/next-task.md 갱신주기 점검 추가 (#292-G5) — P2 | ✅ DONE | P2 | 이슈 #292(문서 신선도) G5 트랙 완료 — next-task.md 가 오래 안 갱신되면 preflight 가 경고(차단 아님) |

--- a/scripts/check-goal-96.mjs
+++ b/scripts/check-goal-96.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// scripts/check-goal-96.mjs — 자동 생성 (vhk goal sync).
+// 기본 게이트 = typecheck + (lint) + test + build. goal 고유 검증은 아래 구역에 추가.
+// sync 재실행해도 기존 파일은 덮어쓰지 않습니다 (idempotent).
+//
+// Env: VHK_GATES_SKIP_DEEP=1  → test + build 스킵 (빠른 typecheck-only 패스)
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+const SHIM = new Set(['pnpm', 'npm', 'npx', 'yarn'])
+function run(cmd, args) {
+  let bin = cmd, argv = args
+  if (process.platform === 'win32' && SHIM.has(cmd)) {
+    // Windows: .cmd shim 직접 spawn 은 Node CVE-2024-27980 으로 EINVAL → cmd.exe 래핑.
+    bin = 'cmd.exe'; argv = ['/d', '/s', '/c', cmd + '.cmd', ...args]
+  }
+  try {
+    // maxBuffer 상향: 큰 빌드/테스트 로그(>1MB)에서 성공해도 ENOBUFS 거짓실패 방지.
+    execFileSync(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
+    return true
+  } catch (e) {
+    const out = (e?.stdout?.toString() ?? '') + (e?.stderr?.toString() ?? '')
+    if (out.trim()) console.log(out.split('\n').slice(-25).join('\n'))
+    return false
+  }
+}
+
+if (existsSync('.vhk/HARD_STOP')) {
+  console.log('🛑 .vhk/HARD_STOP detected — refusing to run goal 96 gate.')
+  process.exit(1)
+}
+
+// BOM-safe 읽기: PowerShell Set-Content -Encoding utf8 의 UTF-8 BOM 제거(없으면 throw).
+const readJson = (p) => { const t = readFileSync(p, 'utf-8'); return JSON.parse(t.charCodeAt(0) === 0xfeff ? t.slice(1) : t) }
+const pkg = existsSync('package.json') ? readJson('package.json') : {}
+const scripts = pkg.scripts ?? {}
+const pm = existsSync('pnpm-lock.yaml') ? 'pnpm' : existsSync('yarn.lock') ? 'yarn' : 'npm'
+const skipDeep = process.env.VHK_GATES_SKIP_DEEP === '1'
+let pass = true
+const gate = (label, ok) => { console.log('[goal 96] ' + label + ': ' + (ok ? '✓' : '✗')); if (!ok) pass = false }
+const must = (cond, label) => { console.log((cond ? '    ✓ ' : '    ✗ ') + label); if (!cond) pass = false }
+
+// typecheck (스크립트 우선, 없으면 tsc --noEmit)
+if (scripts.typecheck) gate('typecheck', run(pm, ['run', 'typecheck']))
+else if (existsSync('tsconfig.json')) gate('tsc --noEmit', run(pm, pm === 'npm' ? ['exec', '--', 'tsc', '--noEmit'] : ['exec', 'tsc', '--noEmit']))
+if (scripts.lint) gate('lint', run(pm, ['run', 'lint']))
+if (!skipDeep) {
+  if (scripts['test:run']) gate('test', run(pm, ['run', 'test:run']))
+  else if (scripts.test && /vitest/.test(scripts.test)) gate('test', run(pm, ['run', 'test', '--', '--run']))
+  else if (scripts.test) gate('test', run(pm, ['run', 'test']))
+  if (scripts.build) gate('build', run(pm, ['run', 'build']))
+}
+
+// ─── goal 96 고유 검증 (직접 추가) ───────────────────────────────
+// #292-G5: 문서 신선도 경고. checkDocsFreshness 가 존재하고 runPreflight 에 배선됐는지,
+// severity 가 'normal'(항상 경고만)인지를 문자열 검증으로 확인한다.
+const read = (p) => existsSync(p) ? readFileSync(p, 'utf-8') : null
+
+const preflightTs = read('src/lib/preflight.ts')
+must(preflightTs?.includes('export function checkDocsFreshness'), 'preflight.ts 가 checkDocsFreshness() export')
+must(preflightTs?.includes("export const DOCS_FRESHNESS_FILE = 'docs/state/next-task.md'"), 'DOCS_FRESHNESS_FILE 이 docs/state/next-task.md 로 고정')
+must(preflightTs?.includes('export const DOCS_FRESHNESS_WARN_DAYS = 7'), 'DOCS_FRESHNESS_WARN_DAYS 기본값 7')
+must(preflightTs?.includes('checkDocsFreshness(deps.run)'), 'runPreflight() 이 checkDocsFreshness(deps.run) 을 반환 배열에 배선')
+must(
+  /function checkDocsFreshness[\s\S]*?const severity: Severity = 'normal'/.test(preflightTs ?? ''),
+  "checkDocsFreshness 의 severity 가 'normal'(항상 경고만, 차단 안 함)"
+)
+must(
+  !/function checkDocsFreshness[\s\S]{0,600}fs\.stat/.test(preflightTs ?? ''),
+  'checkDocsFreshness 가 fs.stat(mtime) 을 쓰지 않음(워크트리 checkout 시각 리셋 함정 회피)'
+)
+
+const preflightTest = read('tests/preflight.test.ts')
+must(preflightTest?.includes('checkDocsFreshness'), 'preflight.test.ts 에 checkDocsFreshness 테스트 존재')
+must(preflightTest?.includes('경계') || preflightTest?.includes('off-by-one'), 'preflight.test.ts 에 7일 경계값(off-by-one) 테스트 존재')
+must(preflightTest?.includes("toHaveLength(9)"), 'preflight.test.ts 의 runPreflight 통합 테스트가 9개 항목으로 갱신됨')
+must(
+  /docs freshness[\s\S]{0,400}blocked\)\.toBe\(false\)/.test(preflightTest ?? ''),
+  'preflight.test.ts 에 docs freshness warn 이어도 blocked 아님을 확인하는 통합 테스트 존재'
+)
+
+if (pass) { console.log('✅ goal 96 gate passes'); process.exit(0) }
+console.log('❌ goal 96 gate failed'); process.exit(1)

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -132,6 +132,39 @@ export function checkGitClean(run: Runner): PreflightCheck {
     : check('git', 'warn', `uncommitted ${lines.length} files`, 'normal')
 }
 
+// #292-G5: docs/state/next-task.md 신선도 경고(severity 'normal' — 절대 차단 안 함).
+// blockers.md 는 대상에서 제외 — append-only 라 "블로커 없음"이 정상적으로 수십 일 지속 가능해
+// 같은 임계값을 적용하면 상시 오탐(false positive)이 된다(실측 확인, RFC/design 조사 참고).
+// mtime 은 워크트리 checkout 시각으로 리셋되므로 절대 쓰지 않고, 반드시 git 커밋시각(%ct)만 사용.
+export const DOCS_FRESHNESS_WARN_DAYS = 7
+export const DOCS_FRESHNESS_FILE = 'docs/state/next-task.md'
+
+export function checkDocsFreshness(
+  run: Runner,
+  opts: { thresholdDays?: number; now?: number } = {}
+): PreflightCheck {
+  const thresholdDays = opts.thresholdDays ?? DOCS_FRESHNESS_WARN_DAYS
+  const now = opts.now ?? Date.now()
+  const name = 'docs freshness'
+  const severity: Severity = 'normal'
+
+  const r = run('git', ['log', '-1', '--format=%ct', '--', DOCS_FRESHNESS_FILE])
+  const ts = r.ok ? Number(r.out.trim()) : NaN
+  if (!r.ok || !r.out.trim() || !Number.isFinite(ts) || ts <= 0) {
+    return check(name, 'skip', `${DOCS_FRESHNESS_FILE} git 이력 없음 — 판정 불가`, severity)
+  }
+  const ageDays = (now - ts * 1000) / 86_400_000
+  if (ageDays > thresholdDays) {
+    return check(
+      name,
+      'warn',
+      `${DOCS_FRESHNESS_FILE} 마지막 갱신 ${Math.floor(ageDays)}일 전(기준 ${thresholdDays}일) — vhk work handoff 로 갱신 확인`,
+      severity
+    )
+  }
+  return check(name, 'pass', `${DOCS_FRESHNESS_FILE} ${Math.floor(ageDays)}일 전 갱신`, severity)
+}
+
 export function checkBranch(run: Runner): PreflightCheck {
   const r = run('git', ['rev-parse', '--abbrev-ref', 'HEAD'])
   const branch = r.out.trim()
@@ -175,7 +208,7 @@ export function statusIcon(c: PreflightCheck): string {
   return c.severity === 'high' ? '🟠' : '🟡'
 }
 
-// ── 오케스트레이션: 8개 항목 점검(읽기 전용, Phase 1) ──
+// ── 오케스트레이션: 9개 항목 점검(읽기 전용, Phase 1) ──
 export function runPreflight(opts: PreflightOptions, deps: PreflightDeps): PreflightCheck[] {
   // #173: 패키지 스크립트 우선 해석. 모든 PM 이 `<pm> run <script>` 를 지원하므로 통일.
   const pm = deps.pm ?? 'npm'
@@ -212,5 +245,6 @@ export function runPreflight(opts: PreflightOptions, deps: PreflightDeps): Prefl
     checkTests(deps.run, { full: opts.full }, testCmd),
     checkGitClean(deps.run),
     checkBranch(deps.run),
+    checkDocsFreshness(deps.run),
   ]
 }

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -8,6 +8,9 @@ import {
   checkTests,
   checkGitClean,
   checkBranch,
+  checkDocsFreshness,
+  DOCS_FRESHNESS_WARN_DAYS,
+  DOCS_FRESHNESS_FILE,
   summarizePreflight,
   runPreflight,
   detectHasLinter,
@@ -186,6 +189,61 @@ describe('#173 — 스크립트 우선 + 출력 증거', () => {
   })
 })
 
+// #292-G5: docs/state/next-task.md 신선도 경고(차단 아님). NOW/DAY 는 version-check.test.ts 패턴 차용
+// (고정 NOW 상수 + 오프셋 계산으로 결정론적 테스트, 실제 Date.now() 호출 없음).
+describe('checkDocsFreshness', () => {
+  const NOW = 1_700_000_000_000
+  const DAY = 24 * 60 * 60 * 1000
+  const gitLogKey = `git log -1 --format=%ct -- ${DOCS_FRESHNESS_FILE}`
+  const tsFor = (msAgo: number): string => String(Math.floor((NOW - msAgo) / 1000))
+
+  it('3일 전 갱신 → pass (normal)', () => {
+    const { run } = mockRunner({ [gitLogKey]: { ok: true, out: tsFor(3 * DAY) } })
+    const r = checkDocsFreshness(run, { now: NOW })
+    expect(r.status).toBe('pass')
+    expect(r.severity).toBe('normal')
+  })
+
+  it('정확히 임계값(7일) 경계 → pass (초과 아님, off-by-one 방지)', () => {
+    const { run } = mockRunner({
+      [gitLogKey]: { ok: true, out: tsFor(DOCS_FRESHNESS_WARN_DAYS * DAY) },
+    })
+    const r = checkDocsFreshness(run, { now: NOW })
+    expect(r.status).toBe('pass')
+  })
+
+  it('임계값 초과(10일) → warn (normal, critical 아님)', () => {
+    const { run } = mockRunner({ [gitLogKey]: { ok: true, out: tsFor(10 * DAY) } })
+    const r = checkDocsFreshness(run, { now: NOW })
+    expect(r.status).toBe('warn')
+    expect(r.severity).toBe('normal')
+  })
+
+  it('git log 실패(r.ok=false) → skip', () => {
+    const { run } = mockRunner({ [gitLogKey]: { ok: false, out: '', err: 'no such path' } })
+    const r = checkDocsFreshness(run, { now: NOW })
+    expect(r.status).toBe('skip')
+  })
+
+  it('출력 빈 문자열 → skip', () => {
+    const { run } = mockRunner({ [gitLogKey]: { ok: true, out: '' } })
+    const r = checkDocsFreshness(run, { now: NOW })
+    expect(r.status).toBe('skip')
+  })
+
+  it('출력 파싱 불가(숫자 아님) → skip', () => {
+    const { run } = mockRunner({ [gitLogKey]: { ok: true, out: 'not-a-number' } })
+    const r = checkDocsFreshness(run, { now: NOW })
+    expect(r.status).toBe('skip')
+  })
+
+  it('thresholdDays 커스텀 오버라이드(3일) — 5일 경과면 warn', () => {
+    const { run } = mockRunner({ [gitLogKey]: { ok: true, out: tsFor(5 * DAY) } })
+    const r = checkDocsFreshness(run, { now: NOW, thresholdDays: 3 })
+    expect(r.status).toBe('warn')
+  })
+})
+
 describe('checkGitClean', () => {
   it('변경 없음 → pass', () => {
     const { run } = mockRunner({ 'git status --porcelain': { ok: true, out: '' } })
@@ -263,6 +321,11 @@ describe('runPreflight', () => {
     'npx vitest --changed --run': { ok: true, out: '' },
     'git status --porcelain': { ok: true, out: '' },
     'git rev-parse --abbrev-ref HEAD': { ok: true, out: 'feat/29-preflight' },
+    // #292-G5: 오늘 커밋으로 mock — 항상 fresh(pass) 처리되어 기존 "정상환경 → blocked 아님" 회귀 없음.
+    [`git log -1 --format=%ct -- ${DOCS_FRESHNESS_FILE}`]: {
+      ok: true,
+      out: String(Math.floor(Date.now() / 1000)),
+    },
   })
   const deps = {
     run: okRunner.run,
@@ -271,9 +334,9 @@ describe('runPreflight', () => {
     worktreeEnv: (): PreflightCheck => ({ name: 'worktree env', status: 'pass', detail: 'ok', severity: 'critical' }),
   }
 
-  it('8개 항목을 점검한다', () => {
+  it('9개 항목을 점검한다', () => {
     const checks = runPreflight({}, deps)
-    expect(checks).toHaveLength(8)
+    expect(checks).toHaveLength(9)
   })
   it('정상 환경 → blocked 아님', () => {
     const checks = runPreflight({}, deps)
@@ -296,5 +359,23 @@ describe('runPreflight', () => {
     const checks = runPreflight({}, { ...deps, hasTsconfig: true })
     const tc = checks.find((c) => c.name === 'typecheck')
     expect(tc?.status).toBe('pass')
+  })
+
+  it('#292-G5: docs freshness 가 warn(오래됨)이어도 blocked 아님(severity normal)', () => {
+    const staleRunner = mockRunner({
+      'npm whoami': { ok: true, out: 'me' },
+      'npx tsc --noEmit': { ok: true, out: '' },
+      'npx vitest --changed --run': { ok: true, out: '' },
+      'git status --porcelain': { ok: true, out: '' },
+      'git rev-parse --abbrev-ref HEAD': { ok: true, out: 'feat/29-preflight' },
+      [`git log -1 --format=%ct -- ${DOCS_FRESHNESS_FILE}`]: {
+        ok: true,
+        out: String(Math.floor((Date.now() - 10 * 24 * 60 * 60 * 1000) / 1000)),
+      },
+    })
+    const checks = runPreflight({}, { ...deps, run: staleRunner.run })
+    const df = checks.find((c) => c.name === 'docs freshness')
+    expect(df?.status).toBe('warn')
+    expect(summarizePreflight(checks).blocked).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- \`vhk preflight\`에 \`checkDocsFreshness()\` 체크 추가 — \`docs/state/next-task.md\`가 7일 이상 미갱신이면 경고(차단 안 함)
- git 커밋시각(\`git log -1 --format=%ct\`)만 사용, mtime 함정 회피(체크아웃 시각 오판정 방지)
- \`blockers.md\`는 대상에서 제외(append-only 특성상 정상 상태도 장기간 안 바뀜 — 같은 임계값 적용 시 상시 오탐 실측 확인)
- README.md·COMMANDS.md의 preflight 체크 개수(8→9) 갱신

문서 자동 부산물화 Epic(#292)의 G5 항목. G1(#288)·G2(#289)·G4(#286) 완료 상태 위에 추가, G3(세션종료 자동캡처)는 별도 스코프(리스크 큼).

## Test plan
- [x] TDD: 9개 신규 테스트 RED→GREEN
- [x] \`pnpm exec tsc --noEmit\` / \`pnpm build\` / \`pnpm test:run\` / \`pnpm lint\` 전부 green
- [x] 적대적 검증 통과(README/COMMANDS 카운트 stale 발견분 수정 완료)

Part of #292 (G5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 출고 전 점검에 문서 최신 상태 확인 항목이 추가되었습니다.
  * `docs/state/next-task.md`가 오래되면 경고로 표시되며, 차단되지는 않습니다.
* **버그 수정**
  * 문서 최신도 점검의 기준과 경계값 처리 방식이 보완되었습니다.
  * 점검 항목 수가 8개에서 9개로 반영되었습니다.
* **문서**
  * `vhk preflight`, 출고 전 점검 항목, 관련 목표 문서가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->