### PR TITLE
chore(vhk): evidence ledger sync (2026-07-05 로컬 잔여 커밋)

### DIFF
--- a/.vhk/events/ai-actions.jsonl
+++ b/.vhk/events/ai-actions.jsonl
@@ -14,3 +14,4 @@
 {"ts":"2026-06-22T04:22:09.270Z","action":"undo","channel":"nl","guard":"preview","ran":false,"reason":"preview-no-approve"}
 {"ts":"2026-06-22T04:26:48.553Z","action":"deploy","channel":"nl","guard":"preview","ran":false,"reason":"preview-no-approve"}
 {"ts":"2026-06-22T04:26:49.071Z","action":"undo","channel":"nl","guard":"preview","ran":false,"reason":"preview-no-approve"}
+{"ts":"2026-07-05T11:58:26.842Z","action":"sync","channel":"cli","guard":"allow","ran":true,"reason":"low-risk"}

--- a/.vhk/ledger.jsonl
+++ b/.vhk/ledger.jsonl
@@ -1,3 +1,4 @@
 {"version":"2.6.0","date":"2026-06-22","status":"PASS","sha":"827c56f7a015b730b7d132ea86e179f8bd59f320","shortSha":"827c56f","dirty":true}
 {"version":"2.7.0","date":"2026-07-01","status":"PASS","sha":"692b4ecd9fea7865fba174ba6530fd0cd5174988","shortSha":"692b4ec","dirty":true}
 {"version":"2.9.0","date":"2026-07-03","status":"PASS","sha":"2ad042c38c18ccde496504909a0f8d1742fa252e","shortSha":"2ad042c","dirty":true}
+{"version":"2.9.0","date":"2026-07-05","status":"FAIL","sha":"ea98eed4ead91d19c3891226d0ede74619c5ad9a","shortSha":"ea98eed","dirty":true}


### PR DESCRIPTION
로컬 main에 남아 있던 evidence ledger 커밋 1건을 보호 브랜치 정책에 맞춰 PR로 전환. 내용은 .vhk/events/ai-actions.jsonl + .vhk/ledger.jsonl 각 1줄 append ([skip ci]).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 이벤트 및 상태 기록이 최신 내용으로 업데이트되었습니다.
  * 일부 기록의 날짜, 상태, 식별 값이 변경되어 추적 정보가 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->