### PR TITLE
feat: AGENTS Ecosystem에 agent-roster 포인터 + mdc v2

### DIFF
--- a/.cursor/rules/ecosystem.mdc
+++ b/.cursor/rules/ecosystem.mdc
@@ -5,12 +5,13 @@ alwaysApply: true
 
 # Ecosystem (Cursor-only)
 
-<!-- ECOSYSTEM-MDC:START v1 (vhk template — 직접 편집 금지) -->
+<!-- ECOSYSTEM-MDC:START v2 (vhk template — 직접 편집 금지) -->
 
-1. **Claude Code = primary** — handoff, release-gate, epic architecture, vhk-auto는 Claude-only (yohan-cc-skills).
-2. **Cursor = secondary** — Composer batch/repeat 보조; 코딩·반복 작업용.
-3. **Cross-repo / harness** — 이 레포 `AGENTS.md` 먼저; 전역 계약·tier는 **yohan-brain** `memory/core/ecosystem-contract.yaml` + `memory/core/inheritance-registry.yaml` (status=active면 obey). 로컬에 brain 없으면 MCP digest 또는 brain clone 경로 사용.
-4. **Concurrency** — same repo + same branch에 에이전트 2개 금지; parallel은 worktree (`vhk worktree` / Cursor `--worktree`).
-5. **Derived files** — `AGENTS.md`·`.cursorrules` 손수 편집 금지 → `RULES.md` 수정 후 `vhk sync`. `.cursor/agents/`에 `.claude/agents/` 중복 금지.
+1. **실행 계층(vhk 명령)은 에이전트 무관** — 어떤 AI 에이전트가 실행해도 vhk 명령 자체는 동일하게 동작.
+2. **트리거 계층(훅·vhk-auto)은 현재 Claude Code 전용** — SessionStart/Stop 훅·yohan-cc-skills 의존이라 다른 에이전트는 수동 트리거 필요(격차 해소 로드맵: RFC 0057).
+3. **Cursor** — Composer batch/repeat 보조; 코딩·반복 작업용.
+4. **Cross-repo / harness** — 이 레포 `AGENTS.md` 먼저; 전역 계약·tier는 **yohan-brain** `memory/core/ecosystem-contract.yaml` + `memory/core/inheritance-registry.yaml` (status=active면 obey). 로컬에 brain 없으면 MCP digest 또는 brain clone 경로 사용.
+5. **Concurrency** — same repo + same branch에 에이전트 2개 금지; parallel은 worktree (`vhk worktree` / Cursor `--worktree`).
+6. **Derived files** — `AGENTS.md`·`.cursorrules` 손수 편집 금지 → `RULES.md` 수정 후 `vhk sync`. `.cursor/agents/`에 `.claude/agents/` 중복 금지.
 
 <!-- ECOSYSTEM-MDC:END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 > Contract SoT: yohan-brain `memory/core/ecosystem-contract.yaml` (obey when status=active).
 
 - **Tier:** yohan-brain `memory/core/inheritance-registry.yaml`
+- **Roster:** yohan-brain `memory/core/agent-roster.yaml` (CLI·모델·effort; obey when active)
 - **Cursor:** `.cursor/rules/ecosystem.mdc` (vhk inject-bootstrap)
 - **금지:** AGENTS.md 손수 편집 → `RULES.md` + `vhk sync`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,11 +148,11 @@ tags: [process, constitution]
 > 세션 종료: 마지막 갱신·버전·Phase·다음 할 일 갱신. (위 🔒 구역은 절대 건드리지 마.)
 > ⚠️ 아래 `**버전:**` 줄은 CI(version-sync.test.ts)가 강제 — 형식 `**버전:** vX.Y.Z` 유지, 릴리즈마다 package.json 따라 갱신.
 
