### PR TITLE
docs: v2.10.0 발행 세션 마감 (next-task·CLAUDE LIVE)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,11 +148,11 @@ tags: [process, constitution]
 > 세션 종료: 마지막 갱신·버전·Phase·다음 할 일 갱신. (위 🔒 구역은 절대 건드리지 마.)
 > ⚠️ 아래 `**버전:**` 줄은 CI(version-sync.test.ts)가 강제 — 형식 `**버전:** vX.Y.Z` 유지, 릴리즈마다 package.json 따라 갱신.
 
-**마지막 갱신:** 2026-07-03
-- **버전:** v2.10.0 — 사실 확인은 package.json·CHANGELOG (Wave 1: init 죽은 안내문 정직화 + 누적 미발행분 발행)
-- **테스트:** 2206 pass(로컬) · **MCP tools:** 35 — 사실값은 package.json·CHANGELOG
-- **Phase:** **[2026-07-03] goal 88~92 완결 + RFC 0057(기억/복리/에이전트불가지론) 브레인스토밍 착수** — init 커스터마이징 트리거(88~90)·core-rules 폴백 가시화(91)·core-rules 자동화(92, `~/.vhk/config.json`) 전부 TDD+critic 2라운드 완결. SEO goal 22~26 재감사(RFC 0054 확인). RFC 0057 실측 감사(트리거계층 CC전용·`ecosystem.mdc` 모순문구·receipt agent필드 없음 확정) → 스코프 제안, **사용자 응답 대기 중 인계**. 상세 docs/state 최상단.
+**마지막 갱신:** 2026-07-13
+- **버전:** v2.10.0 — 사실 확인은 package.json·CHANGELOG (독푸딩 Wave 1 발행 완료: npm·태그·Release·노션 전부 정합)
+- **테스트:** 2353 pass(로컬) · **MCP tools:** 35 — 사실값은 package.json·CHANGELOG
+- **Phase:** **[2026-07-13] 독푸딩 init 감사 → v2.10.0 발행 완결 + Wave 2 RFC 승인 대기** — vhk init 템플릿 배출 독푸딩에서 죽은 안내문·발행격차 P1 2건 수정 후 v2.10.0 발행(npm latest 50th·git 태그·GitHub Release·노션 10곳 정합). 노션 oh-my-agent "필수→선택" 강등(vhk 불가지론·사용자 미사용·Codex 권고). Wave 2 RFC 0060(init 기록 온보딩)·0061(기록 집행 3겹 그물) Draft 작성·머지. 상세 docs/state 최상단.
 - **블로커:** 없음
