### PR TITLE
fix: 전 컨테이너 한글 서브별칭 R1 가드 합류 — NL 가로채기·인자 유실 차단

### DIFF
--- a/docs/log/2026-07-13-hangul-subalias-union.md
+++ b/docs/log/2026-07-13-hangul-subalias-union.md
@@ -1,0 +1,37 @@
+# 2026-07-13 — 전 컨테이너 한글 서브별칭 R1 가드 합류
+
+## 배경 (실증 2회 결함 클래스)
+`CONTAINER_SUBCOMMANDS` 가 영문 서브명만 담아, 한글 서브별칭 경로(`목표 다음`, `진화 제안` 등)가
+`isRealSubcommandPath`(cli-args) 대조를 못 통과 → NL 라우터가 가로채 **서브커맨드·인자 유실**.
+- 2026-07-01 선재버그: evolve 한글 서브별칭 전부 차단
+- 2026-07-13 #457 적대검증 중대-1: `보안 스캔 <파일>` 인자 유실 → 유출 파일 "깨끗" 오보고
+
+#457 수정에서 `CONTAINER_SUBCOMMAND_ALIASES` + `resolveSubcommandAlias` 가 신설됐지만
+secure({스캔:'scan'}) 만 합류된 상태였다 — 이번 작업으로 전 컨테이너 확장.
+
+## 한 일 (TDD)
+1. **드리프트 가드 먼저(red)**: tests/command-registry.test.ts 에 commander 실등록(introspect)
+   ↔ `CONTAINER_SUBCOMMAND_ALIASES` 양방향 대조 테스트 3종 추가.
+   - 순방향: commander 의 모든 서브커맨드 `.alias()` 가 registry 에서 정규화됨 (누락 = R1 재발)
+   - 역방향: registry 의 모든 별칭이 commander 실등록과 1:1 (유령·발명 별칭 0)
+   - shadow 가드: 별칭 키가 같은 컨테이너 영문 서브명과 충돌 금지
+   → red 실행이 누락 34건을 전수 열거 (수동 수집표와 교차검증됨).
+2. **green**: 열거된 34건 전수 등재 — cloud(2)·ref(2)·worktree(2)·memory(7)·work(1)·
+   goal(9)·pattern(3)·evolve(8) + 기존 secure(1). 별칭 없는 컨테이너
+   (mission/seo/config/bootstrap/cost/mode)는 등재하지 않음(발명 금지, commander 가 SoT).
+3. **동작 테스트**: tests/cli-args.test.ts 에 한글 경로 위임 8종 + 회귀 2종
+   (`목표 점검` NL 유지 — '점검' 은 worktree 것, cross-container 오염 금지 / `보안 확인` NL 유지).
+4. isRealSubcommandPath 등 로직 변경 0 — 데이터(레지스트리)만 추가 (보수적 접근).
+
+## 실측 (dist 빌드, 임시 디렉토리)
+- `vhk 목표 다음` ≡ `vhk goal next` (출력 동일 = 같은 핸들러)
+- `vhk 진화 제안` ≡ `vhk evolve suggest` (동일)
+- `vhk 기억 목록` ≡ `vhk memory list` (동일)
+- 인자 보존: `vhk 진화 반영 r1` → evolve apply 핸들러의 TTY_REQUIRED 도달 (NL 가로채기 없음)
+- 회귀: `보안 확인`·`보안 xyz` → NL→secure 유지 / `뭐 바뀌었어` → NL→diff 유지
+
+## 교훈
+- 별칭 계열 레지스트리는 "일부만 우선 합류" 상태가 제일 위험 — 가드가 있다는 착시를 만든다.
+  드리프트 가드(introspect 전수 대조)를 데이터와 같은 커밋에 넣어야 재발 원천 차단.
+- commander 등록이 SoT: 레지스트리를 손으로 수집하지 말고, 가드 테스트의 red 출력으로
+  전수 열거시켜 등재하면 수집 누락·발명이 구조적으로 불가능.

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -29,13 +29,52 @@ export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
 }
 
 /**
- * 컨테이너별 서브커맨드 한글 별칭 → 영문. commander 에는 `.alias('스캔')` 로 등록돼 있지만
+ * 컨테이너별 서브커맨드 한글 별칭 → 영문. commander 에는 `.alias('스캔')` 등으로 등록돼 있지만
  * R1 가드(isRealSubcommandPath)가 영문 집합만 봐서 `보안 스캔 <파일>` 이 NL 라우터에 삼켜져
- * **인자가 유실**되던 결함(#457 적대검증 중대-1). ⚠️ 전 컨테이너 한글 서브별칭 합류는
- * 별도 PR(2026-07-01 선재버그, cli-args:255 노트) — 여기선 보안 게이트 경로만 우선 합류.
+ * **인자가 유실**되던 결함 클래스(2026-07-01 evolve 선재버그 + #457 적대검증 중대-1, 2회 실증).
+ * → 전 컨테이너 한글 서브별칭을 여기 합류해 한글 경로도 영문과 동일하게 commander 위임.
+ *
+ * SoT 는 commander 실등록(index.ts `.alias()`) — 드리프트 가드 테스트
+ * (tests/command-registry.test.ts, introspect 대조)가 양방향(누락·유령) 어긋남을 잡는다.
+ * 별칭 없는 컨테이너(mission/seo/config/bootstrap 등)는 등재하지 않는다(발명 금지).
  */
 export const CONTAINER_SUBCOMMAND_ALIASES: Record<string, Record<string, string>> = {
   secure: { 스캔: 'scan' },
+  cloud: { 올리기: 'push', 내리기: 'pull' },
+  ref: { 목록: 'list', 열기: 'open' },
+  worktree: { 점검: 'check', 추가: 'add' },
+  memory: {
+    목록: 'list',
+    삭제: 'remove',
+    보관: 'archive',
+    해결: 'resolve',
+    복구: 'unarchive',
+    마이그레이션: 'migrate',
+    검증: 'eval',
+  },
+  work: { 인수인계: 'handoff' },
+  goal: {
+    목록: 'list',
+    다음: 'next',
+    미리보기: 'peek',
+    초기화: 'init',
+    검증: 'check',
+    완료: 'done',
+    동기화: 'sync',
+    드리프트: 'drift',
+    마이그레이트: 'migrate',
+  },
+  pattern: { 감지: 'detect', 목록: 'list', 보관: 'dismiss' },
+  evolve: {
+    제안: 'suggest',
+    부정예시: 'negatives',
+    씨앗: 'seed',
+    목록: 'list',
+    묶음: 'digest',
+    반영: 'apply',
+    기각: 'reject',
+    되돌리기: 'undo',
+  },
 }
 
 /** 컨테이너의 서브커맨드 한글 별칭을 영문으로 정규화(별칭 아니면 그대로). */

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -166,6 +166,43 @@ describe('detectNaturalLanguageInput — pattern/evolve 라우팅 (회귀: Goal 
   })
 })
 
