### PR TITLE
fix: 전체 이력 공개 경계 검사를 PCRE로 전환

### DIFF
--- a/scripts/check-public-boundary.mjs
+++ b/scripts/check-public-boundary.mjs
@@ -44,6 +44,7 @@ const PRIVATE_TEXT_PATTERNS = [
 
 const UUID_PATTERN = /\b[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}\b/giu
 const ZERO_UUID = /^0{32}$/u
+const NON_ZERO_UUID_HISTORY_PATTERN = String.raw`\b(?!0{8}-?0{4}-?0{4}-?0{4}-?0{12}\b)[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}\b`
 
 function git(args, options = {}) {
   return execFileSync('git', args, {
@@ -57,6 +58,31 @@ function git(args, options = {}) {
 
 function normalizePath(file) {
   return String(file).replaceAll('\\', '/')
+}
+
+export function buildHistorySearchPattern() {
+  return [
+    ...PRIVATE_TEXT_PATTERNS.map((forbidden) => `(?:${forbidden.pattern.source})`),
+    `(?:${NON_ZERO_UUID_HISTORY_PATTERN})`,
+  ].join('|')
+}
+
+function historyContainsPrivateText() {
+  const commits = git(['rev-list', '--all']).trim().split(/\s+/u).filter(Boolean)
+  const pattern = buildHistorySearchPattern()
+  const batchSize = 48
+
+  for (let offset = 0; offset < commits.length; offset += batchSize) {
+    const batch = commits.slice(offset, offset + batchSize)
+    try {
+      git(['grep', '-I', '-P', '-i', '-l', '-e', pattern, ...batch, '--'])
+      return true
+    } catch (error) {
+      if (typeof error === 'object' && error !== null && 'status' in error && error.status === 1) continue
+      throw error
+    }
+  }
+  return false
 }
 
 function isPrivatePath(file) {
@@ -158,10 +184,7 @@ function checkAllRefs() {
     if (history) problems.push(`${pathPart}: 과거 Git 이력에 개인 운영 경로가 남음`)
   }
 
-  for (const forbidden of PRIVATE_TEXT_PATTERNS) {
-    const history = git(['log', '--all', '--format=%H', `-G${forbidden.pattern.source}`, '--', '.']).trim()
-    if (history) problems.push(`Git 전체 이력: ${forbidden.name}가 포함된 변경이 남음`)
-  }
+  if (historyContainsPrivateText()) problems.push('Git 전체 이력: 개인 텍스트가 포함된 blob이 남음')
   return problems
 }
 

--- a/tests/check-public-boundary.test.ts
+++ b/tests/check-public-boundary.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { checkPublicBoundary, scanPublicText } from '../scripts/check-public-boundary.mjs'
+import { buildHistorySearchPattern, checkPublicBoundary, scanPublicText } from '../scripts/check-public-boundary.mjs'
 
 const manifest = (paths: string[]) => ({ files: paths.map((path) => ({ path })) })
 const requiredPackageFiles = [
@@ -49,5 +49,15 @@ describe('공개 경계 검사', () => {
     const zeroId = ['00000000', '0000', '0000', '0000', '000000000000'].join('-')
     expect(scanPublicText('문서', objectId)).not.toEqual([])
     expect(scanPublicText('테스트', zeroId)).toEqual([])
+  })
+
+  it('전체 이력 검사 패턴은 영 UUID fixture를 제외한다', () => {
+    const pattern = new RegExp(buildHistorySearchPattern(), 'iu')
+    const privateRepository = ['yohan', 'brain'].join('-')
+    const objectId = ['12345678', '1234', '1234', '1234', '123456789abc'].join('-')
+    const zeroId = ['00000000', '0000', '0000', '0000', '000000000000'].join('-')
+    expect(pattern.test(privateRepository)).toBe(true)
+    expect(pattern.test(objectId)).toBe(true)
+    expect(pattern.test(zeroId)).toBe(false)
   })
 })


### PR DESCRIPTION
## 변경 사항
- 전체 Git 이력 검사에서 JavaScript 정규식을 Git POSIX 정규식에 직접 넘기던 호환성 오류를 제거했습니다.
- 모든 도달 가능한 커밋의 blob을 배치 단위 git grep -P로 검사합니다.
- 영 UUID fixture는 허용하면서 실제 UUID와 개인 텍스트는 차단합니다.

## 검증
- 공개 경계 전용 테스트 6개 통과
- TypeScript 타입 검사 통과
- ESLint 통과
- 현재 트리 npm 10개 + Git 587개 경계 검사 통과
- 미정리 이력에 대한 의도된 fail-closed 동작 확인
- PR 전 시크릿 게이트 통과