### PR TITLE
fix: eval --init 후보 0 쿼리도 miss 라벨링 가능 — Recall@5 상향 편향 제거 (#488)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -92,7 +92,7 @@ Cursor에게 한국어로 말해도 됩니다.
 | 목록 | `vhk memory list [--type failure] [--all]` | "기억 보여줘" |
 | 보관(선순환) | `vhk memory archive <번호>` | "이거 보관해" |
 | 삭제 / 해결 / 보관해제 | `vhk memory remove <번호>` · `vhk memory resolve <번호>` · `vhk memory unarchive <번호>` | "이 기억 지워/해결/복원" |
-| recall 품질 평가 | `vhk memory eval [--init]` | "기억 검색 평가해" (RFC 0049) |
+| recall 품질 평가 | `vhk memory eval [--init]` | "기억 검색 평가해" (RFC 0049 · #488: 후보 0 쿼리도 전체 기억에서 정답 지정 가능 — 히트 밖 정답은 miss 라벨) |
 | v1→v2 변환 | `vhk memory migrate` | — |
 
 > **v2.0 BREAKING**: 평면 memory.json → 4버킷(결정/실패/성공/패턴). **조회 명령(`vhk memory list`·`context`·`brief`) 첫 실행 시에도 v1→v2 자동 마이그레이션 + `.v1.bak` 원본 백업**(어느 명령으로 먼저 실행해도 동일). **교훈은 `vhk learn`·`vhk memory add --type failure --lesson` 단일 SoT** (구 `docs/state/learnings.md` 분리 폐지·흡수). 보관(archive)된 항목은 패턴·진화에서 제외(선순환).

--- a/docs/log/2026-07-13-issue488-eval-miss-label.md
+++ b/docs/log/2026-07-13-issue488-eval-miss-label.md
@@ -1,0 +1,28 @@
+# 2026-07-13 — #488 eval --init recall 미스 라벨링 (fix/488-eval-miss-label)
+
+## 결론
+`vhk memory eval --init` 이 recall 후보 0 쿼리를 전부 자동 skip 해 **미스가 평가셋에서 구조적으로 제외**되던 편향(Recall@5 상향 + 라벨링 dead-end)을 제거. 후보 0 쿼리도 전체 기억(4버킷, 패턴 포함)에서 정답을 고르거나 "정답 없음(쿼리 무효)"을 선택할 수 있고, 히트 밖 정답은 그대로 **miss 라벨**로 기록돼 Recall@5 분모·분자에 정확히 반영된다. 스키마(`{query, expectIds, queryType?}`)·채점기(recall-eval.ts)는 무변경.
+
+## 근인
+`src/commands/memory-eval.ts` `memoryEvalInit()` — `recallMemories()` 가 빈 배열을 반환하면 `(후보 없음 — skip)` 출력 후 `continue`. 라벨 선택지가 recall top-5 히트로만 한정돼 있어 ① 후보 0 쿼리는 라벨 자체가 불가, ② 후보가 있어도 top-5 밖 정답을 지정할 방법이 없음 → `--init` 산 라벨은 사실상 전부 hit 로만 구성(미스 표본 0). 이슈 실사례: 실쿼리 6건 전부 후보 0 → 라벨 0 → 평가셋 미생성.
+
+## 수정
+- **후보 0 분기**: 자동 skip 제거 → 전체 기억 픽커(`pickExpectedFromAll`) 진입. 엔터 = "정답 없음(쿼리 무효)" 로만 skip.
+- **전체 기억 픽커 신설**: decisions→failures→successes→patterns 4버킷 평탄화, 20건 초과 시 키워드 필터(부분일치, `f` 로 재필터), 번호(쉼표 구분) 선택. patterns 는 recall 코퍼스(orderedAll) 밖이라 골라도 항상 miss — 그게 recall 의 실제 사각지대이므로 숨기지 않고 라벨 가능하게 유지.
+- **히트 있는 쿼리 확장(additive)**: 기존 숫자 선택·엔터 skip 그대로 + `m` 입력 시 전체 목록에서 top-5 밖 정답 지정 가능(→ 채점 시 miss).
+- **문구 i18n**: 신규 사용자 대면 문구 전부 `src/i18n/ko.ts` `memory.evalInit.*` 로.
+- **문서**: COMMANDS.md 해당 행에 한 줄 반영. 비-TTY 가드(`ensureInteractive`)·기존 플래그/시그니처 무변경, MCP 미노출(대화형 유지).
+
+## 검증
+- TDD: `tests/memory-eval-init.test.ts` 신설(9건) — 구현 전 red(신규 동작 4건 실패) 확인 후 구현 → green.
+  - 후보 0 → 전체 목록(패턴 포함)에서 선택 → 라벨 기록 / scoreEval 에서 found:false·recallAt5 0 반영
+  - 후보 0 + 엔터(정답 없음) → skip·평가셋 미생성 / 목록 >20 → 키워드 필터 후 선택
+  - 히트 쿼리: 기존 숫자 선택·엔터 skip 하위호환 / `m` → top-5 밖 정답(miss 라벨)
+  - 픽커 무효 입력 → skip / 빈 memory → 프롬프트 0회 skip / 비-TTY → 프롬프트 0회 + exitCode 2
+- 게이트: `pnpm build` ✅ · `pnpm typecheck` ✅ · `pnpm test:run` 2396 pass(214 files) ✅ · `pnpm lint` ✅
+- 라벨 데이터는 생성하지 않음(라벨링은 사람 몫) · recall-log.jsonl 무접촉.
+
+## 한계
+- patterns 정답은 recall 코퍼스 제외 때문에 영구 miss — recall 이 patterns 를 검색해야 하는지는 별도 논의(이번 스코프 밖, 이슈로 분리 가능).
+- "정답 없음" 쿼리는 기록이 안 남음(스키마 확장 최소화 원칙) — 무효 쿼리 비율 계측이 필요해지면 별도 스키마 논의.
+- 픽커 페이지는 상위 20건 + 필터 유도 방식(진짜 페이지네이션 아님) — 기억 수백 건 규모에서 불편하면 후속 개선.

--- a/src/commands/memory-eval.ts
+++ b/src/commands/memory-eval.ts
@@ -1,8 +1,15 @@
 import { existsSync, mkdirSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import chalk from 'chalk'
+import { t } from '../i18n/ko.js'
 import { prompt } from '../lib/prompt.js'
-import { readMemory, recallMemories, type FailEntry } from './memory.js'
+import {
+  readMemory,
+  recallMemories,
+  type FailEntry,
+  type MemoryFileV2,
+  type PatternEntry,
+} from './memory.js'
 import {
   scoreEval,
   validateEvalLabels,
@@ -30,6 +37,98 @@ interface EvalFile {
 function entryText(e: { content?: string; lesson?: string; id: string }): string {
   const f = e as FailEntry
   return e.content || f.lesson || e.id
+}
+
+// ── #488: 후보 0/히트 밖 정답 라벨링용 전체 기억 픽커 ──
+// recall 이 못 찾은 정답(=miss)을 평가셋에 남길 수 있어야 Recall@5 분모·분자가 정직해진다.
+// patterns 는 recall 코퍼스(orderedAll) 밖이라 여기서 골라도 항상 miss — 그게 recall 의
+// 실제 사각지대이므로 숨기지 않고 라벨 가능하게 둔다(구조적 제외 = 상향 편향의 재생산).
+
+/** 한 화면에 보여줄 최대 항목 수 — 초과분은 키워드 필터로 좁히게 안내. */
+const PICKER_PAGE_SIZE = 20
+
+interface PickItem {
+  id: string
+  label: string
+}
+
+function patternText(p: PatternEntry): string {
+  const summary = typeof p.summary === 'string' ? p.summary : ''
+  const signal = typeof p.signal === 'string' ? p.signal : ''
+  return summary || signal || p.id
+}
+
+/** 4버킷 전체(decisions→failures→successes→patterns)를 픽커 항목으로 평탄화. */
+function listAllPickItems(mem: MemoryFileV2): PickItem[] {
+  const items: PickItem[] = []
+  const push = (bucketKo: string, id: string, text: string, tags: string[]): void => {
+    const tagSuffix = tags.length > 0 ? ` [${tags.join(', ')}]` : ''
+    items.push({ id, label: `(${bucketKo}) ${text}${tagSuffix}` })
+  }
+  for (const e of mem.decisions) push('결정', e.id, entryText(e), e.tags)
+  for (const e of mem.failures) push('실패', e.id, entryText(e), e.tags)
+  for (const e of mem.successes) push('성공', e.id, entryText(e), e.tags)
+  for (const p of mem.patterns) {
+    const tags = Array.isArray(p.tags) ? p.tags.filter((x): x is string => typeof x === 'string') : []
+    push('패턴', p.id, patternText(p), tags)
+  }
+  return items
+}
+
+/**
+ * 전체 기억에서 expected id 를 대화형으로 고른다(목록이 길면 키워드 필터).
+ * 빈 입력 = "정답 없음(쿼리 무효)" → 빈 배열(skip). CLI 전용 — 호출부가 TTY 가드 통과 후에만 도달.
+ */
+async function pickExpectedFromAll(mem: MemoryFileV2): Promise<string[]> {
+  const all = listAllPickItems(mem)
+  if (all.length === 0) {
+    console.log(chalk.dim(`   ${t('memory.evalInit.pickerEmpty')}`))
+    return []
+  }
+  let filter = ''
+  let askFilter = all.length > PICKER_PAGE_SIZE
+  // 필터↔선택 루프 — 종료는 사용자 명시(빈 입력=정답 없음 / 번호 선택)로만. 'f' = 재필터.
+  for (;;) {
+    if (askFilter) {
+      const { kw } = await prompt<{ kw: string }>([
+        { type: 'input', name: 'kw', message: t('memory.evalInit.pickerFilterPrompt') },
+      ])
+      filter = String(kw || '').trim().toLowerCase()
+      askFilter = false
+    }
+    const filtered = filter
+      ? all.filter((it) => `${it.label} ${it.id}`.toLowerCase().includes(filter))
+      : all
+    if (filtered.length === 0) {
+      console.log(chalk.yellow(`   ${t('memory.evalInit.pickerNoMatch', filter)}`))
+      askFilter = true
+      continue
+    }
+    const shown = filtered.slice(0, PICKER_PAGE_SIZE)
+    shown.forEach((it, i) => console.log(`   [${i + 1}] ${it.label}`))
+    if (filtered.length > shown.length) {
+      console.log(chalk.dim(`   ${t('memory.evalInit.pickerMore', filtered.length - shown.length)}`))
+    }
+    const { ans } = await prompt<{ ans: string }>([
+      { type: 'input', name: 'ans', message: t('memory.evalInit.pickerSelectPrompt') },
+    ])
+    const raw = String(ans || '').trim()
+    if (raw === '') return [] // 정답 없음(쿼리 무효) — 이 경우만 skip 이 정당하다(#488).
+    if (raw.toLowerCase() === 'f') {
+      askFilter = true
+      continue
+    }
+    const ids = raw
+      .split(',')
+      .map((s) => parseInt(s.trim(), 10))
+      .filter((n) => Number.isInteger(n) && n >= 1 && n <= shown.length)
+      .map((n) => shown[n - 1].id)
+    if (ids.length === 0) {
+      console.log(chalk.dim(`   ${t('memory.evalInit.pickerInvalidSkip')}`))
+      return []
+    }
+    return [...new Set(ids)]
+  }
 }
 
 export async function memoryEval(opts: { init?: boolean } = {}): Promise<void> {
@@ -110,19 +209,29 @@ async function memoryEvalInit(): Promise<void> {
   for (const query of queries.slice(-20)) {
     const hits = recallMemories(mem, query, 5)
     console.log(chalk.cyan(`\n🔎 "${query}"`))
+    let ids: string[]
     if (hits.length === 0) {
-      console.log(chalk.dim('   (후보 없음 — skip)'))
-      continue
+      // #488: 후보 0 을 자동 skip 하면 recall 미스가 평가셋에서 구조적으로 제외돼 Recall@5 가
+      //       상향 편향 → kill-gate 판정 무력화. 전체 기억에서 정답을 고르게 해 miss 라벨로 남긴다.
+      console.log(chalk.dim(`   ${t('memory.evalInit.noCandidates')}`))
+      ids = await pickExpectedFromAll(mem)
+    } else {
+      hits.forEach((h, i) => console.log(`   [${i + 1}] ${entryText(h.entry)}`))
+      const { ans } = await prompt<{ ans: string }>([
+        { type: 'input', name: 'ans', message: t('memory.evalInit.selectPrompt') },
+      ])
+      const raw = String(ans || '').trim()
+      if (raw.toLowerCase() === 'm') {
+        // #488: 정답이 top-5 밖일 때도 지정 가능 — 히트에 없는 expected 는 채점에서 그대로 miss.
+        ids = await pickExpectedFromAll(mem)
+      } else {
+        ids = raw
+          .split(',')
+          .map((s) => parseInt(s.trim(), 10))
+          .filter((n) => Number.isInteger(n) && n >= 1 && n <= hits.length)
+          .map((n) => hits[n - 1].entry.id)
+      }
     }
-    hits.forEach((h, i) => console.log(`   [${i + 1}] ${entryText(h.entry)}`))
-    const { ans } = await prompt<{ ans: string }>([
-      { type: 'input', name: 'ans', message: '정답 기억 번호 (쉼표 구분, 없으면 엔터로 skip):' },
-    ])
-    const ids = String(ans || '')
-      .split(',')
-      .map((s) => parseInt(s.trim(), 10))
-      .filter((n) => Number.isInteger(n) && n >= 1 && n <= hits.length)
-      .map((n) => hits[n - 1].entry.id)
     if (ids.length > 0) labels.push({ query, expectIds: [...new Set(ids)] })
   }
 

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -508,6 +508,17 @@ export const ko = {
   memory: {
     addTitle: '기억 추가',
     listTitle: '기억 목록',
+    // #488: eval --init — recall 후보 0 쿼리도 라벨링 가능(자동 skip = 미스가 평가셋에서 구조적 제외 → 상향 편향).
+    evalInit: {
+      noCandidates: '(recall 후보 0 — 전체 기억에서 정답을 고르면 miss 라벨로 기록됩니다)',
+      selectPrompt: '정답 기억 번호 (쉼표 구분 · m=전체 목록에서 선택 · 엔터=skip):',
+      pickerEmpty: '(기억이 비어 있어 정답을 고를 수 없습니다 — skip)',
+      pickerFilterPrompt: '키워드 필터 (엔터=전체 목록):',
+      pickerNoMatch: (kw: string) => `"${kw}" 매칭 0건 — 다른 키워드를 입력하세요.`,
+      pickerMore: (n: number) => `…외 ${n}개 — 키워드로 좁히세요 (f=필터 다시).`,
+      pickerSelectPrompt: '정답 기억 번호 (쉼표 구분 · f=필터 다시 · 엔터=정답 없음 skip):',
+      pickerInvalidSkip: '(유효한 번호 없음 — 정답 없음으로 skip)',
+    },
   },
   mcp: {
     initTitle: 'Cursor MCP 연동 설정',

--- a/tests/memory-eval-init.test.ts
+++ b/tests/memory-eval-init.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+// #488: eval --init 이 recall 후보 0 쿼리를 전부 자동 skip → 미스가 평가셋에서 구조적으로 제외
+//       (Recall@5 상향 편향 + 라벨링 dead-end). 후보 0 에서도 전체 기억(패턴 포함)에서 정답을
+//       고르거나 '정답 없음(쿼리 무효)'을 선택할 수 있어야 하고, 히트 밖 정답은 miss 라벨로
+//       분모·분자에 정확히 반영돼야 한다. prompt 는 큐 기반 mock(초과 호출 = throw 로 검출).
+const promptQueue: Array<Record<string, unknown>> = []
+const promptSpy = vi.fn(async () => {
+  const next = promptQueue.shift()
+  if (!next) throw new Error('PROMPT_QUEUE_EMPTY: 예상보다 많은 프롬프트 호출')
+  return next
+})
+vi.mock('../src/lib/prompt.js', () => ({ prompt: promptSpy }))
+
+const EVAL_REL = path.join('.vhk', 'eval', 'recall-eval.json')
+
+interface WrittenEval {
+  labels: Array<{ query: string; expectIds: string[] }>
+}
+
+function writeMemoryFixture(dir: string, mem: Record<string, unknown>): void {
+  fs.mkdirSync(path.join(dir, '.vhk'), { recursive: true })
+  fs.writeFileSync(path.join(dir, '.vhk', 'memory.json'), JSON.stringify(mem), 'utf-8')
+}
+
+function writeRecallLogFixture(dir: string, queries: string[]): void {
+  fs.mkdirSync(path.join(dir, '.vhk'), { recursive: true })
+  const lines = queries.map((q) =>
+    JSON.stringify({ ts: '2026-06-22T00:00:00Z', source: 'recall', query: q, hitIds: [], topScore: 0 })
+  )
+  fs.writeFileSync(path.join(dir, '.vhk', 'recall-log.jsonl'), lines.join('\n') + '\n', 'utf-8')
+}
+
+/** 기본 픽스처: recall 가능한 failure 1건 + recall 코퍼스 밖 pattern 1건. */
+function baseMemory(): Record<string, unknown> {
+  return {
+    schemaVersion: 2,
+    decisions: [],
+    failures: [
+      {
+        id: 'f1',
+        content: 'publish 가드가 feature 브랜치 발행 차단',
+        tags: ['publish'],
+        createdAt: '2026-06-01T00:00:00Z',
+        status: 'active',
+      },
+    ],
+    successes: [],
+    patterns: [
+      {
+        id: 'pat-1',
+        kind: 'avoid',
+        axis: 'keyword',
+        signal: '누수',
+        summary: '메모리 누수 반복 실패 패턴',
+        count: 3,
+        sources: [],
+        createdAt: '2026-06-01T00:00:00Z',
+        status: 'active',
+        tags: [],
+        _sig: 'avoid:keyword:누수',
+      },
+    ],
+  }
+}
+
+function readEvalFile(dir: string): WrittenEval {
+  return JSON.parse(fs.readFileSync(path.join(dir, EVAL_REL), 'utf-8')) as WrittenEval
+}
+
+describe('vhk memory eval --init — #488 recall 미스 라벨링', () => {
+  let origCwd: string
+  let dir: string
+  let origTty: boolean | undefined
+  let origExitCode: number | string | undefined
+
+  beforeEach(() => {
+    origCwd = process.cwd()
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-eval-init-'))
+    process.chdir(dir)
+    promptQueue.length = 0
+    promptSpy.mockClear()
+    origTty = process.stdin.isTTY
+    process.stdin.isTTY = true
+    origExitCode = process.exitCode
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    process.stdin.isTTY = origTty
+    process.exitCode = origExitCode
+    process.chdir(origCwd)
+    fs.rmSync(dir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  it('후보 0 쿼리 → 자동 skip 아님: 전체 기억(패턴 포함)에서 정답 선택 → 라벨 기록', async () => {
+    writeMemoryFixture(dir, baseMemory())
+    writeRecallLogFixture(dir, ['버그 메모리 누수'])
+    const { memoryEval } = await import('../src/commands/memory-eval.js')
+    // 전체 목록: [1] f1(실패) → [2] pat-1(패턴). 정답으로 패턴 선택.
+    promptQueue.push({ ans: '2' })
+    await memoryEval({ init: true })
+
+    const written = readEvalFile(dir)
+    expect(written.labels).toEqual([{ query: '버그 메모리 누수', expectIds: ['pat-1'] }])
+  })
+
+  it('후보 0 에서 고른 정답이 recall 히트에 없으면 scoreEval 에서 miss 로 반영(분모·분자 정확)', async () => {
+    writeMemoryFixture(dir, baseMemory())
+    writeRecallLogFixture(dir, ['버그 메모리 누수'])
+    const { memoryEval } = await import('../src/commands/memory-eval.js')
+    promptQueue.push({ ans: '2' })
+    await memoryEval({ init: true })
+
+    const { scoreEval, validateEvalLabels } = await import('../src/lib/recall-eval.js')
+    const { readMemory } = await import('../src/commands/memory.js')
+    const labels = validateEvalLabels(JSON.parse(fs.readFileSync(path.join(dir, EVAL_REL), 'utf-8')))
+    const r = scoreEval(readMemory(dir), labels)
+    expect(r.n).toBe(1)
+    expect(r.perQuery[0]).toMatchObject({ found: false, rank: null })
+    expect(r.recallAt5).toBe(0)
+  })
+
+  it('후보 0 + 엔터(정답 없음 — 쿼리 무효) → skip, 평가셋 미생성', async () => {
+    writeMemoryFixture(dir, baseMemory())
+    writeRecallLogFixture(dir, ['버그 메모리 누수'])
+    const { memoryEval } = await import('../src/commands/memory-eval.js')
+    promptQueue.push({ ans: '' })
+    await memoryEval({ init: true })
+
+    expect(fs.existsSync(path.join(dir, EVAL_REL))).toBe(false)
+  })
+
+  it('후보 0 + 전체 목록이 길면(>20) 키워드 필터로 좁혀서 선택', async () => {
+    const failures = Array.from({ length: 24 }, (_, i) => ({
+      id: `f${i + 1}`,
+      content: `케이스 자료 항목 번호${i + 1}`,
+      tags: [],
+      createdAt: '2026-06-01T00:00:00Z',
+      status: 'active',
+    }))
+    failures.push({
+      id: 'f25',
+      content: '메모리 누수 케이스 원인분석',
+      tags: [],
+      createdAt: '2026-06-01T00:00:00Z',
+      status: 'active',
+    })
+    writeMemoryFixture(dir, { schemaVersion: 2, decisions: [], failures, successes: [], patterns: [] })
+    writeRecallLogFixture(dir, ['아예없는단어쿼리'])
+    const { memoryEval } = await import('../src/commands/memory-eval.js')
+    // 25건 > 20 → 필터 프롬프트 먼저 → '누수' 필터 → [1] f25 선택.
+    promptQueue.push({ kw: '누수' }, { ans: '1' })
+    await memoryEval({ init: true })
+
+    const written = readEvalFile(dir)
+    expect(written.labels).toEqual([{ query: '아예없는단어쿼리', expectIds: ['f25'] }])
+  })
+
+  it('히트 있는 쿼리 — 기존 숫자 선택·엔터 skip 하위호환 유지', async () => {
+    writeMemoryFixture(dir, baseMemory())
+    writeRecallLogFixture(dir, ['publish 배포', 'publish 준비'])
+    const { memoryEval } = await import('../src/commands/memory-eval.js')
+    // 1번째 쿼리: 히트 [1]=f1 선택 / 2번째 쿼리: 엔터 skip.
+    promptQueue.push({ ans: '1' }, { ans: '' })
+    await memoryEval({ init: true })
+
+    const written = readEvalFile(dir)
+    expect(written.labels).toEqual([{ query: 'publish 배포', expectIds: ['f1'] }])
+  })
+
+  it("히트 있어도 'm' 입력 → 전체 목록에서 top-5 밖 정답 지정(miss 라벨) 가능", async () => {
+    writeMemoryFixture(dir, baseMemory())
+    writeRecallLogFixture(dir, ['publish 배포'])
+    const { memoryEval } = await import('../src/commands/memory-eval.js')
+    // 히트 프롬프트에서 'm' → 전체 목록 [1] f1, [2] pat-1 → 패턴 선택.
+    promptQueue.push({ ans: 'm' }, { ans: '2' })
+    await memoryEval({ init: true })
+
+    const written = readEvalFile(dir)
+    expect(written.labels).toEqual([{ query: 'publish 배포', expectIds: ['pat-1'] }])
+  })
+
+  it('픽커에서 유효한 번호가 하나도 없는 입력 → 해당 쿼리 skip (라벨 미기록)', async () => {
+    writeMemoryFixture(dir, baseMemory())
+    writeRecallLogFixture(dir, ['버그 메모리 누수'])
+    const { memoryEval } = await import('../src/commands/memory-eval.js')
+    promptQueue.push({ ans: 'abc' })
+    await memoryEval({ init: true })
+
+    expect(fs.existsSync(path.join(dir, EVAL_REL))).toBe(false)
+  })
+
+  it('기억이 아예 없으면(빈 memory) 후보 0 쿼리는 픽커 프롬프트 없이 skip', async () => {
+    // memory.json 없음 → 빈 v2 로 읽힘. 프롬프트 큐 비움 — 호출되면 큐 고갈 throw 로 실패.
+    writeRecallLogFixture(dir, ['버그 메모리 누수'])
+    const { memoryEval } = await import('../src/commands/memory-eval.js')
+    await memoryEval({ init: true })
+
+    expect(promptSpy).not.toHaveBeenCalled()
+    expect(fs.existsSync(path.join(dir, EVAL_REL))).toBe(false)
+  })
+
+  it('비-TTY → 기존 가드 유지: 프롬프트 0회 + exitCode 2', async () => {
+    process.stdin.isTTY = undefined
+    writeMemoryFixture(dir, baseMemory())
+    writeRecallLogFixture(dir, ['버그 메모리 누수'])
+    const { memoryEval } = await import('../src/commands/memory-eval.js')
+    await memoryEval({ init: true })
+
+    expect(promptSpy).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(2)
+  })
+})


### PR DESCRIPTION
## 근인

`src/commands/memory-eval.ts` `memoryEvalInit()` — 라벨 선택지가 recall top-5 히트로만 한정돼 있어:

1. `recallMemories()` 가 후보 0을 반환하면 `(후보 없음 — skip)` 후 `continue` → **라벨 자체가 불가** (이슈 실사례: 실쿼리 6건 전부 skip → 라벨 0 → 평가셋 미생성 dead-end)
2. 후보가 있어도 top-5 밖 정답을 지정할 방법이 없음 → `--init` 산 라벨은 사실상 전부 hit 로만 구성

→ **미스가 평가셋에서 구조적으로 제외 = Recall@5 상향 편향** (RFC 0049 kill-gate 판정 무력화)

## 수정

- **후보 0 분기**: 자동 skip 제거 → 전체 기억 픽커 진입. 엔터 = "정답 없음(쿼리 무효)" 일 때만 skip (이슈 제안 그대로)
- **전체 기억 픽커 신설** (`pickExpectedFromAll`): 4버킷(decisions→failures→successes→patterns) 평탄화, 20건 초과 시 키워드 필터(`f` 로 재필터), 번호(쉼표 구분) 선택
  - patterns 는 recall 코퍼스(orderedAll) 밖이라 골라도 항상 miss — recall 의 실제 사각지대이므로 숨기지 않고 라벨 가능하게 유지 (한계로 dev log 에 명시)
- **히트 있는 쿼리 확장(additive)**: 기존 숫자 선택·엔터 skip 하위호환 유지 + `m` 입력 시 전체 목록에서 top-5 밖 정답 지정 → 채점 시 그대로 miss
- **스키마·채점기 무변경**: `{query, expectIds, queryType?}` 그대로 — 히트 밖 expected 는 기존 `scoreEval` 이 이미 found:false 로 분모·분자에 정확 반영
- 신규 사용자 대면 문구 전부 `src/i18n/ko.ts` (`memory.evalInit.*`) · 비-TTY 가드(`ensureInteractive`) 유지 · MCP 미노출(대화형 유지) · 기존 플래그/시그니처 breaking 없음
- COMMANDS.md 해당 행 1줄 갱신 + 세션 dev log 동반

## 검증 (TDD)

`tests/memory-eval-init.test.ts` 신설 9건 — 구현 전 red(신규 동작 4건 실패) 확인 후 green:

- 후보 0 → 전체 목록(패턴 포함)에서 선택 → 라벨 기록
- 후보 0 에서 고른 정답이 히트에 없으면 scoreEval 에서 miss 반영(found:false·recallAt5 0)
- 후보 0 + 엔터(정답 없음) → skip·평가셋 미생성
- 후보 0 + 목록 >20 → 키워드 필터로 좁혀서 선택
- 히트 쿼리 — 기존 숫자 선택·엔터 skip 하위호환
- 히트 있어도 `m` → top-5 밖 정답 지정(miss 라벨)
- 픽커 무효 입력 → skip / 빈 memory → 프롬프트 0회 skip / 비-TTY → 프롬프트 0회 + exitCode 2

## 게이트

- `pnpm build` ✅ · `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm test:run` **2396 pass (214 files)** ✅
- 라벨 데이터 생성 없음(라벨링은 사람 몫) · recall-log.jsonl 무접촉

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * `memory eval --init`에서 검색 결과가 없거나 상위 결과에 정답이 없더라도 전체 기억에서 정답을 선택할 수 있습니다.
  * 검색 결과 밖의 정답도 평가 데이터에 `miss`로 기록할 수 있습니다.
  * 기억 유형 및 키워드 필터를 활용해 정답 선택이 쉬워졌습니다.
  * 초기화 과정의 안내 문구와 입력 메시지가 한국어로 개선되었습니다.

* **문서**
  * 관련 평가 동작 기준과 라벨링 규칙을 명확히 안내하도록 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->