### PR TITLE
feat: RFC 0060 T1b — vhk check 잔여 슬롯 카운트

### DIFF
--- a/docs/log/2026-07-13-rfc-0060-init-onboarding.md
+++ b/docs/log/2026-07-13-rfc-0060-init-onboarding.md
@@ -83,6 +83,22 @@ RFC [0060](../rfc/0060-init-record-onboarding.md) 승인(사용자) → 4트랙 
 
 ## RFC 0060 완료 (T1~T4)
 - T1 마커 · T2 인터뷰 2단계 · T3 자동sync+영수증 · T4 트리거 계승 — 전부 TDD+실 init 검증.
-- **유보**: T1b(`vhk check` 잔여 슬롯 카운트, RFC §4 성공기준·§7 열린결정3) — 선택 트랙, 별도 iteration. init 온보딩 핵심(채우기 쉽게 + 배선 완비 + 정직 보고)은 T1~T4로 달성.
+- T1~T4 = PR #481 (main `55852b8`).
+
+## T1b — `vhk check` 잔여 슬롯 카운트 (RFC §4 성공기준 달성)
+
+### 변경
+- `src/lib/install-receipt.ts` — `countFillSlots(rootDir)`: PRD·ARCHITECTURE 의 `[여기에 작성:` 개수(순수).
+- `src/commands/check.ts` — 규칙 렌더 뒤 "📝 미완성 슬롯 N개" 콘솔 라인 + `--json` 에 `fillSlots` 필드(하위호환 추가).
+- 테스트: countFillSlots 2 · check JSON.
+
+### 효과 (실 check)
+- init 직후 `vhk check` → "📝 미완성 슬롯 13개 — PRD 9 · ARCHITECTURE 4", `--json` `fillSlots:{prd:9,architecture:4,total:13}`.
+- **§4 성공기준 "vhk check 가 잔여 슬롯 수 카운트(측정 가능)" 달성** — 사용자가 온보딩 진행을 숫자로 확인, 채울수록 감소.
+
+### 게이트
+- tsc 0 · lint 0 · install-receipt·check 테스트 green · 실 check 콘솔·JSON 검증.
+
+## RFC 0060 최종 — T1~T4 + T1b 전부 완료. init 기록 온보딩 클로저.
 - T4 — 트리거 격차 계승(RFC 0057 §7): 마커 규칙 문구 → sync 전 에이전트 전파.
 - T1b(선택) — `vhk check` 잔여 슬롯 카운트.

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -7,6 +7,7 @@ import { log } from '../utils/logger.js'
 import { printNextStep } from '../lib/next-step.js'
 import { goalCheck } from './goal.js'
 import { appendCheckLog, buildCheckLogEntry } from '../lib/check-log.js'
