### PR TITLE
feat: #456 뒷단 산출물 RULES.md 치명 규칙 상속 — 런타임 주입(복붙 0)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -212,10 +212,10 @@ vhk doctor
 | `vhk brief` | 프로젝트 요약 보고서 생성 |
 | `vhk loop-brief` | 루프 1틱 앵커 생성 (의도+goal1+교훈+STOP → `.vhk/loop-brief.md`) |
 | `vhk remind` | 치명 규칙 재주입 (RULES.md NON-NEGOTIABLE/Forbidden 압축 → `.vhk/remind.md`) |
-| `vhk content` | 콘텐츠 초안 프롬프트 생성 (풀사이클 뒷단 — 콘텐츠/마케팅 → `.vhk/content-prompt.md`) |
-| `vhk launch` | 런칭 게시물 프롬프트 생성 (풀사이클 뒷단 — 런칭 → `.vhk/launch-prompt.md`) · `ship`=코드 npm 배포와 구분 |
-| `vhk ops` | 운영 회고 프롬프트 생성 (풀사이클 뒷단 — 운영 → `.vhk/ops-prompt.md`) · 유지/피벗/아카이브 회고, 중단·삭제는 사람이 |
-| `vhk sell` | 판매 카피 프롬프트 생성 (풀사이클 뒷단 — 판매 → `.vhk/sell-prompt.md`) · 가격 페이지·FAQ 초안, 결제·과금은 사람이 |
+| `vhk content` | 콘텐츠 초안 프롬프트 생성 (풀사이클 뒷단 — 콘텐츠/마케팅 → `.vhk/content-prompt.md`) · RULES.md 치명 규칙 상속 |
+| `vhk launch` | 런칭 게시물 프롬프트 생성 (풀사이클 뒷단 — 런칭 → `.vhk/launch-prompt.md`) · `ship`=코드 npm 배포와 구분 · RULES.md 치명 규칙 상속 |
+| `vhk ops` | 운영 회고 프롬프트 생성 (풀사이클 뒷단 — 운영 → `.vhk/ops-prompt.md`) · 유지/피벗/아카이브 회고, 중단·삭제는 사람이 · RULES.md 치명 규칙 상속 |
+| `vhk sell` | 판매 카피 프롬프트 생성 (풀사이클 뒷단 — 판매 → `.vhk/sell-prompt.md`) · 가격 페이지·FAQ 초안, 결제·과금은 사람이 · RULES.md 치명 규칙 상속 |
 | `vhk work` | AI 작업 시작/이어하기 (+ handoff) |
 | `vhk goal` | Goal 단계별 미션 관리 |
 | `vhk blocker` | 블로커 기록 (3건 누적 시 HARD_STOP) |

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ VHK 프로젝트에서 **active goal 1개를 혼자 한 바퀴 돌리고 멈춰 
 | --- | --- | --- |
 | 시작 | `vhk`, `vhk gate`, `vhk start`, `vhk init` | 메뉴, 아이디어 검증, 새 프로젝트 마법사, 하네스 초기화(+기록 집행 커밋훅 배선 — 세션일지 없는 코드 커밋 차단, `[skip-record]` 우회) |
 | 규칙/맥락 | `vhk sync`, `vhk context`, `vhk context-show`, `vhk brief`, `vhk loop-brief`, `vhk remind`, `vhk work`, `vhk work handoff` | 규칙 동기화, 프로젝트 맥락 생성, 루프 1틱 의도 앵커, 치명 규칙 재주입, 세션 시작/인수인계 |
-| 풀사이클 뒷단 | `vhk content`, `vhk launch`, `vhk ops`, `vhk sell` | 콘텐츠/런칭/운영/판매 초안 프롬프트 생성 (초안만, 게시·발송·결제는 사람이) |
+| 풀사이클 뒷단 | `vhk content`, `vhk launch`, `vhk ops`, `vhk sell` | 콘텐츠/런칭/운영/판매 초안 프롬프트 생성 (초안만, 게시·발송·결제는 사람이) · 프롬프트에 프로젝트 RULES.md 치명 규칙 자동 상속 |
 | Goal | `vhk goal init/list/next/check/done/sync/drift` | 단계별 목표, 게이트, 상태 드리프트 관리 |
 | Trust | `vhk verify`, `vhk review`, `vhk receipt`, `vhk preflight`, `vhk testmap`, `vhk mission set/show/check/clear` | 증거 생성, 거짓완료 탐지, 증거 영수증, 출고 전 점검, 테스트 매핑, 작업 범위 계약 |
 | 안전 | `vhk blocker`, `vhk resume --confirm`, `vhk mode`, `vhk secure scan` | HARD_STOP, safety mode, 시크릿 스캔 |

