### PR TITLE
fix: 남은 #517 기능을 보안 보완해 통합

### DIFF
--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -392,7 +392,8 @@ export async function goalCheck(opts: { id?: string; force?: boolean }): Promise
 // "shipped 인데 status: NOT_STARTED" 인 goal 을 잡아 exit 1. 깨끗하면 exit 0.
 export async function goalDrift(): Promise<void> {
   console.log(chalk.bold(`\n${ko.goal.driftTitle}\n`))
-  const candidates = findStatusDriftCandidates(GOALS_DIR, SCRIPTS_DIR)
+  // projectRoot=cwd — 소비자 레포 goals 본문 경로 증거(축약·exact) 해석용
+  const candidates = findStatusDriftCandidates(GOALS_DIR, SCRIPTS_DIR, process.cwd())
   if (candidates.length === 0) {
     console.log(chalk.green(`  ✅ ${ko.goal.driftClean}`))
     return

--- a/src/lib/goal-drift.ts
+++ b/src/lib/goal-drift.ts
@@ -1,20 +1,34 @@
-import { existsSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { basename, dirname, join, relative, sep } from 'node:path'
 import { listGoals, type GoalStatus } from './goal-frontmatter.js'
 
 // Goal 43: goal 상태 ↔ 코드 현실 드리프트 게이트.
 //
-// 불변 규칙: "goal 고유 게이트 검증(custom must() 호출)이 있는 goal 은 status: NOT_STARTED 이면 안 된다."
-//   근거: check-goal-<id>.mjs 는 `vhk goal sync` 가 백필하는데, 스캐폴드 상태에는 must() **정의**와
-//         **주석 처리된 예시**만 있다. 실제 must() **호출**은 그 goal 을 구현하면서 손으로 추가한다.
-//         즉 custom must() = "코드 구현 흔적". 그게 있는데 status 가 NOT_STARTED 면 드리프트.
-//   실측: Goal 19(pattern)가 src/commands/pattern.ts 풀구현 + v2.1.0 출시인데 status: NOT_STARTED 로
-//         남아 이 규칙을 위반했다(이 게이트가 막으려는 원형 사례).
+// 신호 A (원본): check-goal-<id>.mjs 에 custom must() 호출이 있는데 status: NOT_STARTED.
+// 신호 B (dogfood 2026-07-25): goals/*.md 본문 백틱 경로가 디스크에 존재하는데 NOT_STARTED.
+//   소비자 레포(aroo 등)는 check-goal 스크립트 없이 goals MD만 쓰는 경우가 많아
+//   신호 A만으로는 항상 0건(false negative). 경로 증거를 보조 신호로 추가.
 //
 // 보수적 설계(거짓 양성보다 미탐 선호):
 //   - NOT_STARTED 만 본다. IN_PROGRESS/DONE/BLOCKED 는 대상 아님.
-//   - 게이트 스크립트가 없으면(예: 아직 sync 안 한 SEO goal 21~26) 후보 아님.
-//   - 스캐폴드(정의/주석만)면 후보 아님 → 새 goal 무더기 오탐 0.
+//   - 경로 증거는 확정 히트 ≥ PATH_EVIDENCE_MIN 일 때만(단일 aspirational 경로 오탐 방지).
+//   - 경로 해석: exact → 흔한 prefix(lib/src/…) → basename 한정 탐색(노드 상한).
+
+/** 경로 증거로 드리프트를 인정하기 위한 최소 히트 수. */
+export const PATH_EVIDENCE_MIN = 2
+
+/** basename 탐색 시 방문할 최대 파일/디렉터리 노드 수(성능 bound). */
+const BASENAME_WALK_MAX_NODES = 4_000
+
+const SKIP_DIR_NAMES = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  'build',
+  '.next',
+  'coverage',
+  '.vhk',
+])
 
 /**
  * check-goal 스크립트 본문에 goal 고유 검증(custom `must()` 호출)이 있는지.
@@ -33,13 +47,10 @@ export function hasCustomGateAssertions(scriptContent: string): boolean {
 }
 
 // Goal 53: 가드 신뢰도 — 정규식 shape 단언 측정.
-//   `must(/.../.test(src), ...)` 형태는 함수명만 바꿔도 깨지고(거짓음성), import 만 해두면 통과(거짓양성).
-//   비율을 측정해 상한(ratchet)으로 묶고, 핵심 행동은 behavior 테스트(tests/*.test.ts)로 검증한다.
 const REGEX_SHAPE_ASSERTION = /must\([^)]*\/.*\/\.test/
 
 /**
  * check-goal 본문에서 정규식 shape 단언(`must(/.../.test(...))`)의 개수와 예시(최대 5).
- * 주석(`//`)·헬퍼 정의(`const must =`) 라인은 제외.
  */
 export function countRegexAssertions(content: string): { count: number; examples: string[] } {
   const examples: string[] = []
@@ -57,10 +68,7 @@ export function countRegexAssertions(content: string): { count: number; examples
   return { count, examples }
 }
 
-/**
- * check-goal 본문의 전체 `must()` 호출 수(정규식 비율의 분모).
- * 주석·헬퍼 정의 라인 제외 — countRegexAssertions 와 동일 기준.
- */
+/** check-goal 본문의 전체 `must()` 호출 수(정규식 비율의 분모). */
 export function countMustAssertions(content: string): number {
   let count = 0
   for (const raw of content.split(/\r?\n/)) {
@@ -81,35 +89,222 @@ export interface DriftCandidate {
   reason: string
 }
 
+/** 백틱 안 문자열이 파일/디렉터리 상대경로처럼 보이는지. */
+export function looksLikeRepoRelPath(raw: string): boolean {
+  const s = raw.trim()
+  if (!s || /\s/.test(s)) return false
+  if (/^https?:\/\//i.test(s)) return false
+  if (s.startsWith('#') || s.startsWith('@')) return false
+  // 웹 경로(`/sign-in`)·절대경로는 레포 상대경로가 아님
+  if (s.startsWith('/')) return false
+  // 경로 구분자 또는 확장자(또는 글롭) — 순수 식별자(`zod`) 제외
+  return /[\\/]/.test(s) || /\.\w{1,8}$/.test(s) || s.includes('*')
+}
+
+/** goal 본문에서 백틱 경로 후보를 추출(중복 제거, 등장 순). */
+export function extractBacktickPaths(body: string): string[] {
+  const out: string[] = []
+  const seen = new Set<string>()
+  const re = /`([^`\n]+)`/g
+  for (const m of body.matchAll(re)) {
+    const cand = m[1].trim().replace(/^\.\//, '')
+    if (!looksLikeRepoRelPath(cand)) continue
+    if (seen.has(cand)) continue
+    seen.add(cand)
+    out.push(cand)
+  }
+  return out
+}
+
+function globLastSegmentMatches(name: string, pattern: string): boolean {
+  // 단순: `*` 만 지원(checkout-*). 정규식 escape 후 * → .*
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')
+  return new RegExp(`^${escaped}$`).test(name)
+}
+
+type BasenameIndex = Map<string, string[]>
+
+function buildBasenameIndex(projectRoot: string): BasenameIndex {
+  const index: BasenameIndex = new Map()
+  let nodes = 0
+  const stack = [projectRoot]
+  while (stack.length > 0 && nodes < BASENAME_WALK_MAX_NODES) {
+    const dir = stack.pop() as string
+    let entries: string[]
+    try {
+      entries = readdirSync(dir)
+    } catch {
+      // 권한·경합으로 읽을 수 없는 하위 경로만 제외하고 나머지 색인은 계속 만든다.
+      continue
+    }
+    for (const name of entries) {
+      nodes++
+      if (nodes > BASENAME_WALK_MAX_NODES) break
+      if (SKIP_DIR_NAMES.has(name)) continue
+      const abs = join(dir, name)
+      let st
+      try {
+        st = statSync(abs)
+      } catch {
+        // 스캔 도중 사라진 파일은 증거로 사용할 수 없으므로 건너뛴다.
+        continue
+      }
+      if (st.isDirectory()) {
+        stack.push(abs)
+        continue
+      }
+      const rel = relative(projectRoot, abs).split(sep).join('/')
+      const matches = index.get(name) ?? []
+      matches.push(rel)
+      index.set(name, matches)
+    }
+  }
+  return index
+}
+
+function selectBasenameEvidence(normalized: string, candidates: string[]): string | null {
+  if (candidates.length === 0) return null
+  const requested = normalized.split('/')
+  const requestedParents = requested.slice(0, -1)
+  if (requestedParents.length === 0) return candidates.length === 1 ? candidates[0] : null
+
+  const scored = candidates.map((candidate) => {
+    const candidateParents = candidate.split('/').slice(0, -1)
+    let score = 0
+    while (
+      score < requestedParents.length &&
+      score < candidateParents.length &&
+      requestedParents[requestedParents.length - 1 - score] ===
+        candidateParents[candidateParents.length - 1 - score]
+    ) {
+      score++
+    }
+    return { candidate, score }
+  })
+  const bestScore = Math.max(...scored.map(({ score }) => score))
+  if (bestScore === 0) return null
+  const best = scored.filter(({ score }) => score === bestScore)
+  return best.length === 1 ? best[0].candidate : null
+}
+
 /**
- * goals/ ↔ scripts/ 를 대조해 "shipped 인데 NOT_STARTED" 드리프트 후보를 찾는다(순수, fs 읽기만).
- * 판정: status === NOT_STARTED 이고 check-goal-<id>.mjs 가 존재하며 custom must() 호출이 있는 goal.
+ * 상대경로가 projectRoot 아래 실재하는지.
+ * 1) exact  2) 흔한 prefix 접합  3) 마지막 세그먼트 글롭  4) basename 한정 walk
  */
-export function findStatusDriftCandidates(goalsDir: string, scriptsDir: string): DriftCandidate[] {
+export function resolvePathEvidence(
+  projectRoot: string,
+  relPath: string,
+  basenameIndex?: BasenameIndex,
+): string | null {
+  const normalized = relPath.replace(/\\/g, '/').replace(/^\.\//, '')
+  if (!normalized) return null
+
+  const tryExact = (rel: string): string | null => {
+    const abs = join(projectRoot, ...rel.split('/'))
+    return existsSync(abs) ? rel : null
+  }
+
+  const hit = tryExact(normalized)
+  if (hit) return hit
+
+  // 축약 경로(`providers/image-openai.ts`) → lib/engine/providers/… 등
+  const PREFIXES = ['lib', 'src', 'app', 'lib/engine', 'src/lib', 'packages']
+  for (const prefix of PREFIXES) {
+    const prefixed = `${prefix}/${normalized}`
+    const pHit = tryExact(prefixed)
+    if (pHit) return pHit
+  }
+
+  // `app/api/checkout-*` — 부모 dir 목록에서 글롭 매칭
+  if (normalized.includes('*')) {
+    const parent = dirname(normalized).replace(/\\/g, '/')
+    const pat = basename(normalized)
+    const parentAbs =
+      parent === '.' ? projectRoot : join(projectRoot, ...parent.split('/'))
+    if (existsSync(parentAbs)) {
+      try {
+        for (const name of readdirSync(parentAbs)) {
+          if (globLastSegmentMatches(name, pat)) {
+            return parent === '.' ? name : `${parent}/${name}`
+          }
+        }
+      } catch {
+        // 존재 확인 뒤 경합으로 디렉터리를 읽지 못하면 글롭 증거 없음으로 처리한다.
+      }
+    }
+  }
+
+  // basename 탐색(노드 상한) — 부모 suffix가 가장 잘 맞는 유일 후보만 증거로 인정한다.
+  const base = basename(normalized)
+  if (!base || base.includes('*')) return null
+  const index = basenameIndex ?? buildBasenameIndex(projectRoot)
+  return selectBasenameEvidence(normalized, index.get(base) ?? [])
+}
+
+/** body 백틱 경로 중 디스크에 존재하는 것(해석된 상대경로). */
+export function findExistingPathEvidence(body: string, projectRoot: string): string[] {
+  const hits: string[] = []
+  const seen = new Set<string>()
+  const basenameIndex = buildBasenameIndex(projectRoot)
+  for (const rel of extractBacktickPaths(body)) {
+    const resolved = resolvePathEvidence(projectRoot, rel, basenameIndex)
+    if (!resolved || seen.has(resolved)) continue
+    seen.add(resolved)
+    hits.push(resolved)
+  }
+  return hits
+}
+
+/**
+ * goals/ ↔ scripts/ (+ goals 본문 경로 증거) 를 대조해 드리프트 후보를 찾는다.
+ * @param projectRoot 경로 증거 해석 루트(기본: goalsDir 의 부모)
+ */
+export function findStatusDriftCandidates(
+  goalsDir: string,
+  scriptsDir: string,
+  projectRoot: string = dirname(goalsDir),
+): DriftCandidate[] {
   const out: DriftCandidate[] = []
   for (const g of listGoals(goalsDir)) {
     const status = (g.frontmatter.status ?? 'NOT_STARTED')
     if (status !== 'NOT_STARTED') continue
     const id = g.frontmatter.id
     if (typeof id !== 'number') continue
+
     const scriptFile = join(scriptsDir, `check-goal-${id}.mjs`)
-    if (!existsSync(scriptFile)) continue
-    let content: string
-    try {
-      content = readFileSync(scriptFile, 'utf-8')
-    } catch {
+    let hasMust = false
+    if (existsSync(scriptFile)) {
+      try {
+        hasMust = hasCustomGateAssertions(readFileSync(scriptFile, 'utf-8'))
+      } catch {
+        hasMust = false
+      }
+    }
+
+    if (hasMust) {
+      out.push({
+        id,
+        title: g.frontmatter.title ?? '',
+        status,
+        goalFile: g.filePath,
+        scriptFile,
+        reason:
+          'status: NOT_STARTED 인데 check-goal 게이트에 goal 고유 검증(코드 구현 흔적)이 있음 — 구현됐는데 status 만 안 바뀐 드리프트 의심',
+      })
       continue
     }
-    if (!hasCustomGateAssertions(content)) continue
-    out.push({
-      id,
-      title: g.frontmatter.title ?? '',
-      status,
-      goalFile: g.filePath,
-      scriptFile,
-      reason:
-        'status: NOT_STARTED 인데 check-goal 게이트에 goal 고유 검증(코드 구현 흔적)이 있음 — 구현됐는데 status 만 안 바뀐 드리프트 의심',
-    })
+
+    const pathHits = findExistingPathEvidence(g.body, projectRoot)
+    if (pathHits.length >= PATH_EVIDENCE_MIN) {
+      out.push({
+        id,
+        title: g.frontmatter.title ?? '',
+        status,
+        goalFile: g.filePath,
+        scriptFile: existsSync(scriptFile) ? scriptFile : '(no check-goal script)',
+        reason: `status: NOT_STARTED 인데 goals 본문 경로 증거 ${pathHits.length}건 존재(${pathHits.slice(0, 3).join(', ')}${pathHits.length > 3 ? '…' : ''}) — 구현됐는데 status 만 안 바뀐 드리프트 의심`,
+      })
+    }
   }
   return out
 }

--- a/src/lib/scan-secrets.ts
+++ b/src/lib/scan-secrets.ts
@@ -24,6 +24,85 @@ function isGenericApiKeyFalsePositive(matchText: string): boolean {
   return PLACEHOLDER_MARKER.test(value)
 }
 
+export type GitleaksIgnoreRule = {
+  /** repo-relative path (posix) */
+  path: string
+  /** gitleaks rule id ≈ our patternId (optional) */
+  rule?: string
+  line?: number
+}
+
+/**
+ * `.gitleaksignore` 파싱.
+ * 지원 형식:
+ * - `# comment`
+ * - `path:rule:line` 또는 `commitHash:path:rule:line` (gitleaks fingerprint)
+ * - `path` 단독
+ */
+export function parseGitleaksIgnore(content: string): GitleaksIgnoreRule[] {
+  const rules: GitleaksIgnoreRule[] = []
+  for (const raw of content.split(/\r?\n/)) {
+    const line = raw.trim()
+    if (!line || line.startsWith('#')) continue
+    const parts = line.split(':')
+    const hasCommit = /^[a-f0-9]{7,40}$/i.test(parts[0])
+    const lineText = parts[parts.length - 1]
+    const pathStart = hasCommit ? 1 : 0
+    // path:rule:line / commit:path:rule:line — 오른쪽부터 해석해 경로 안의 ':'를 보존한다.
+    if (parts.length - pathStart >= 3 && /^\d+$/.test(lineText)) {
+      const lineNo = Number(lineText)
+      const rule = parts[parts.length - 2]
+      const pathParts = parts.slice(pathStart, parts.length - 2)
+      const filePath = pathParts.join(':').replace(/\\/g, '/')
+      if (!filePath || !rule) continue
+      rules.push({
+        path: filePath,
+        rule,
+        line: lineNo,
+      })
+      continue
+    }
+    // bare path
+    rules.push({ path: line.replace(/\\/g, '/') })
+  }
+  return rules
+}
+
+export function loadGitleaksIgnoreRules(cwd: string): GitleaksIgnoreRule[] {
+  const fp = path.join(cwd, '.gitleaksignore')
+  if (!fs.existsSync(fp)) return []
+  try {
+    return parseGitleaksIgnore(fs.readFileSync(fp, 'utf-8'))
+  } catch {
+    // 선택적 allowlist를 읽지 못했을 때 탐지를 약화하지 않고 전체 finding을 유지한다.
+    return []
+  }
+}
+
+export function isFindingIgnoredByGitleaks(
+  finding: SecretFinding,
+  rules: GitleaksIgnoreRule[],
+): boolean {
+  if (rules.length === 0) return false
+  const file = finding.file.replace(/\\/g, '/')
+  for (const r of rules) {
+    if (r.path !== file) continue
+    if (r.rule && r.rule !== finding.patternId) continue
+    if (typeof r.line === 'number' && r.line !== finding.line) continue
+    return true
+  }
+  return false
+}
+
+/** allowlist 적용 — 매칭 finding 제거(gitleaks 와 동일 의도: 사람 확인 픽스처). */
+export function applyGitleaksIgnore(
+  findings: SecretFinding[],
+  rules: GitleaksIgnoreRule[],
+): SecretFinding[] {
+  if (rules.length === 0) return findings
+  return findings.filter((f) => !isFindingIgnoredByGitleaks(f, rules))
+}
+
 // #316: .env.example/.sample/.template 은 '시크릿 값 없는 커밋용 템플릿'(risk-policy.ts 의
 //   RISKY_TARGET_PATTERNS 예외·check-secure.ts 의 isSensitiveName(.example/.sample 제외)와 정합). 이 파일들의
 //   비주석 KEY=value placeholder(ghp_xxxx· secret_xxxx 등)는 진짜 시크릿이 아니라 예시값이다.
@@ -136,7 +215,14 @@ export function scanProjectForSecrets(cwd: string): ProjectSecretScan {
     }
   )
 
-  return { findings, scannedFiles, truncated: reasons.size > 0, truncationReasons: [...reasons] }
+  // dogfood: 레포 `.gitleaksignore` 존중(verify/secure/save 공통 경로)
+  const allowed = applyGitleaksIgnore(findings, loadGitleaksIgnoreRules(cwd))
+  return {
+    findings: allowed,
+    scannedFiles,
+    truncated: reasons.size > 0,
+    truncationReasons: [...reasons],
+  }
 }
 
 export type DraftScanResult = {

--- a/tests/goal-drift.test.ts
+++ b/tests/goal-drift.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { hasCustomGateAssertions, findStatusDriftCandidates } from '../src/lib/goal-drift.js'
+import {
+  hasCustomGateAssertions,
+  findStatusDriftCandidates,
+  extractBacktickPaths,
+  resolvePathEvidence,
+  PATH_EVIDENCE_MIN,
+} from '../src/lib/goal-drift.js'
 
 // `vhk goal sync` 가 생성하는 스캐폴드 게이트의 핵심(must 정의 + 주석 예시만 — 고유 검증 0).
 const SCAFFOLD = `#!/usr/bin/env node
@@ -25,10 +31,83 @@ describe('hasCustomGateAssertions', () => {
   })
 })
 
+describe('path evidence helpers', () => {
+  it('백틱에서 경로만 추출(URL·순수식별자 제외)', () => {
+    const body = [
+      '- `providers/image-openai.ts`',
+      '- `zod`',
+      '- `https://example.com`',
+      '- `poc/run.ts`',
+      '- `app/api/checkout-*`',
+    ].join('\n')
+    expect(extractBacktickPaths(body)).toEqual([
+      'providers/image-openai.ts',
+      'poc/run.ts',
+      'app/api/checkout-*',
+    ])
+  })
+
+  it('축약 경로 → lib/engine prefix 해석', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-path-ev-'))
+    try {
+      const target = path.join(root, 'lib', 'engine', 'providers')
+      fs.mkdirSync(target, { recursive: true })
+      fs.writeFileSync(path.join(target, 'image-openai.ts'), 'export {}\n')
+      expect(resolvePathEvidence(root, 'providers/image-openai.ts')).toBe(
+        'lib/engine/providers/image-openai.ts',
+      )
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('동일 basename 후보가 여럿이면 부모 경로가 일치하는 유일 후보만 선택', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-path-parent-'))
+    try {
+      fs.mkdirSync(path.join(root, 'packages', 'a', 'providers'), { recursive: true })
+      fs.mkdirSync(path.join(root, 'packages', 'b', 'adapters'), { recursive: true })
+      fs.writeFileSync(path.join(root, 'packages', 'a', 'providers', 'image.ts'), 'export {}\n')
+      fs.writeFileSync(path.join(root, 'packages', 'b', 'adapters', 'image.ts'), 'export {}\n')
+      expect(resolvePathEvidence(root, 'providers/image.ts')).toBe(
+        'packages/a/providers/image.ts',
+      )
+      expect(resolvePathEvidence(root, 'legacy/image.ts')).toBeNull()
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('부모 경로까지 같은 basename 후보가 여럿이면 오탐 대신 null', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-path-ambiguous-'))
+    try {
+      fs.mkdirSync(path.join(root, 'packages', 'a', 'providers'), { recursive: true })
+      fs.mkdirSync(path.join(root, 'packages', 'b', 'providers'), { recursive: true })
+      fs.writeFileSync(path.join(root, 'packages', 'a', 'providers', 'image.ts'), 'export {}\n')
+      fs.writeFileSync(path.join(root, 'packages', 'b', 'providers', 'image.ts'), 'export {}\n')
+      expect(resolvePathEvidence(root, 'providers/image.ts')).toBeNull()
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('글롭 checkout-* 매칭', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-glob-ev-'))
+    try {
+      const dir = path.join(root, 'app', 'api')
+      fs.mkdirSync(dir, { recursive: true })
+      fs.mkdirSync(path.join(dir, 'checkout-pdf'))
+      expect(resolvePathEvidence(root, 'app/api/checkout-*')).toBe('app/api/checkout-pdf')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
 describe('findStatusDriftCandidates', () => {
   function setup(
     goals: Record<string, string>,
-    scripts: Record<string, string>
+    scripts: Record<string, string>,
+    files: Record<string, string> = {},
   ): { root: string; gdir: string; sdir: string } {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-drift-'))
     const gdir = path.join(root, 'goals')
@@ -37,32 +116,78 @@ describe('findStatusDriftCandidates', () => {
     fs.mkdirSync(sdir)
     for (const [name, content] of Object.entries(goals)) fs.writeFileSync(path.join(gdir, name), content)
     for (const [name, content] of Object.entries(scripts)) fs.writeFileSync(path.join(sdir, name), content)
+    for (const [rel, content] of Object.entries(files)) {
+      const abs = path.join(root, ...rel.split('/'))
+      fs.mkdirSync(path.dirname(abs), { recursive: true })
+      fs.writeFileSync(abs, content)
+    }
     return { root, gdir, sdir }
   }
-  const goalCard = (id: number, status: string): string =>
-    `---\nvhk_format: 1\ntype: goal\nid: ${id}\ntitle: G${id}\nstatus: ${status}\npriority: P1\n---\n\n# Goal ${id}\n`
+  const goalCard = (id: number, status: string, body = ''): string =>
+    `---\nvhk_format: 1\ntype: goal\nid: ${id}\ntitle: G${id}\nstatus: ${status}\npriority: P1\n---\n\n# Goal ${id}\n${body}\n`
 
   it('NOT_STARTED + custom 게이트 → 드리프트로 잡음', () => {
     const { root, gdir, sdir } = setup({ '5-x.md': goalCard(5, 'NOT_STARTED') }, { 'check-goal-5.mjs': CUSTOM })
-    expect(findStatusDriftCandidates(gdir, sdir).map((x) => x.id)).toEqual([5])
+    expect(findStatusDriftCandidates(gdir, sdir, root).map((x) => x.id)).toEqual([5])
     fs.rmSync(root, { recursive: true, force: true })
   })
 
   it('NOT_STARTED + 스캐폴드 게이트 → 통과(오탐 0)', () => {
     const { root, gdir, sdir } = setup({ '6-y.md': goalCard(6, 'NOT_STARTED') }, { 'check-goal-6.mjs': SCAFFOLD })
-    expect(findStatusDriftCandidates(gdir, sdir)).toEqual([])
+    expect(findStatusDriftCandidates(gdir, sdir, root)).toEqual([])
     fs.rmSync(root, { recursive: true, force: true })
   })
 
   it('DONE + custom 게이트 → 통과(정상 완료)', () => {
     const { root, gdir, sdir } = setup({ '7-z.md': goalCard(7, 'DONE') }, { 'check-goal-7.mjs': CUSTOM })
-    expect(findStatusDriftCandidates(gdir, sdir)).toEqual([])
+    expect(findStatusDriftCandidates(gdir, sdir, root)).toEqual([])
     fs.rmSync(root, { recursive: true, force: true })
   })
 
   it('NOT_STARTED + 게이트 스크립트 없음 → 통과(아직 sync 안 한 goal)', () => {
     const { root, gdir, sdir } = setup({ '8-w.md': goalCard(8, 'NOT_STARTED') }, {})
-    expect(findStatusDriftCandidates(gdir, sdir)).toEqual([])
+    expect(findStatusDriftCandidates(gdir, sdir, root)).toEqual([])
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it(`NOT_STARTED + 본문 경로 증거 ≥${PATH_EVIDENCE_MIN} (스크립트 없음) → 드리프트`, () => {
+    const body = '## 완료조건\n- `poc/run.ts`\n- `lib/engine/providers/image-openai.ts`\n'
+    const { root, gdir, sdir } = setup(
+      { '2-engine.md': goalCard(2, 'NOT_STARTED', body) },
+      {},
+      {
+        'poc/run.ts': 'console.log(1)\n',
+        'lib/engine/providers/image-openai.ts': 'export {}\n',
+      },
+    )
+    const hits = findStatusDriftCandidates(gdir, sdir, root)
+    expect(hits.map((x) => x.id)).toEqual([2])
+    expect(hits[0].reason).toContain('경로 증거')
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('NOT_STARTED + 축약 경로 본문도 prefix 해석으로 드리프트', () => {
+    const body = '## 완료조건\n- `providers/image-openai.ts`\n- `providers/text-openai.ts`\n'
+    const { root, gdir, sdir } = setup(
+      { '2-engine.md': goalCard(2, 'NOT_STARTED', body) },
+      {},
+      {
+        'lib/engine/providers/image-openai.ts': 'export {}\n',
+        'lib/engine/providers/text-openai.ts': 'export {}\n',
+      },
+    )
+    expect(findStatusDriftCandidates(gdir, sdir, root).map((x) => x.id)).toEqual([2])
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('경로 증거 1건만 → 미탐 선호(오탐 방지)', () => {
+    const body = '- `poc/run.ts`\n'
+    const { root, gdir, sdir } = setup(
+      { '9-one.md': goalCard(9, 'NOT_STARTED', body) },
+      {},
+      { 'poc/run.ts': 'ok\n' },
+    )
+    expect(findStatusDriftCandidates(gdir, sdir, root)).toEqual([])
     fs.rmSync(root, { recursive: true, force: true })
   })
 

--- a/tests/scan-secrets.test.ts
+++ b/tests/scan-secrets.test.ts
@@ -10,6 +10,8 @@ import {
   downgradeTestFixtureFindings,
   isTestFixturePath,
   isEnvTemplateFile,
+  parseGitleaksIgnore,
+  applyGitleaksIgnore,
 } from '../src/lib/scan-secrets.js'
 import { MAX_SCAN_FILE_BYTES } from '../src/lib/scan-files.js'
 
@@ -63,6 +65,76 @@ describe('scan-secrets', () => {
     const actual = 'z'.repeat(24)
     const findings = findSecretsInLine(`api_key = "${actual}"`, 'script.py', 1)
     expect(findings.filter((f) => f.patternId === 'generic-api-key')).toHaveLength(1)
+  })
+
+  it('generic: sk_test_ 접두도 자동 예외 없이 탐지해 allowlist 검토를 강제', () => {
+    // 런타임에는 완성되지만 소스에는 연속 토큰을 남기지 않아 self-scan 픽스처가 되지 않게 한다.
+    const vendorTestKey = 'sk_' + 'test_' + '123456789'
+    expect(
+      findSecretsInLine(`apiKey: '${vendorTestKey}'`, 'tests/print-provider.test.ts', 40).filter(
+        (f) => f.patternId === 'generic-api-key',
+      ),
+    ).toHaveLength(1)
+  })
+
+  it('.gitleaksignore fingerprint 줄이 finding 을 제외', () => {
+    const rules = parseGitleaksIgnore(
+      [
+        '# comment',
+        '926592fa566af185868c41d1c971d00a626ea6a7:tests/print-provider.test.ts:generic-api-key:40',
+      ].join('\n'),
+    )
+    expect(rules).toEqual([
+      { path: 'tests/print-provider.test.ts', rule: 'generic-api-key', line: 40 },
+    ])
+    const kept = applyGitleaksIgnore(
+      [
+        {
+          patternId: 'generic-api-key',
+          patternName: 'Generic API Key',
+          severity: 'high' as const,
+          file: 'tests/print-provider.test.ts',
+          line: 40,
+          match: 'apiKey: ****',
+        },
+        {
+          patternId: 'generic-api-key',
+          patternName: 'Generic API Key',
+          severity: 'high' as const,
+          file: 'src/real.ts',
+          line: 1,
+          match: 'api_key: ****',
+        },
+      ],
+      rules,
+    )
+    expect(kept).toHaveLength(1)
+    expect(kept[0].file).toBe('src/real.ts')
+  })
+
+  it('.gitleaksignore 의 commit 없는 path:rule:line 형식도 파싱', () => {
+    expect(parseGitleaksIgnore('tests/x.test.ts:generic-api-key:7')).toEqual([
+      { path: 'tests/x.test.ts', rule: 'generic-api-key', line: 7 },
+    ])
+  })
+
+  it('scanProjectForSecrets 가 .gitleaksignore 를 적용', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-gitleaks-ignore-'))
+    try {
+      fs.mkdirSync(path.join(tmp, 'tests'), { recursive: true })
+      // 의도적으로 sk_live 가 아닌 긴 generic 값(벤더 test 접두 아닌 FP 경로)
+      const apiKey = 'z'.repeat(24)
+      fs.writeFileSync(path.join(tmp, 'tests', 'a.test.ts'), `apiKey: '${apiKey}'\n`, 'utf-8')
+      fs.writeFileSync(
+        path.join(tmp, '.gitleaksignore'),
+        `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:tests/a.test.ts:generic-api-key:1\n`,
+        'utf-8',
+      )
+      const { findings } = scanProjectForSecrets(tmp)
+      expect(findings.filter((f) => f.patternId === 'generic-api-key')).toHaveLength(0)
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
   })
 
   it('generic: 상태 접두어라도 실제 값 대입은 계속 탐지', () => {


### PR DESCRIPTION
## 요약
- check-goal 스크립트가 없는 소비자 레포에서도 goal 본문의 실재 경로로 상태 드리프트를 탐지합니다.
- 프로젝트의 .gitleaksignore를 공개 스캔 경로에서 존중합니다.
- 자동 test-key 예외를 제거하고, 3·4필드 fingerprint를 지원합니다.
- basename 탐색을 1회 색인으로 제한하고 부모 경로가 맞는 유일 후보만 인정합니다.

## 검증
- pnpm typecheck / lint / build
- 225 files, 2545 tests passed
- public boundary current/history PASS
- secret-pr-guard PASS
- pnpm audit: high 이상 0건 (low 2건)