+import { countFillSlots } from '../lib/install-receipt.js'
 
 export interface CheckOptions {
   goal?: string
@@ -119,8 +120,11 @@ async function checkRules(opts: CheckOptions = {}) {
     /* 원장 append 실패 비치명 — check 본 판정은 이미 계산됨 */
   }
 
+  // RFC 0060 T1b: PRD·ARCHITECTURE 잔여 [여기에 작성:] 슬롯 카운트 — 온보딩 진행 측정.
+  const fillSlots = countFillSlots(cwd)
+
   if (opts.json) {
-    console.log(JSON.stringify(summary, null, 2))
+    console.log(JSON.stringify({ ...summary, fillSlots }, null, 2))
     if (summary.errors > 0) process.exitCode = 1
     return
   }
@@ -154,6 +158,15 @@ async function checkRules(opts: CheckOptions = {}) {
   }
 
   console.log('')
+
+  // RFC 0060 T1b: 아직 못 채운 기획·설계 슬롯을 노출(진행 측정 + 다음 행동 유도).
+  if (fillSlots.total > 0) {
+    console.log(
+      chalk.yellow(`  📝 미완성 슬롯 ${fillSlots.total}개`) +
+      chalk.dim(` — docs/PRD.md ${fillSlots.prd} · docs/ARCHITECTURE.md ${fillSlots.architecture} ([여기에 작성:] 대화로 채우기)`)
+    )
+    console.log('')
+  }
 
   if (summary.violations.length === 0) {
     // VHK-011: "모든 규칙 통과" 거짓안심 금지 — 자동 검증된 부분만 통과라고 명시.

--- a/src/lib/install-receipt.ts
+++ b/src/lib/install-receipt.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 
 // RFC 0060 T3: init 자동 sync 후 "다 준비됐나"를 디스크 실측(읽기검증)으로 보고한다.
@@ -52,6 +52,21 @@ export function collectInstallReceipt(rootDir: string): InstallReceipt {
     recordDirsTotal: RECORD_DIRS.length,
     interviewPending,
   }
+}
+
+// RFC 0060 T1b: PRD·ARCHITECTURE 에 남은 [여기에 작성:] 슬롯 수를 센다. vhk check 가 노출해
+// "얼마나 채웠나"를 측정 가능하게(§4 성공기준). 마커 문자열은 T1 의 관행 마커와 정확히 일치.
+const FILL_MARKER = '[여기에 작성:'
+
+export function countFillSlots(rootDir: string): { prd: number; architecture: number; total: number } {
+  const count = (rel: string): number => {
+    const full = path.join(rootDir, rel)
+    if (!existsSync(full)) return 0
+    return readFileSync(full, 'utf-8').split(FILL_MARKER).length - 1
+  }
+  const prd = count('docs/PRD.md')
+  const architecture = count('docs/ARCHITECTURE.md')
+  return { prd, architecture, total: prd + architecture }
 }
 
 /** 설치 점검 영수증을 사람이 읽는 실무 톤 문자열로. 전문용어 대신 "규칙 파일/기록 폴더". */

--- a/tests/install-receipt.test.ts
+++ b/tests/install-receipt.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { collectInstallReceipt, formatInstallReceipt } from '../src/lib/install-receipt.js'
+import { collectInstallReceipt, formatInstallReceipt, countFillSlots } from '../src/lib/install-receipt.js'
 
 function mkTmp(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-receipt-'))
@@ -50,6 +50,36 @@ describe('install-receipt (RFC 0060 T3)', () => {
     } finally {
       fs.rmSync(dir, { recursive: true, force: true })
     }
+  })
+
+  // RFC 0060 T1b: vhk check 가 잔여 [여기에 작성:] 슬롯을 카운트(진행 측정).
+  describe('countFillSlots', () => {
+    it('PRD·ARCHITECTURE 의 [여기에 작성:] 개수를 센다', () => {
+      const dir = mkTmp()
+      try {
+        fs.mkdirSync(path.join(dir, 'docs'), { recursive: true })
+        fs.writeFileSync(path.join(dir, 'docs', 'PRD.md'), '[여기에 작성: a]\n채워짐\n[여기에 작성: b]')
+        fs.writeFileSync(path.join(dir, 'docs', 'ARCHITECTURE.md'), '[여기에 작성: c]')
+        const s = countFillSlots(dir)
+        expect(s.prd).toBe(2)
+        expect(s.architecture).toBe(1)
+        expect(s.total).toBe(3)
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('파일 없거나 다 채워지면 0', () => {
+      const dir = mkTmp()
+      try {
+        expect(countFillSlots(dir).total).toBe(0)
+        fs.mkdirSync(path.join(dir, 'docs'), { recursive: true })
+        fs.writeFileSync(path.join(dir, 'docs', 'PRD.md'), '다 채워진 문서')
+        expect(countFillSlots(dir).total).toBe(0)
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true })
+      }
+    })
   })
 
   it('영수증 문자열 — 실무 톤, 누락 시 복구 명령 노출', () => {


### PR DESCRIPTION
RFC 0060 마무리 트랙(T1~T4 = #481 머지 완료). 유보했던 T1b — 온보딩 진행 측정.

## 무엇
`vhk check` 가 PRD·ARCHITECTURE 의 미완성 `[여기에 작성:]` 슬롯 수를 노출:
- 콘솔: `📝 미완성 슬롯 13개 — docs/PRD.md 9 · docs/ARCHITECTURE.md 4`
- `--json`: `fillSlots: { prd, architecture, total }` (하위호환 필드 추가)

## 왜
RFC 0060 §4 성공기준 "vhk check 가 잔여 슬롯 수 카운트(측정 가능)". 사용자가 채울수록 숫자가 줄어 온보딩 진행을 확인.

## 게이트
- TDD · 전체 2367 test · lint · tsc green · 실 check 콘솔·JSON 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)