### PR TITLE
feat: verify→learn bridge + bootstrap cursor (#466/#467)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -17,6 +17,14 @@ Cursor에게 한국어로 말해도 됩니다.
 
 > `vhk sync` 대상(7): `.cursorrules` · `.windsurfrules` · `.github/copilot-instructions.md` · `.agents/rules/vhk-rules.md` · `AGENTS.md` · `GEMINI.md`(Gemini CLI) · `.clinerules/vhk-rules.md`(Cline) + `CLAUDE.md`(하이브리드). 모두 RULES.md 단일소스에서 생성.
 
+## Cursor bootstrap (#467)
+
+| 하고 싶은 것 | 터미널 명령 | Cursor에게 말하기 |
+|-------------|-----------|------------------|
+| Cursor 독푸딩 (설치+배선) | `vhk bootstrap cursor` (`-y`, `--skip-verify`) | "VHK 독푸딩 해줘" |
+
+> doctor → goal migrate --dry-run → inject-bootstrap → mcp-init → sync → `.cursor/skills/vhk-*` 5종 → verify(선택). brownfield Cursor 마이그레이션용.
+
 | 빌드+테스트 | `pnpm build; pnpm test --run` | "빌드하고 테스트 돌려" |
 | 배포 | `vhk 배포` | "배포해" |
 
@@ -25,6 +33,7 @@ Cursor에게 한국어로 말해도 됩니다.
 | 하고 싶은 것 | 터미널 명령 | Cursor에게 말하기 |
 |-------------|-----------|------------------|
 | goals/ 스캐폴딩 | `vhk goal init` | (대상 프로젝트에서 직접) |
+| goal frontmatter 마이그레이션 | `vhk goal migrate` (`--dry-run`) | "goal 스키마 맞춰줘" |
 | goal 목록 | `vhk goal list` | "목표 목록" |
 | 다음 goal | `vhk goal next` | "다음 목표" |
 | 다음 goal 미리보기(읽기전용) | `vhk goal peek` | "목표 미리보기" |
@@ -152,6 +161,7 @@ vhk doctor
 |------|---------|
 | `vhk gate` | 아이디어 검증 |
 | `vhk start` | 새 프로젝트 시작 마법사 |
+| `vhk bootstrap` | Cursor/에이전트 배선 bootstrap (서브: `cursor`) |
 | `vhk init` | 하네스 파일 생성 |
 | `vhk recap` | 오늘 한 일 정리 + ADR 분리 (비-TTY/헤드리스: `--summary/--next/--decisions/--blockers/--yes`) |
 | `vhk sync` | RULES.md → 규칙 파일 동기화 (`--check` = drift 검사만, Goal 63) |

--- a/scripts/gen-cursor-skills.mjs
+++ b/scripts/gen-cursor-skills.mjs
@@ -1,0 +1,13 @@
+import fs from 'node:fs'
+import path from 'node:path'
+const skills = ['vhk-gate','vhk-evolve-loop','vhk-dogfood-issue','vhk-goal-health','vhk-bootstrap-cursor']
+const base = 'C:/Users/Public/dev/yohan-ecosystem/yohan-cc-skills/plugins/workflow/skills'
+const entries = {}
+for (const name of skills) {
+  entries[name] = fs.readFileSync(path.join(base, name, 'SKILL.md'), 'utf8')
+}
+const header = "import { existsSync, mkdirSync, writeFileSync } from 'node:fs'\nimport { join } from 'node:path'\n\n/** yohan-cc-skills workflow skills bundle — bootstrap cursor installs create-if-missing. */\nexport const CURSOR_SKILL_TEMPLATES: Readonly<Record<string, string>> = "
+const footer = "\n\nexport interface InstallCursorSkillsResult {\n  created: string[]\n  skipped: string[]\n}\n\nexport function installCursorSkills(cwd: string = process.cwd()): InstallCursorSkillsResult {\n  const skillsRoot = join(cwd, '.cursor', 'skills')\n  const created: string[] = []\n  const skipped: string[] = []\n  for (const [name, content] of Object.entries(CURSOR_SKILL_TEMPLATES)) {\n    const skillDir = join(skillsRoot, name)\n    const skillFile = join(skillDir, 'SKILL.md')\n    if (existsSync(skillFile)) {\n      skipped.push(name)\n      continue\n    }\n    mkdirSync(skillDir, { recursive: true })\n    writeFileSync(skillFile, content, 'utf-8')\n    created.push(name)\n  }\n  return { created, skipped }\n}\n"
+const out = header + JSON.stringify(entries, null, 2) + footer
+fs.writeFileSync('C:/Users/Public/dev/yohan-ecosystem/vhk/src/lib/cursor-skill-templates.ts', out, 'utf8')
+console.log('ok')

--- a/src/commands/bootstrap-cursor.ts
+++ b/src/commands/bootstrap-cursor.ts
@@ -1,0 +1,71 @@
+import chalk from 'chalk'
+import { doctor } from './doctor.js'
+import { goalMigrate } from './goal.js'
+import { injectBootstrapCommand } from './inject-bootstrap.js'
+import { mcpInit } from './mcp-init.js'
+import { sync } from './sync.js'
+import { verify } from './verify.js'
+import { ko } from '../i18n/ko.js'
+import { log } from '../utils/logger.js'
+import { printNextStep } from '../lib/next-step.js'
+import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
+import { installCursorSkills } from '../lib/cursor-skill-templates.js'
+
+export type BootstrapCursorOptions = {
+  yes?: boolean
+  skipVerify?: boolean
+}
+
+async function runStep<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn()
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    log.error(`${label} 실패: ${msg}`)
+    throw err
+  }
+}
+
+/** #467 MVP: Cursor 독푸딩 — doctor + goal migrate + inject-bootstrap + mcp-init + sync + skills + verify */
+export async function bootstrapCursor(options: BootstrapCursorOptions = {}): Promise<void> {
+  if (!ensureNotHardStopped('bootstrap cursor')) return
+
+  const yes = options.yes === true
+  console.log(chalk.bold(`\n${ko.bootstrapCursor.title}\n`))
+
+  log.step(ko.bootstrapCursor.stepDoctor)
+  await runStep(ko.bootstrapCursor.stepDoctor, () => doctor({ strict: false }))
+
+  log.step(ko.bootstrapCursor.stepGoalMigrate)
+  await runStep(ko.bootstrapCursor.stepGoalMigrate, () => goalMigrate({ dryRun: true }))
+
+  log.step(ko.bootstrapCursor.stepInject)
+  await runStep(ko.bootstrapCursor.stepInject, () => injectBootstrapCommand({ yes }))
+
+  log.step(ko.bootstrapCursor.stepMcp)
+  await runStep(ko.bootstrapCursor.stepMcp, () => mcpInit())
+
+  log.step(ko.bootstrapCursor.stepSync)
+  await runStep(ko.bootstrapCursor.stepSync, () => sync({ yes }))
+
+  log.step(ko.bootstrapCursor.stepSkills)
+  const skills = installCursorSkills()
+  if (skills.created.length > 0) {
+    console.log(chalk.green(`  ${ko.bootstrapCursor.skillsCreated(skills.created)}`))
+  }
+  if (skills.skipped.length > 0) {
+    console.log(chalk.dim(`  ${ko.bootstrapCursor.skillsSkipped(skills.skipped)}`))
+  }
+
+  if (!options.skipVerify) {
+    log.step(ko.bootstrapCursor.stepVerify)
+    await runStep(ko.bootstrapCursor.stepVerify, () => verify({}))
+  }
+
+  console.log(chalk.bold.green(`\n${ko.bootstrapCursor.done}\n`))
+  printNextStep({
+    message: ko.bootstrapCursor.nextHint,
+    command: 'vhk gate',
+    cursorHint: 'vhk-gate skill 로 verify receipt review 실행해줘',
+  })
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -21,6 +21,8 @@ import { buildVhkDiag } from '../doctor/diagnostics/vhk.js'
 import { buildMcpDiag, mcpToolCount } from '../doctor/diagnostics/mcp.js'
 import { buildAuditDiag } from '../doctor/diagnostics/audit.js'
 import { findSkippedGoalFiles, listGoals } from '../lib/goal-frontmatter.js'
+import { ECOSYSTEM_MDC_REL } from '../lib/inject-bootstrap.js'
+import { agentsMdReferencesEcosystemMd } from './sync.js'
 import { readSelectedPM } from '../doctor/pm.js'
 import type { DiagDeps, DoctorOptions, DiagFn } from '../doctor/types.js'
 // 업데이트 체크 함수는 version-check.ts 단일 소스로 이동(메뉴와 공용). 여기선 import + re-export
@@ -190,6 +192,7 @@ export async function doctor(opts: DoctorOptions = {}) {
 
   // Goal frontmatter — silent skip 감지 (#465)
   let goalSchemaWarn = false
+  let ecosystemMdcWarn = false
   const goalsDir = path.join(cwd, 'goals')
   if (fs.existsSync(goalsDir)) {
     console.log('')
@@ -216,6 +219,19 @@ export async function doctor(opts: DoctorOptions = {}) {
       console.log(chalk.dim('    → vhk goal migrate [--dry-run]'))
     } else {
       console.log(chalk.green(`    ${ko.doctor.goalSchemaOk(parsed.length)}`))
+    }
+  }
+
+  const agentsPath = path.join(cwd, 'AGENTS.md')
+  const ecoPath = path.join(cwd, ECOSYSTEM_MDC_REL)
+  if (fs.existsSync(agentsPath)) {
+    const agentsContent = fs.readFileSync(agentsPath, 'utf-8')
+    if (agentsMdReferencesEcosystemMd(agentsContent) && !fs.existsSync(ecoPath)) {
+      ecosystemMdcWarn = true
+      console.log('')
+      console.log(chalk.bold(`  ${ko.doctor.ecosystemMdcTitle}`))
+      console.log(chalk.yellow(`    ${ko.doctor.ecosystemMdcMissing}`))
+      console.log(chalk.dim('    → vhk inject-bootstrap 또는 vhk sync'))
     }
   }
 
@@ -252,6 +268,11 @@ export async function doctor(opts: DoctorOptions = {}) {
   if (opts.strict && goalSchemaWarn) {
     console.log('')
     console.log(chalk.red.bold('  ❌ --strict: goal frontmatter 스키마 경고 → 실패 처리 (vhk goal migrate)'))
+    process.exitCode = 1
+  }
+  if (opts.strict && ecosystemMdcWarn) {
+    console.log('')
+    console.log(chalk.red.bold('  ❌ --strict: ecosystem.mdc 누락 → 실패 처리 (vhk inject-bootstrap)'))
     process.exitCode = 1
   }
 }

--- a/src/commands/recap.ts
+++ b/src/commands/recap.ts
@@ -12,6 +12,7 @@ import { printSecurityWarnings } from '../lib/check-secure.js'
 import { isInteractive } from '../lib/interactive.js'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
 import { localDate } from '../lib/date.js'
+import { getWorkingTreeChanges } from '../lib/git-repo.js'
 
 export type RecapOptions = {
   since?: string
@@ -44,8 +45,9 @@ export async function recap(options: RecapOptions = {}) {
   const since = options.since || localDate()
   const diff = await getSessionDiff(since)
   const commits = await getRecentCommits(10, since)
+  const workingTree = getWorkingTreeChanges()
 
-  if (diff.filesChanged === 0 && commits.length === 0) {
+  if (diff.filesChanged === 0 && commits.length === 0 && workingTree.length === 0) {
     console.log(chalk.yellow(ko.recap.noChanges))
     return
   }
@@ -74,12 +76,33 @@ export async function recap(options: RecapOptions = {}) {
     })
   }
 
+  if (workingTree.length > 0) {
+    console.log(chalk.bold(`\n${ko.recap.workingTreeTitle}`))
+    workingTree.slice(0, 15).forEach((w) => {
+      console.log(chalk.yellow(`  • ${w.path}`))
+    })
+    if (workingTree.length > 15) {
+      console.log(chalk.dim(`  ... 외 ${workingTree.length - 15}개`))
+    }
+  }
+
   console.log('')
   // #288: 비-TTY(헤드리스 AI·파이프) 또는 --yes 면 프롬프트 대신 플래그값(없으면 미입력 표식)으로
   // 회고를 구성한다. 과거엔 여기서 ensureInteractive 가 TTY_REQUIRED(exit 2)로 중단해 AI 워크플로가
   // 끊겼다(COMMANDS.md "오늘 한 일 정리해" 안내와 모순). 대화형 경로는 그대로 — 프롬프트 호출 금지
   // 규칙은 아래 비-TTY 분기(프롬프트 미호출)에서 지킨다.
   const interactive = isInteractive({ yes: options.yes })
+
+  const autoSummary =
+    !interactive && !options.summary?.trim() && workingTree.length > 0
+      ? ko.recap.autoDirtySummary(
+          workingTree.length,
+          workingTree
+            .slice(0, 5)
+            .map((w) => w.path)
+            .join(', ')
+        )
+      : undefined
 
   const answers = interactive
     ? await prompt<{ summary: string; decisions: string; nextTodo: string; blockers: string }>([
@@ -107,7 +130,7 @@ export async function recap(options: RecapOptions = {}) {
         },
       ])
     : {
-        summary: options.summary?.trim() || ko.recap.notProvided,
+        summary: options.summary?.trim() || autoSummary || ko.recap.notProvided,
         decisions: options.decisions?.trim() || '없음',
         nextTodo: options.next?.trim() || ko.recap.notProvided,
         blockers: options.blockers?.trim() || '없음',

--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -386,7 +386,7 @@ export async function receipt(opts: ReceiptOptions = {}): Promise<void> {
       message: ko.receipt.nextBlockMessage,
       command: 'vhk verify',
       cursorHint: '막힌 증거부터 고쳐줘',
-      alternative: r.reasons[0],
+      alternative: `vhk learn "${ko.receipt.learnBlockHint}"`,
     })
   } else if (r.decision === 'caution') {
     printNextStep({

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -8,6 +8,7 @@ import { printNextStep } from '../lib/next-step.js'
 import { normalizeForCompare } from '../lib/drift.js'
 import { saveBackup, pruneBackups, ensureVhkIgnored } from '../lib/backup.js'
 import { atomicWriteFile } from '../lib/atomic-write.js'
+import { injectBootstrapAll, ECOSYSTEM_MDC_REL } from '../lib/inject-bootstrap.js'
 import { PREAMBLE_TITLE } from '../lib/rules-import.js'
 import { isInteractive, promptOrDefault } from '../lib/interactive.js'
 
@@ -346,8 +347,17 @@ export function resolveAgentCompactRel(rootDir: string): string | null {
   return null
 }
 
+/** AGENTS.md 가 ecosystem.mdc 를 참조하는지 (brownfield drift 감지). */
+export function agentsMdReferencesEcosystemMd(content: string): boolean {
+  return content.includes('ecosystem.mdc')
+}
+
 /** E6-01: tier S/A child AGENTS.md — ecosystem cross-repo block (Loop Protocol 직후 고정 삽입). */
-export function agentsMdEcosystemBlock(): string[] {
+export function agentsMdEcosystemBlock(rootDir?: string): string[] {
+  if (rootDir) {
+    const ecoPath = path.join(rootDir, ECOSYSTEM_MDC_REL)
+    if (!fs.existsSync(ecoPath)) return []
+  }
   return [
     '## Ecosystem (cross-repo)',
     '',
@@ -370,6 +380,7 @@ export function toAgentsMd(
   projectName: string,
   /** null = compact 안내 생략. undefined = 레거시 테스트 기본(경로 문자열 포함). */
   compactRel: string | null | undefined = 'docs/context/agent-compact.md',
+  rootDir?: string,
 ): string {
   const codingSections = sections.filter(s => CURSORRULES_KEYS.some(k => s.title.includes(k)))
   const recordSections = sections.filter(s => CLAUDE_MD_KEYS.some(k => s.title.includes(k)))
@@ -406,7 +417,7 @@ export function toAgentsMd(
     '- 교훈·결정·실패·성공은 `vhk memory`(memory v2 4버킷, 단일 출처).',
     '- 게이트(tsc / test:run / build) 통과해야만 `vhk goal done`.',
     '',
-    ...agentsMdEcosystemBlock(),
+    ...agentsMdEcosystemBlock(rootDir),
   )
 
   for (const section of orderedMapped) {
@@ -543,7 +554,7 @@ export function buildSyncPlan(
     const exists = fs.existsSync(fullPath)
     const newContent =
       target.path === 'AGENTS.md'
-        ? toAgentsMd(sections, projectName, resolveAgentCompactRel(rootDir))
+        ? toAgentsMd(sections, projectName, resolveAgentCompactRel(rootDir), rootDir)
         : target.generate(sections, projectName)
     // drift = 정규화 후 비교. 공백/EOL(CRLF)-only 차이는 의도적으로 drift 아님(거짓경보·백업 churn 방지)
     // → 그 차이는 백업 없이 덮어써질 수 있으나 규칙 본문은 절대 손실 안 됨(범위 한정).
@@ -652,6 +663,20 @@ export async function syncCore(
   fs.mkdirSync(path.join(rootDir, '.vhk'), { recursive: true })
   atomicWriteFile(path.join(rootDir, SYNCED_MARKER_REL), new Date().toISOString() + '\n')
   ensureVhkIgnored(rootDir, '.synced')
+
+  // #468 brownfield: ecosystem.mdc 없으면 inject-bootstrap 으로 생성 후 AGENTS 재생성
+  const ecoPath = path.join(rootDir, ECOSYSTEM_MDC_REL)
+  if (!fs.existsSync(ecoPath)) {
+    const injected = injectBootstrapAll(rootDir, { yes: true })
+    if (
+      (injected.ecosystem === 'created' || injected.ecosystem === 'updated')
+      && written.includes('AGENTS.md')
+    ) {
+      const agentsPath = path.join(rootDir, 'AGENTS.md')
+      const refreshed = toAgentsMd(sections, projectName, resolveAgentCompactRel(rootDir), rootDir)
+      fs.writeFileSync(agentsPath, refreshed, 'utf-8')
+    }
+  }
 
   return { dryRun: false, firstSync, backupId, backedUp, written, skipped, truncated, plan, unmapped, claudeMigration }
 }

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -271,6 +271,15 @@ export function buildNextActions(gates: GateResult[]): string[] {
       actions.push(`${g.label} 불완전 — ${g.detail ?? '한도로 일부 미스캔'}. 한도 완화/대상 축소 후 재검증 권장`)
     }
   }
+  const failed = gates.filter((g) => g.status === 'fail')
+  if (failed.length > 0) {
+    const first = failed[0]
+    const lesson =
+      first.id === 'secure'
+        ? '시크릿 유출 수정 후 재검증'
+        : `${first.label} 실패 수정 — 원인·재발방지`
+    actions.push(`교훈 기록 — vhk learn "${lesson}"`)
+  }
   if (actions.length === 0) actions.push('검증 통과 — vhk save 로 저장하세요.')
   return actions
 }

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -296,6 +296,8 @@ export const ko = {
     goalSchemaOk: (n: number) => `✅ goals/ ${n}개 goal 파싱 정상`,
     goalSchemaSkipped: (n: number) => `⚠️ 스키마 불일치로 무시된 goal 파일 ${n}개`,
     goalSchemaEmpty: (n: number) => `⚠️ goals/*.md ${n}개 있으나 파싱된 goal 0개 — type/id 누락 가능`,
+    ecosystemMdcTitle: 'Ecosystem rule file',
+    ecosystemMdcMissing: '⚠️ AGENTS.md references .cursor/rules/ecosystem.mdc but file is missing',
   },
   preflight: {
     title: '🛫 Preflight — 출고 전 안전점검',

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -256,6 +256,23 @@ export const ko = {
     notProvided: '_(미입력 — 비대화형 실행)_',
     nonInteractiveNote: '비대화형 모드 — 회고 본문은 --summary / --next / --decisions / --blockers 플래그로 채울 수 있어요 (미지정 항목은 "미입력"으로 기록).',
     detectSkipNonInteractive: '비대화형 모드 — 문서 자동 생성은 대화형(vhk recap)에서만. 위 후보를 참고해 직접 기록하세요.',
+    workingTreeTitle: '📂 미커밋 변경 (working tree):',
+    autoDirtySummary: (n: number, sample: string) =>
+      `미커밋 변경 ${n}건${sample ? `: ${sample}${n > 5 ? ' …' : ''}` : ''}`,
+  },
+  bootstrapCursor: {
+    title: '🚀 VHK Cursor bootstrap (설치 + 배선)',
+    stepDoctor: '[1/6] vhk doctor',
+    stepGoalMigrate: '[2/6] vhk goal migrate --dry-run',
+    stepInject: '[3/6] vhk inject-bootstrap',
+    stepMcp: '[4/6] vhk mcp-init',
+    stepSync: '[5/6] vhk sync',
+    stepSkills: '[6/6] Cursor skills 설치',
+    stepVerify: '배선 검증 — vhk verify',
+    skillsCreated: (names: string[]) => `Cursor skills 생성: ${names.join(', ')}`,
+    skillsSkipped: (names: string[]) => `Cursor skills 이미 있음(건너뜀): ${names.join(', ')}`,
+    done: '✅ Cursor bootstrap 완료',
+    nextHint: 'goal/receipt/review/learn 루프를 vhk-gate skill 로 실행하세요.',
   },
   check: {
     title: '🔍 프로젝트 규칙 점검',
@@ -329,6 +346,7 @@ export const ko = {
     noCommit: 'git 커밋을 찾을 수 없습니다 — 작업시작 기준선을 기록하려면 커밋이 1개 이상 필요합니다.',
     markStartDone: '작업시작 기준선 SHA 기록 완료 (이후 stale 비교 기준):',
     nextBlockMessage: '🔴 기계증거가 "됐어요"와 모순 — 아직 완료 아님. 막힌 증거(red/dirty/stale/forbidden)부터 고치세요:',
+    learnBlockHint: 'receipt BLOCK — 막힌 증거 원인과 재발방지',
     nextCautionMessage: '🟡 실차단은 없으나 약신호 있음(수동 확인 권장). 보강 후 다시 떼세요:',
     nextPassMessage: '🟢 게으른 거짓완료 징후 없음(미묘한 오류는 못 잡음). 완료 처리하려면:',
     // Goal 87 방향 2-1: glob 미지원 문법 경고 — 거짓 안전을 caution 으로 드러냄.

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ import { work, workHandoff } from './commands/work.js'
 import { getUpdateInfo } from './lib/version-check.js'
 import { QUICK_ACTIONS } from './commands/help.js'
 import { start } from './commands/start.js'
+import { bootstrapCursor } from './commands/bootstrap-cursor.js'
 import { mode } from './commands/mode.js'
 import { configSetBrainRoot } from './commands/config.js'
 import { verify } from './commands/verify.js'
@@ -240,6 +241,19 @@ program
   .option('--type <type>', '프로젝트 유형 (webapp|extension|cli|notion|mobile|other)')
   .option('-y, --yes', '모든 확인 스킵 (자동 yes)')
   .action(start)
+
+const bootstrapCmd = program
+  .command('bootstrap')
+  .description('Cursor/에이전트 배선 bootstrap (#467)')
+
+bootstrapCmd
+  .command('cursor')
+  .description('Cursor 독푸딩 — doctor + goal migrate + inject-bootstrap + skills + verify')
+  .option('-y, --yes', '확인 스킵 (비대화형)')
+  .option('--skip-verify', '마지막 vhk verify 생략')
+  .action(async (opts: { yes?: boolean; skipVerify?: boolean }) => {
+    await bootstrapCursor({ yes: opts.yes, skipVerify: opts.skipVerify })
+  })
 
 // 2단계(저수준) — 문서/하네스만 생성. 일반 사용자는 'vhk start' 권장.
 program

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -5,6 +5,7 @@ import { CONTAINER_SUBCOMMANDS, CONTAINER_ALIASES } from './command-registry.js'
 export const KNOWN_COMMAND_TOKENS = new Set([
   'gate', '검증', '아이디어',
   'start', '시작', '새프로젝트',
+  'bootstrap',
   'init', '초기화', '만들기',
   'recap', '정리', '오늘',
   'sync', '맞추기', '규칙',

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -25,6 +25,7 @@ export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
   worktree: ['add', 'check'],
   seo: ['init', 'submit', 'check', 'report', 'automate'],
   config: ['set-brain-root'],
+  bootstrap: ['cursor'],
 }
 
 /** 한국어 별칭 → 영문 컨테이너 명령. 별칭도 같은 서브커맨드 집합을 공유한다. */
@@ -59,6 +60,7 @@ export const CONTAINER_ALIASES: Record<string, string> = {
 export const TOP_LEVEL_COMMANDS: ReadonlyArray<{ name: string; desc: string }> = [
   { name: 'gate', desc: '아이디어 검증' },
   { name: 'start', desc: '새 프로젝트 시작 마법사' },
+  { name: 'bootstrap', desc: 'Cursor/에이전트 배선 bootstrap (cursor)' },
   { name: 'init', desc: '하네스 파일 생성' },
   { name: 'recap', desc: '오늘 한 일 정리 + ADR 분리' },
   { name: 'sync', desc: 'RULES.md → 규칙 파일 동기화' },

--- a/src/lib/cursor-skill-templates.ts
+++ b/src/lib/cursor-skill-templates.ts
@@ -1,0 +1,34 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/** yohan-cc-skills workflow skills bundle — bootstrap cursor installs create-if-missing. */
+export const CURSOR_SKILL_TEMPLATES: Readonly<Record<string, string>> = {
+  "vhk-gate": "---\r\nname: vhk-gate\r\ndescription: VHK 검증 게이트 전체 — verify → receipt → review. 트리거: \"검증\", \"게이트\", \"완료\", goal done 전, 코드 변경 후.\r\n---\r\n\r\n# VHK Gate\r\n\r\n코드·완료 주장 전 **반드시** 실행. red/BLOCK/skip이면 아래 분기 스킬로.\r\n\r\n## 순서 (Windows)\r\n\r\n```powershell\r\npnpm.cmd typecheck\r\npnpm.cmd test\r\npnpm.cmd lint\r\nvhk verify\r\nvhk receipt\r\nvhk review\r\n```\r\n\r\n## 판정 분기\r\n\r\n| 결과 | 다음 |\r\n|---|---|\r\n| verify red | `.vhk/reports/latest.json` → 수정 → 재실행 |\r\n| receipt BLOCK | dirty/stale → commit 또는 `vhk receipt --mark-start` → **vhk-evolve-loop** |\r\n| review skip (goal 0) | **vhk-goal-health** |\r\n| review fail | **vhk-evolve-loop** + 앱 결함이면 수정 |\r\n\r\n## L1 vs L2\r\n\r\n- VHK CLI 버그/크래시 → **vhk-dogfood-issue**\r\n- 프로젝트 반복 실수 → **vhk-evolve-loop**\r\n\r\n## Pass criteria\r\n\r\nverify exit 0 + receipt pass/caution + review pass (또는 skip 사유 goal-health 해결 후).\r\n\r\n완료 선언 금지 until pass.\r\n",
+  "vhk-evolve-loop": "---\r\nname: vhk-evolve-loop\r\ndescription: VHK L2 자기개선 — learn/win → pattern → evolve. 트리거: gate FAIL, critic/security finding, receipt BLOCK, 반복 실수.\r\n---\r\n\r\n# VHK Evolve Loop (L2 프로젝트)\r\n\r\n**SoT:** `.vhk/memory.json` → `vhk evolve` → `RULES.md` (프로젝트만). VHK CLI 버그는 **vhk-dogfood-issue** (L1).\r\n\r\n## 1. 기록\r\n\r\n```powershell\r\nvhk learn \"한 줄 교훈 — why 포함\"\r\nvhk win \"한 줄 성공 — reinforce\"\r\n```\r\n\r\n팀 공유 필요 시 `docs/context/recurring-defects.md` 또는 ADR.\r\n\r\n## 2. 패턴\r\n\r\n```powershell\r\nvhk pattern detect\r\nvhk pattern list\r\nvhk evolve suggest\r\nvhk evolve list\r\n```\r\n\r\n## 3. 반영\r\n\r\n- TTY + 사람 확인: `vhk evolve apply <id>` → `vhk sync`\r\n- Headless/agent: `vhk evolve digest` → RULES 초안 제안만 (자동 apply 금지)\r\n\r\n## 4. L3 후보\r\n\r\n동일 교훈이 **2+ VHK 프로젝트**면 yohan-cc-skills 스킬/RULES 템플릿 PR 검토.\r\n\r\n## 금지\r\n\r\n- L1 CLI 결함을 learn만으로 끝내기 — vhk 레포 이슈 병행\r\n- memory.json만 믿고 RULES 미갱신 (로컬 전용, gitignore)\r\n",
+  "vhk-dogfood-issue": "---\r\nname: vhk-dogfood-issue\r\ndescription: VHK L1 — CLI/하네스 결함 재현·분류·vhk 레포 이슈 등록. 트리거: vhk exit≠0, doctor/review/receipt 버그, \"VHK 버그\", \"vhk 이슈\".\r\n---\r\n\r\n# VHK Dogfood Issue (L1 제품)\r\n\r\n**SoT:** https://github.com/byh3071-cpu/vhk/issues\r\n\r\n## 분류 (먼저)\r\n\r\n| 유형 | 등록 | 예 |\r\n|---|---|---|\r\n| **도구 결함** | vhk 레po | goal silent skip, recap headless |\r\n| **앱 버그** | **현재 프로젝트** 이슈/수정 | aroo 결제 로직 |\r\n| **배선 갭** | 프로젝트 skill/RULES + (공통이면) vhk enhancement | verify만 하고 receipt 생략 |\r\n\r\n교차검증 필요 시 **dogfood-crosscheck** 선행.\r\n\r\n## 절차\r\n\r\n1. **재현** — 최소 명령·exit code·`vhk --version`\r\n2. **중복 검색**\r\n   ```powershell\r\n   gh issue list -R byh3071-cpu/vhk --search \"키워드\" --state all\r\n   ```\r\n3. **body 작성** — `.vhk/issue-<slug>.md` (재현/기대/실제/환경)\r\n4. **등록** — 사용자가 \"등록해\" / \"ㅇㅋ 이슈\" 명시 후:\r\n   ```powershell\r\n   gh issue create -R byh3071-cpu/vhk --title \"...\" --label \"bug,dogfooding\" --body-file .vhk/issue-<slug>.md\r\n   ```\r\n5. **로컬 흔적** — `vhk learn \"dogfood: ...\"` (태그 dogfood)\r\n\r\n## 금지\r\n\r\n- 사용자 승인 없이 `gh issue create`\r\n- 앱 버그를 vhk 레po에 등록\r\n",
+  "vhk-goal-health": "---\r\nname: vhk-goal-health\r\ndescription: goals/*.md 스키마修復 — type:goal 누락 silent skip 해소. 트리거: vhk review skip, vhk goal list ignored files, \"정의된 goal 없음\".\r\n---\r\n\r\n# VHK Goal Health\r\n\r\n## 진단\r\n\r\n```powershell\r\nvhk goal list\r\nvhk review\r\n```\r\n\r\n`스키마 불일치로 무시` / `goal 없음` → frontmatter修復.\r\n\r\n##修復\r\n\r\n각 `goals/*.md` frontmatter:\r\n\r\n```yaml\r\n---\r\ntype: goal\r\nid: 4          # 숫자\r\ntitle: ...\r\nstatus: IN_PROGRESS   # NOT_STARTED | IN_PROGRESS | DONE (대문자 enum)\r\n---\r\n```\r\n\r\nLegacy 매핑: `active`→`IN_PROGRESS`, `done`→`DONE`, `pending`→`NOT_STARTED`\r\n\r\n- legacy `id`만 있으면 `type: goal` 추가\r\n- `goals/_meta.md` 없으면 `vhk goal init` 참고 생성\r\n\r\n## 검증\r\n\r\n```powershell\r\nvhk goal list    # 4 files recognized\r\nvhk goal peek    # IN_PROGRESS 1개\r\nvhk review       # skip 아님\r\n```\r\n\r\n## L1\r\n\r\ndoctor/goal list가 legacy status를 경고 없이 무시 → **vhk-dogfood-issue** (#465, #467 follow-up).\r\n",
+  "vhk-bootstrap-cursor": "---\r\nname: vhk-bootstrap-cursor\r\ndescription: VHK Cursor 독푸딩 — 설치+배선 한 번에. 트리거: \"VHK 도입\", \"독푸딩\", \"vhk bootstrap\", Claude→Cursor 전환.\r\n---\r\n\r\n# VHK Bootstrap Cursor (설치 + 배선)\r\n\r\n**목표:** `vhk doctor` green + **goal/receipt/review/learn 루프 연결** + gate 1회 PASS.\r\n\r\n## Phase 0 — CLI\r\n\r\n```powershell\r\nvhk doctor\r\nvhk context\r\nvhk brief\r\nvhk sync\r\nvhk mcp-init\r\n```\r\n\r\n## Phase 1 — Goal (필수)\r\n\r\n```powershell\r\nvhk goal list\r\n```\r\n\r\n- silent skip 있으면 → **vhk-goal-health**\r\n- 없으면 `goals/_meta.md` + active goal 1개\r\n\r\n## Phase 2 — Cursor 산출물\r\n\r\n| 산출물 | 최소 |\r\n|---|---|\r\n| `.cursor/rules/` | context, windows-shell |\r\n| `.cursor/skills/` | vhk-gate, vhk-evolve-loop, vhk-dogfood-issue, vhk-bootstrap-cursor, recap |\r\n| `.cursor/hooks.json` | session-start, stop-recap |\r\n| `docs/state/` | next-task, blockers |\r\n| `docs/context/agent-compact.md` | 1페이지 |\r\n\r\n프로젝트 skill은 **vhk-gate 위임** (로직 중복 금지).\r\n\r\n## Phase 3 — 배선 검증\r\n\r\n```powershell\r\nvhk pattern detect\r\npnpm.cmd typecheck; pnpm.cmd test; pnpm.cmd lint\r\nvhk verify\r\nvhk receipt\r\nvhk review\r\n```\r\n\r\nreview skip → goal-health 재실행.\r\n\r\n## Phase 4 — L1 갭\r\n\r\nbootstrap 중 CLI 결함 → **vhk-dogfood-issue** (inject-bootstrap 누락, doctor goal 미검 등).\r\n\r\n## 완료 기준\r\n\r\n- `vhk goal list` ≥ 1 active\r\n- vhk-gate skill 존재\r\n- verify PASS; receipt not BLOCK (또는 사유 해소)\r\n"
+}
+
+export interface InstallCursorSkillsResult {
+  created: string[]
+  skipped: string[]
+}
+
+export function installCursorSkills(cwd: string = process.cwd()): InstallCursorSkillsResult {
+  const skillsRoot = join(cwd, '.cursor', 'skills')
+  const created: string[] = []
+  const skipped: string[] = []
+  for (const [name, content] of Object.entries(CURSOR_SKILL_TEMPLATES)) {
+    const skillDir = join(skillsRoot, name)
+    const skillFile = join(skillDir, 'SKILL.md')
+    if (existsSync(skillFile)) {
+      skipped.push(name)
+      continue
+    }
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(skillFile, content, 'utf-8')
+    created.push(name)
+  }
+  return { created, skipped }
+}

--- a/src/lib/git-repo.ts
+++ b/src/lib/git-repo.ts
@@ -1,6 +1,6 @@
 import { safeExecFile } from './exec.js'
 import { parsePorcelainLines } from './git-porcelain.js'
-import { filterSelfTrackedLines } from './self-tracked.js'
+import { filterSelfTrackedLines, porcelainPath } from './self-tracked.js'
 
 // Goal 46: git 접근 단일 통로화 — 직접 execFileSync 대신 safeExecFile 경유.
 // 얻는 것: timeout 백스톱 + 일관된 에러(실제 git stderr) + cwd 지원. 기존 throw 계약은 보존.
@@ -103,5 +103,25 @@ export function getCommitInfo(cwd: string = process.cwd()): CommitInfo | null {
     return { sha, shortSha: sha.slice(0, 7), dirty }
   } catch {
     return null
+  }
+}
+
+export interface WorkingTreeChange {
+  path: string
+  statusCode: string
+}
+
+/** 미커밋 working tree 변경(vhk 자기 산출 ledger 제외). recap 헤드리스 dirty 요약용. */
+export function getWorkingTreeChanges(cwd: string = process.cwd()): WorkingTreeChange[] {
+  try {
+    const lines = filterSelfTrackedLines(
+      parsePorcelainLines(gitOut(['status', '--porcelain', '--untracked-files=all'], cwd))
+    )
+    return lines.map((line) => ({
+      statusCode: line.slice(0, 2),
+      path: porcelainPath(line),
+    }))
+  } catch {
+    return []
   }
 }

--- a/tests/cursor-skill-templates.test.ts
+++ b/tests/cursor-skill-templates.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { installCursorSkills, CURSOR_SKILL_TEMPLATES } from '../src/lib/cursor-skill-templates.js'
+
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-bootstrap-'))
+}
+
+describe('cursor-skill-templates', () => {
+  it('5개 skill 템플릿 번들', () => {
+    expect(Object.keys(CURSOR_SKILL_TEMPLATES).sort()).toEqual([
+      'vhk-bootstrap-cursor',
+      'vhk-dogfood-issue',
+      'vhk-evolve-loop',
+      'vhk-gate',
+      'vhk-goal-health',
+    ])
+  })
+
+  let dir = ''
+  beforeEach(() => { dir = tmp() })
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }) })
+
+  it('installCursorSkills — create-if-missing', () => {
+    const r1 = installCursorSkills(dir)
+    expect(r1.created).toHaveLength(5)
+    expect(r1.skipped).toHaveLength(0)
+    expect(fs.existsSync(path.join(dir, '.cursor', 'skills', 'vhk-gate', 'SKILL.md'))).toBe(true)
+
+    const r2 = installCursorSkills(dir)
+    expect(r2.created).toHaveLength(0)
+    expect(r2.skipped).toHaveLength(5)
+  })
+})

--- a/tests/recap.test.ts
+++ b/tests/recap.test.ts
@@ -6,6 +6,11 @@ const mockGetSessionDiff = vi.fn()
 const mockGetRecentCommits = vi.fn()
 const mockPrompt = vi.fn()
 const mockWriteFileSync = vi.fn()
+const mockGetWorkingTreeChanges = vi.fn(() => [] as { path: string; statusCode: string }[])
+
+vi.mock('../src/lib/git-repo.js', () => ({
+  getWorkingTreeChanges: (...a: unknown[]) => mockGetWorkingTreeChanges(...a),
+}))
 
 vi.mock('../src/lib/git.js', () => ({
   isGitRepo: (...a: unknown[]) => mockIsGitRepo(...a),
@@ -62,6 +67,7 @@ function setTTY(value: boolean | undefined): boolean | undefined {
 describe('vhk recap', () => {
   beforeEach(() => {
     vi.resetAllMocks()
+    mockGetWorkingTreeChanges.mockReturnValue([])
     vi.spyOn(console, 'log').mockImplementation(() => {})
     vi.spyOn(console, 'error').mockImplementation(() => {})
     mockPrompt.mockResolvedValue({})
@@ -167,6 +173,25 @@ describe('vhk recap', () => {
 
       const content = mockWriteFileSync.mock.calls[0]?.[1] as string
       expect(content).toContain('미입력') // summary·nextTodo 가 미입력 표식
+    })
+
+    it('#466 미커밋 working tree → 헤드리스 summary 자동 채움', async () => {
+      mockGetWorkingTreeChanges.mockReturnValue([{ path: 'src/dirty.ts', statusCode: ' M' }])
+      mockGetSessionDiff.mockResolvedValue({
+        filesChanged: 0,
+        insertions: 0,
+        deletions: 0,
+        files: [],
+      })
+      mockGetRecentCommits.mockResolvedValue([{ hash: 'abc1234', message: 'fix: x' }])
+
+      const { recap } = await import('../src/commands/recap.js')
+      await recap({})
+
+      const content = mockWriteFileSync.mock.calls[0]?.[1] as string
+      expect(content).toContain('src/dirty.ts')
+      const summarySection = content.split('## 작업 요약')[1]?.split('## 결정 사항')[0] ?? ''
+      expect(summarySection).not.toContain('미입력')
     })
   })
 })

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -134,6 +134,28 @@ describe('vhk sync — AGENTS.md 생성 (배치3 6번째 타겟)', () => {
     expect(block).toContain('vhk sync')
   })
 
+  it('agentsMdEcosystemBlock — rootDir 에 ecosystem.mdc 없으면 빈 배열 (#468)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-eco-'))
+    try {
+      expect(agentsMdEcosystemBlock(dir)).toEqual([])
+      fs.mkdirSync(path.join(dir, '.cursor', 'rules'), { recursive: true })
+      fs.writeFileSync(path.join(dir, '.cursor', 'rules', 'ecosystem.mdc'), 'test\n', 'utf-8')
+      expect(agentsMdEcosystemBlock(dir).length).toBeGreaterThan(0)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('toAgentsMd — rootDir without ecosystem.mdc omits Ecosystem block', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-agents-eco-'))
+    try {
+      const out = toAgentsMd(parseRulesMd(SAMPLE_RULES), 'P', null, dir)
+      expect(out).not.toContain('## Ecosystem (cross-repo)')
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it('toAgentsMd — compactRel null 이면 agent-compact 포인터 생략 (tier S dead link 방지)', () => {
     const out = toAgentsMd(parseRulesMd(SAMPLE_RULES), 'P', null)
     expect(out).not.toContain('agent-compact')

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -60,6 +60,9 @@ describe('verify — nextActions', () => {
   it('fail 이면 수정 힌트', () => {
     expect(buildNextActions([gate('test', 'fail', 1)]).join(' ')).toMatch(/실패|수정/)
   })
+  it('fail 이면 vhk learn 힌트 (#466)', () => {
+    expect(buildNextActions([gate('test', 'fail', 1)]).join(' ')).toMatch(/vhk learn/)
+  })
   it('skip 이면 스크립트 추가 힌트', () => {
     expect(buildNextActions([gate('build', 'skip', null)]).join(' ')).toMatch(/scripts|게이트/)
   })


### PR DESCRIPTION
## Summary
- #466: `vhk verify` fail / `vhk receipt` BLOCK → `vhk learn` one-liner in nextActions
- #466: `vhk recap` headless — working tree dirty summary + auto `--summary` when uncommitted changes exist
- #467: `vhk bootstrap cursor` — doctor + goal migrate --dry-run + inject-bootstrap + mcp-init + sync + 5 Cursor skills + verify

## Test plan
- [x] `pnpm exec vitest run tests/verify.test.ts tests/recap.test.ts`
- [ ] CI green
- [ ] `vhk bootstrap cursor --yes --skip-verify` smoke in brownfield project

Depends on #472/#473 (stacked on wave2 branches — retarget to main after merge or merge sequentially)