--- a/docs/log/2026-07-13-issue456-rules-inherit.md
+++ b/docs/log/2026-07-13-issue456-rules-inherit.md
@@ -1,0 +1,42 @@
+# 2026-07-13 — #456 뒷단 산출물 RULES.md 상속 (feat/456-rules-inherit)
+
+## 목표
+이슈 #456(#279 분리 서브이슈 2/5): 런칭·판매·운영 산출물(content/launch/sell/ops 프롬프트)이
+프로젝트 RULES.md 단일소스를 상속하는지 검증·구현.
+
+## 실측 (정찰 결과)
+- `buildContentPrompt`/`buildLaunchPrompt`/`buildSellPrompt`/`buildOpsPrompt` 전부 하드코딩
+  치명 규칙(Fable5 위생)만 담고 **RULES.md 를 전혀 읽지 않음** — 추정 그대로 확정.
+- 재사용 가능한 추출기 발견: `src/commands/remind.ts` 의 `extractCriticalRules`
+  (NON-NEGOTIABLE/절대 규칙/Forbidden/전역 금지 섹션 불릿 추출 + `compressRule` 압축).
+- #457(오늘 머지)의 "게시 전 보안 게이트" 줄이 content/launch/sell 에 존재(ops 는 의도적 제외) —
+  최신 main(769bfc7) 기준 작업, 해당 줄 보존.
+
+## 설계 결정
+1. **주입 대상**: RULES.md 치명 섹션 불릿 — `vhk remind` 와 동일 정의. 발행·콘텐츠 키워드
+   필터링은 안 함(휴리스틱 오탐/누락 위험 — 치명 규칙은 모든 산출물에 적용이 정직한 기본).
+2. **상속 방식**: 정적 복붙이 아닌 **런타임 추출·주입** — 프롬프트 생성 시점에 RULES.md 를
+   직접 읽으므로 드리프트가 구조적으로 불가(이슈 완료기준 "드리프트 감지"를 원천 차단으로 충족).
+3. **아키텍처**: 추출기를 `src/lib/rules-inherit.ts` 로 이동(lib→commands 역의존 금지 —
+   rules-import.ts 의 로컬 섹션파서 선례). remind.ts 는 재수출로 기존 API·테스트 호환 유지.
+4. **프롬프트 위생(Fable5)**: 하드리밋 `MAX_INHERIT_RULES=10`(초과분 "…외 N개" 1줄) +
+   `MAX_RULE_LEN=120`(말줄임) — 무한정 주입으로 인한 프롬프트 비대 방지.
+5. **빌더 순수성 유지**: `rules?: string[]` 파라미터 주입, fs 읽기는 커맨드 액션에서
+   (`readCriticalRules()`). RULES.md 없으면 정직한 안내 1줄(현행 동작 유지).
+
+## 산출물
+- 신규: `src/lib/rules-inherit.ts` · `tests/rules-inherit.test.ts` · `tests/rules-inherit-wiring.test.ts`
+- 수정: `src/commands/{content,launch,sell,ops}.ts`(상속 블록 주입) ·
+  `src/commands/remind.ts`(추출기 lib 이동+재수출) · 4개 커맨드 테스트(+상속 검증) ·
+  README.md · COMMANDS.md (뒷단 설명에 상속 1줄)
+
+## 검증
+- TDD: 레드(14 fail) → 구현 → 그린. 신규·관련 8파일 66 pass.
+- 게이트: `pnpm build` ✅ · `pnpm test:run` 2433 pass ✅ · `pnpm lint` ✅ · `pnpm typecheck` ✅ ·
+  `node scripts/check-rules-sync.mjs` PASS ✅
+- E2E(스크래치 프로젝트): RULES.md 有 → content/ops 프롬프트에 Forbidden 불릿 상속 확인 ·
+  RULES.md 無 → "상속 생략" 정직 안내 확인 · #457 보안 게이트 줄 보존 확인.
+
+## 교훈
+- 격리 worktree 에 node_modules 가 없으면 tsup/vitest 는 상위 폴더 폴백으로 돌지만
+  `pnpm lint`(eslint)는 못 찾는다 — worktree 에서 게이트 돌리기 전 `pnpm install --frozen-lockfile` 필수.

--- a/src/commands/content.ts
+++ b/src/commands/content.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { emitPrompt } from '../lib/emit-prompt.js'
+import { buildRulesInheritLines, readCriticalRules } from '../lib/rules-inherit.js'
 
 /**
  * goal 74 — 풀사이클 뒷단 첫 트랙(content). RFC 0052 §4.
@@ -12,11 +13,13 @@ import { emitPrompt } from '../lib/emit-prompt.js'
 
 export interface ContentInput {
   what?: string // 제품 한 줄 (VISION.md What)
+  rules?: string[] // RULES.md 치명 규칙(#456) — undefined = RULES.md 없음(정직 안내로 표기)
 }
 
 /**
  * 콘텐츠 초안 생성 프롬프트(순수·결정적). Fable5 프롬프트 위생 상속(goal 68/69):
- * good/bad 예시쌍(✅/❌) + 수치 하드리밋(≤3종·글자수) + 치명 규칙(사람 승인 전 게시·발송 금지).
+ * good/bad 예시쌍(✅/❌) + 수치 하드리밋(≤3종·글자수) + 치명 규칙(사람 승인 전 게시·발송 금지)
+ * + 프로젝트 RULES.md 치명 규칙 상속(#456 — 런타임 주입, 복붙 0).
  */
 export function buildContentPrompt(input: ContentInput): string {
   const what = input.what?.trim() || '(VISION.md 의 What 미정 — vhk init 후 채우기)'
@@ -38,6 +41,8 @@ export function buildContentPrompt(input: ContentInput): string {
     '- 사람 승인 전에는 어디에도 게시·발송하지 마세요 (이 명령은 초안만 만듭니다)',
     '- 게시 전 보안 게이트(#457): 초안을 파일로 저장하고 `vhk secure scan <파일>` 을 실행 — CRITICAL/HIGH 0 확인 후에만 게시하세요',
     '',
+    ...buildRulesInheritLines(input.rules),
+    '',
     '모든 응답은 한국어로.',
   ].join('\n')
 }