+describe('detectNaturalLanguageInput — 한글 서브별칭 경로 가드 (R1 합류: 전 컨테이너)', () => {
+  // 실증 결함 클래스: 한글 서브별칭이 CONTAINER_SUBCOMMAND_ALIASES 에 없어 R1 가드를 못 통과 →
+  // NL 라우터가 가로채 서브커맨드·인자 유실 (2026-07-01 evolve 선재버그 + #457 보안 스캔 인자 유실).
+  it('vhk 목표 다음 → null (commander 가 goal next 실행)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '목표', '다음'])).toBeNull()
+  })
+  it('vhk 진화 제안 → null (commander 가 evolve suggest 실행)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '진화', '제안'])).toBeNull()
+  })
+  it('vhk 기억 목록 → null (commander 가 memory list 실행)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '기억', '목록'])).toBeNull()
+  })
+  it('vhk 진화 반영 <id> → null (인자 보존)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '진화', '반영', 'r1'])).toBeNull()
+  })
+  it('vhk 기억 삭제 <index> → null (인자 보존)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '기억', '삭제', '3'])).toBeNull()
+  })
+  it('vhk 워크트리 추가 <branch> → null (인자 보존)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '워크트리', '추가', 'feat-x'])).toBeNull()
+  })
+  it('vhk 작업 인수인계 → null (commander 가 work handoff 실행)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '작업', '인수인계'])).toBeNull()
+  })
+  it('vhk 클라우드 올리기 → null (commander 가 cloud push 실행)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '클라우드', '올리기'])).toBeNull()
+  })
+  // 회귀: 별칭은 컨테이너별로 격리 — '점검' 은 worktree check 의 별칭이지 goal 것이 아니다.
+  it('회귀: vhk 목표 점검 → 여전히 자연어 (goal 에 점검 별칭 없음, cross-container 오염 금지)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '목표', '점검'])).toBe('목표 점검')
+  })
+  // 회귀: 서브별칭이 아닌 한국어는 여전히 NL 로 흐른다.
+  it('회귀: vhk 보안 확인 → 여전히 자연어 (확인은 서브별칭 아님)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '보안', '확인'])).toBe('보안 확인')
+  })
+})
+
 describe('detectNaturalLanguageInput — freeform 인자 명령 NLP 가로채기 금지 (#147)', () => {
   // 실결함: learn/blocker 는 자유형식 본문을 받는데, 본문에 'sync' 같은 NLP 키워드가
   // 들어가면 라우터가 가로채 vhk sync 가 실행되고 learn()/blocker() 가 안 돔.

--- a/tests/command-registry.test.ts
+++ b/tests/command-registry.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import { program } from '../src/index.js'
-import { CONTAINER_SUBCOMMANDS, CONTAINER_ALIASES, TOP_LEVEL_COMMANDS } from '../src/lib/command-registry.js'
+import {
+  CONTAINER_SUBCOMMANDS,
+  CONTAINER_ALIASES,
+  CONTAINER_SUBCOMMAND_ALIASES,
+  resolveSubcommandAlias,
+  TOP_LEVEL_COMMANDS,
+} from '../src/lib/command-registry.js'
 import { detectNaturalLanguageInput, KNOWN_COMMAND_TOKENS } from '../src/lib/cli-args.js'
 
 // R1 드리프트 가드: commander 정의(index.ts)와 R1 가드의 단일 소스(command-registry)가
@@ -80,6 +86,66 @@ describe('R1 드리프트 가드 — command-registry 단일 소스', () => {
         KNOWN_COMMAND_TOKENS.has(alias),
         `한글 별칭 '${alias}' 가 KNOWN_COMMAND_TOKENS 에 없음 → 한글 서브커맨드가 자연어로 둔갑`
       ).toBe(true)
+    }
+  })
+})
+
+// 서브커맨드 별칭 드리프트 가드: commander 의 `.alias('한글')` 실등록과
+// CONTAINER_SUBCOMMAND_ALIASES 가 어긋나면 실패한다.
+// 실증 2회: 2026-07-01 선재버그(evolve 한글 서브별칭 전부 NL 라우터에 차단) +
+// #457 적대검증 중대-1(`보안 스캔 <파일>` 인자 유실 → 유출 파일 "깨끗" 오보고).
+// 원인 클래스 = 레지스트리가 영문 서브명만 알아서 한글 별칭 경로가 R1 가드를 못 통과.
+describe('R1 드리프트 가드 — 서브커맨드 한글 별칭 (CONTAINER_SUBCOMMAND_ALIASES 단일 소스)', () => {
+  it('commander 의 모든 서브커맨드 별칭이 registry 에서 정규화됨 (누락 = 한글 경로가 NL 로 새서 인자 유실)', () => {
+    const missing: string[] = []
+    for (const container of program.commands) {
+      for (const sub of container.commands) {
+        for (const alias of sub.aliases()) {
+          if (resolveSubcommandAlias(container.name(), alias) !== sub.name()) {
+            missing.push(`${container.name()}.${sub.name()} ← '${alias}'`)
+          }
+        }
+      }
+    }
+    expect(
+      missing,
+      `CONTAINER_SUBCOMMAND_ALIASES 누락(commander 엔 등록됨): ${missing.join(', ')}`
+    ).toEqual([])
+  })
+
+  it('registry 의 모든 별칭이 commander 실등록과 1:1 (유령 별칭 0)', () => {
+    for (const [containerName, aliases] of Object.entries(CONTAINER_SUBCOMMAND_ALIASES)) {
+      const cmd = program.commands.find((c) => c.name() === containerName)
+      expect(cmd, `registry 의 '${containerName}' 가 commander 컨테이너가 아님`).toBeDefined()
+      for (const [alias, canonical] of Object.entries(aliases)) {
+        const sub = cmd!.commands.find((c) => c.name() === canonical)
+        expect(
+          sub,
+          `${containerName}.${canonical} 가 commander 에 없음 (별칭 '${alias}' 의 대상 = 유령)`
+        ).toBeDefined()
+        expect(
+          sub!.aliases(),
+          `'${alias}' 가 commander ${containerName}.${canonical} 의 실제 별칭이 아님 (발명된 별칭)`
+        ).toContain(alias)
+        // R1 가드(isRealSubcommandPath)는 정규화 결과를 CONTAINER_SUBCOMMANDS 로 대조하므로
+        // 별칭 대상이 거기 없으면 별칭이 조용히 무효가 된다 — 일관성 강제.
+        expect(
+          CONTAINER_SUBCOMMANDS[containerName],
+          `별칭 '${alias}' 의 대상 '${canonical}' 이 CONTAINER_SUBCOMMANDS.${containerName} 에 없음`
+        ).toContain(canonical)
+      }
+    }
+  })
+
+  it('별칭 키가 같은 컨테이너의 영문 서브명을 가리지 않음 (shadow 0)', () => {
+    for (const [containerName, aliases] of Object.entries(CONTAINER_SUBCOMMAND_ALIASES)) {
+      const subs = CONTAINER_SUBCOMMANDS[containerName] ?? []
+      for (const alias of Object.keys(aliases)) {
+        expect(
+          subs,
+          `'${containerName}' 별칭 키 '${alias}' 가 영문 서브명과 충돌 — resolve 가 실제 경로를 뒤바꿈`
+        ).not.toContain(alias)
+      }
     }
   })
 })


