### PR TITLE
fix: goal drift FN(경로 증거) + secure가 .gitleaksignore 존중 (#514 #515)

### DIFF
--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -392,7 +392,8 @@ export async function goalCheck(opts: { id?: string; force?: boolean }): Promise
 // "shipped 인데 status: NOT_STARTED" 인 goal 을 잡아 exit 1. 깨끗하면 exit 0.
 export async function goalDrift(): Promise<void> {
   console.log(chalk.bold(`\n${ko.goal.driftTitle}\n`))
-  const candidates = findStatusDriftCandidates(GOALS_DIR, SCRIPTS_DIR)
+  // projectRoot=cwd — 소비자 레포 goals 본문 경로 증거(축약·exact) 해석용
+  const candidates = findStatusDriftCandidates(GOALS_DIR, SCRIPTS_DIR, process.cwd())
   if (candidates.length === 0) {
     console.log(chalk.green(`  ✅ ${ko.goal.driftClean}`))
     return

--- a/src/lib/goal-drift.ts
+++ b/src/lib/goal-drift.ts
@@ -1,20 +1,34 @@
-import { existsSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { basename, dirname, join, sep } from 'node:path'
 import { listGoals, type GoalStatus } from './goal-frontmatter.js'
 
 // Goal 43: goal 상태 ↔ 코드 현실 드리프트 게이트.
 //
-// 불변 규칙: "goal 고유 게이트 검증(custom must() 호출)이 있는 goal 은 status: NOT_STARTED 이면 안 된다."
-//   근거: check-goal-<id>.mjs 는 `vhk goal sync` 가 백필하는데, 스캐폴드 상태에는 must() **정의**와
-//         **주석 처리된 예시**만 있다. 실제 must() **호출**은 그 goal 을 구현하면서 손으로 추가한다.
-//         즉 custom must() = "코드 구현 흔적". 그게 있는데 status 가 NOT_STARTED 면 드리프트.
-//   실측: Goal 19(pattern)가 src/commands/pattern.ts 풀구현 + v2.1.0 출시인데 status: NOT_STARTED 로
-//         남아 이 규칙을 위반했다(이 게이트가 막으려는 원형 사례).
+// 신호 A (원본): check-goal-<id>.mjs 에 custom must() 호출이 있는데 status: NOT_STARTED.
+// 신호 B (dogfood 2026-07-25): goals/*.md 본문 백틱 경로가 디스크에 존재하는데 NOT_STARTED.
+//   소비자 레포(aroo 등)는 check-goal 스크립트 없이 goals MD만 쓰는 경우가 많아
+//   신호 A만으로는 항상 0건(false negative). 경로 증거를 보조 신호로 추가.
 //
 // 보수적 설계(거짓 양성보다 미탐 선호):
 //   - NOT_STARTED 만 본다. IN_PROGRESS/DONE/BLOCKED 는 대상 아님.
-//   - 게이트 스크립트가 없으면(예: 아직 sync 안 한 SEO goal 21~26) 후보 아님.
-//   - 스캐폴드(정의/주석만)면 후보 아님 → 새 goal 무더기 오탐 0.
+//   - 경로 증거는 확정 히트 ≥ PATH_EVIDENCE_MIN 일 때만(단일 aspirational 경로 오탐 방지).
+//   - 경로 해석: exact → 흔한 prefix(lib/src/…) → basename 한정 탐색(노드 상한).
+
+/** 경로 증거로 드리프트를 인정하기 위한 최소 히트 수. */
+export const PATH_EVIDENCE_MIN = 2
+
+/** basename 탐색 시 방문할 최대 파일/디렉터리 노드 수(성능 bound). */
+const BASENAME_WALK_MAX_NODES = 4_000
+
+const SKIP_DIR_NAMES = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  'build',
+  '.next',
+  'coverage',
+  '.vhk',
+])
 
 /**
  * check-goal 스크립트 본문에 goal 고유 검증(custom `must()` 호출)이 있는지.
@@ -33,13 +47,10 @@ export function hasCustomGateAssertions(scriptContent: string): boolean {
 }
 
 // Goal 53: 가드 신뢰도 — 정규식 shape 단언 측정.
-//   `must(/.../.test(src), ...)` 형태는 함수명만 바꿔도 깨지고(거짓음성), import 만 해두면 통과(거짓양성).
-//   비율을 측정해 상한(ratchet)으로 묶고, 핵심 행동은 behavior 테스트(tests/*.test.ts)로 검증한다.
 const REGEX_SHAPE_ASSERTION = /must\([^)]*\/.*\/\.test/
 
 /**
  * check-goal 본문에서 정규식 shape 단언(`must(/.../.test(...))`)의 개수와 예시(최대 5).
- * 주석(`//`)·헬퍼 정의(`const must =`) 라인은 제외.
  */
 export function countRegexAssertions(content: string): { count: number; examples: string[] } {
   const examples: string[] = []
@@ -57,10 +68,7 @@ export function countRegexAssertions(content: string): { count: number; examples
   return { count, examples }
 }
 
-/**
- * check-goal 본문의 전체 `must()` 호출 수(정규식 비율의 분모).
- * 주석·헬퍼 정의 라인 제외 — countRegexAssertions 와 동일 기준.
- */
+/** check-goal 본문의 전체 `must()` 호출 수(정규식 비율의 분모). */
 export function countMustAssertions(content: string): number {
   let count = 0
   for (const raw of content.split(/\r?\n/)) {
@@ -81,35 +89,181 @@ export interface DriftCandidate {
   reason: string
 }
 
+/** 백틱 안 문자열이 파일/디렉터리 상대경로처럼 보이는지. */
+export function looksLikeRepoRelPath(raw: string): boolean {
+  const s = raw.trim()
+  if (!s || /\s/.test(s)) return false
+  if (/^https?:\/\//i.test(s)) return false
+  if (s.startsWith('#') || s.startsWith('@')) return false
+  // 웹 경로(`/sign-in`)·절대경로는 레포 상대경로가 아님
+  if (s.startsWith('/')) return false
+  // 경로 구분자 또는 확장자(또는 글롭) — 순수 식별자(`zod`) 제외
+  return /[\\/]/.test(s) || /\.\w{1,8}$/.test(s) || s.includes('*')
+}
+
+/** goal 본문에서 백틱 경로 후보를 추출(중복 제거, 등장 순). */
+export function extractBacktickPaths(body: string): string[] {
+  const out: string[] = []
+  const seen = new Set<string>()
+  const re = /`([^`\n]+)`/g
+  for (const m of body.matchAll(re)) {
+    const cand = m[1].trim().replace(/^\.\//, '')
+    if (!looksLikeRepoRelPath(cand)) continue
+    if (seen.has(cand)) continue
+    seen.add(cand)
+    out.push(cand)
+  }
+  return out
+}
+
+function globLastSegmentMatches(name: string, pattern: string): boolean {
+  // 단순: `*` 만 지원(checkout-*). 정규식 escape 후 * → .*
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')
+  return new RegExp(`^${escaped}$`).test(name)
+}
+
 /**
- * goals/ ↔ scripts/ 를 대조해 "shipped 인데 NOT_STARTED" 드리프트 후보를 찾는다(순수, fs 읽기만).
- * 판정: status === NOT_STARTED 이고 check-goal-<id>.mjs 가 존재하며 custom must() 호출이 있는 goal.
+ * 상대경로가 projectRoot 아래 실재하는지.
+ * 1) exact  2) 흔한 prefix 접합  3) 마지막 세그먼트 글롭  4) basename 한정 walk
  */
-export function findStatusDriftCandidates(goalsDir: string, scriptsDir: string): DriftCandidate[] {
+export function resolvePathEvidence(projectRoot: string, relPath: string): string | null {
+  const normalized = relPath.replace(/\\/g, '/').replace(/^\.\//, '')
+  if (!normalized) return null
+
+  const tryExact = (rel: string): string | null => {
+    const abs = join(projectRoot, ...rel.split('/'))
+    return existsSync(abs) ? rel : null
+  }
+
+  const hit = tryExact(normalized)
+  if (hit) return hit
+
+  // 축약 경로(`providers/image-openai.ts`) → lib/engine/providers/… 등
+  const PREFIXES = ['lib', 'src', 'app', 'lib/engine', 'src/lib', 'packages']
+  for (const prefix of PREFIXES) {
+    const prefixed = `${prefix}/${normalized}`
+    const pHit = tryExact(prefixed)
+    if (pHit) return pHit
+  }
+
+  // `app/api/checkout-*` — 부모 dir 목록에서 글롭 매칭
+  if (normalized.includes('*')) {
+    const parent = dirname(normalized).replace(/\\/g, '/')
+    const pat = basename(normalized)
+    const parentAbs =
+      parent === '.' ? projectRoot : join(projectRoot, ...parent.split('/'))
+    if (existsSync(parentAbs)) {
+      try {
+        for (const name of readdirSync(parentAbs)) {
+          if (globLastSegmentMatches(name, pat)) {
+            return parent === '.' ? name : `${parent}/${name}`
+          }
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  // basename 탐색(노드 상한) — 축약/이동된 파일
+  const base = basename(normalized)
+  if (!base || base.includes('*')) return null
+  let nodes = 0
+  const stack = [projectRoot]
+  while (stack.length > 0 && nodes < BASENAME_WALK_MAX_NODES) {
+    const dir = stack.pop() as string
+    let entries: string[]
+    try {
+      entries = readdirSync(dir)
+    } catch {
+      continue
+    }
+    for (const name of entries) {
+      nodes++
+      if (nodes > BASENAME_WALK_MAX_NODES) break
+      if (SKIP_DIR_NAMES.has(name)) continue
+      const abs = join(dir, name)
+      let st
+      try {
+        st = statSync(abs)
+      } catch {
+        continue
+      }
+      if (st.isDirectory()) {
+        stack.push(abs)
+        continue
+      }
+      if (name === base) {
+        return abs.slice(projectRoot.length + 1).split(sep).join('/')
+      }
+    }
+  }
+  return null
+}
+
+/** body 백틱 경로 중 디스크에 존재하는 것(해석된 상대경로). */
+export function findExistingPathEvidence(body: string, projectRoot: string): string[] {
+  const hits: string[] = []
+  const seen = new Set<string>()
+  for (const rel of extractBacktickPaths(body)) {
+    const resolved = resolvePathEvidence(projectRoot, rel)
+    if (!resolved || seen.has(resolved)) continue
+    seen.add(resolved)
+    hits.push(resolved)
+  }
+  return hits
+}
+
+/**
+ * goals/ ↔ scripts/ (+ goals 본문 경로 증거) 를 대조해 드리프트 후보를 찾는다.
+ * @param projectRoot 경로 증거 해석 루트(기본: goalsDir 의 부모)
+ */
+export function findStatusDriftCandidates(
+  goalsDir: string,
+  scriptsDir: string,
+  projectRoot: string = dirname(goalsDir),
+): DriftCandidate[] {
   const out: DriftCandidate[] = []
   for (const g of listGoals(goalsDir)) {
     const status = (g.frontmatter.status ?? 'NOT_STARTED')
     if (status !== 'NOT_STARTED') continue
     const id = g.frontmatter.id
     if (typeof id !== 'number') continue
+
     const scriptFile = join(scriptsDir, `check-goal-${id}.mjs`)
-    if (!existsSync(scriptFile)) continue
-    let content: string
-    try {
-      content = readFileSync(scriptFile, 'utf-8')
-    } catch {
+    let hasMust = false
+    if (existsSync(scriptFile)) {
+      try {
+        hasMust = hasCustomGateAssertions(readFileSync(scriptFile, 'utf-8'))
+      } catch {
+        hasMust = false
+      }
+    }
+
+    if (hasMust) {
+      out.push({
+        id,
+        title: g.frontmatter.title ?? '',
+        status,
+        goalFile: g.filePath,
+        scriptFile,
+        reason:
+          'status: NOT_STARTED 인데 check-goal 게이트에 goal 고유 검증(코드 구현 흔적)이 있음 — 구현됐는데 status 만 안 바뀐 드리프트 의심',
+      })
       continue
     }
-    if (!hasCustomGateAssertions(content)) continue
-    out.push({
-      id,
-      title: g.frontmatter.title ?? '',
-      status,
-      goalFile: g.filePath,
-      scriptFile,
-      reason:
-        'status: NOT_STARTED 인데 check-goal 게이트에 goal 고유 검증(코드 구현 흔적)이 있음 — 구현됐는데 status 만 안 바뀐 드리프트 의심',
-    })
+
+    const pathHits = findExistingPathEvidence(g.body, projectRoot)
+    if (pathHits.length >= PATH_EVIDENCE_MIN) {
+      out.push({
+        id,
+        title: g.frontmatter.title ?? '',
+        status,
+        goalFile: g.filePath,
+        scriptFile: existsSync(scriptFile) ? scriptFile : '(no check-goal script)',
+        reason: `status: NOT_STARTED 인데 goals 본문 경로 증거 ${pathHits.length}건 존재(${pathHits.slice(0, 3).join(', ')}${pathHits.length > 3 ? '…' : ''}) — 구현됐는데 status 만 안 바뀐 드리프트 의심`,
+      })
+    }
   }
   return out
 }

--- a/src/lib/scan-secrets.ts
+++ b/src/lib/scan-secrets.ts
@@ -14,6 +14,9 @@ function globalPattern(pattern: RegExp): RegExp {
   return new RegExp(pattern.source, flags)
 }
 
+/** Stripe/Polar 등 벤더가 명시한 test 접두 — live 키가 아님(secret-patterns stripe-live-key 도 sk_test_ 제외). */
+const VENDOR_TEST_KEY_PREFIX = /^(?:sk|pk|rk)_test_|^(?:whsk)_test/i
+
 function isGenericApiKeyFalsePositive(matchText: string): boolean {
   const delimiterIndex = matchText.search(/[:=]/)
   if (delimiterIndex < 0) return false
@@ -21,7 +24,83 @@ function isGenericApiKeyFalsePositive(matchText: string): boolean {
   const delimiter = matchText[delimiterIndex]
   if (delimiter === ':' && STATUS_KEY_PREFIX.test(key)) return true
   const value = matchText.slice(delimiterIndex + 1).trim().replace(/^['"]/, '')
+  if (VENDOR_TEST_KEY_PREFIX.test(value)) return true
   return PLACEHOLDER_MARKER.test(value)
+}
+
+export type GitleaksIgnoreRule = {
+  /** repo-relative path (posix) */
+  path: string
+  /** gitleaks rule id ≈ our patternId (optional) */
+  rule?: string
+  line?: number
+}
+
+/**
+ * `.gitleaksignore` 파싱.
+ * 지원 형식:
+ * - `# comment`
+ * - `commitHash:path:rule:line` (gitleaks fingerprint 줄 — path/rule/line 사용)
+ * - `path` 단독
+ */
+export function parseGitleaksIgnore(content: string): GitleaksIgnoreRule[] {
+  const rules: GitleaksIgnoreRule[] = []
+  for (const raw of content.split(/\r?\n/)) {
+    const line = raw.trim()
+    if (!line || line.startsWith('#')) continue
+    const parts = line.split(':')
+    // commit(40hex):path:rule:line
+    if (parts.length >= 4 && /^[a-f0-9]{7,40}$/i.test(parts[0])) {
+      const lineNo = Number(parts[parts.length - 1])
+      const rule = parts[parts.length - 2]
+      const pathParts = parts.slice(1, parts.length - 2)
+      const filePath = pathParts.join(':').replace(/\\/g, '/')
+      if (!filePath) continue
+      rules.push({
+        path: filePath,
+        rule,
+        line: Number.isFinite(lineNo) ? lineNo : undefined,
+      })
+      continue
+    }
+    // bare path
+    rules.push({ path: line.replace(/\\/g, '/') })
+  }
+  return rules
+}
+
+export function loadGitleaksIgnoreRules(cwd: string): GitleaksIgnoreRule[] {
+  const fp = path.join(cwd, '.gitleaksignore')
+  if (!fs.existsSync(fp)) return []
+  try {
+    return parseGitleaksIgnore(fs.readFileSync(fp, 'utf-8'))
+  } catch {
+    return []
+  }
+}
+
+export function isFindingIgnoredByGitleaks(
+  finding: SecretFinding,
+  rules: GitleaksIgnoreRule[],
+): boolean {
+  if (rules.length === 0) return false
+  const file = finding.file.replace(/\\/g, '/')
+  for (const r of rules) {
+    if (r.path !== file) continue
+    if (r.rule && r.rule !== finding.patternId) continue
+    if (typeof r.line === 'number' && r.line !== finding.line) continue
+    return true
+  }
+  return false
+}
+
+/** allowlist 적용 — 매칭 finding 제거(gitleaks 와 동일 의도: 사람 확인 픽스처). */
+export function applyGitleaksIgnore(
+  findings: SecretFinding[],
+  rules: GitleaksIgnoreRule[],
+): SecretFinding[] {
+  if (rules.length === 0) return findings
+  return findings.filter((f) => !isFindingIgnoredByGitleaks(f, rules))
 }
 
 // #316: .env.example/.sample/.template 은 '시크릿 값 없는 커밋용 템플릿'(risk-policy.ts 의
@@ -136,7 +215,14 @@ export function scanProjectForSecrets(cwd: string): ProjectSecretScan {
     }
   )
 
-  return { findings, scannedFiles, truncated: reasons.size > 0, truncationReasons: [...reasons] }
+  // dogfood: 레포 `.gitleaksignore` 존중(verify/secure/save 공통 경로)
+  const allowed = applyGitleaksIgnore(findings, loadGitleaksIgnoreRules(cwd))
+  return {
+    findings: allowed,
+    scannedFiles,
+    truncated: reasons.size > 0,
+    truncationReasons: [...reasons],
+  }
 }
 
 export type DraftScanResult = {

--- a/tests/goal-drift.test.ts
+++ b/tests/goal-drift.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { hasCustomGateAssertions, findStatusDriftCandidates } from '../src/lib/goal-drift.js'
+import {
+  hasCustomGateAssertions,
+  findStatusDriftCandidates,
+  extractBacktickPaths,
+  resolvePathEvidence,
+  PATH_EVIDENCE_MIN,
+} from '../src/lib/goal-drift.js'
 
 // `vhk goal sync` 가 생성하는 스캐폴드 게이트의 핵심(must 정의 + 주석 예시만 — 고유 검증 0).
 const SCAFFOLD = `#!/usr/bin/env node
@@ -25,10 +31,54 @@ describe('hasCustomGateAssertions', () => {
   })
 })
 
+describe('path evidence helpers', () => {
+  it('백틱에서 경로만 추출(URL·순수식별자 제외)', () => {
+    const body = [
+      '- `providers/image-openai.ts`',
+      '- `zod`',
+      '- `https://example.com`',
+      '- `poc/run.ts`',
+      '- `app/api/checkout-*`',
+    ].join('\n')
+    expect(extractBacktickPaths(body)).toEqual([
+      'providers/image-openai.ts',
+      'poc/run.ts',
+      'app/api/checkout-*',
+    ])
+  })
+
+  it('축약 경로 → lib/engine prefix 해석', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-path-ev-'))
+    try {
+      const target = path.join(root, 'lib', 'engine', 'providers')
+      fs.mkdirSync(target, { recursive: true })
+      fs.writeFileSync(path.join(target, 'image-openai.ts'), 'export {}\n')
+      expect(resolvePathEvidence(root, 'providers/image-openai.ts')).toBe(
+        'lib/engine/providers/image-openai.ts',
+      )
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('글롭 checkout-* 매칭', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-glob-ev-'))
+    try {
+      const dir = path.join(root, 'app', 'api')
+      fs.mkdirSync(dir, { recursive: true })
+      fs.mkdirSync(path.join(dir, 'checkout-pdf'))
+      expect(resolvePathEvidence(root, 'app/api/checkout-*')).toBe('app/api/checkout-pdf')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
 describe('findStatusDriftCandidates', () => {
   function setup(
     goals: Record<string, string>,
-    scripts: Record<string, string>
+    scripts: Record<string, string>,
+    files: Record<string, string> = {},
   ): { root: string; gdir: string; sdir: string } {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-drift-'))
     const gdir = path.join(root, 'goals')
@@ -37,32 +87,78 @@ describe('findStatusDriftCandidates', () => {
     fs.mkdirSync(sdir)
     for (const [name, content] of Object.entries(goals)) fs.writeFileSync(path.join(gdir, name), content)
     for (const [name, content] of Object.entries(scripts)) fs.writeFileSync(path.join(sdir, name), content)
+    for (const [rel, content] of Object.entries(files)) {
+      const abs = path.join(root, ...rel.split('/'))
+      fs.mkdirSync(path.dirname(abs), { recursive: true })
+      fs.writeFileSync(abs, content)
+    }
     return { root, gdir, sdir }
   }
-  const goalCard = (id: number, status: string): string =>
-    `---\nvhk_format: 1\ntype: goal\nid: ${id}\ntitle: G${id}\nstatus: ${status}\npriority: P1\n---\n\n# Goal ${id}\n`
+  const goalCard = (id: number, status: string, body = ''): string =>
+    `---\nvhk_format: 1\ntype: goal\nid: ${id}\ntitle: G${id}\nstatus: ${status}\npriority: P1\n---\n\n# Goal ${id}\n${body}\n`
 
   it('NOT_STARTED + custom 게이트 → 드리프트로 잡음', () => {
     const { root, gdir, sdir } = setup({ '5-x.md': goalCard(5, 'NOT_STARTED') }, { 'check-goal-5.mjs': CUSTOM })
-    expect(findStatusDriftCandidates(gdir, sdir).map((x) => x.id)).toEqual([5])
+    expect(findStatusDriftCandidates(gdir, sdir, root).map((x) => x.id)).toEqual([5])
     fs.rmSync(root, { recursive: true, force: true })
   })
 
   it('NOT_STARTED + 스캐폴드 게이트 → 통과(오탐 0)', () => {
     const { root, gdir, sdir } = setup({ '6-y.md': goalCard(6, 'NOT_STARTED') }, { 'check-goal-6.mjs': SCAFFOLD })
-    expect(findStatusDriftCandidates(gdir, sdir)).toEqual([])
+    expect(findStatusDriftCandidates(gdir, sdir, root)).toEqual([])
     fs.rmSync(root, { recursive: true, force: true })
   })
 
   it('DONE + custom 게이트 → 통과(정상 완료)', () => {
     const { root, gdir, sdir } = setup({ '7-z.md': goalCard(7, 'DONE') }, { 'check-goal-7.mjs': CUSTOM })
-    expect(findStatusDriftCandidates(gdir, sdir)).toEqual([])
+    expect(findStatusDriftCandidates(gdir, sdir, root)).toEqual([])
     fs.rmSync(root, { recursive: true, force: true })
   })
 
   it('NOT_STARTED + 게이트 스크립트 없음 → 통과(아직 sync 안 한 goal)', () => {
     const { root, gdir, sdir } = setup({ '8-w.md': goalCard(8, 'NOT_STARTED') }, {})
-    expect(findStatusDriftCandidates(gdir, sdir)).toEqual([])
+    expect(findStatusDriftCandidates(gdir, sdir, root)).toEqual([])
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it(`NOT_STARTED + 본문 경로 증거 ≥${PATH_EVIDENCE_MIN} (스크립트 없음) → 드리프트`, () => {
+    const body = '## 완료조건\n- `poc/run.ts`\n- `lib/engine/providers/image-openai.ts`\n'
+    const { root, gdir, sdir } = setup(
+      { '2-engine.md': goalCard(2, 'NOT_STARTED', body) },
+      {},
+      {
+        'poc/run.ts': 'console.log(1)\n',
+        'lib/engine/providers/image-openai.ts': 'export {}\n',
+      },
+    )
+    const hits = findStatusDriftCandidates(gdir, sdir, root)
+    expect(hits.map((x) => x.id)).toEqual([2])
+    expect(hits[0].reason).toContain('경로 증거')
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('NOT_STARTED + 축약 경로 본문도 prefix 해석으로 드리프트', () => {
+    const body = '## 완료조건\n- `providers/image-openai.ts`\n- `providers/text-openai.ts`\n'
+    const { root, gdir, sdir } = setup(
+      { '2-engine.md': goalCard(2, 'NOT_STARTED', body) },
+      {},
+      {
+        'lib/engine/providers/image-openai.ts': 'export {}\n',
+        'lib/engine/providers/text-openai.ts': 'export {}\n',
+      },
+    )
+    expect(findStatusDriftCandidates(gdir, sdir, root).map((x) => x.id)).toEqual([2])
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('경로 증거 1건만 → 미탐 선호(오탐 방지)', () => {
+    const body = '- `poc/run.ts`\n'
+    const { root, gdir, sdir } = setup(
+      { '9-one.md': goalCard(9, 'NOT_STARTED', body) },
+      {},
+      { 'poc/run.ts': 'ok\n' },
+    )
+    expect(findStatusDriftCandidates(gdir, sdir, root)).toEqual([])
     fs.rmSync(root, { recursive: true, force: true })
   })
 

--- a/tests/scan-secrets.test.ts
+++ b/tests/scan-secrets.test.ts
@@ -10,6 +10,8 @@ import {
   downgradeTestFixtureFindings,
   isTestFixturePath,
   isEnvTemplateFile,
+  parseGitleaksIgnore,
+  applyGitleaksIgnore,
 } from '../src/lib/scan-secrets.js'
 import { MAX_SCAN_FILE_BYTES } from '../src/lib/scan-files.js'
 
@@ -63,6 +65,73 @@ describe('scan-secrets', () => {
     const actual = 'z'.repeat(24)
     const findings = findSecretsInLine(`api_key = "${actual}"`, 'script.py', 1)
     expect(findings.filter((f) => f.patternId === 'generic-api-key')).toHaveLength(1)
+  })
+
+  it('generic: sk_test_ / whsk_test 벤더 test 접두는 FP 스킵 (stripe-live 와 정합)', () => {
+    expect(
+      findSecretsInLine(`apiKey: 'sk_test_123456789'`, 'tests/print-provider.test.ts', 40).filter(
+        (f) => f.patternId === 'generic-api-key',
+      ),
+    ).toHaveLength(0)
+    expect(
+      findSecretsInLine(`webhookSecret: 'whsk_test_abcdef'`, 'tests/x.test.ts', 1).filter(
+        (f) => f.patternId === 'generic-api-key',
+      ),
+    ).toHaveLength(0)
+  })
+
+  it('.gitleaksignore fingerprint 줄이 finding 을 제외', () => {
+    const rules = parseGitleaksIgnore(
+      [
+        '# comment',
+        '926592fa566af185868c41d1c971d00a626ea6a7:tests/print-provider.test.ts:generic-api-key:40',
+      ].join('\n'),
+    )
+    expect(rules).toEqual([
+      { path: 'tests/print-provider.test.ts', rule: 'generic-api-key', line: 40 },
+    ])
+    const kept = applyGitleaksIgnore(
+      [
+        {
+          patternId: 'generic-api-key',
+          patternName: 'Generic API Key',
+          severity: 'high' as const,
+          file: 'tests/print-provider.test.ts',
+          line: 40,
+          match: 'apiKey: ****',
+        },
+        {
+          patternId: 'generic-api-key',
+          patternName: 'Generic API Key',
+          severity: 'high' as const,
+          file: 'src/real.ts',
+          line: 1,
+          match: 'api_key: ****',
+        },
+      ],
+      rules,
+    )
+    expect(kept).toHaveLength(1)
+    expect(kept[0].file).toBe('src/real.ts')
+  })
+
+  it('scanProjectForSecrets 가 .gitleaksignore 를 적용', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-gitleaks-ignore-'))
+    try {
+      fs.mkdirSync(path.join(tmp, 'tests'), { recursive: true })
+      // 의도적으로 sk_live 가 아닌 긴 generic 값(벤더 test 접두 아닌 FP 경로)
+      const apiKey = 'z'.repeat(24)
+      fs.writeFileSync(path.join(tmp, 'tests', 'a.test.ts'), `apiKey: '${apiKey}'\n`, 'utf-8')
+      fs.writeFileSync(
+        path.join(tmp, '.gitleaksignore'),
+        `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:tests/a.test.ts:generic-api-key:1\n`,
+        'utf-8',
+      )
+      const { findings } = scanProjectForSecrets(tmp)
+      expect(findings.filter((f) => f.patternId === 'generic-api-key')).toHaveLength(0)
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
   })
 
   it('generic: 상태 접두어라도 실제 값 대입은 계속 탐지', () => {


### PR DESCRIPTION
Closes #514
Closes #515

## 뭐가 바뀌나

**`goal drift` false negative 해소 + `secure`가 `.gitleaksignore`를 존중한다.** 5파일 / 1커밋.

### #514 `goal drift` FN — 경로 증거를 보조 신호로 추가

| 신호 | 내용 |
|---|---|
| A (기존) | `check-goal-<id>.mjs`에 custom `must()` 호출이 있는데 status `NOT_STARTED` |
| **B (신규)** | `goals/*.md` 본문 백틱 경로가 **디스크에 존재하는데** `NOT_STARTED` |

**왜 B가 필관리자가**: 소비자 레포(aroo 등)는 `check-goal` 스크립트 없이 goals MD만 쓰는 경우가 많다 → 신호 A만으로는 **항상 0건**. aroo 실측에서 `goals/2·3`이 엔진·`/poc`·checkout·webhook·inngest 구현이 분명한데도 드리프트 0건으로 보고됐다.

오탐 방어가 잘 잡혀 있다:
- `PATH_EVIDENCE_MIN = 2` — 단일 aspirational 경로로는 드리프트 인정 안 함
- `BASENAME_WALK_MAX_NODES = 4000` — basename 탐색 성능 상한
- `SKIP_DIR_NAMES` — `node_modules`·`.git`·`dist`·`.next`·`coverage`·`.vhk` 제외
- 경로 해석 3단계: exact → 흔한 prefix(`lib`/`src`/…) → basename 한정 탐색

### #515 `.gitleaksignore` 존중

`parseGitleaksIgnore` 신설 — gitleaks fingerprint 형식(`commitHash:path:rule:line`)과 bare path 둘 다 파싱.

**이게 #515의 핵심이다.** aroo에서 사람이 7/17에 눈확인하고 등록한 오탐이 무시돼서 `verify`가 구조적으로 항상 exit 1이었고, 그게 게이트가 150커밋 방치된 유력 원인이었다.

## 지적 1건 — `VENDOR_TEST_KEY_PREFIX` 하드코딩 allowlist는 분리 재검토 권장

```
const VENDOR_TEST_KEY_PREFIX = /^(?:sk|pk|rk)_test_|^(?:whsk)_test/i
if (VENDOR_TEST_KEY_PREFIX.test(value)) return true   // = 무시
```

**왜 문제인가 — 승인 게이트를 우회하는 두 번째 경로가 생긴다:**

`.gitleaksignore`는 **사람이 승인하는 경로**다. 관리자이 aroo에서 그 오탐을 눈으로 확인하고 등록했다. 이 PR의 `parseGitleaksIgnore`가 바로 그 경로를 존중하게 만드는 픽스다 — 옳다.

그런데 같은 커밋에 들어간 `VENDOR_TEST_KEY_PREFIX`는 **사람 승인 없이 도구가 알아서 무시**한다. 시크릿 스캐너의 계약은 "의심되면 알린다"인데 이건 반대 방향이다. 구체적 실패:

- 누가 **유효한** `sk_test_` 키를 커밋해도 조용히 통과한다. 테스트 키도 유출되면 벤더 계정 노출·rate limit 남용 소지가 있다.
- `sk_test_`가 항상 테스트 키라는 보장은 **벤더 관례**일 뿐이다. 다른 벤더가 다르게 쓰면 실키가 통과한다.
- 오탐이 실제로 생기면 `.gitleaksignore`에 등록하면 된다 — **이미 그 경로가 이 PR로 작동하게 됐다.** 하드코딩은 중복이면서 더 위험한 쪽이다.

**어떻게**: 이 정규식을 별도 커밋/PR로 분리해서 따로 판단받는 게 맞다. 남기더라도 최소한 (a) 기본 off + opt-in 플래그, 또는 (b) 무시하지 말고 severity 강등(LOW) + 리포트에 남기기 — 조용히 사라지지 않게.

`#515`를 닫는 데는 `parseGitleaksIgnore`만으로 충분하다.

## 검증

```
pnpm build   OK
vitest       223 files / 2536 tests passed
```

주의: 새 워크트리에서 `dist/` 없이 vitest를 돌리면 e2e CLI 테스트 15건이 실패한다(`vhk --version` 포함). 브랜치 결함이 아니라 빌드 선행 필요 — `pnpm build` 후 전건 통과.

---
🤖 리뷰: Claude Code (aroo 독푸딩 세션)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 상태 드리프트 감지가 목표 문서의 경로 증거와 축약·글롭 경로까지 분석해 정확도를 높였습니다.
  - 경로 증거가 충분한 경우 스크립트가 없어도 드리프트 후보로 탐지합니다.
  - 테스트용 API 키와 `.gitleaksignore` 규칙을 지원해 비밀정보 검사 오탐을 줄였습니다.
  - 특정 파일, 규칙, 줄을 기준으로 비밀정보 검사 결과를 제외할 수 있습니다.

- **테스트**
  - 드리프트 경로 분석 및 비밀정보 제외 동작에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->