### PR TITLE
docs: v2.11.0 발행 완결 클로저

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,10 +149,10 @@ tags: [process, constitution]
 > ⚠️ 아래 `**버전:**` 줄은 CI(version-sync.test.ts)가 강제 — 형식 `**버전:** vX.Y.Z` 유지, 릴리즈마다 package.json 따라 갱신.
 
 **마지막 갱신:** 2026-07-13
-- **버전:** v2.11.0 — 사실 확인은 package.json·CHANGELOG (Wave 2 완주: RFC 0060 init 기록 온보딩 + RFC 0061 record-net 커밋훅. **npm 발행 = 사람 2FA 대기**)
-- **테스트:** 2353 pass(로컬) · **MCP tools:** 35 — 사실값은 package.json·CHANGELOG
-- **Phase:** **[2026-07-13] 독푸딩 init 감사 → v2.10.0 발행 완결 + Wave 2 RFC 승인 대기** — vhk init 템플릿 배출 독푸딩에서 죽은 안내문·발행격차 P1 2건 수정 후 v2.10.0 발행(npm latest 50th·git 태그·GitHub Release·노션 10곳 정합). 노션 oh-my-agent "필수→선택" 강등(vhk 불가지론·사용자 미사용·Codex 권고). Wave 2 RFC 0060(init 기록 온보딩)·0061(기록 집행 3겹 그물) Draft 작성·머지. 상세 docs/state 최상단.
+- **버전:** v2.11.0 — 사실 확인은 package.json·CHANGELOG (**발행 완결**: npm latest·git 태그·GitHub Release·노션 정합 전부 v2.11.0)
+- **테스트:** 2387 pass(로컬) · **MCP tools:** 35 — 사실값은 package.json·CHANGELOG
+- **Phase:** **[2026-07-13] 로드맵 재정렬 + Wave 2 완주 + v2.11.0 발행 완결** — 3관점 플랜+skeptic 검증으로 로드맵 재편(roadmap.md=분기층 SoT, Phase 0~4) → 문서 정합화(#482)·계측 재가동(receipt 90일 개시·계측 DB 순수 VHK 첫 행) → RFC 0060(#481·#483, 별도 세션)+0061(#485, critic 2라운드) 병렬 완주 → v2.11.0 발행. 신규 도그푸딩 이슈 #488(eval --init 이 recall 미스 쿼리 라벨 불가 — 측정 편향). 상세 docs/state 최상단.
 - **블로커:** 외부의존 2건 유지(blockers.md — goal-50 실데이터, SEO 22~26 자격증명·둘 다 [skip-hardstop] 사람 대기). 진행 차단 아님.
-- **진행 중(미완):** Wave 2 RFC 0060·0061 = Draft·구현 HARD-GATE(승인 필요, 0060 T1은 별도 세션 착수됨). 별도 숙제 = "vhk 강화가 뭔지"(Codex 권고 실체) 브레인스토밍.
-- **다음 할 일:** **v2.11.0 npm publish(사람 2FA — 실 터미널 `npm publish --ignore-scripts`)** → 태그·Release·노션 정합. 이후 순서 SoT = **[docs/state/roadmap.md](docs/state/roadmap.md)** Phase 2(RFC 0062·#457 report-mode·GTM). 세션 단위 상세는 **[docs/state/next-task.md](docs/state/next-task.md)** 최상단. main 직접 push 차단 → PR 경유.
+- **진행 중(미완):** Recall 라벨링이 #488 로 dead-end(수정 후 재시도) · G3 육안 3항목(색상·Ctrl+C·리사이즈) 사람 채점 대기(종료감지·통과는 실측 완료). 별도 숙제 = "vhk 강화가 뭔지"(Codex 권고 실체) 브레인스토밍.
+- **다음 할 일:** 순서 SoT = **[docs/state/roadmap.md](docs/state/roadmap.md)** **Phase 2** — RFC 0062(드리프트 자동감지) 초안 → #457 report-mode(preflight.ts 접촉은 #457 먼저 직렬) → #455/#456/#458 → GTM(준비=AI·게시=사람). #488 수정도 후보. 세션 단위 상세는 **[docs/state/next-task.md](docs/state/next-task.md)** 최상단. main 직접 push 차단 → PR 경유.
 - **주의:** publish는 main에서만(#119)·사용자 직접(2FA=Windows 보안키→실 터미널 `npm publish --ignore-scripts`) / 직접 main push 차단 → PR 경유 / 로컬 게이트에 **`pnpm lint` 필수**(CI gate=lint 포함 — typecheck+test만으론 CI fail) / 적대리뷰 워크플로 에이전트 read-only 명시 / **워크트리 병합 직전 `git branch --show-current` 재확인**(다른 동시 세션이 공유 체크아웃 브랜치를 바꿀 수 있음, 2026-07-03 `vhk-readme-redesign` 오염 사고로 실증) / 동시세션 docs/state 충돌 주의

--- a/docs/log/2026-07-13-v2.11.0-release.md
+++ b/docs/log/2026-07-13-v2.11.0-release.md
@@ -17,3 +17,8 @@ Wave 2 양축(RFC 0060 init 기록 온보딩 #481/#483 + RFC 0061 record-net 커
 ## 남은 절차 (발행 의례)
 1. **사람**: main 에서 `git pull` → 실 터미널 `npm publish --ignore-scripts`(보안키 2FA).
 2. AI: `npm view @byh3071/vhk version` 으로 2.11.0 확인 → `git tag v2.11.0` + push(Release workflow 자동) → 노션 본체 callout 버전 정합(v2.10.0→v2.11.0).
+
+## 발행 완결 (2026-07-13 심야, append)
+- ✅ 사람 발행 완료 → `npm view` latest = **2.11.0** 확인 · 태그 v2.11.0 push · **GitHub Release workflow success** · 노션 스타터킷 callout "npm 실측 v2.11.0" 정합.
+- 🆕 **도그푸딩 이슈 #488**: 사용자의 첫 Recall 라벨링 시도에서 `vhk memory eval --init` 이 recall 미스 쿼리(실쿼리 6건 전부 후보 0)를 라벨 불가 처리 → 라벨 0 dead-end. 미스가 평가셋에서 구조적으로 제외되는 측정 편향 — Recall@5 kill-gate 판정 무의미화. 수정 전까지 라벨링 보류.
+- 부수: 미발행 블로그 초안(노션 "개발 특강인 줄 알고 갔다가 보안을 만났다")의 VHK Secure 과장 서술을 사실로 정정(발행 전 원본 수정 — 대외 정정 불필요). 좀비 원격 브랜치 5개 삭제(사용자 승인).

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -3,13 +3,13 @@
 > "지금 무엇부터"의 **세션층** SoT — 본문 15줄 상한, 역사는 링크로 밀어냄. 순서(Phase)의 SoT = [roadmap.md](roadmap.md), 사실값(버전·테스트)은 package.json·CHANGELOG.
 > ⚠️ `vhk goal next`/`vhk work`가 이 파일을 스텁으로 **전체 덮어쓸 수 있음** — 소실 시 `git restore docs/state/next-task.md`.
 
-**갱신:** 2026-07-13 (심야 2차)
-**Phase:** [roadmap.md](roadmap.md) Phase 0~1 ✅ 완료 · **Phase 3 코어 완료(Wave 2 양축 main 착지)** — 0060(#481·#483, 별도 세션) + 0061(#485, 승인→구현→critic 2라운드) 동일 자정 병렬 완주
+**갱신:** 2026-07-13 (심야 3차)
+**Phase:** [roadmap.md](roadmap.md) **Phase 0~1·3 ✅ 완결** — Wave 2 양축(0060 #481·#483 / 0061 #485) + **v2.11.0 발행 완결**(npm latest·태그·Release·노션 정합, e2e 도그푸딩 영수증 첨부). 다음 = **Phase 2**.
 
 ## 지금
-- **사람 큐:** G3 스파이크 TTY 채점(`scripts/spike-g3-process-wrap.mjs`) · Recall 라벨 시작(`vhk memory eval --init`, 실쿼리만·건수 강제 금지) · SEO 키 발급 신청만(투입은 Phase 2 GTM 주간) · 블로그 과장 정정 게시 · **v2.11.0 publish 판단**(Wave 2 완주분 — e2e 도그푸딩 후 권장)
-- **AI 큐:** Wave 2 e2e 도그푸딩 영수증(신규 프로젝트에 init→기록→집행→수확 실측) → Phase 2(RFC 0062 초안 · #457 report-mode — preflight.ts 접촉은 #457 먼저 직렬) → GTM 준비(quickstart·데모)
-- **최근 이력:** [07-13 RFC 0061 완주(record-net 커밋훅)](../log/2026-07-13-rfc0061-record-net.md)(#485) · [07-13 RFC 0060 완료(init 기록 온보딩 T1~T4+T1b)](../log/2026-07-13-rfc-0060-init-onboarding.md)(#481·#483) · [07-13 로드맵 재편](../log/2026-07-13-roadmap-realign-p1.md)(#482, #464·#461 머지 포함) · [07-12 독푸딩 Wave1 + v2.10.0 발행](../log/2026-07-12-dogfood-init-wave1.md)
+- **사람 큐:** G3 육안 3항목만(색상·Ctrl+C 래퍼 생존·리사이즈 — 종료감지/통과는 실측 완료) · Recall 라벨은 **#488 수정 후 재시도**(eval --init 이 recall 미스 쿼리 라벨 불가 — 첫 시도 라벨 0 dead-end) · SEO 키 발급(가이드는 07-13 세션 보고, 투입은 GTM 주간)
+- **AI 큐:** Phase 2 — RFC 0062(드리프트 자동감지) 초안 → #457 report-mode(preflight.ts 접촉은 #457 먼저 직렬) → #455/#456/#458 → #488 수정 → GTM 준비(quickstart·데모)
+- **최근 이력:** [07-13 v2.11.0 릴리즈](../log/2026-07-13-v2.11.0-release.md)(#487·태그·Release·노션 정합·#488 발견) · [07-13 RFC 0061 완주](../log/2026-07-13-rfc0061-record-net.md)(#485) · [07-13 RFC 0060 완료](../log/2026-07-13-rfc-0060-init-onboarding.md)(#481·#483) · [07-13 로드맵 재편](../log/2026-07-13-roadmap-realign-p1.md)(#482) · [07-12 독푸딩 Wave1 + v2.10.0 발행](../log/2026-07-12-dogfood-init-wave1.md)
 
 ## 블로커
 - [blockers.md](blockers.md) 활성 2건(goal-50 실데이터 · SEO 22~26 자격증명) — [skip-hardstop] 사람 대기, 진행 차단 아님.


### PR DESCRIPTION
npm latest 2.11.0·태그·Release·노션 정합 확인을 상태 SoT 에 즉시 반영.
도그푸딩 이슈 #488(eval --init 미스 쿼리 라벨 불가) 발견 기록.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