-**마지막 갱신:** 2026-07-13
-- **버전:** v2.11.0 — 사실 확인은 package.json·CHANGELOG (**발행 완결**: npm latest·git 태그·GitHub Release·노션 정합 전부 v2.11.0)
-- **테스트:** 2387 pass(로컬) · **MCP tools:** 35 — 사실값은 package.json·CHANGELOG
-- **Phase:** **[2026-07-13] 로드맵 재정렬 + Wave 2 완주 + v2.11.0 발행 완결** — 3관점 플랜+skeptic 검증으로 로드맵 재편(roadmap.md=분기층 SoT, Phase 0~4) → 문서 정합화(#482)·계측 재가동(receipt 90일 개시·계측 DB 순수 VHK 첫 행) → RFC 0060(#481·#483, 별도 세션)+0061(#485, critic 2라운드) 병렬 완주 → v2.11.0 발행. 신규 도그푸딩 이슈 #488(eval --init 이 recall 미스 쿼리 라벨 불가 — 측정 편향). 상세 docs/state 최상단.
-- **블로커:** 외부의존 2건 유지(blockers.md — goal-50 실데이터, SEO 22~26 자격증명·둘 다 [skip-hardstop] 사람 대기). 진행 차단 아님.
-- **진행 중(미완):** Recall 라벨링이 #488 로 dead-end(수정 후 재시도) · G3 육안 3항목(색상·Ctrl+C·리사이즈) 사람 채점 대기(종료감지·통과는 실측 완료). 별도 숙제 = "vhk 강화가 뭔지"(Codex 권고 실체) 브레인스토밍.
-- **다음 할 일:** 순서 SoT = **[docs/state/roadmap.md](docs/state/roadmap.md)** **Phase 2** — RFC 0062(드리프트 자동감지) 초안 → #457 report-mode(preflight.ts 접촉은 #457 먼저 직렬) → #455/#456/#458 → GTM(준비=AI·게시=사람). #488 수정도 후보. 세션 단위 상세는 **[docs/state/next-task.md](docs/state/next-task.md)** 최상단. main 직접 push 차단 → PR 경유.
-- **주의:** publish는 main에서만(#119)·사용자 직접(2FA=Windows 보안키→실 터미널 `npm publish --ignore-scripts`) / 직접 main push 차단 → PR 경유 / 로컬 게이트에 **`pnpm lint` 필수**(CI gate=lint 포함 — typecheck+test만으론 CI fail) / 적대리뷰 워크플로 에이전트 read-only 명시 / **워크트리 병합 직전 `git branch --show-current` 재확인**(다른 동시 세션이 공유 체크아웃 브랜치를 바꿀 수 있음, 2026-07-03 `vhk-readme-redesign` 오염 사고로 실증) / 동시세션 docs/state 충돌 주의
+**마지막 갱신:** 2026-07-16
+- **버전:** v2.11.0 — 사실 확인은 package.json·CHANGELOG
+- **테스트:** 사실값은 package.json·CHANGELOG · **MCP tools:** 사실값은 package.json·CHANGELOG
+- **Phase:** Phase 2 코어 완주 이후(GTM·사람 큐). 사이드 = Orca ADE 탭 스크롤 PR #8968 OPEN(perf 우려·대기).
+- **블로커:** 외부의존 2건 유지(blockers.md — [skip-hardstop]). 진행 차단 아님.
+- **진행 중(미완):** Orca #8968 머지/릴리즈 대기. VHK = #455 종결 판단·G3 육안·GTM(사람).
+- **다음 할 일:** SoT = [docs/state/next-task.md](docs/state/next-task.md) 최상단. Orca 업데이트 후 탭 스크롤 재확인. VHK 본선 GTM/사람 큐.
+- **주의:** publish는 main에서만(#119) / PR 경유 / `pnpm lint` 필수 / worktree 병합 직전 브랜치 재확인 / 동시세션 docs/state 충돌 주의

--- a/docs/log/2026-07-16-agent-roster-enforcement.md
+++ b/docs/log/2026-07-16-agent-roster-enforcement.md
@@ -1,0 +1,12 @@
+# 2026-07-16 — agent roster enforcement wiring
+
+## 한 일
+- brain: agent-roster active + Goal 7/8 + handoff/inventory
+- mcp: agent_roster_digest on get_context + get_agent_roster
+- vhk: AGENTS Ecosystem Roster 포인터 1줄 (sync.ts)
+- Tier S ecosystem.mdc v2 inject; Tier A/B/C AGENTS 포인터
+
+## 검증
+- orca-enforcement.ps1 smoke pass_paths_and_cli
+- yohan-mcp pytest test_agent_roster 4 passed
+- check-ecosystem roster status=active

--- a/docs/log/2026-07-16-orca-tab-scroll-session.md
+++ b/docs/log/2026-07-16-orca-tab-scroll-session.md
@@ -1,0 +1,23 @@
+# 2026-07-16 — Orca ADE 탭 스크롤 + 세션 마감
+
+## 지금까지 한 것
+- Orca ADE 상단 탭 전환 시 메인 터미널 스크롤이 맨 위로 가는 문제 재현·원인 확정 (`display: none` → xterm viewport 0).
+- 수정: intra-worktree 탭 숨김을 `opacity: 0` 레이아웃 유지로 변경 + legacy `Terminal.tsx` 에디터/브라우저 park 동일 처리.
+- 업스트림 PR: https://github.com/stablyai/orca/pull/8968 (`byh3071-cpu/orca` fork, branch `fix/tab-switch-preserve-terminal-scroll`).
+- 메인테이너(nwparker) 코멘트: "Might be some perf concerns" — 미머지(OPEN). 사용자 선택 = 업데이트 대기(답글/로컬빌드 보류).
+- (같은 날 선행) yohan-cc-skills `/handoff` 채팅 종료 검증·workflow 0.3.4 — 별도 레포 로그: `yohan-cc-skills/docs/log/2026-07-16-handoff-session-end-verify.md`.
+- (같은 날 선행) Cursor Agent Lazyweb MCP 콘솔 팝업 → `node` 런처로 수정 완료(`~/.cursor/mcp.json`).
+
+## 핵심 결정
+- vhk 설정만으로는 ADE 스크롤 버그 불가 → stablyai/orca 업스트림 수정 필요.
+- 성능 우려 댓글에 대해 당장 추가 패치/답글 안 함 → 릴리즈 대기.
+
+## 다음 할 일
+1. Orca PR #8968 머지·릴리즈 감시 → 설치본 업데이트 후 탭 전환 스크롤 재확인.
+2. (선택) 성능 우려에 답글: cold-park 30s 언마운트 유지·축소안 제안.
+3. VHK 본선: next-task 사람 큐(#455 종결·G3 육안·GTM) / AI 큐(GTM 준비·T6).
+
+## 산출물 포인터
+- 진입점: https://github.com/stablyai/orca/pull/8968
+- 로컬 fork: `C:\Users\Public\dev\vendor\orca` @ `fix/tab-switch-preserve-terminal-scroll`
+- 핵심 파일: `terminal-tab-visibility-style.ts` · `TerminalPane.tsx` · `TerminalPaneOverlayLayer.tsx` · `Terminal.tsx`

--- a/docs/state/next-task.md
+++ b/docs/state/next-task.md
@@ -3,18 +3,18 @@
 > "지금 무엇부터"의 **세션층** SoT — 본문 15줄 상한, 역사는 링크로 밀어냄. 순서(Phase)의 SoT = [roadmap.md](roadmap.md), 사실값(버전·테스트)은 package.json·CHANGELOG.
 > ⚠️ `vhk goal next`/`vhk work`가 이 파일을 스텁으로 **전체 덮어쓸 수 있음** — 소실 시 `git restore docs/state/next-task.md`.
 
-**갱신:** 2026-07-13 (오후 — Phase 2 코어 완주)
-**Phase:** [roadmap.md](roadmap.md) **Phase 0~1·3 ✅ + Phase 2 코어 ✅** — 5트랙 병렬 완주(RFC 0062 #498 · #457 report-mode #492 · #455 가드 #497 · #456 상속 #495 · #458 recall 주입 #496 · 한글 서브별칭 #494 · #488 수정 #490). 각 트랙 critic 적대검증(불통과→수정 2회 포함) 후 머지. 잔여 = **GTM**(게시=사람)·T6·goal 65 판정.
+**갱신:** 2026-07-16 (세션 마감 — Orca 탭 스크롤 PR 대기)
+**Phase:** [roadmap.md](roadmap.md) Phase 2 코어 ✅ 이후 — VHK 본선은 사람/GTM 큐. 사이드: Orca ADE 스크롤 수정 PR 대기.
 
 ## 지금
-- **사람 큐:** ① **#455 종결 판단**(가드 구현 완료 — "승인 큐"는 자문형 구조상 무의미가 critic 판정, 수용 시 close) ② G3 육안 3항목(색상·Ctrl+C·리사이즈) ③ **Recall 라벨 재시도 가능**(#488 수정 머지됨 — `vhk memory eval --init`, 이제 미스도 라벨 가능) ④ GTM 게시 판단(Show HN·블로그 정정 — 초안은 AI 준비 예정) ⑤ SEO 키 발급(투입은 GTM 주간)
-- **AI 큐:** GTM 준비(README 30초 quickstart·거짓완료 적발 데모·이슈템플릿 자발제출) → T6 부채정리 → goal 65 흡수판정 브리핑 → Phase 4(트리거 불가지론화 Cursor 스파이크)
-- **최근 이력:** [07-13 Phase 2 코어 5트랙](../log/2026-07-13-phase2-leg1.md)(#490·#492·#494~#498) · [07-13 v2.11.0 릴리즈](../log/2026-07-13-v2.11.0-release.md) · [07-13 RFC 0061 완주](../log/2026-07-13-rfc0061-record-net.md)(#485) · [07-13 RFC 0060 완료](../log/2026-07-13-rfc-0060-init-onboarding.md)(#481·#483·#491) · [07-13 로드맵 재편](../log/2026-07-13-roadmap-realign-p1.md)(#482)
+- **사이드(대기):** Orca [PR #8968](https://github.com/stablyai/orca/pull/8968) OPEN — 탭 전환 스크롤 보존. 메인테이너 perf 우려 코멘트. 머지·릴리즈 후 ADE 업데이트로 검증. 로그: [2026-07-16-orca-tab-scroll-session.md](../log/2026-07-16-orca-tab-scroll-session.md)
+- **사람 큐:** ① **#455 종결 판단** ② G3 육안 3항목 ③ Recall 라벨 재시도(`vhk memory eval --init`) ④ GTM 게시 판단 ⑤ SEO 키
+- **AI 큐:** GTM 준비 → T6 → goal 65 판정 → Phase 4
+- **최근 이력:** [07-16 Orca 탭 스크롤](../log/2026-07-16-orca-tab-scroll-session.md) · [07-13 Phase 2 코어](../log/2026-07-13-phase2-leg1.md)
 
 ## 블로커
-- [blockers.md](blockers.md) 활성 2건(goal-50 실데이터 · SEO 22~26 자격증명) — [skip-hardstop] 사람 대기, 진행 차단 아님.
+- [blockers.md](blockers.md) 활성 2건 — [skip-hardstop] 사람 대기, 진행 차단 아님.
 
 ## 주의
-- publish = main에서만(#119)·사람 2FA(실 터미널 `npm publish --ignore-scripts`) / main 직접 push 차단 → PR 경유 / 로컬 게이트에 `pnpm lint` 필수 / 적대리뷰 에이전트 read-only 명시 / worktree 병합 직전 `git branch --show-current` 재확인.
-- active goal은 goals/ 동적 계산(`vhk goal peek` 권장 — `goal next`는 이 파일 덮어씀). 완료 goal은 goals/archive/.
-- 과거 이력 전문: [2026-07-13-next-task-archive.md](../log/2026-07-13-next-task-archive.md) + git history.
+- publish = main에서만(#119) / main 직접 push 차단 → PR 경유 / `pnpm lint` 필수 / worktree 병합 직전 `git branch --show-current` 재확인.
+- active goal은 `vhk goal peek` 권장.

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -402,6 +402,7 @@ export function agentsMdEcosystemBlock(rootDir?: string): string[] {
     '> Contract SoT: yohan-brain `memory/core/ecosystem-contract.yaml` (obey when status=active).',
     '',
     '- **Tier:** yohan-brain `memory/core/inheritance-registry.yaml`',
+    '- **Roster:** yohan-brain `memory/core/agent-roster.yaml` (CLI·모델·effort; obey when active)',
     '- **Cursor:** `.cursor/rules/ecosystem.mdc` (vhk inject-bootstrap)',
     '- **금지:** AGENTS.md 손수 편집 → `RULES.md` + `vhk sync`',
     '',

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -130,11 +130,12 @@ describe('vhk sync — AGENTS.md 생성 (배치3 6번째 타겟)', () => {
     expect(out).toContain('agent-compact.md')
   })
 
-  it('agentsMdEcosystemBlock — contract SoT + tier + 금지 3줄', () => {
+  it('agentsMdEcosystemBlock — contract SoT + tier + roster + 금지', () => {
     const block = agentsMdEcosystemBlock().join('\n')
     expect(block).toContain('status=active')
     expect(block).toContain('inject-bootstrap')
     expect(block).toContain('vhk sync')
+    expect(block).toContain('agent-roster.yaml')
   })
 
   it('agentsMdEcosystemBlock — rootDir 에 ecosystem.mdc 없으면 빈 배열 (#468)', () => {


### PR DESCRIPTION
## Summary
- sync.ts AGENTS Ecosystem 블록에 roster 포인터 1줄
- ecosystem.mdc v2
- session log: agent-roster-enforcement
- (포함) Orca 탭 스크롤 세션 핸드오프 docs

## Test plan
- [x] sync.test.ts 기대값에 agent-roster.yaml
- [ ] CI gate
