### PR TITLE
feat: goal migrate + status enum (RFC 0058 T3, #465 #469)

### DIFF
--- a/goals/50-coverage-diff-gate.md
+++ b/goals/50-coverage-diff-gate.md
@@ -3,7 +3,7 @@ vhk_format: 1
 type: goal
 id: 50
 title: 커버리지 측정 + diff-coverage 게이트 — 미검증 경로 가시화 — P1
-status: IN_PROGRESS
+status: DEFERRED
 priority: P1
 created: 2026-06-08
 leads_to: 테스트 4→5 · 1162 pass에 분모 부여

--- a/goals/73-objective-llm-eval.md
+++ b/goals/73-objective-llm-eval.md
@@ -3,7 +3,7 @@ vhk_format: 1
 type: goal
 id: 73
 title: Objective LLM 판정 — "목표를 실제로 달성했나"를 LLM judge로 평가 (`vhk check --evals`)
-status: BLOCKED
+status: CANCELED
 priority: P2
 created: 2026-06-25
 blocked_by: "결정 완료(2026-07-04) — 착수 안 함. 근거: ①VHK 자체 출력물 중 주관적 품질판정이 필요한 케이스가 현재 0건(content/launch/ops/sell은 초안생성까지만, goal75~77 DONE) — 검증된 수요 없이 다른 프로젝트(youtube-summary) 패턴 선이식은 헛수고 리스크 ②opt-in 격리로 설계해도 'LLM 판단 0' 원칙에 첫 진입로가 생겨 향후 verify/receipt 침범 유혹의 전례가 됨(격리는 기술이 아니라 사람 규율에 의존). 재개 조건: VHK 자체 기능에서 주관적 품질채점이 실제로 필요한 구체 케이스가 생기면 그때 그 케이스 기준으로 재설계."

--- a/goals/79-verify-local-env-split.md
+++ b/goals/79-verify-local-env-split.md
@@ -3,7 +3,7 @@ vhk_format: 1
 type: goal
 id: 79
 title: verify 로컬 환경의존 테스트 분리 — 선조사 후 범위 재조정(확실한 것만) — P0
-status: IN_PROGRESS
+status: OBSERVING
 priority: P0
 created: 2026-06-20
 leads_to: 로컬 verify 신뢰 — 선조사로 회귀 0 확인, 확실한 조치만 적용

--- a/goals/README.md
+++ b/goals/README.md
@@ -2,16 +2,16 @@
 
 # goals/ 인덱스
 
-> 총 21 goal — IN_PROGRESS 2 · NOT_STARTED 2 · BLOCKED 1 · DONE 16
+> 총 21 goal — DEFERRED 1 · NOT_STARTED 2 · CANCELED 1 · OBSERVING 1 · DONE 16
 > 공통 게이트 = [_meta.md](_meta.md) · 카드 형식/상태 의미는 각 파일 frontmatter 참조.
 
 | # | 제목 | 상태 | 우선순위 | 다음 연결 |
 |--:|------|:----:|:--------:|-----------|
-| 50 | 커버리지 측정 + diff-coverage 게이트 — 미검증 경로 가시화 — P1 | 🔄 IN_PROGRESS | P1 | 테스트 4→5 · 1162 pass에 분모 부여 |
+| 50 | 커버리지 측정 + diff-coverage 게이트 — 미검증 경로 가시화 — P1 |  DEFERRED | P1 | 테스트 4→5 · 1162 pass에 분모 부여 |
 | 62 | docs-first 작업 의례 — 문서 선행 갱신 + docs-diff 산출물 (자문형) — P2 | ⬜ NOT_STARTED | P2 | 스펙-코드 드리프트 사전 차단 · RFC 0051(사후 감지)의 사전 보완 |
 | 65 | pre-commit L2 기록 집행 — 조건부(우회 실측 시에만 착수) — P2 | ⬜ NOT_STARTED | P2 | 기록 집행 우회 경로 0 (ADR-001 L2 트리거 이행) |
-| 73 | Objective LLM 판정 — "목표를 실제로 달성했나"를 LLM judge로 평가 (`vhk check --evals`) | ⛔ BLOCKED | P2 | 결정론(scope/forbidden)으로 잡지 못하는 "목표 달성 여부" 판정 계층 확보 → 의도 검증 깊이 확장 |
-| 79 | verify 로컬 환경의존 테스트 분리 — 선조사 후 범위 재조정(확실한 것만) — P0 | 🔄 IN_PROGRESS | P0 | 로컬 verify 신뢰 — 선조사로 회귀 0 확인, 확실한 조치만 적용 |
+| 73 | Objective LLM 판정 — "목표를 실제로 달성했나"를 LLM judge로 평가 (`vhk check --evals`) |  CANCELED | P2 | 결정론(scope/forbidden)으로 잡지 못하는 "목표 달성 여부" 판정 계층 확보 → 의도 검증 깊이 확장 |
+| 79 | verify 로컬 환경의존 테스트 분리 — 선조사 후 범위 재조정(확실한 것만) — P0 |  OBSERVING | P0 | 로컬 verify 신뢰 — 선조사로 회귀 0 확인, 확실한 조치만 적용 |
 | 85 | receipt/verify dirty 판정에서 자기 산출 추적파일 제외 (#315 자기참조 봉인) — P0 | ✅ DONE | P0 | receipt가 자기 ledger 때문에 늘 block되는 자기모순 제거 (RFC 0056 T1 선결) |
 | 86 | vhk receipt MVP — 4대 기계증거를 영수증 1장으로 (RFC 0056 T1) — P0 | ✅ DONE | P0 | 에이전트 "됐어요"를 기계증거 영수증으로 — 거짓완료 탐지 90일 쐐기 |
 | 87 | 의도 대조 — receipt/review가 mission(시킨 것)을 검증에 반영 (의도 장갑 손바닥) — P0 | ✅ DONE | P0 | "AI가 시킨 대로(scope/forbidden) 했나"를 자동 판정 — 경쟁사 못 하는 해자(남들은 의도를 모름) 실현 |

--- a/goals/_meta.md
+++ b/goals/_meta.md
@@ -39,7 +39,7 @@ version: v1.1
 5. **README.md / COMMANDS.md** 명령어 표에 신규 명령어가 반영됨.
 6. **완료(DONE) 표시된 goal 은 비스텁 게이트를 가진다** (Goal 60, M.4). status `DONE`
    인데 `check-goal-<id>.mjs` 가 미싱이거나 빈 스캐폴드(`고유 검증 (직접 추가)` 마커만)면
-   "헛통과 DONE" — `check-meta` 가 FAIL. `NOT_STARTED`/`IN_PROGRESS`/`BLOCKED` 은 제외
+   "헛통과 DONE" — `check-meta` 가 FAIL. `NOT_STARTED`/`IN_PROGRESS`/`BLOCKED`/`CANCELED`/`DEFERRED`/`OBSERVING` 은 제외
    (미구현/진행 중/미주장 — 스텁 게이트 정상. IN_PROGRESS 완화: 머지 시 in-flight goal 오탐 방지).
 
 각 condition 은 source-of-truth 로부터 enumerate 된다:

--- a/scripts/check-goal-20.mjs
+++ b/scripts/check-goal-20.mjs
@@ -53,7 +53,7 @@ if (!skipDeep) {
 const g20 = read('goals/20-evolve.md') ?? ''
 must(g20.includes('id: 20'), 'goals/20-evolve.md: id: 20')
 // status 유효값 체크 (IN_PROGRESS/DONE 모두 허용)
-const VALID_GOAL_STATUSES = ['NOT_STARTED', 'IN_PROGRESS', 'DONE', 'BLOCKED']
+const VALID_GOAL_STATUSES = ['NOT_STARTED', 'IN_PROGRESS', 'DONE', 'BLOCKED', 'CANCELED', 'DEFERRED', 'OBSERVING']
 must(VALID_GOAL_STATUSES.some(s => g20.includes('status: ' + s)), 'goals/20-evolve.md: 유효한 status 값')
 must(g20.includes('version: v2.3.0'), 'goals/20-evolve.md: version v2.3.0')
 must(g20.includes('depends_on'), 'goals/20-evolve.md: depends_on 선언')

--- a/scripts/check-goal-frontmatter.mjs
+++ b/scripts/check-goal-frontmatter.mjs
@@ -11,7 +11,7 @@ import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { isMainModule, parseFlatFrontmatter, ensureNoHardStop } from './_lib.mjs'
 
-const STATUSES = new Set(['NOT_STARTED', 'IN_PROGRESS', 'DONE', 'BLOCKED'])
+const STATUSES = new Set(['NOT_STARTED', 'IN_PROGRESS', 'DONE', 'BLOCKED', 'CANCELED', 'DEFERRED', 'OBSERVING'])
 const VERSION_RE = /^v?\d+\.\d+(\.\d+)?$/
 
 /** flat frontmatter 객체 → {errors, warnings}. type!=='goal' 은 호출 전에 걸러진다. */

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -20,6 +20,7 @@ import { diagOs } from '../doctor/diagnostics/os.js'
 import { buildVhkDiag } from '../doctor/diagnostics/vhk.js'
 import { buildMcpDiag, mcpToolCount } from '../doctor/diagnostics/mcp.js'
 import { buildAuditDiag } from '../doctor/diagnostics/audit.js'
+import { findSkippedGoalFiles, listGoals } from '../lib/goal-frontmatter.js'
 import { readSelectedPM } from '../doctor/pm.js'
 import type { DiagDeps, DoctorOptions, DiagFn } from '../doctor/types.js'
 // 업데이트 체크 함수는 version-check.ts 단일 소스로 이동(메뉴와 공용). 여기선 import + re-export
@@ -187,6 +188,37 @@ export async function doctor(opts: DoctorOptions = {}) {
     console.log(chalk.yellow(`    ${ko.doctor.driftContextWarn}`))
   }
 
+  // Goal frontmatter — silent skip 감지 (#465)
+  let goalSchemaWarn = false
+  const goalsDir = path.join(cwd, 'goals')
+  if (fs.existsSync(goalsDir)) {
+    console.log('')
+    console.log(chalk.bold(`  ${ko.doctor.goalSchemaTitle}`))
+    const parsed = listGoals(goalsDir)
+    const skipped = findSkippedGoalFiles(goalsDir)
+    let mdCount = 0
+    try {
+      mdCount = fs.readdirSync(goalsDir).filter((n) => n.endsWith('.md') && n !== '_meta.md').length
+    } catch {
+      mdCount = 0
+    }
+    if (skipped.length > 0) {
+      goalSchemaWarn = true
+      console.log(chalk.yellow(`    ${ko.doctor.goalSchemaSkipped(skipped.length)}`))
+      for (const s of skipped.slice(0, 5)) {
+        console.log(chalk.yellow(`      - goals/${s.file}: ${s.reason}`))
+      }
+      if (skipped.length > 5) console.log(chalk.dim(`      … 외 ${skipped.length - 5}건`))
+      console.log(chalk.dim('    → vhk goal migrate [--dry-run]'))
+    } else if (mdCount > 0 && parsed.length === 0) {
+      goalSchemaWarn = true
+      console.log(chalk.yellow(`    ${ko.doctor.goalSchemaEmpty(mdCount)}`))
+      console.log(chalk.dim('    → vhk goal migrate [--dry-run]'))
+    } else {
+      console.log(chalk.green(`    ${ko.doctor.goalSchemaOk(parsed.length)}`))
+    }
+  }
+
   console.log('')
   if (anyFail) {
     // 치명(fail) — 도구 부재 등. exit 1.
@@ -215,6 +247,11 @@ export async function doctor(opts: DoctorOptions = {}) {
   if (opts.strict && ruleDrifted) {
     console.log('')
     console.log(chalk.red.bold('  ❌ --strict: 규칙 드리프트 발견 → 실패 처리 (vhk sync 로 동기화 후 다시 실행)'))
+    process.exitCode = 1
+  }
+  if (opts.strict && goalSchemaWarn) {
+    console.log('')
+    console.log(chalk.red.bold('  ❌ --strict: goal frontmatter 스키마 경고 → 실패 처리 (vhk goal migrate)'))
     process.exitCode = 1
   }
 }

--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import chalk from 'chalk'
 import { ko } from '../i18n/ko.js'
@@ -13,6 +13,9 @@ import {
   findDuplicateIds,
   findSkippedGoalFiles,
   updateFrontmatterStatus,
+  planGoalFileMigrate,
+  normalizeLegacyStatus,
+  GOAL_STATUSES,
   type GoalStatus,
   type ParsedGoal,
 } from '../lib/goal-frontmatter.js'
@@ -27,6 +30,16 @@ const STATUS_ICON: Record<GoalStatus, string> = {
   IN_PROGRESS: '🟡',
   DONE: '✅',
   BLOCKED: '🛑',
+  CANCELED: '⛔',
+  DEFERRED: '⏸',
+  OBSERVING: '👁',
+}
+
+function effectiveGoalStatus(fm: ParsedGoal['frontmatter']): GoalStatus | undefined {
+  const raw = fm.status
+  if (raw == null) return undefined
+  const s = String(raw)
+  return normalizeLegacyStatus(s) ?? (GOAL_STATUSES.includes(s as GoalStatus) ? (s as GoalStatus) : undefined)
 }
 
 // #329: --id 없이 active goal 이 null 일 때, goalNext(VHK-017)와 동일하게 0개/전부완료를 구분 안내.
@@ -45,12 +58,12 @@ function reportNoActiveGoal(goals: ParsedGoal[]): boolean {
 // active goal 선택: IN_PROGRESS 우선, 없으면 첫 NOT_STARTED.
 // (BLOCKED 는 자동 선택 안 함 — 사람이 풀어야 함.)
 export function selectActiveId(goals: ParsedGoal[]): number | null {
-  const ip = goals.find((g) => g.frontmatter.status === 'IN_PROGRESS')
+  const ip = goals.find((g) => effectiveGoalStatus(g.frontmatter) === 'IN_PROGRESS')
   if (ip && typeof ip.frontmatter.id === 'number') return ip.frontmatter.id
-  const ns = goals.find(
-    (g) =>
-      g.frontmatter.status === 'NOT_STARTED' || g.frontmatter.status === undefined
-  )
+  const ns = goals.find((g) => {
+    const s = effectiveGoalStatus(g.frontmatter)
+    return s === 'NOT_STARTED' || s === undefined
+  })
   if (ns && typeof ns.frontmatter.id === 'number') return ns.frontmatter.id
   return null
 }
@@ -83,7 +96,7 @@ export async function goalList(): Promise<void> {
   }
   for (const g of goals) {
     const fm = g.frontmatter
-    const status = (fm.status ?? 'NOT_STARTED')
+    const status = (effectiveGoalStatus(fm) ?? 'NOT_STARTED')
     const icon = STATUS_ICON[status] ?? '?'
     const id = String(fm.id).padStart(2)
     const pri = String(fm.priority ?? '--').padEnd(3)
@@ -109,7 +122,7 @@ function printSkippedGoalWarnings(skipped: ReturnType<typeof findSkippedGoalFile
     for (const s of skipped) {
       console.log(chalk.yellow(`    - goals/${s.file}: ${s.reason}`))
     }
-    console.log(chalk.dim('    필수: type: goal + 숫자 id. 스키마 전체: goals/_meta.md'))
+    console.log(chalk.dim('    필수: type: goal + 숫자 id. 스키마 전체: goals/_meta.md · vhk goal migrate'))
   }
 }
 
@@ -603,4 +616,57 @@ export async function goalSync(): Promise<GoalSyncResult> {
     })
   }
   return result
+}
+
+export async function goalMigrate(opts: { dryRun?: boolean } = {}): Promise<void> {
+  if (!ensureNotHardStopped('goal migrate')) return
+  const dryRun = opts.dryRun === true
+  console.log(chalk.bold(`\n${ko.goal.migrateTitle}${dryRun ? ' (dry-run)' : ''}\n`))
+  let entries: string[]
+  try {
+    entries = readdirSync(GOALS_DIR)
+  } catch {
+    console.log(chalk.yellow('  📭 goals/ 디렉토리가 없습니다.'))
+    return
+  }
+  const plans: { file: string; actions: string[]; path: string; nextContent: string }[] = []
+  for (const name of entries) {
+    if (!name.endsWith('.md') || name === '_meta.md') continue
+    const fp = join(GOALS_DIR, name)
+    let content: string
+    try {
+      content = readFileSync(fp, 'utf-8')
+    } catch {
+      continue
+    }
+    const plan = planGoalFileMigrate(fp, content)
+    if (!plan) continue
+    plans.push({ file: name, actions: plan.actions, path: fp, nextContent: plan.nextContent })
+  }
+  if (plans.length === 0) {
+    console.log(chalk.green('  ✓ migrate 대상 없음 (이미 표준 스키마)'))
+    return
+  }
+  for (const p of plans) {
+    console.log(chalk.cyan(`  goals/${p.file}`))
+    for (const a of p.actions) console.log(chalk.dim(`    · ${a}`))
+    if (!dryRun) atomicWriteFile(p.path, p.nextContent)
+  }
+  console.log('')
+  console.log(
+    chalk.bold(`  📊 ${dryRun ? 'would migrate' : 'migrated'}=${plans.length}`),
+  )
+  if (dryRun) {
+    printNextStep({
+      message: '미리보기만 — 적용하려면:',
+      command: 'vhk goal migrate',
+      cursorHint: 'goal migrate 실행해줘',
+    })
+  } else {
+    printNextStep({
+      message: 'migrate 완료 — 목록 확인:',
+      command: 'vhk goal list',
+      cursorHint: 'goal list 보여줘',
+    })
+  }
 }

--- a/src/daily/types.ts
+++ b/src/daily/types.ts
@@ -11,7 +11,14 @@ export interface CommitSummary {
   date: string // YYYY-MM-DD (KST 로컬 날짜)
 }
 
-export type GoalStatusLite = 'NOT_STARTED' | 'IN_PROGRESS' | 'DONE' | 'BLOCKED'
+export type GoalStatusLite =
+  | 'NOT_STARTED'
+  | 'IN_PROGRESS'
+  | 'DONE'
+  | 'BLOCKED'
+  | 'CANCELED'
+  | 'DEFERRED'
+  | 'OBSERVING'
 
 export interface GoalState {
   id: number

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -292,6 +292,10 @@ export const ko = {
     driftRuleWarn: (files: string) =>
       `⚠️ RULES.md와 어긋난 규칙 파일: ${files} — vhk sync 를 다시 실행하세요`,
     driftContextWarn: '⚠️ .vhk/context.md 가 현재 코드보다 낡았어요 — vhk context 로 갱신하세요',
+    goalSchemaTitle: 'Goal frontmatter',
+    goalSchemaOk: (n: number) => `✅ goals/ ${n}개 goal 파싱 정상`,
+    goalSchemaSkipped: (n: number) => `⚠️ 스키마 불일치로 무시된 goal 파일 ${n}개`,
+    goalSchemaEmpty: (n: number) => `⚠️ goals/*.md ${n}개 있으나 파싱된 goal 0개 — type/id 누락 가능`,
   },
   preflight: {
     title: '🛫 Preflight — 출고 전 안전점검',
@@ -572,6 +576,7 @@ export const ko = {
     checkTitle: '✅ Goal 게이트 검증',
     doneTitle: '🏁 Goal 완료 처리',
     syncTitle: '🔄 Goal 게이트 스크립트 동기화',
+    migrateTitle: '🔧 Goal frontmatter migrate',
     duplicateId: (ids: string) =>
       `⚠ 중복된 goal id: ${ids} — 같은 id 파일이 여러 개면 첫 매치만 사용됩니다. id 를 유일하게 고치세요.`,
     skippedFiles: (n: number) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,7 @@ async function guardCliDefer(
   )
 }
 import { cloudPush, cloudPull } from './commands/cloud.js'
-import { goalCheck, goalDone, goalDrift, goalInit, goalList, goalNext, goalPeek, goalSync } from './commands/goal.js'
+import { goalCheck, goalDone, goalDrift, goalInit, goalList, goalMigrate, goalNext, goalPeek, goalSync } from './commands/goal.js'
 import { blocker, learn, resume, win, autonomyLog, parseAutonomyIntArg, INVALID_AUTONOMY_ARG } from './commands/agent.js'
 import { watch } from './commands/watch.js'
 import { patternDetect, patternList, patternDismiss } from './commands/pattern.js'
@@ -878,6 +878,13 @@ goalCmd
   .alias('드리프트')
   .description('goal 상태↔코드 드리프트 점검 — 구현됐는데 NOT_STARTED 인 goal 탐지 (read-only, 발견 시 exit 1)')
   .action(async () => { await goalDrift() })
+
+goalCmd
+  .command('migrate')
+  .alias('마이그레이트')
+  .option('--dry-run', '변경 미리보기만 (파일 미수정)')
+  .description('goal frontmatter 표준화 — type:goal · legacy status 정규화 (idempotent)')
+  .action(async (opts: { dryRun?: boolean }) => { await goalMigrate(opts) })
 
 program
   // #147: variadic — 따옴표 없는 다단어 본문도 받는다 (vhk blocker sync 중단 증상). join 으로 원문 복원.

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -7,7 +7,7 @@
  * 드리프트 가드 테스트가 실패해 R1(자연어 라우터가 명령 가로채기) 재발을 사전에 잡는다.
  */
 export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
-  goal: ['list', 'next', 'peek', 'check', 'init', 'done', 'sync', 'drift'],
+  goal: ['list', 'next', 'peek', 'check', 'init', 'done', 'sync', 'drift', 'migrate'],
   cost: ['add', 'check', 'budget'],
   ref: ['add', 'list', 'open'],
   memory: ['add', 'list', 'remove', 'archive', 'resolve', 'unarchive', 'migrate', 'eval'],

--- a/src/lib/goal-frontmatter.ts
+++ b/src/lib/goal-frontmatter.ts
@@ -3,7 +3,24 @@ import { join } from 'node:path'
 import { stripBom } from './read-json.js'
 
 // VHK goals/<n>-<name>.md frontmatter 표준. vspec/vooster 호환.
-export type GoalStatus = 'NOT_STARTED' | 'IN_PROGRESS' | 'DONE' | 'BLOCKED'
+export type GoalStatus =
+  | 'NOT_STARTED'
+  | 'IN_PROGRESS'
+  | 'DONE'
+  | 'BLOCKED'
+  | 'CANCELED'
+  | 'DEFERRED'
+  | 'OBSERVING'
+
+export const GOAL_STATUSES: readonly GoalStatus[] = [
+  'NOT_STARTED',
+  'IN_PROGRESS',
+  'DONE',
+  'BLOCKED',
+  'CANCELED',
+  'DEFERRED',
+  'OBSERVING',
+] as const
 export type GoalPriority = 'P0' | 'P1' | 'P2'
 export type GoalType = 'goal' | 'meta'
 
@@ -70,6 +87,114 @@ function parseSimpleYaml(yaml: string): GoalFrontmatter {
     }
   }
   return out
+}
+
+/** legacy / 비표준 status → GoalStatus. 매핑 불가면 null. */
+export function normalizeLegacyStatus(raw: string): GoalStatus | null {
+  const trimmed = raw.trim()
+  if (GOAL_STATUSES.includes(trimmed as GoalStatus)) return trimmed as GoalStatus
+  const key = trimmed.toLowerCase().replace(/\s+/g, '_')
+  const map: Record<string, GoalStatus> = {
+    active: 'IN_PROGRESS',
+    done: 'DONE',
+    pending: 'NOT_STARTED',
+    canceled: 'CANCELED',
+    cancelled: 'CANCELED',
+    deferred: 'DEFERRED',
+    observing: 'OBSERVING',
+    blocked: 'BLOCKED',
+    not_started: 'NOT_STARTED',
+    in_progress: 'IN_PROGRESS',
+  }
+  return map[key] ?? null
+}
+
+export function inferGoalIdFromFilename(name: string): number | null {
+  const m = name.match(/^(\d+)-/)
+  if (!m) return null
+  const n = Number(m[1])
+  return Number.isFinite(n) ? n : null
+}
+
+export interface GoalMigrateAction {
+  file: string
+  actions: string[]
+}
+
+/** 단일 goal 파일 migrate 계획. 변경 없으면 null. */
+export function planGoalFileMigrate(filePath: string, content: string): {
+  actions: string[]
+  nextContent: string
+} | null {
+  const name = filePath.replace(/^.*[/\\]/, '')
+  if (name === '_meta.md') return null
+  const { frontmatter } = parseFrontmatter(content)
+  if (frontmatter.type === 'meta') return null
+
+  const patch: Record<string, string | number> = {}
+  const actions: string[] = []
+
+  if (frontmatter.type !== 'goal') {
+    patch.type = 'goal'
+    actions.push("type: goal 추가")
+  }
+
+  if (typeof frontmatter.id !== 'number') {
+    const inferred = inferGoalIdFromFilename(name)
+    if (inferred != null) {
+      patch.id = inferred
+      actions.push(`id: ${inferred} (파일명)`)
+    }
+  }
+
+  const rawStatus = frontmatter.status
+  if (typeof rawStatus === 'string') {
+    const normalized = normalizeLegacyStatus(rawStatus)
+    if (normalized && normalized !== rawStatus) {
+      patch.status = normalized
+      actions.push(`status: ${rawStatus} → ${normalized}`)
+    }
+  }
+
+  if (actions.length === 0) return null
+
+  let nextContent = content
+  for (const [key, value] of Object.entries(patch)) {
+    nextContent = patchGoalFrontmatter(nextContent, key, value)
+  }
+  return { actions, nextContent }
+}
+
+/** frontmatter 단일 필드 추가/갱신 (status 전용 updateFrontmatterStatus 의 일반형). */
+export function patchGoalFrontmatter(
+  content: string,
+  key: string,
+  value: string | number,
+): string {
+  const normalized = stripBom(content)
+  const m = normalized.match(FRONTMATTER_RE)
+  if (!m) return content
+  const fmRaw = m[1]
+  const body = m[2] ?? ''
+  const lines = fmRaw.split(/\r?\n/)
+  let hadKey = false
+  const rendered = typeof value === 'number' ? String(value) : value
+
+  const updated = lines.map((raw) => {
+    const trimmed = raw.trim()
+    if (!trimmed || trimmed.startsWith('#')) return raw
+    const idx = trimmed.indexOf(':')
+    if (idx <= 0) return raw
+    const lineKey = trimmed.slice(0, idx).trim()
+    if (lineKey === key) {
+      hadKey = true
+      return `${key}: ${rendered}`
+    }
+    return raw
+  })
+
+  if (!hadKey) updated.push(`${key}: ${rendered}`)
+  return `---\n${updated.join('\n')}\n---\n${body}`
 }
 
 export function parseGoalFile(filePath: string): ParsedGoal | null {

--- a/tests/goal-frontmatter.test.ts
+++ b/tests/goal-frontmatter.test.ts
@@ -8,6 +8,8 @@ import {
   listGoals,
   updateFrontmatterStatus,
   findDuplicateIds,
+  normalizeLegacyStatus,
+  planGoalFileMigrate,
   type ParsedGoal,
 } from '../src/lib/goal-frontmatter.js'
 
@@ -194,5 +196,37 @@ describe('findDuplicateIds', () => {
 
   it('빈 입력은 빈 배열', () => {
     expect(findDuplicateIds([])).toEqual([])
+  })
+})
+
+describe('normalizeLegacyStatus', () => {
+  it('maps legacy active to IN_PROGRESS', () => {
+    expect(normalizeLegacyStatus('active')).toBe('IN_PROGRESS')
+  })
+
+  it('passes through standard enum', () => {
+    expect(normalizeLegacyStatus('DONE')).toBe('DONE')
+  })
+
+  it('returns null for unknown', () => {
+    expect(normalizeLegacyStatus('weird')).toBeNull()
+  })
+})
+
+describe('planGoalFileMigrate', () => {
+  it('adds type goal and normalizes legacy status', () => {
+    const content = `---
+id: 99
+status: active
+title: test
+---
+
+body`
+    const plan = planGoalFileMigrate('goals/99-test.md', content)
+    expect(plan).not.toBeNull()
+    expect(plan!.actions.some((a) => a.includes('type: goal'))).toBe(true)
+    expect(plan!.actions.some((a) => a.includes('IN_PROGRESS'))).toBe(true)
+    expect(plan!.nextContent).toContain('type: goal')
+    expect(plan!.nextContent).toContain('status: IN_PROGRESS')
   })
 })


### PR DESCRIPTION
## Summary
- GoalStatus: CANCELED, DEFERRED, OBSERVING
- vhk goal migrate [--dry-run]
- doctor warns on skipped goals (--strict fail)
- Relabel goal 73/79/50
- check-goal-frontmatter sync

Closes #465, #469

Made with [Cursor](https://cursor.com)