### PR DESCRIPTION
## 배경 (실증 2회 결함 클래스)
`CONTAINER_SUBCOMMANDS` 는 영문 서브명만 담아, 한글 서브별칭 경로(`목표 다음`·`진화 제안`·`기억 목록` 등)가 `isRealSubcommandPath` 대조를 못 통과 → NL 라우터가 가로채 **서브커맨드·인자 유실**.
- 2026-07-01 선재버그: evolve 한글 서브별칭 전부 차단
- #457 적대검증 중대-1: `보안 스캔 <파일>` 인자 유실 → 유출 파일 깨끗 오보고

#457 수정에서 신설된 `CONTAINER_SUBCOMMAND_ALIASES` + `resolveSubcommandAlias` 에 secure만 합류된 상태였음 → **전 컨테이너 확장**.

## 변경
- **registry 전수 등재 (34건)**: cloud(2)·ref(2)·worktree(2)·memory(7)·work(1)·goal(9)·pattern(3)·evolve(8) + 기존 secure(1). commander 실등록(`.alias()`)이 SoT — 발명 별칭 0. 별칭 없는 컨테이너(mission/seo/config/bootstrap/cost/mode)는 미등재.
- **드리프트 가드 (핵심 가치, 재발 원천 차단)**: commander introspect ↔ registry 양방향 대조 3종
  - 순방향: commander 의 모든 서브커맨드 별칭이 registry 에서 정규화됨 (누락 시 전수 열거하며 실패)
  - 역방향: registry 별칭이 commander 실등록과 1:1 (유령·발명 별칭 0)
  - shadow: 별칭 키가 같은 컨테이너 영문 서브명 충돌 금지
- **동작 테스트**: cli-args 한글 경로 위임 8종 + 회귀 2종(`목표 점검`·`보안 확인` NL 유지 — 컨테이너별 별칭 격리)
- **로직 변경 0**: `isRealSubcommandPath` 그대로 — 데이터(레지스트리) 추가만, breaking 없음

## 실측 (dist 빌드, 임시 디렉토리)
| 경로 | 결과 |
|---|---|
| `vhk 목표 다음` ≡ `vhk goal next` | 출력 동일 = 같은 핸들러 |
| `vhk 진화 제안` ≡ `vhk evolve suggest` | 동일 |
| `vhk 기억 목록` ≡ `vhk memory list` | 동일 |
| `vhk 진화 반영 r1` | evolve apply 핸들러 도달 (인자 보존) |
| `vhk 보안 확인` / `vhk 보안 xyz` / `vhk 뭐 바뀌었어` | NL 라우팅 기존 그대로 (회귀 없음) |

## 게이트
`pnpm build` ✅ · `pnpm test:run` ✅ 2421/2421 (215 files) · `pnpm lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)