@@ -57,7 +62,7 @@ export function content(): void {
   console.log(chalk.bold('\n📝 ' + t('content.title')))
   console.log(chalk.gray('─'.repeat(40)))
 
-  const prompt = buildContentPrompt({ what: readVisionWhat() })
+  const prompt = buildContentPrompt({ what: readVisionWhat(), rules: readCriticalRules() })
   emitPrompt(prompt, 'content-prompt.md', '콘텐츠 초안 프롬프트')
 
   printNextStep({

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { emitPrompt } from '../lib/emit-prompt.js'
+import { buildRulesInheritLines, readCriticalRules } from '../lib/rules-inherit.js'
 
 /**
  * goal 75 — 풀사이클 뒷단 둘째 트랙(launch). RFC 0052 §4·§5.
@@ -13,11 +14,13 @@ import { emitPrompt } from '../lib/emit-prompt.js'
 
 export interface LaunchInput {
   what?: string // 제품 한 줄 (VISION.md What)
+  rules?: string[] // RULES.md 치명 규칙(#456) — undefined = RULES.md 없음(정직 안내로 표기)
 }
 
 /**
  * 런칭 게시물 초안 생성 프롬프트(순수·결정적). Fable5 프롬프트 위생 상속(goal 68/69):
- * good/bad 예시쌍(✅/❌) + 수치 하드리밋(≤3 변형·X 280자) + 치명 규칙(사람 승인 전 게시·발송 금지).
+ * good/bad 예시쌍(✅/❌) + 수치 하드리밋(≤3 변형·X 280자) + 치명 규칙(사람 승인 전 게시·발송 금지)
+ * + 프로젝트 RULES.md 치명 규칙 상속(#456 — 런타임 주입, 복붙 0).
  */
 export function buildLaunchPrompt(input: LaunchInput): string {
   const what = input.what?.trim() || '(VISION.md 의 What 미정 — vhk init 후 채우기)'
@@ -45,6 +48,8 @@ export function buildLaunchPrompt(input: LaunchInput): string {
     '- 사람 승인 전에는 어디에도 게시·발송하지 마세요 (이 명령은 초안만 만듭니다)',
     '- 게시 전 보안 게이트(#457): 초안을 파일로 저장하고 `vhk secure scan <파일>` 을 실행 — CRITICAL/HIGH 0 확인 후에만 게시하세요',
     '',
+    ...buildRulesInheritLines(input.rules),
+    '',
     '모든 응답은 한국어로.',
   ].join('\n')
 }
@@ -64,7 +69,7 @@ export function launch(): void {
   console.log(chalk.bold('\n🚀 ' + t('launch.title')))
   console.log(chalk.gray('─'.repeat(40)))
 
-  const prompt = buildLaunchPrompt({ what: readVisionWhat() })
+  const prompt = buildLaunchPrompt({ what: readVisionWhat(), rules: readCriticalRules() })
   emitPrompt(prompt, 'launch-prompt.md', '런칭 게시물 프롬프트')
 
   // 후속 트랙 vhk sell(goal 77)은 미구현 — command 힌트는 구현된 ops(76)까지만(댕글링 전방참조 금지).

--- a/src/commands/ops.ts
+++ b/src/commands/ops.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { emitPrompt } from '../lib/emit-prompt.js'
+import { buildRulesInheritLines, readCriticalRules } from '../lib/rules-inherit.js'
 
 /**
  * goal 76 — 풀사이클 뒷단 셋째 트랙(ops). RFC 0052 §4·§5.
@@ -13,11 +14,13 @@ import { emitPrompt } from '../lib/emit-prompt.js'
 
 export interface OpsInput {
   what?: string // 제품 한 줄 (VISION.md What)
+  rules?: string[] // RULES.md 치명 규칙(#456) — undefined = RULES.md 없음(정직 안내로 표기)
 }
 
 /**
  * 운영 회고·다음 결정 생성 프롬프트(순수·결정적). Fable5 프롬프트 위생 상속(goal 68/69):
- * good/bad 예시쌍(✅/❌) + 수치 하드리밋(액션 ≤3개) + 치명 규칙(사람 승인 전 제품 중단·삭제 금지).
+ * good/bad 예시쌍(✅/❌) + 수치 하드리밋(액션 ≤3개) + 치명 규칙(사람 승인 전 제품 중단·삭제 금지)
+ * + 프로젝트 RULES.md 치명 규칙 상속(#456 — 런타임 주입, 복붙 0).
  */
 export function buildOpsPrompt(input: OpsInput): string {
   const what = input.what?.trim() || '(VISION.md 의 What 미정 — vhk init 후 채우기)'
@@ -42,6 +45,8 @@ export function buildOpsPrompt(input: OpsInput): string {
     '- 결과물은 회고 1편 + 다음 결정 1개로 압축, 액션은 ≤3개',
     '- 사람 승인 전에는 제품 중단·삭제·대량 변경을 실행하지 마세요 (이 명령은 회고·제안 초안만 만듭니다)',
     '',
+    ...buildRulesInheritLines(input.rules),
+    '',
     '모든 응답은 한국어로.',
   ].join('\n')
 }
@@ -61,7 +66,7 @@ export function ops(): void {
   console.log(chalk.bold('\n🛠️ ' + t('ops.title')))
   console.log(chalk.gray('─'.repeat(40)))
 
-  const prompt = buildOpsPrompt({ what: readVisionWhat() })
+  const prompt = buildOpsPrompt({ what: readVisionWhat(), rules: readCriticalRules() })
   emitPrompt(prompt, 'ops-prompt.md', '운영 회고 프롬프트')
 
   // sell(goal 77)로 체인 — content→launch→ops→sell 흐름 완성. 제품 중단·피벗·결제는 사람이 직접(헌법).

--- a/src/commands/remind.ts
+++ b/src/commands/remind.ts
@@ -2,33 +2,14 @@ import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs'
 import chalk from 'chalk'
 import { printNextStep } from '../lib/next-step.js'
 import { t } from '../i18n/ko.js'
-import { parseRulesMd } from './sync.js'
+import { compressRule, extractCriticalRules } from '../lib/rules-inherit.js'
+
+// #456: 추출기(compressRule/extractCriticalRules)는 lib/rules-inherit 로 이동 —
+// 뒷단 4명령(content/launch/sell/ops)과 단일 SoT 공유. 기존 import 경로 호환용 재수출.
+export { compressRule, extractCriticalRules }
 
 const REMIND_PATH = '.vhk/remind.md'
 const RULES_PATH = 'RULES.md'
-
-// 치명 규칙으로 간주할 RULES.md 섹션 헤더. 카드(goal68)는 NON-NEGOTIABLE·절대 규칙을 명시하지만
-// 실제 vhk RULES.md 는 'VHK 운영 — Forbidden (전역 금지)' 를 쓴다 → 헤더 변형을 모두 흡수해야
-// 빈 산출물(쓸모 0)을 피한다. 추가 변형은 OR 로 확장.
-const CRITICAL_HEADER = /non-negotiable|절대\s*규칙|forbidden|전역\s*금지/i
-
-// 불릿 한 줄 → 치명 규칙 핵심. 선행 '-/*' 와 후행 괄호주석(가드#·이유 등 메타)을 떼어
-// 1번째 턴과 100번째 턴이 같은 무게로 읽히는 최소 포맷으로 압축(원문 보존 아닌 핵심).
-export function compressRule(line: string): string {
-  return line
-    .replace(/^\s*[-*]\s+/, '')
-    .replace(/\s*\([^)]*\)\s*$/, '')
-    .trim()
-}
-
-export function extractCriticalRules(content: string): string[] {
-  return parseRulesMd(content)
-    .filter((s) => CRITICAL_HEADER.test(s.title))
-    .flatMap((s) => s.content.split('\n'))
-    .filter((l) => /^\s*[-*]\s+/.test(l))
-    .map(compressRule)
-    .filter((r) => r.length > 0)
-}
 
 export function remind(): void {
   console.log(chalk.bold('\n🔔 ' + t('remind.title')))

--- a/src/commands/sell.ts
+++ b/src/commands/sell.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk'
 import { t } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { emitPrompt } from '../lib/emit-prompt.js'
+import { buildRulesInheritLines, readCriticalRules } from '../lib/rules-inherit.js'
 
 /**
  * goal 77 — 풀사이클 뒷단 넷째(마지막) 트랙(sell). RFC 0052 §4·§5.
@@ -12,11 +13,13 @@ import { emitPrompt } from '../lib/emit-prompt.js'
 
 export interface SellInput {
   what?: string // 제품 한 줄 (VISION.md What)
+  rules?: string[] // RULES.md 치명 규칙(#456) — undefined = RULES.md 없음(정직 안내로 표기)
 }
 
 /**
  * 가격 페이지 카피·FAQ 생성 프롬프트(순수·결정적). Fable5 프롬프트 위생 상속(goal 68/69):
- * good/bad 예시쌍(✅/❌) + 수치 하드리밋(FAQ ≤3개) + 치명 규칙(사람 승인 전 결제·과금 연동 금지).
+ * good/bad 예시쌍(✅/❌) + 수치 하드리밋(FAQ ≤3개) + 치명 규칙(사람 승인 전 결제·과금 연동 금지)
+ * + 프로젝트 RULES.md 치명 규칙 상속(#456 — 런타임 주입, 복붙 0).
  */
 export function buildSellPrompt(input: SellInput): string {
   const what = input.what?.trim() || '(VISION.md 의 What 미정 — vhk init 후 채우기)'
@@ -43,6 +46,8 @@ export function buildSellPrompt(input: SellInput): string {
     '- 사람 승인 전에는 결제·과금·구독을 연동·실행하지 마세요 (이 명령은 카피 초안만 만듭니다)',
     '- 게시 전 보안 게이트(#457): 카피 초안을 파일로 저장하고 `vhk secure scan <파일>` 을 실행 — CRITICAL/HIGH 0 확인 후에만 게시하세요',
     '',
+    ...buildRulesInheritLines(input.rules),
+    '',
     '모든 응답은 한국어로.',
   ].join('\n')
 }
@@ -62,7 +67,7 @@ export function sell(): void {
   console.log(chalk.bold('\n💰 ' + t('sell.title')))
   console.log(chalk.gray('─'.repeat(40)))
 
-  const prompt = buildSellPrompt({ what: readVisionWhat() })
+  const prompt = buildSellPrompt({ what: readVisionWhat(), rules: readCriticalRules() })
   emitPrompt(prompt, 'sell-prompt.md', '판매 카피 프롬프트')
 
   // sell = 뒷단 4트랙 마지막 — 다음 터미널 명령 없음(content→launch→ops→sell 체인 끝).

--- a/src/lib/rules-inherit.ts
+++ b/src/lib/rules-inherit.ts
@@ -1,0 +1,97 @@
+import { existsSync, readFileSync } from 'node:fs'
+
+/**
+ * #456 — 뒷단(content/launch/sell/ops) 산출물 프롬프트에 프로젝트 RULES.md 의
+ * 치명 규칙(NON-NEGOTIABLE/절대 규칙/Forbidden/전역 금지)을 상속시키는 단일 SoT.
+ * remind.ts 의 추출기를 lib 로 이동 — remind + 뒷단 4명령이 같은 추출기를 공유하고,
+ * 프롬프트는 RULES.md 를 런타임에 직접 읽는다(정적 복붙 0 = 드리프트 구조적 불가).
+ */
+
+// 치명 규칙으로 간주할 RULES.md 섹션 헤더. 카드(goal68)는 NON-NEGOTIABLE·절대 규칙을 명시하지만
+// 실제 vhk RULES.md 는 'VHK 운영 — Forbidden (전역 금지)' 를 쓴다 → 헤더 변형을 모두 흡수해야
+// 빈 산출물(쓸모 0)을 피한다. 추가 변형은 OR 로 확장.
+const CRITICAL_HEADER = /non-negotiable|절대\s*규칙|forbidden|전역\s*금지/i
+
+/** 프롬프트에 주입할 규칙 수 하드리밋 — 무한정 늘리면 프롬프트 비대(Fable5 위생). */
+export const MAX_INHERIT_RULES = 10
+
+/** 규칙 1개당 길이 하드리밋(자) — 병적으로 긴 불릿이 프롬프트를 삼키는 것 방어. */
+export const MAX_RULE_LEN = 120
+
+interface ParsedSection {
+  title: string
+  content: string
+}
+
+// `## ` 기준 섹션 분리 — sync.parseRulesMd 와 동형. lib→commands 역의존을 피하려고
+// 로컬 구현(rules-import.splitSections 선례). 동작 핀(### 하위 흡수·CRLF)은 remind.test 가 지킨다.
+function splitSections(content: string): ParsedSection[] {
+  const sections: ParsedSection[] = []
+  let title = ''
+  let buf: string[] = []
+  for (const line of content.split('\n')) {
+    if (line.startsWith('## ')) {
+      if (title) sections.push({ title, content: buf.join('\n').trim() })
+      title = line.replace('## ', '').trim()
+      buf = []
+    } else if (title) {
+      buf.push(line)
+    }
+  }
+  if (title) sections.push({ title, content: buf.join('\n').trim() })
+  return sections
+}
+
+// 불릿 한 줄 → 치명 규칙 핵심. 선행 '-/*' 와 후행 괄호주석(가드#·이유 등 메타)을 떼어
+// 1번째 턴과 100번째 턴이 같은 무게로 읽히는 최소 포맷으로 압축(원문 보존 아닌 핵심).
+export function compressRule(line: string): string {
+  return line
+    .replace(/^\s*[-*]\s+/, '')
+    .replace(/\s*\([^)]*\)\s*$/, '')
+    .trim()
+}
+
+export function extractCriticalRules(content: string): string[] {
+  return splitSections(content)
+    .filter((s) => CRITICAL_HEADER.test(s.title))
+    .flatMap((s) => s.content.split('\n'))
+    .filter((l) => /^\s*[-*]\s+/.test(l))
+    .map(compressRule)
+    .filter((r) => r.length > 0)
+}
+
+/**
+ * RULES.md 를 읽어 치명 규칙을 추출한다.
+ * undefined = 파일 없음/읽기 실패(정직 폴백 신호) · [] = 파일은 있으나 치명 섹션 없음.
+ */
+export function readCriticalRules(rulesPath = 'RULES.md'): string[] | undefined {
+  try {
+    if (!existsSync(rulesPath)) return undefined
+    return extractCriticalRules(readFileSync(rulesPath, 'utf-8'))
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * 프롬프트 상속 블록 포매터(순수). 뒷단 4명령 공용 — RULES.md 없음/치명 섹션 없음도
+ * 숨기지 않고 1줄로 정직하게 알린다(#456 완료기준: 없으면 정직한 안내, 현행 동작 유지).
+ */
+export function buildRulesInheritLines(rules: string[] | undefined): string[] {
+  const lines = ['[프로젝트 규칙 — RULES.md 치명 규칙 상속(단일소스)]']
+  if (rules === undefined) {
+    lines.push('(RULES.md 없음 또는 읽기 실패 — 프로젝트 규칙 상속 생략. `vhk init` 으로 생성하면 여기 주입됩니다)')
+    return lines
+  }
+  if (rules.length === 0) {
+    lines.push('(RULES.md 에 치명 규칙 섹션 없음 — `## 절대 규칙` 또는 `## Forbidden` 을 추가하면 여기 상속됩니다)')
+    return lines
+  }
+  for (const r of rules.slice(0, MAX_INHERIT_RULES)) {
+    lines.push(`- ${r.length > MAX_RULE_LEN ? r.slice(0, MAX_RULE_LEN) + '…' : r}`)
+  }
+  if (rules.length > MAX_INHERIT_RULES) {
+    lines.push(`- …외 ${rules.length - MAX_INHERIT_RULES}개는 RULES.md 원문 참조`)
+  }
+  return lines
+}

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -40,3 +40,21 @@ describe('content — buildContentPrompt 순수함수 (goal 74)', () => {
     expect(p).toContain('❌')
   })
 })
+
+// #456: 산출물이 프로젝트 RULES.md 치명 규칙을 상속 — 하드코딩 복붙 아닌 런타임 주입(드리프트 0).
+describe('content — RULES.md 치명 규칙 상속 (#456)', () => {
+  it('rules 주입 시 프롬프트에 규칙 + RULES.md 출처 표기 포함', async () => {
+    const { buildContentPrompt } = await import('../src/commands/content.js')
+    const p = buildContentPrompt({ what: 'x', rules: ['`execSync` 신규 사용 금지', 'publish 는 main 에서만'] })
+    expect(p).toContain('RULES.md')
+    expect(p).toContain('- `execSync` 신규 사용 금지')
+    expect(p).toContain('- publish 는 main 에서만')
+  })
+
+  it('rules 미주입(RULES.md 없음) → 정직한 안내 + 기존 구조 유지', async () => {
+    const { buildContentPrompt } = await import('../src/commands/content.js')
+    const p = buildContentPrompt({ what: 'x' })
+    expect(p).toContain('RULES.md 없음')
+    expect(p).toContain('블로그') // 현행 동작 유지
+  })
+})

--- a/tests/launch.test.ts
+++ b/tests/launch.test.ts
@@ -40,3 +40,20 @@ describe('launch — buildLaunchPrompt 순수함수 (goal 75)', () => {
     expect(p).toContain('❌')
   })
 })
+
+// #456: 산출물이 프로젝트 RULES.md 치명 규칙을 상속 — 하드코딩 복붙 아닌 런타임 주입(드리프트 0).
+describe('launch — RULES.md 치명 규칙 상속 (#456)', () => {
+  it('rules 주입 시 프롬프트에 규칙 + RULES.md 출처 표기 포함', async () => {
+    const { buildLaunchPrompt } = await import('../src/commands/launch.js')
+    const p = buildLaunchPrompt({ what: 'x', rules: ['publish 는 main 에서만 + 사람 승인'] })
+    expect(p).toContain('RULES.md')
+    expect(p).toContain('- publish 는 main 에서만 + 사람 승인')
+  })
+
+  it('rules 미주입(RULES.md 없음) → 정직한 안내 + 기존 구조 유지', async () => {
+    const { buildLaunchPrompt } = await import('../src/commands/launch.js')
+    const p = buildLaunchPrompt({ what: 'x' })
+    expect(p).toContain('RULES.md 없음')
+    expect(p).toContain('체크리스트') // 현행 동작 유지
+  })
+})

--- a/tests/ops.test.ts
+++ b/tests/ops.test.ts
@@ -39,3 +39,20 @@ describe('ops — buildOpsPrompt 순수함수 (goal 76)', () => {
     expect(p).toContain('❌')
   })
 })
+
+// #456: 산출물이 프로젝트 RULES.md 치명 규칙을 상속 — 하드코딩 복붙 아닌 런타임 주입(드리프트 0).
+describe('ops — RULES.md 치명 규칙 상속 (#456)', () => {
+  it('rules 주입 시 프롬프트에 규칙 + RULES.md 출처 표기 포함', async () => {
+    const { buildOpsPrompt } = await import('../src/commands/ops.js')
+    const p = buildOpsPrompt({ what: 'x', rules: ['게이트 실패 상태에서 done 처리 금지'] })
+    expect(p).toContain('RULES.md')
+    expect(p).toContain('- 게이트 실패 상태에서 done 처리 금지')
+  })
+
+  it('rules 미주입(RULES.md 없음) → 정직한 안내 + 기존 구조 유지', async () => {
+    const { buildOpsPrompt } = await import('../src/commands/ops.js')
+    const p = buildOpsPrompt({ what: 'x' })
+    expect(p).toContain('RULES.md 없음')
+    expect(p).toContain('회고') // 현행 동작 유지
+  })
+})

--- a/tests/rules-inherit-wiring.test.ts
+++ b/tests/rules-inherit-wiring.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// #456 배선 검증 — 뒷단 4명령 액션이 실제로 RULES.md 를 읽어(readCriticalRules) 프롬프트에
+// 상속하는지. 순수 빌더 테스트가 못 잡는 "빌더에 rules 안 넘김" 회귀를 emitPrompt 캡처로 고정.
+const mockExistsSync = vi.fn()
+const mockReadFileSync = vi.fn()
+
+vi.mock('node:fs', () => ({
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
+  readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
+}))
+
+const emitted: string[] = []
+vi.mock('../src/lib/emit-prompt.js', () => ({
+  emitPrompt: (prompt: string) => {
+    emitted.push(prompt)
+  },
+}))
+vi.mock('../src/lib/next-step.js', () => ({
+  printNextStep: () => {},
+}))
+
+describe('뒷단 4명령 — RULES.md 상속 배선 (#456)', () => {
+  beforeEach(() => {
+    emitted.length = 0
+    mockExistsSync.mockReset()
+    mockReadFileSync.mockReset()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    // RULES.md 만 존재(VISION.md 없음) — 치명 규칙 1개짜리 최소 픽스처
+    mockExistsSync.mockImplementation((p: unknown) => String(p).includes('RULES.md'))
+    mockReadFileSync.mockReturnValue('# t\n\n## Forbidden\n- 테스트 치명 규칙 X\n')
+  })
+
+  it.each([
+    ['content', async () => (await import('../src/commands/content.js')).content()],
+    ['launch', async () => (await import('../src/commands/launch.js')).launch()],
+    ['ops', async () => (await import('../src/commands/ops.js')).ops()],
+    ['sell', async () => (await import('../src/commands/sell.js')).sell()],
+  ])('%s 액션이 RULES.md 치명 규칙을 프롬프트에 상속', async (_name, run) => {
+    await run()
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0]).toContain('테스트 치명 규칙 X')
+    expect(emitted[0]).toContain('RULES.md')
+  })
+
+  it('RULES.md 없는 프로젝트 → 정직한 안내로 폴백(크래시 0)', async () => {
+    mockExistsSync.mockReturnValue(false)
+    const { content } = await import('../src/commands/content.js')
+    expect(() => content()).not.toThrow()
+    expect(emitted[0]).toContain('RULES.md 없음')
+  })
+})