-- **진행 중(미완):** RFC 0057 브레인스토밍 — 스코프 제안(①`ecosystem.mdc` 모순 제거 ②receipt agent 필드 ③트리거 격차 문서화)까지 진행, **사용자 승인 대기**(brainstorming 스킬 HARD-GATE — 설계 승인 전 구현 금지). 다음 세션은 이 승인 질문부터.
-- **다음 할 일:** RFC 0057 스코프 승인받고 스펙 작성 → 구현. **push origin 안 함**(main 직접 push 가드 #119 — 로컬 커밋 4개, PR 경유 여부 사용자 판단) · npm publish 안 함(2FA, 사람만). 상세 **[docs/state/next-task.md](docs/state/next-task.md)** 최상단.
+- **진행 중(미완):** Wave 2 RFC 0060·0061 = Draft·구현 HARD-GATE(승인 필요). 다음 세션은 이 둘 승인받고 스펙→구현. 별도 숙제 = "vhk 강화가 뭔지"(Codex 권고 실체) 브레인스토밍.
+- **다음 할 일:** RFC 0060·0061 승인 → 스펙 → 구현. **npm publish 안 함**(2FA, 사람만 — 이번 v2.10.0은 발행 완료) · main 직접 push 차단 → PR 경유. 상세 **[docs/state/next-task.md](docs/state/next-task.md)** 최상단.
 - **주의:** publish는 main에서만(#119)·사용자 직접(2FA=Windows 보안키→실 터미널 `npm publish --ignore-scripts`) / 직접 main push 차단 → PR 경유 / 로컬 게이트에 **`pnpm lint` 필수**(CI gate=lint 포함 — typecheck+test만으론 CI fail) / 적대리뷰 워크플로 에이전트 read-only 명시 / **워크트리 병합 직전 `git branch --show-current` 재확인**(다른 동시 세션이 공유 체크아웃 브랜치를 바꿀 수 있음, 2026-07-03 `vhk-readme-redesign` 오염 사고로 실증) / 동시세션 docs/state 충돌 주의

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -4,10 +4,15 @@
 > ⚠️ `vhk goal next`/`vhk work`가 이 파일을 스텁으로 **전체 덮어쓸 수 있음** — 수동 편집
 > 직후 해당 명령 실행 주의. 소실 시 복구: `git restore docs/state/next-task.md`.
 
-**갱신:** 2026-07-08
-**Phase:** **RFC 0058 Wave 1~4 main merge 완료** — npm publish만 남음 (사람 2FA)
+**갱신:** 2026-07-13
+**Phase:** **v2.10.0 발행 완료(npm·태그·Release·노션 정합) + 독푸딩 Wave 2 RFC 승인 대기**
 
 ## 다음 할 일 (measure-first 최우선)
+- **🆕🆕🆕 [2026-07-13 · 독푸딩 init 감사 → v2.10.0 발행 완료] 세션 마감** — vhk init 템플릿 배출 독푸딩(`/dogfood`)에서 P1 2건 발견·수정 후 **v2.10.0 발행 완결**. 진입점 [docs/log/2026-07-12-dogfood-init-wave1.md](../log/2026-07-12-dogfood-init-wave1.md).
+  - **✅ 발행 체인 전부 정합**: npm `2.10.0` latest(50th) · git 태그 `v2.10.0`(수동 보강 — npm publish는 태그 안 붙임) · GitHub Release(태그 push→workflow 자동생성) · README 3곳 · 노션 본체 callout(v2.7.0→v2.10.0·47→50 versions).
+  - **✅ 노션 스타터킷 정합 10곳**: 팩트3(MCP30→35·`secure guard` 없음→scan·learnings v2 동결) + 버전2 + **구조전환5**(START HERE·Phase2매핑·삼중하네스callout·세팅순서·폴더주석). **oh-my-agent 강등 결정**: 사용자 미사용 + Codex "vhk 강화 권고" + vhk 불가지론 → 필수단계에서 빼고 "선택(안 써도 됨)"으로. vhk는 규칙·기록·게이트만 흡수, 에이전트팀은 미흡수(실측 확정).
+  - **🔜 Wave 2 RFC 2개 = Draft·구현 HARD-GATE(승인 필요)**: [RFC 0060](../rfc/0060-init-record-onboarding.md)(`[여기에 작성:]` 마커+인터뷰2단계+자동sync+설치점검영수증, 트리거격차는 0057§7 계승) · [RFC 0061](../rfc/0061-record-enforcement-net.md)(기록집행 3겹 그물: 규칙선언·커밋훅·세션종료수확). **다음 세션 = 이 둘 승인받고 스펙→구현.**
+  - **🔜 미탐구 숙제**: "vhk 강화가 구체적으로 뭔지"(Codex 권고의 실체) — oh-my-agent/claude 대비 vhk를 뭘로 강화할지 별도 브레인스토밍 필요.
 - **🆕 [2026-07-08 · Wave 1~4 merge 완료] VHK·cc-skills·control-tower salvage + RFC 0058 T1~T4** — 전 PR squash merge·CI green 확인 후 머지. 진입점 [docs/log/2026-07-08-wave1-4-merge-closure.md](../log/2026-07-08-wave1-4-merge-closure.md). **다음 = npm publish (집에서 2FA)** · measure-first · #455~458 · T5/T6.
 - **✅ Wave 요약 (merged):** CT #20 orphan guard · CC #27 CRLF/0.3.2 · vhk #471 T1 docs · #472 goal migrate/enum · #473 #468 sync/doctor · #474 #466/#467 learn+bootstrap cursor · #475 T4 atomic write · brain #45 HANDOFF.
 - **✅ [2026-07-07 · goal 100 완결] `vhk evolve seed` — PR #463 main 머지 완료** — cold-start 역채굴·게이트 green(2342 test). 다른 머신은 각자 `evolve seed --write` 재실행 필요(memory.json gitignored). 진입점 [docs/log/2026-07-07-goal-100-evolve-seed-coldstart.md](../log/2026-07-07-goal-100-evolve-seed-coldstart.md).


### PR DESCRIPTION
독푸딩 init 감사 → v2.10.0 발행 완결 세션의 상태 문서 갱신. 코드 변경 0.

- next-task.md·CLAUDE.md LIVE에 v2.10.0 발행 체인(npm·태그·Release·노션 10곳) + Wave 2 RFC 0060·0061 승인 대기 상태 기록
- oh-my-agent "필수→선택" 강등 결정 반영
- 미탐구 숙제("vhk 강화 실체") 다음 세션 이월

🤖 Generated with [Claude Code](https://claude.com/claude-code)