### PR TITLE
chore: v2.11.0 릴리즈 준비 — Wave 2 완주분 (0060+0061)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형식, [Semantic Versioning](https://semver.org/lang/ko/).
 
-## [Unreleased]
+## [2.11.0] - 2026-07-13
 
 ### Added
 
+- **기록 집행 커밋훅(record-net)** (RFC 0061 T1~T3) — 새 프로젝트가 `vhk init` 만 하면 세션일지 없는 실질 코드변경 커밋이 git `commit-msg` 훅에서 차단된다. git 훅이라 Claude Code·Cursor·Codex 어디서 커밋해도 동작(도구 불가지론).
+  - **3겹 그물**: ①규칙 선언(RULES·CLAUDE 템플릿에 handoff 의례·집행 체계 명시) ②커밋훅(결정적 검사만 차단 — src/** 스테이지 + 오늘·어제 일지 미스테이지, 에러는 AI 작업지시서·`[skip-record]` 우회) ③세션종료 수확(`vhk work handoff` 의례 배출).
+  - **정직한 경계**: merge/pull·cherry-pick·revert·rebase 는 화이트리스트 통과(병합엔 새 일지가 없는 게 정상), amend·같은 날 후속 커밋은 HEAD 의 일지 인정, `core.hooksPath`(husky 등) 감지 시 거짓 배선 대신 수동 통합 안내, node 부재·게이트 결함은 fail-open. 기존 commit-msg 훅은 불가침(`vhk:record-net` 마커 소유권).
+  - 적대검증(critic) 2라운드 실측 통과 — merge 차단 지옥·amend false-block·husky 거짓 성공을 라운드 1에서 잡아 수정.
 - **`vhk init` 기록 온보딩** (RFC 0060) — 새 프로젝트 첫걸음의 세 구멍을 닫음.
   - **채움 마커**: PRD·ARCHITECTURE 의 빈 칸이 개발자 은어 `**FILL**` 이던 것을 `[여기에 작성: 구체 질문]` 관행 마커 + 상단 "AI 추측 금지" 가드로 교체(비개발자가 뭘 채울지 질문으로 읽음).
   - **첫 세션 인터뷰 2단계**: 도메인 규칙(1단계) 뒤에 PRD·ARCHITECTURE 슬롯을 사용자 답변으로만 채우는 2단계 추가(핵심 5±2·컨펌·옵트아웃·VISION 미터치).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,10 +149,10 @@ tags: [process, constitution]
 > ⚠️ 아래 `**버전:**` 줄은 CI(version-sync.test.ts)가 강제 — 형식 `**버전:** vX.Y.Z` 유지, 릴리즈마다 package.json 따라 갱신.
 
 **마지막 갱신:** 2026-07-13
-- **버전:** v2.10.0 — 사실 확인은 package.json·CHANGELOG (독푸딩 Wave 1 발행 완료: npm·태그·Release·노션 전부 정합)
+- **버전:** v2.11.0 — 사실 확인은 package.json·CHANGELOG (Wave 2 완주: RFC 0060 init 기록 온보딩 + RFC 0061 record-net 커밋훅. **npm 발행 = 사람 2FA 대기**)
 - **테스트:** 2353 pass(로컬) · **MCP tools:** 35 — 사실값은 package.json·CHANGELOG
 - **Phase:** **[2026-07-13] 독푸딩 init 감사 → v2.10.0 발행 완결 + Wave 2 RFC 승인 대기** — vhk init 템플릿 배출 독푸딩에서 죽은 안내문·발행격차 P1 2건 수정 후 v2.10.0 발행(npm latest 50th·git 태그·GitHub Release·노션 10곳 정합). 노션 oh-my-agent "필수→선택" 강등(vhk 불가지론·사용자 미사용·Codex 권고). Wave 2 RFC 0060(init 기록 온보딩)·0061(기록 집행 3겹 그물) Draft 작성·머지. 상세 docs/state 최상단.
 - **블로커:** 외부의존 2건 유지(blockers.md — goal-50 실데이터, SEO 22~26 자격증명·둘 다 [skip-hardstop] 사람 대기). 진행 차단 아님.
 - **진행 중(미완):** Wave 2 RFC 0060·0061 = Draft·구현 HARD-GATE(승인 필요, 0060 T1은 별도 세션 착수됨). 별도 숙제 = "vhk 강화가 뭔지"(Codex 권고 실체) 브레인스토밍.
-- **다음 할 일:** **[docs/state/roadmap.md](docs/state/roadmap.md) 분기층 Phase 0~4가 순서 SoT**(2026-07-13 재편 — 출고→정합화+계측→감사층/0062→Wave 2→확장판정). 세션 단위 상세는 **[docs/state/next-task.md](docs/state/next-task.md)** 최상단. npm publish 안 함(v2.10.0 발행 완료) · main 직접 push 차단 → PR 경유.
+- **다음 할 일:** **v2.11.0 npm publish(사람 2FA — 실 터미널 `npm publish --ignore-scripts`)** → 태그·Release·노션 정합. 이후 순서 SoT = **[docs/state/roadmap.md](docs/state/roadmap.md)** Phase 2(RFC 0062·#457 report-mode·GTM). 세션 단위 상세는 **[docs/state/next-task.md](docs/state/next-task.md)** 최상단. main 직접 push 차단 → PR 경유.
 - **주의:** publish는 main에서만(#119)·사용자 직접(2FA=Windows 보안키→실 터미널 `npm publish --ignore-scripts`) / 직접 main push 차단 → PR 경유 / 로컬 게이트에 **`pnpm lint` 필수**(CI gate=lint 포함 — typecheck+test만으론 CI fail) / 적대리뷰 워크플로 에이전트 read-only 명시 / **워크트리 병합 직전 `git branch --show-current` 재확인**(다른 동시 세션이 공유 체크아웃 브랜치를 바꿀 수 있음, 2026-07-03 `vhk-readme-redesign` 오염 사고로 실증) / 동시세션 docs/state 충돌 주의

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 ---
 id: vhk-readme
 date: 2026-06-08
-tags: [vhk, cli, readme, v2.10.0, mcp, proof, ai-coding]
+tags: [vhk, cli, readme, v2.11.0, mcp, proof, ai-coding]
 ---
 
 <div align="center">
 
 # VHK — Vibe Harness Kit
 
-**v2.10.0**
+**v2.11.0**
 
 **모델·에이전트를 뭘로 바꿔도 안 무너지는 풀사이클 AI 코딩 하네스.**
 
@@ -40,7 +40,7 @@ Claude Code든 Cursor든 그 위에 얹어 리뷰·검증·기억을 한 루프�
   🟢 Node     v24.13.0 (shim-safe)
   🟢 pnpm     11.2.2
   🟢 git      2.53.0 (user configured)
-  🟢 VHK      v2.10.0 (최신)
+  🟢 VHK      v2.11.0 (최신)
   🟢 MCP      35 tools 등록
 
   📁 프로젝트 파일 확인:

--- a/docs/log/2026-07-13-v2.11.0-release.md
+++ b/docs/log/2026-07-13-v2.11.0-release.md
@@ -1,0 +1,19 @@
+# 2026-07-13 — v2.11.0 릴리즈 준비 (Wave 2 완주분)
+
+## 결론
+Wave 2 양축(RFC 0060 init 기록 온보딩 #481/#483 + RFC 0061 record-net 커밋훅 #485)을 v2.11.0 으로 묶어 발행 준비 완료. 발행 전 검증으로 **신규 프로젝트 e2e 도그푸딩 영수증** 확보(아래). 발행 자체는 사람 2FA.
+
+## e2e 도그푸딩 영수증 (최신 main 빌드, 실 git 픽스처)
+스크래치 신규 프로젝트에 `git init` → `vhk init -y` 실행:
+- ✅ 0060: PRD `[여기에 작성:]` 마커 9개 · ARCHITECTURE 마커 4개 배출.
+- ✅ 0061: `.vhk/hooks/record-check.mjs` 배출 + `.git/hooks/commit-msg` 배선 로그.
+- ✅ 집행 실측: src 변경+일지 없는 커밋 → `[record-check BLOCK]` + AI 작업지시서, exit 1 / `[skip-record]` 커밋 → 통과 / src+오늘 일지 동반 커밋 → 통과.
+- ✅ RULES.md 에 handoff 의례·3겹 그물 문구 2줄 배출.
+- ⚠️ 교훈: 1차 e2e 에서 PRD 마커 0 으로 오탐 — 원인은 **stale dist**(0060 머지 전 빌드로 테스트). 최신 main 리빌드 후 재검증으로 해소. e2e 는 반드시 검증 대상 커밋 기준 빌드로.
+
+## 버전업 내역
+- package.json 2.10.0→2.11.0 · CHANGELOG `[Unreleased]`→`[2.11.0] - 2026-07-13`(0061 항목 신규 추가, 0060 항목은 기존 작성분 승격) · README 3곳 · CLAUDE.md LIVE(버전 줄+다음 할 일).
+
+## 남은 절차 (발행 의례)
+1. **사람**: main 에서 `git pull` → 실 터미널 `npm publish --ignore-scripts`(보안키 2FA).
+2. AI: `npm view @byh3071/vhk version` 으로 2.11.0 확인 → `git tag v2.11.0` + push(Release workflow 자동) → 노션 본체 callout 버전 정합(v2.10.0→v2.11.0).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byh3071/vhk",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "packageManager": "pnpm@11.2.2",
   "description": "VHK — AI 코딩 세션을 목표·증거·기억·규칙으로 묶는 한국어 CLI. 규칙 동기화, MCP 35 tools, verify/review/preflight 게이트.",
   "bin": {


### PR DESCRIPTION
발행 전 검증: 신규 프로젝트 e2e 도그푸딩 영수증(마커 9+4·훅 배선·차단/우회/
일지동반 실측) — docs/log/2026-07-13-v2.11.0-release.md.
발행(npm publish)은 사람 2FA. 게이트 2387 pass·lint 0·version-sync green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