--- a/tests/rules-inherit.test.ts
+++ b/tests/rules-inherit.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// #456: 뒷단(content/launch/sell/ops) 산출물 프롬프트가 RULES.md 치명 규칙을 상속.
+// remind 의 추출기(extractCriticalRules)를 lib 로 이동해 단일 SoT — 복붙 0 = 드리프트 구조적 불가.
+const mockExistsSync = vi.fn()
+const mockReadFileSync = vi.fn()
+
+vi.mock('node:fs', () => ({
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
+  readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
+}))
+
+const RULES_MD =
+  '# t\n\n' +
+  '## VHK 운영 — Forbidden (전역 금지)\n\n' +
+  '> 주석은 제외.\n' +
+  '- publish 는 main 에서만 + 사람 승인 (가드 #119)\n' +
+  '- `execSync` 신규 사용 금지 → `safeExecFile`\n\n' +
+  '## 코딩 규칙\n\n' +
+  '- 비치명 일반 규칙\n'
+
+describe('rules-inherit — extractCriticalRules (remind 에서 이동, 동작 보존)', () => {
+  it('치명 섹션(Forbidden/절대 규칙) 불릿만 추출, 주석·비치명 섹션 제외', async () => {
+    const { extractCriticalRules } = await import('../src/lib/rules-inherit.js')
+    const out = extractCriticalRules(RULES_MD)
+    expect(out).toEqual(['publish 는 main 에서만 + 사람 승인', '`execSync` 신규 사용 금지 → `safeExecFile`'])
+  })
+
+  it('CRLF 입력에서도 \\r 잔존 없이 추출', async () => {
+    const { extractCriticalRules } = await import('../src/lib/rules-inherit.js')
+    const out = extractCriticalRules('# t\r\n\r\n## Forbidden\r\n\r\n- 규칙A\r\n- 규칙B\r\n')
+    expect(out).toEqual(['규칙A', '규칙B'])
+  })
+
+  it('여러 치명섹션(Forbidden+절대규칙+전역금지) 동시 추출', async () => {
+    const { extractCriticalRules } = await import('../src/lib/rules-inherit.js')
+    const md = '# t\n\n## Forbidden\n- A\n\n## 절대 규칙\n- B\n\n## 전역 금지\n- C\n'
+    expect(extractCriticalRules(md)).toEqual(['A', 'B', 'C'])
+  })
+})
+
+describe('rules-inherit — buildRulesInheritLines (프롬프트 블록 포매터, 순수)', () => {
+  it('규칙 배열 → 상속 블록(헤더 + 불릿), RULES.md 출처 명시', async () => {
+    const { buildRulesInheritLines } = await import('../src/lib/rules-inherit.js')
+    const lines = buildRulesInheritLines(['A 금지', 'B 는 사람 승인'])
+    const block = lines.join('\n')
+    expect(block).toContain('RULES.md')
+    expect(block).toContain('- A 금지')
+    expect(block).toContain('- B 는 사람 승인')
+  })
+
+  it('하드리밋 — 규칙 수 상한(MAX_INHERIT_RULES) 초과분은 잘리고 "외 N개" 정직 안내', async () => {
+    const { buildRulesInheritLines, MAX_INHERIT_RULES } = await import('../src/lib/rules-inherit.js')
+    const many = Array.from({ length: MAX_INHERIT_RULES + 3 }, (_, i) => `규칙${i + 1}`)
+    const lines = buildRulesInheritLines(many)
+    const block = lines.join('\n')
+    expect(block).toContain(`규칙${MAX_INHERIT_RULES}`)
+    expect(block).not.toContain(`- 규칙${MAX_INHERIT_RULES + 1}`)
+    expect(block).toContain('외 3개')
+  })
+
+  it('하드리밋 — 규칙당 길이 상한(MAX_RULE_LEN) 초과 시 말줄임', async () => {
+    const { buildRulesInheritLines, MAX_RULE_LEN } = await import('../src/lib/rules-inherit.js')
+    const long = 'x'.repeat(MAX_RULE_LEN + 50)
+    const block = buildRulesInheritLines([long]).join('\n')
+    expect(block).not.toContain(long)
+    expect(block).toContain('x'.repeat(MAX_RULE_LEN) + '…')
+  })
+
+  it('undefined(RULES.md 없음/읽기 실패) → 정직한 안내 1줄, 크래시 0', async () => {
+    const { buildRulesInheritLines } = await import('../src/lib/rules-inherit.js')
+    const block = buildRulesInheritLines(undefined).join('\n')
+    expect(block).toContain('RULES.md 없음')
+    expect(block).toContain('상속 생략')
+  })
+
+  it('빈 배열(치명 섹션 없음) → 정직한 안내 1줄', async () => {
+    const { buildRulesInheritLines } = await import('../src/lib/rules-inherit.js')
+    const block = buildRulesInheritLines([]).join('\n')
+    expect(block).toContain('치명 규칙 섹션 없음')
+  })
+})
+
+describe('rules-inherit — readCriticalRules (fs 래퍼)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('RULES.md 존재 → 치명 규칙 배열 반환', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(RULES_MD)
+    const { readCriticalRules } = await import('../src/lib/rules-inherit.js')
+    expect(readCriticalRules()).toEqual([
+      'publish 는 main 에서만 + 사람 승인',
+      '`execSync` 신규 사용 금지 → `safeExecFile`',
+    ])
+  })
+
+  it('RULES.md 없음 → undefined (정직 폴백 신호)', async () => {
+    mockExistsSync.mockReturnValue(false)
+    const { readCriticalRules } = await import('../src/lib/rules-inherit.js')
+    expect(readCriticalRules()).toBeUndefined()
+  })
+
+  it('읽기 실패(throw) → undefined, 크래시 0', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('EACCES')
+    })
+    const { readCriticalRules } = await import('../src/lib/rules-inherit.js')
+    expect(() => readCriticalRules()).not.toThrow()
+    expect(readCriticalRules()).toBeUndefined()
+  })
+
+  it('치명 섹션 없는 RULES.md → 빈 배열([])', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue('# t\n\n## 코딩 규칙\n- 일반\n')
+    const { readCriticalRules } = await import('../src/lib/rules-inherit.js')
+    expect(readCriticalRules()).toEqual([])
+  })
+})

