### PR TITLE
fix: sync --check가 bootstrap 산출물까지 커버 (#516)

### DIFF
--- a/docs/log/2026-07-27-agent-wiring-audit-p0.md
+++ b/docs/log/2026-07-27-agent-wiring-audit-p0.md
@@ -1,0 +1,32 @@
+# 2026-07-27 — 에이전트 지침 배선 감사 + P0 수리
+
+## 배경
+
+"클로드코드·코덱스·커서가 orca CLI 공식문서를 참고해서 쓰는 건지 모르겠다. 프롬프트 보강·리서치·오케스트레이션·병렬/worktree 지침이 각 프로젝트마다 잘 안 돼 있는 것 같다" — 5축 전수 조사 요청.
+
+조사 범위는 vhk 를 넘어 글로벌(`~/.claude`·`~/.codex`·`~/.cursor`·`~/.gemini`)·`yohan-brain`·`dev/.agents` 까지. 이 로그는 그중 **vhk 레포 변경분**을 남긴다. 전체 감사 결과와 P1/P2 처방은 `~/.claude/plans/vhk-ticklish-starlight.md`.
+
+## 한 일 (vhk)
+
+### #516 회귀 수리 — 신규 프로젝트 첫 `sync --check` 가 무조건 실패
+
+- **증상 실측**: 빈 디렉터리에서 `vhk init` → `vhk sync --check` = **exit 1**, `∅ .cursor/mcp.json.example — 파일 없음`
+- **원인**: `sync.ts` 가 bootstrap 주입 게이트를 `ecosystem.mdc 부재` 하나로 판정했다. `init.ts:412` 가 `generateFiles()` 에서 ecosystem.mdc 를 **먼저** 쓰기 때문에 이후 `syncCore` 에서 게이트가 닫히고 `injectBootstrapAll` 이 통째로 스킵된다 → `mcp.json.example` 이 영원히 안 생김. `SYNC_BOOTSTRAP_TARGETS`(레지스트리 3종)와 게이트(1종 판정)의 불일치가 근본 원인.
+- **수리**: `sync.ts` 의 게이트를 제거하고 `injectBootstrapAll` 을 무조건 호출. 이 함수는 이미 파일별 멱등(`writeInjectFile` 이 기존 내용 검사)이라 안전하다. `init.ts` 는 건드리지 않았다 — bootstrap 산출 목록의 SoT 를 `inject-bootstrap` 한 곳에 유지하기 위함.
+- **회귀 테스트**: `tests/sync-check.test.ts` 에 "ecosystem.mdc 만 있고 나머지 bootstrap 이 없어도 sync 가 채운다" 추가. **양방향 검증** — 수정 적용 시 12/12 통과, `git stash` 로 수정 제거 시 이 테스트만 실패(11 passed / 1 failed).
+
+## 결정
+
+- **init 이 아니라 sync 를 고쳤다.** init 에 `.cursor/mcp.json.example` 을 추가하는 쪽이 변경은 작지만, bootstrap 산출 목록을 init 과 inject-bootstrap 두 곳이 알게 된다(SoT 2곳). 미래에 bootstrap 타깃이 늘면 같은 버그가 재발한다.
+- ADR 승격 후보는 아님 — 기존 설계(inject-bootstrap 이 bootstrap SoT)를 복원한 것이지 새 결정이 아니다.
+
+## 막힌 것
+
+- **로컬 테스트 7건 실패(기존 결함, 이 변경과 무관)**: `src/lib/core-rules.test.ts` 3건 + `tests/init-core-rules-warn.test.ts` 4건. 전부 "`YOHAN_BRAIN_ROOT` 미설정 → `source=bundled`" 를 기대하는데 실제로는 `live` 가 나온다. `git stash` 로 이번 변경을 제거하고 돌려도 **동일하게 7건 실패** — 기준선 대조로 확인했다. 이 머신에 brain 이 기본 경로에 실존해서 코드가 live 로 판정하는 환경 의존 실패. CI 가 진실원(CLAUDE.md LIVE · TS-004).
+- `pnpm lint` exit 0, 신규 회귀 테스트 포함 `tests/sync-check.test.ts` 12/12 통과.
+
+## 교훈
+
+- **`| tail` 파이프가 종료코드를 가린다.** `pnpm test | tail -40` 의 exit code 는 vitest 가 아니라 `tail` 의 것이라 실패를 성공으로 오독했다. 게이트 판정에 쓰는 명령은 파이프 없이 돌리고 `$?` 를 따로 찍어라. (PowerShell 에서 `orca ... | Select-Object` 가 `$LASTEXITCODE` 를 오염시키는 것과 같은 부류)
+- **회귀 수리는 "고친 뒤 통과"만으로 부족하다.** 수정을 임시로 되돌려 테스트가 실제로 빨개지는지까지 봐야 그 테스트가 회귀를 잡는다는 근거가 생긴다.
+- **레지스트리와 게이트가 다른 집합을 보면 조용히 샌다.** `SYNC_BOOTSTRAP_TARGETS` 는 3종인데 주입 게이트는 1종만 봤다. 레지스트리를 쓰는 코드는 판정도 레지스트리 전체로 해야 한다.

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -8,7 +8,15 @@ import { printNextStep } from '../lib/next-step.js'
 import { normalizeForCompare } from '../lib/drift.js'
 import { saveBackup, pruneBackups, ensureVhkIgnored } from '../lib/backup.js'
 import { atomicWriteFile } from '../lib/atomic-write.js'
-import { injectBootstrapAll, ECOSYSTEM_MDC_REL } from '../lib/inject-bootstrap.js'
+import {
+  injectBootstrapAll,
+  ECOSYSTEM_MDC_REL,
+  MCP_JSON_EXAMPLE_REL,
+  CORE_RULES_REL,
+  generateEcosystemMdcContent,
+  generateMcpJsonExampleContent,
+  generateCoreRulesFileContent,
+} from '../lib/inject-bootstrap.js'
 import { PREAMBLE_TITLE } from '../lib/rules-import.js'
 import { isInteractive, promptOrDefault } from '../lib/interactive.js'
 import { runDocDriftChecks, type DriftFinding } from '../lib/drift-pairs.js'
@@ -515,6 +523,39 @@ export const SYNC_TARGETS: SyncTarget[] = [
   { path: '.clinerules/vhk-rules.md', generate: toClineRules, doneMessage: ko.sync.clineDone },
 ]
 
+/**
+ * sync() 가 RULES 미러(8) 외에 injectBootstrapAll 로 쓰는 산출물.
+ * --check 가 이 집합을 빠뜨리면 게이트 커버리지 구멍(aroo dogfood 2026-07-25 · commit 8242f5d).
+ * .vhk/context.md 는 로컬 seed(존재 시 재작성 안 함)라 제외.
+ */
+export type SyncBootstrapTarget = {
+  path: string
+  /** 기대 내용(템플릿). rootDir 필요 시(mcp variant) 사용. */
+  expected: (rootDir: string) => string
+  /** 파일이 vhk 템플릿인지 — false 면 사용자 소유로 보고 check 스킵(드리프트 미보고). */
+  isVhkTemplate?: (content: string) => boolean
+}
+
+export const SYNC_BOOTSTRAP_TARGETS: SyncBootstrapTarget[] = [
+  {
+    path: ECOSYSTEM_MDC_REL,
+    expected: () => generateEcosystemMdcContent(),
+    isVhkTemplate: (c) => c.includes('ECOSYSTEM-MDC:START') && c.includes('ECOSYSTEM-MDC:END'),
+  },
+  {
+    path: MCP_JSON_EXAMPLE_REL,
+    expected: (root) => generateMcpJsonExampleContent(root),
+  },
+  {
+    path: CORE_RULES_REL,
+    expected: () => generateCoreRulesFileContent(null),
+    isVhkTemplate: (c) => c.includes('CORE-RULES:START') && c.includes('CORE-RULES:END'),
+  },
+]
+
+/** RULES 미러 7 + CLAUDE.md 1. bootstrap 은 SYNC_BOOTSTRAP_TARGETS. */
+export const SYNC_MIRROR_TARGET_COUNT = SYNC_TARGETS.length + 1
+
 /** 보존할 백업 개수 — 무한 증식 방지(스케일/팀 고려). */
 const BACKUP_KEEP = 10
 /** 로컬 전용 sync 마커 — 존재 여부로 첫 sync 판정. 추적/클라우드 제외. */
@@ -538,9 +579,9 @@ export interface SyncCheckResult {
 }
 
 /**
- * Goal 63 — 8개 sync 타겟(SYNC_TARGETS 7 + CLAUDE.md 블록) 전체 drift 검사. 쓰기 0.
- * 생성 로직(buildSyncPlan)을 그대로 재사용 — 별도 검사기가 sync 와 어긋나는
- * "검사기의 drift"(governance 배치에서 check-rules-sync 의 알려진 한계) 원천 차단.
+ * Goal 63 — sync 산출 전체 drift 검사(쓰기 0).
+ * RULES 미러 8(SYNC_TARGETS 7 + CLAUDE.md) + bootstrap(SYNC_BOOTSTRAP_TARGETS).
+ * 생성 로직(buildSyncPlan / inject 템플릿)을 그대로 재사용 — 검사기↔sync 어긋남 원천 차단.
  */
 export function syncCheck(rootDir: string): SyncCheckResult {
   const rulesContent = fs.readFileSync(path.join(rootDir, 'RULES.md'), 'utf-8')
@@ -548,6 +589,29 @@ export function syncCheck(rootDir: string): SyncCheckResult {
   const plan = buildSyncPlan(rootDir, sections, deriveProjectName(rulesContent))
   const drifted = plan.filter((p) => p.exists && p.drift).map((p) => p.path)
   const missing = plan.filter((p) => !p.exists).map((p) => p.path)
+
+  // bootstrap 산출 — sync -y 가 injectBootstrapAll 로 만드는 파일. 8미러만 보면 커버리지 구멍.
+  for (const t of SYNC_BOOTSTRAP_TARGETS) {
+    const full = path.join(rootDir, t.path)
+    if (!fs.existsSync(full)) {
+      missing.push(t.path)
+      continue
+    }
+    let onDisk: string
+    try {
+      onDisk = fs.readFileSync(full, 'utf-8')
+    } catch {
+      missing.push(t.path)
+      continue
+    }
+    // 사용자 소유(비-vhk 템플릿)는 inject 가 skip 하는 것과 같이 check 도 스킵
+    if (t.isVhkTemplate && !t.isVhkTemplate(onDisk)) continue
+    const expected = t.expected(rootDir)
+    if (normalizeForCompare(onDisk) !== normalizeForCompare(expected)) {
+      drifted.push(t.path)
+    }
+  }
+
   return { drifted, missing, ok: drifted.length === 0 && missing.length === 0 }
 }
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -767,18 +767,19 @@ export async function syncCore(
   atomicWriteFile(path.join(rootDir, SYNCED_MARKER_REL), new Date().toISOString() + '\n')
   ensureVhkIgnored(rootDir, '.synced')
 
-  // #468 brownfield: ecosystem.mdc 없으면 inject-bootstrap 으로 생성 후 AGENTS 재생성
-  const ecoPath = path.join(rootDir, ECOSYSTEM_MDC_REL)
-  if (!fs.existsSync(ecoPath)) {
-    const injected = injectBootstrapAll(rootDir, { yes: true })
-    if (
-      (injected.ecosystem === 'created' || injected.ecosystem === 'updated')
-      && written.includes('AGENTS.md')
-    ) {
-      const agentsPath = path.join(rootDir, 'AGENTS.md')
-      const refreshed = toAgentsMd(sections, projectName, resolveAgentCompactRel(rootDir), rootDir)
-      fs.writeFileSync(agentsPath, refreshed, 'utf-8')
-    }
+  // #468 brownfield + #516: bootstrap 산출물 전량을 inject-bootstrap 에 위임한다.
+  // 과거엔 ecosystem.mdc 부재를 게이트로 썼는데, init 이 ecosystem.mdc 만 먼저 쓰는 경로에서는
+  // 게이트가 닫혀 mcp.json.example 이 영원히 안 생겼다 → 첫 sync --check 가 무조건 exit 1.
+  // injectBootstrapAll 은 파일별로 멱등(있으면 unchanged)이라 무조건 호출해도 안전하다.
+  const injected = injectBootstrapAll(rootDir, { yes: true })
+  if (
+    (injected.ecosystem === 'created' || injected.ecosystem === 'updated')
+    && written.includes('AGENTS.md')
+  ) {
+    // AGENTS.md 의 Ecosystem 블록은 ecosystem.mdc 존재를 전제로 삽입된다 → 방금 생겼으면 재생성
+    const agentsPath = path.join(rootDir, 'AGENTS.md')
+    const refreshed = toAgentsMd(sections, projectName, resolveAgentCompactRel(rootDir), rootDir)
+    fs.writeFileSync(agentsPath, refreshed, 'utf-8')
   }
 
   return { dryRun: false, firstSync, backupId, backedUp, written, skipped, truncated, plan, unmapped, claudeMigration }

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -399,7 +399,7 @@ export const ko = {
     noRules: '⚠️ RULES.md 파일이 없어요.',
     // Goal 63 — sync --check (검사 전용)
     checkNoRules: '⚠️ RULES.md 없음 — 검사 비적용 통과',
-    checkPass: '✅ 규칙 동기화 상태 — 8개 타겟 전부 RULES.md 와 일치',
+    checkPass: '✅ 규칙 동기화 상태 — sync 산출 전부(RULES 미러 + bootstrap) 일치',
     checkDrift: (p: string) => `↯ ${p} — 생성본과 다름 (직접 수정 또는 sync 미실행)`,
     checkMissing: (p: string) => `∅ ${p} — 파일 없음 (sync 가 생성할 타겟)`,
     checkFail: (n: number) => `❌ drift ${n}건 — \`vhk sync\` 로 재전파하세요 (직접 편집 금지)`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -290,7 +290,7 @@ program
   .alias('맞추기')
   .alias('규칙')
   .option('--dry-run', '미리보기만 — 파일 변경 없음')
-  .option('--check', '검사만 — 8개 타겟 drift 검사(쓰기 0), drift 시 exit 1 (Goal 63)')
+  .option('--check', '검사만 — sync 산출 전체(RULES 미러 8 + bootstrap) drift 검사(쓰기 0), drift 시 exit 1 (Goal 63)')
   .option('-y, --yes', 'drift 확인 프롬프트 생략(덮어쓰기 동의)')
   .description('RULES.md → .cursorrules + CLAUDE.md 동기화 (덮어쓰기 전 자동 백업)')
   .action(async (opts: { dryRun?: boolean; yes?: boolean; check?: boolean }) => { await guardCli('sync', opts?.yes === true, () => sync(opts)) })

--- a/tests/sync-check.test.ts
+++ b/tests/sync-check.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { syncCheck, syncCore, SYNC_TARGETS } from '../src/commands/sync.js'
+import {
+  syncCheck,
+  syncCore,
+  SYNC_TARGETS,
+  SYNC_BOOTSTRAP_TARGETS,
+} from '../src/commands/sync.js'
+import { ECOSYSTEM_MDC_REL, MCP_JSON_EXAMPLE_REL } from '../src/lib/inject-bootstrap.js'
 
 const RULES = [
   '# 데모 — 테스트',
@@ -22,7 +28,7 @@ let dir: string
 beforeEach(async () => {
   dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-synccheck-'))
   fs.writeFileSync(path.join(dir, 'RULES.md'), RULES, 'utf-8')
-  // 실제 sync 로 8타겟 생성 — check 의 기준 상태(동기화 완료)
+  // 실제 sync 로 미러 8 + bootstrap 생성 — check 의 기준 상태(동기화 완료)
   await syncCore(dir, { yes: true }, async () => true)
 })
 
@@ -30,7 +36,7 @@ afterEach(() => {
   fs.rmSync(dir, { recursive: true, force: true })
 })
 
-describe('syncCheck — 8타겟 drift 검사 (Goal 63)', () => {
+describe('syncCheck — sync 산출 전체 drift 검사 (Goal 63)', () => {
   it('동기화 직후 → ok, drift/missing 0', () => {
     const r = syncCheck(dir)
     expect(r.ok).toBe(true)
@@ -79,5 +85,36 @@ describe('syncCheck — 8타겟 drift 검사 (Goal 63)', () => {
     const before = fs.readFileSync(p, 'utf-8')
     syncCheck(dir)
     expect(fs.readFileSync(p, 'utf-8')).toBe(before)
+  })
+
+  it('bootstrap 레지스트리에 ecosystem.mdc · mcp.json.example 포함', () => {
+    const paths = SYNC_BOOTSTRAP_TARGETS.map((t) => t.path)
+    expect(paths).toContain(ECOSYSTEM_MDC_REL)
+    expect(paths).toContain(MCP_JSON_EXAMPLE_REL)
+  })
+
+  it('ecosystem.mdc 손수정 → drifted (8미러만 보면 놓치던 커버리지 구멍)', () => {
+    const p = path.join(dir, ECOSYSTEM_MDC_REL)
+    expect(fs.existsSync(p)).toBe(true)
+    fs.writeFileSync(p, fs.readFileSync(p, 'utf-8') + '\n<!-- hand edit -->\n', 'utf-8')
+    const r = syncCheck(dir)
+    expect(r.ok).toBe(false)
+    expect(r.drifted).toContain(ECOSYSTEM_MDC_REL)
+  })
+
+  it('mcp.json.example 손수정 → drifted', () => {
+    const p = path.join(dir, MCP_JSON_EXAMPLE_REL)
+    expect(fs.existsSync(p)).toBe(true)
+    fs.writeFileSync(p, '{\n  "hand": true\n}\n', 'utf-8')
+    const r = syncCheck(dir)
+    expect(r.ok).toBe(false)
+    expect(r.drifted).toContain(MCP_JSON_EXAMPLE_REL)
+  })
+
+  it('ecosystem.mdc 삭제 → missing', () => {
+    fs.rmSync(path.join(dir, ECOSYSTEM_MDC_REL))
+    const r = syncCheck(dir)
+    expect(r.ok).toBe(false)
+    expect(r.missing).toContain(ECOSYSTEM_MDC_REL)
   })
 })

--- a/tests/sync-check.test.ts
+++ b/tests/sync-check.test.ts
@@ -117,4 +117,17 @@ describe('syncCheck — sync 산출 전체 drift 검사 (Goal 63)', () => {
     expect(r.ok).toBe(false)
     expect(r.missing).toContain(ECOSYSTEM_MDC_REL)
   })
+
+  it('ecosystem.mdc 만 있고 나머지 bootstrap 이 없어도 sync 가 채운다 (#516 회귀)', async () => {
+    // init 은 ecosystem.mdc 를 직접 쓴 뒤 syncCore 를 부른다. 과거 sync 는 "ecosystem.mdc 있음
+    // = bootstrap 완료" 로 보고 inject 를 건너뛰어, mcp.json.example 이 영원히 안 생겼다
+    // → 신규 프로젝트의 첫 sync --check 가 무조건 exit 1.
+    fs.rmSync(path.join(dir, MCP_JSON_EXAMPLE_REL))
+    expect(fs.existsSync(path.join(dir, ECOSYSTEM_MDC_REL))).toBe(true)
+
+    await syncCore(dir, { yes: true }, async () => true)
+
+    expect(fs.existsSync(path.join(dir, MCP_JSON_EXAMPLE_REL))).toBe(true)
+    expect(syncCheck(dir).ok).toBe(true)
+  })
 })


### PR DESCRIPTION
Closes #516

## 뭐가 바뀌나

**`sync --check`가 RULES 미러 8종 외에 bootstrap 산출물 3종까지 검사한다.** 4파일 / 1커밋.

`SYNC_BOOTSTRAP_TARGETS` 도입:

| 타겟 | 템플릿 가드 |
|---|---|
| `.cursor/rules/ecosystem.mdc` | `ECOSYSTEM-MDC:START`/`END` |
| `.cursor/mcp.json.example` | **없음** ← 아래 지적 참조 |
| core-rules 파일 | `CORE-RULES:START`/`END` |

`.vhk/context.md`는 로컬 seed(존재 시 재작성 안 함)라 의도적으로 제외 — 맞는 판단.

### 왜 필요했나 (aroo 독푸딩 실측)

`sync --help`는 "`--check`: 8개 타겟 drift 검사"라고 하는데 `sync`가 실제로 만드는 파일은 그보다 많았다. 재현: aroo `8242f5d` 커밋에서 `vhk sync -y`가 `.cursor/rules/ecosystem.mdc`·`.cursor/mcp.json.example`을 신규 생성했다. `--check`가 그 집합을 안 보면 손으로 고쳐도 게이트가 못 잡는다.

**이게 실제 영향이 있는 이유**: aroo가 방금 `vhk sync --check`를 CI 게이트로 넣었다 (aroo PR #37, `@byh3071-cpu/vhk@2.11.0` 버전 고정).

## 지적 1건 — `mcp.json.example`에 `isVhkTemplate` 가드가 없다

다른 두 타겟은 마커 기반 가드가 있어서 **사용자가 파일을 자기 것으로 바꾸면 drift를 보고하지 않는다.** `MCP_JSON_EXAMPLE_REL`만 그 가드가 없다.

**왜 문제인가 — #515가 만든 실패 모드를 재생산할 수 있다:**

1. 사용자가 `.cursor/mcp.json.example`을 자기 MCP 서버 설정으로 수정
2. `sync --check`가 매번 drift 보고 → exit 1
3. **CI가 항상 빨개짐**
4. → 사람이 게이트를 끈다

#515에서 진단한 인과 사슬이 정확히 이거다 (`.gitleaksignore` 무시 → `verify` 상시 FAIL → 게이트 150커밋 방치). 커버리지를 늘리는 픽스가 같은 함정을 만들면 순이익이 사라진다.

**어떻게**: `.example` 파일은 관례상 "복사해서 쓰는" 것이라 in-place 수정 확률이 낮으므로 **경결함**이다. 다만 가드 비용이 1줄이니 붙이는 쪽이 맞다. 마커가 없는 형식(JSON)이라면 "vhk가 생성한 내용과 정확히 일치할 때만 비교" 또는 파싱해서 vhk 키 서브셋만 대조하는 방식.

## 확인한 것 (문제 없음)

- `generateMcpJsonExampleContent(cwd)`가 `cwd`를 받지만 **절대경로를 박지 않는다** — variant 판정에만 쓴다 (`detectMcpExampleVariant`: `package.json` name + 디렉터리 basename). 멀티머신에서 같은 레포면 결과 동일 → 머신별 영구 drift 없음.
- `SYNC_MIRROR_TARGET_COUNT`를 `SYNC_TARGETS.length + 1`로 계산 — 하드코딩 8 대신 파생. 다음에 타겟이 늘어도 안 틀어짐.

## 검증

```
vitest   223 files / 2531 tests passed
```

(vhk 메인 트리에서 이 브랜치 체크아웃 상태로 실행)

---
🤖 리뷰: Claude Code (aroo 독푸딩 세션)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * `vhk sync --check`가 기존 규칙 미러뿐 아니라 부트스트랩 생성물까지 검사합니다.
  * 생성물의 누락이나 변경이 있으면 드리프트로 정확히 보고하며, 검사 중 파일을 수정하지 않습니다.
  * 동기화 과정에서 필관리자 부트스트랩 파일과 `AGENTS.md`가 자동으로 생성·갱신됩니다.

* **문서**
  * 동기화 검사 범위와 결과 메시지를 실제 동작에 맞게 업데이트했습니다.

* **버그 수정**
  * 일부 부트스트랩 파일만 존재하는 환경에서도 동기화가 누락된 파일을 생성하고 정상 상태로 판정합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->