--- a/tests/sell.test.ts
+++ b/tests/sell.test.ts
@@ -39,3 +39,20 @@ describe('sell — buildSellPrompt 순수함수 (goal 77)', () => {
     expect(p).toContain('❌')
   })
 })
+
+// #456: 산출물이 프로젝트 RULES.md 치명 규칙을 상속 — 하드코딩 복붙 아닌 런타임 주입(드리프트 0).
+describe('sell — RULES.md 치명 규칙 상속 (#456)', () => {
+  it('rules 주입 시 프롬프트에 규칙 + RULES.md 출처 표기 포함', async () => {
+    const { buildSellPrompt } = await import('../src/commands/sell.js')
+    const p = buildSellPrompt({ what: 'x', rules: ['토큰/시크릿 코드·커밋 평문 노출 금지'] })
+    expect(p).toContain('RULES.md')
+    expect(p).toContain('- 토큰/시크릿 코드·커밋 평문 노출 금지')
+  })
+
+  it('rules 미주입(RULES.md 없음) → 정직한 안내 + 기존 구조 유지', async () => {
+    const { buildSellPrompt } = await import('../src/commands/sell.js')
+    const p = buildSellPrompt({ what: 'x' })
+    expect(p).toContain('RULES.md 없음')
+    expect(p).toContain('FAQ') // 현행 동작 유지
+  })
+})


### PR DESCRIPTION
## 요약
런칭·판매·운영 산출물 프롬프트(content/launch/sell/ops)가 프로젝트 **RULES.md 단일소스를 상속하지 않는다는 추정을 실측으로 확정**하고, 치명 규칙(NON-NEGOTIABLE/절대 규칙/Forbidden/전역 금지)을 **런타임에 추출·주입**하도록 구현했다.

Closes #456 (원 Epic #279 서브이슈 2/5)

## 실측 (정찰)
- `buildContentPrompt`/`buildLaunchPrompt`/`buildSellPrompt`/`buildOpsPrompt` 전부 하드코딩 치명 규칙만 담고 RULES.md 를 전혀 읽지 않았음
- 재사용 추출기 발견: `remind.ts` 의 `extractCriticalRules`(치명 섹션 불릿 추출 + `compressRule` 압축) — `vhk remind`(치명 규칙 재주입)와 동일 정의
- #457(어제 머지) '게시 전 보안 게이트' 줄: content/launch/sell 에 존재(ops 는 의도적 제외) — 최신 main(769bfc7) 기준 작업, **해당 줄 보존**(기존 테스트 `secure-scan-drafts.test.ts` 핀 유지 green)

## 설계 결정
| 결정 | 내용 |
| --- | --- |
| 무엇을 주입 | RULES.md 치명 섹션 불릿 — `vhk remind` 와 동일 정의(단일 추출기 공유) |
| 상속 방식 | 정적 복붙 0 — 프롬프트 생성 시점에 RULES.md 런타임 읽기 → **드리프트 구조적 불가** |
| 얼마나 주입 | 하드리밋 `MAX_INHERIT_RULES=10`(초과분 '…외 N개는 RULES.md 원문 참조' 1줄) + `MAX_RULE_LEN=120`자 말줄임 — 프롬프트 비대 방지(Fable5 위생) |
| 아키텍처 | 추출기를 `src/lib/rules-inherit.ts` 로 이동(lib→commands 역의존 금지 — rules-import 로컬 파서 선례), remind 는 재수출로 기존 API·테스트 호환 |
| 폴백 | RULES.md 없음/읽기 실패 → '상속 생략' 정직 안내 1줄(현행 동작 유지, 크래시 0) · 치명 섹션 없음 → 섹션 추가 안내 1줄 |
| 순수성 | 빌더에 `rules?: string[]` 주입(옵셔널 — breaking 0), fs 읽기는 커맨드 액션의 `readCriticalRules()` |

## 검증
- TDD: 레드(14 fail) → 구현 → 그린
- 신규 테스트: `tests/rules-inherit.test.ts`(추출기·포매터·fs 래퍼 단위) + `tests/rules-inherit-wiring.test.ts`(4명령 액션이 실제 RULES.md 를 읽어 emitPrompt 에 상속하는지 배선 고정) + 4커맨드 테스트에 상속·정직 폴백 케이스 추가
- 게이트: `pnpm build` ✅ · `pnpm test:run` **2433 pass** ✅ · `pnpm lint` ✅ · `pnpm typecheck` ✅ · `node scripts/check-rules-sync.mjs` **PASS** ✅
- E2E(스크래치 프로젝트): RULES.md 有 → content/ops 프롬프트에 Forbidden 불릿 상속 실확인 · RULES.md 無 → 정직 안내 실확인

## 스코프 정직화 (이슈 완료기준 대비)
- ✅ "뒷단 산출물이 RULES.md 단일소스를 상속" — 런타임 주입으로 충족, check-rules-sync green(이 게이트 대상인 CLAUDE.md 블록은 건드리지 않음)
- ✅ "드리프트 발생 시 감지" — **감지가 아니라 원천 차단**으로 충족: 프롬프트가 RULES.md 를 매 실행 직접 읽으므로 복사본 자체가 없음(감지할 드리프트가 생기지 않는 구조). 별도 드리프트 검사기는 추가하지 않음
- ⚠️ 명령별 '관련 규칙만' 선별(예: 발행·콘텐츠 규칙 필터링)은 **안 함** — 키워드 휴리스틱은 오탐·누락 위험이 커서 치명 규칙 전체(≤10)를 일괄 상속. 필요 시 후속 이슈로

🤖 Generated with [Claude Code](https://claude.com/claude-code)