### PR TITLE
fix: 로컬 게이트 복구 — 환경의존 테스트 격리 + 드리프트 오탐 제거 (112-T7)

### DIFF
--- a/src/lib/core-rules.test.ts
+++ b/src/lib/core-rules.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -12,6 +12,7 @@ import {
   type CoreRuleset,
 } from './core-rules.js'
 import { writeHomeConfig } from './home-config.js'
+import { useIsolatedHome, type IsolatedHome } from './test-support/isolated-home.js'
 
 const MINIMAL: CoreRuleset = {
   version: '0.1.0',
@@ -88,6 +89,14 @@ describe('applyMarkerBlock — 멱등 마커 교체', () => {
 })
 
 describe('generateCoreRulesContent', () => {
+  // generateCoreRulesContent 는 homeDir 인자가 없어 os.homedir() 를 그대로 탄다.
+  // 홈에 rulesFile 이 설정된 머신에서는 live 규칙이 실려 번들 스냅샷 단언이 깨지므로
+  // 홈을 격리해 번들 폴백 경로를 강제한다 (작업 단위 79).
+  let home: IsolatedHome
+
+  beforeEach(() => { home = useIsolatedHome('vhk-core-rules-content-') })
+  afterEach(() => { home.restore() })
+
   it('null 입력 시 마커 블록 반환', () => {
     const result = generateCoreRulesContent(null)
     expect(result).toContain(CORE_RULES_START_TAG)

--- a/src/lib/goal-drift.ts
+++ b/src/lib/goal-drift.ts
@@ -5,12 +5,19 @@ import { listGoals, type GoalStatus } from './goal-frontmatter.js'
 // Goal 43: goal 상태 ↔ 코드 현실 드리프트 게이트.
 //
 // 신호 A (원본): check-goal-<id>.mjs 에 custom must() 호출이 있는데 status: NOT_STARTED.
-// 신호 B (dogfood 2026-07-25): goals/*.md 본문 백틱 경로가 디스크에 존재하는데 NOT_STARTED.
-//   소비자 레포(aroo 등)는 check-goal 스크립트 없이 goals MD만 쓰는 경우가 많아
-//   신호 A만으로는 항상 0건(false negative). 경로 증거를 보조 신호로 추가.
+// 신호 B (작업 단위 112-T7, 2026-07-28): 카드 체크박스가 전부 완료인데 status: NOT_STARTED.
+// 신호 C (dogfood 2026-07-25, 폴백): 본문 백틱 경로가 디스크에 존재하는데 NOT_STARTED.
+//   소비자 레포(체크박스 없는 카드만 쓰는 경우)는 A·B 로 항상 0건(false negative)이라 남긴다.
+//
+// why 신호 C 가 폴백으로 밀렸나 (112-T7 실측):
+//   계획 카드는 "앞으로 고칠 파일"의 경로를 인용하고 그 경로는 당연히 이미 존재한다.
+//   즉 인용 경로의 존재는 구현 증거가 될 수 없고, 잘 쓴 계획 카드일수록 확실히 걸린다.
+//   실측에서 신규 계획 카드 14장이 100% 오탐이었다. 체크박스가 있는 카드는 체크 상태가
+//   훨씬 정확한 신호이므로, 경로 증거는 체크박스가 아예 없는 카드에서만 쓴다.
 //
 // 보수적 설계(거짓 양성보다 미탐 선호):
 //   - NOT_STARTED 만 본다. IN_PROGRESS/DONE/BLOCKED 는 대상 아님.
+//   - 체크박스는 **전부** 완료일 때만(진행 중 카드는 정상이므로 건드리지 않는다).
 //   - 경로 증거는 확정 히트 ≥ PATH_EVIDENCE_MIN 일 때만(단일 aspirational 경로 오탐 방지).
 //   - 경로 해석: exact → 흔한 prefix(lib/src/…) → basename 한정 탐색(노드 상한).
 
@@ -87,6 +94,30 @@ export interface DriftCandidate {
   goalFile: string
   scriptFile: string
   reason: string
+}
+
+/** 카드 본문의 마크다운 체크박스 집계. */
+export interface CheckboxTally {
+  total: number
+  checked: number
+}
+
+const CHECKBOX_LINE = /^\s*[-*]\s+\[( |x|X)\]\s/
+
+/**
+ * goal 카드 본문의 체크박스를 센다(티켓 · Completion Check 구분 없이 전부).
+ * 구분을 두지 않는 이유: "전부 완료" 판정이 목적이라 섹션이 늘어나도 더 엄격해질 뿐이다.
+ */
+export function tallyCheckboxes(body: string): CheckboxTally {
+  let total = 0
+  let checked = 0
+  for (const raw of body.split(/\r?\n/)) {
+    const m = CHECKBOX_LINE.exec(raw)
+    if (!m) continue
+    total++
+    if (m[1] !== ' ') checked++
+  }
+  return { total, checked }
 }
 
 /** 백틱 안 문자열이 파일/디렉터리 상대경로처럼 보이는지. */
@@ -294,6 +325,26 @@ export function findStatusDriftCandidates(
       continue
     }
 
+    const noScript = existsSync(scriptFile) ? scriptFile : '(no check-goal script)'
+
+    // 신호 B — 체크박스가 있는 카드는 체크 상태가 경로 인용보다 정확한 신호다.
+    const boxes = tallyCheckboxes(g.body)
+    if (boxes.total > 0) {
+      if (boxes.checked === boxes.total) {
+        out.push({
+          id,
+          title: g.frontmatter.title ?? '',
+          status,
+          goalFile: g.filePath,
+          scriptFile: noScript,
+          reason: `status: NOT_STARTED 인데 카드 체크박스 ${boxes.total}개가 전부 완료 표시 — 구현됐는데 status 만 안 바뀐 드리프트 의심`,
+        })
+      }
+      // 체크박스가 있으면 경로 증거는 보지 않는다 — 계획 카드의 인용 경로는 항상 존재하므로 오탐만 만든다.
+      continue
+    }
+
+    // 신호 C (폴백) — 체크박스가 아예 없는 카드에서만.
     const pathHits = findExistingPathEvidence(g.body, projectRoot)
     if (pathHits.length >= PATH_EVIDENCE_MIN) {
       out.push({
@@ -301,7 +352,7 @@ export function findStatusDriftCandidates(
         title: g.frontmatter.title ?? '',
         status,
         goalFile: g.filePath,
-        scriptFile: existsSync(scriptFile) ? scriptFile : '(no check-goal script)',
+        scriptFile: noScript,
         reason: `status: NOT_STARTED 인데 goals 본문 경로 증거 ${pathHits.length}건 존재(${pathHits.slice(0, 3).join(', ')}${pathHits.length > 3 ? '…' : ''}) — 구현됐는데 status 만 안 바뀐 드리프트 의심`,
       })
     }

--- a/src/lib/test-support/isolated-home.ts
+++ b/src/lib/test-support/isolated-home.ts
@@ -1,0 +1,55 @@
+/**
+ * isolated-home.ts — 테스트용 홈 디렉터리 격리 (작업 단위 79)
+ *
+ * why: `loadCoreRuleset()` 은 인자 없이 불리면 `os.homedir()` 아래
+ * `~/.vhk/config.json` 의 `rulesFile` 을 읽어 번들 스냅샷 대신 live 규칙 파일을 쓴다.
+ * 개발 머신에는 그 설정이 있고 CI 체크아웃에는 없으므로, 번들 스냅샷 내용을 단언하는
+ * 테스트가 CI 에서는 green 인데 로컬에서만 red 가 된다. 판정이 머신마다 갈리면
+ * 로컬 게이트도 CI 게이트도 신뢰할 수 없다.
+ *
+ * `os.homedir()` 는 POSIX 에서 `HOME`, Windows 에서 `USERPROFILE` 환경변수를 우선
+ * 참조한다(실측 확인). 둘 다 빈 임시 디렉터리로 덮으면 홈 설정이 있는 머신에서도
+ * 번들 폴백 경로가 강제된다. `VHK_RULES_FILE` 은 그보다 우선순위가 높으므로 같이 지운다.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+/** `os.homedir()` 가 참조하는 환경변수 (POSIX · Windows) */
+const HOME_ENV_KEYS = ['HOME', 'USERPROFILE'] as const
+
+/** `loadCoreRuleset` 이 홈 설정보다 먼저 보는 환경변수 */
+const OVERRIDE_ENV_KEYS = ['VHK_RULES_FILE'] as const
+
+export type IsolatedHome = {
+  /** 임시 홈 디렉터리 절대경로 */
+  dir: string
+  /** 환경변수를 원래대로 되돌리고 임시 디렉터리를 지운다 */
+  restore: () => void
+}
+
+export function useIsolatedHome(prefix = 'vhk-isolated-home-'): IsolatedHome {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+  const saved = new Map<string, string | undefined>()
+
+  for (const key of HOME_ENV_KEYS) {
+    saved.set(key, process.env[key])
+    process.env[key] = dir
+  }
+  for (const key of OVERRIDE_ENV_KEYS) {
+    saved.set(key, process.env[key])
+    delete process.env[key]
+  }
+
+  return {
+    dir,
+    restore() {
+      for (const [key, value] of saved) {
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      }
+      fs.rmSync(dir, { recursive: true, force: true })
+    },
+  }
+}

--- a/src/lib/test-support/repo-goals.ts
+++ b/src/lib/test-support/repo-goals.ts
@@ -1,0 +1,27 @@
+/**
+ * repo-goals.ts — "실물 레포 goals/" 회귀 가드의 실행 조건 (작업 단위 112-T7)
+ *
+ * why: `goals/` 는 `.gitignore` 에 있어 CI 체크아웃에는 아예 없다. 그런데 실물 goals/ 를
+ * 읽는 회귀 가드들은 디렉터리가 없으면 빈 결과를 비교하거나 "비적용 통과"로 빠져
+ * **CI 에서 무조건 통과**한다. 판정력이 로컬에만 있는데 초록으로 보이는 것이 더 위험하다
+ * (도그푸딩 #526 "차단이 로컬에서만"과 같은 형태).
+ *
+ * 그래서 그런 가드는 이 조건으로 `it.skipIf` 를 걸어 **건너뛴 사실이 보이게** 만든다.
+ * 로직 자체의 판정력은 같은 파일의 픽스처 기반 케이스가 CI 에서도 유지한다.
+ */
+
+import { existsSync, readdirSync } from 'node:fs'
+
+/** `<번호>-<슬러그>.md` 카드가 하나라도 있는 실물 goals 디렉터리인지. */
+export function repoGoalsPresent(goalsDir = 'goals'): boolean {
+  if (!existsSync(goalsDir)) return false
+  try {
+    return readdirSync(goalsDir).some((name) => /^\d+-.*\.md$/.test(name))
+  } catch {
+    // 권한·경합으로 못 읽으면 판정력이 없는 것과 같으므로 건너뛴다.
+    return false
+  }
+}
+
+/** 건너뛸 때 사람이 읽을 사유 — 테스트 제목에 붙여 쓴다. */
+export const REPO_GOALS_SKIP_NOTE = '로컬 전용 — goals/ 는 비추적이라 CI 에는 없다'

--- a/tests/check-goal-frontmatter.test.ts
+++ b/tests/check-goal-frontmatter.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os'
 import path from 'node:path'
 // tsc 는 tests/ 미검사 → .mjs 직접 import 안전(meta-gate.test.ts 선례).
 import { validateGoalFrontmatter } from '../scripts/check-goal-frontmatter.mjs'
+import { repoGoalsPresent, REPO_GOALS_SKIP_NOTE } from '../src/lib/test-support/repo-goals.js'
 
 const SCRIPT = path.join(process.cwd(), 'scripts', 'check-goal-frontmatter.mjs')
 
@@ -75,7 +76,11 @@ describe('check-goal-frontmatter e2e', () => {
     fs.rmSync(d, { recursive: true, force: true })
   })
 
-  it('실물 레포 goals/ 62건 — 필수 전부 충족(회귀)', () => {
-    execFileSync('node', [SCRIPT], { cwd: process.cwd(), encoding: 'utf-8', stdio: 'pipe' })
-  })
+  // 112-T7(b): goals/ 가 없으면 스크립트가 "비적용 통과"(exit 0)로 빠져 CI 에서 무조건 통과했다.
+  it.skipIf(!repoGoalsPresent())(
+    `실물 레포 goals/ — 필수 전부 충족(회귀 — ${REPO_GOALS_SKIP_NOTE})`,
+    () => {
+      execFileSync('node', [SCRIPT], { cwd: process.cwd(), encoding: 'utf-8', stdio: 'pipe' })
+    },
+  )
 })

--- a/tests/goal-drift.test.ts
+++ b/tests/goal-drift.test.ts
@@ -7,8 +7,10 @@ import {
   findStatusDriftCandidates,
   extractBacktickPaths,
   resolvePathEvidence,
+  tallyCheckboxes,
   PATH_EVIDENCE_MIN,
 } from '../src/lib/goal-drift.js'
+import { repoGoalsPresent, REPO_GOALS_SKIP_NOTE } from '../src/lib/test-support/repo-goals.js'
 
 // `vhk goal sync` 가 생성하는 스캐폴드 게이트의 핵심(must 정의 + 주석 예시만 — 고유 검증 0).
 const SCAFFOLD = `#!/usr/bin/env node
@@ -191,7 +193,63 @@ describe('findStatusDriftCandidates', () => {
     fs.rmSync(root, { recursive: true, force: true })
   })
 
-  it('실제 repo goals/ ↔ scripts/ 드리프트 0 (회귀 가드)', () => {
-    expect(findStatusDriftCandidates('goals', 'scripts')).toEqual([])
+  it('NOT_STARTED + 체크박스 전부 완료 → 드리프트 (경로 증거 없이도)', () => {
+    const body = '## 티켓\n- [x] **T1** 하나\n- [x] **T2** 둘\n'
+    const { root, gdir, sdir } = setup({ '10-done.md': goalCard(10, 'NOT_STARTED', body) }, {})
+    const hits = findStatusDriftCandidates(gdir, sdir, root)
+    expect(hits.map((x) => x.id)).toEqual([10])
+    expect(hits[0].reason).toContain('체크박스')
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('NOT_STARTED + 체크박스 일부만 완료 → 통과(진행 중은 드리프트 아님)', () => {
+    const body = '## 티켓\n- [x] **T1** 하나\n- [ ] **T2** 둘\n'
+    const { root, gdir, sdir } = setup({ '11-partial.md': goalCard(11, 'NOT_STARTED', body) }, {})
+    expect(findStatusDriftCandidates(gdir, sdir, root)).toEqual([])
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  // 112-T7(a) 회귀: 계획 카드는 "앞으로 고칠 파일" 경로를 인용하고 그 경로는 이미 존재한다.
+  // 예전 구현은 이것만으로 드리프트 판정해 신규 계획 카드 14장이 100% 오탐이었다.
+  it('NOT_STARTED + 미완 체크박스 + 실재 경로 인용 → 통과(계획 카드 오탐 0)', () => {
+    const body = [
+      '## 티켓',
+      '- [ ] **T1** `src/commands/goal.ts` 수정',
+      '- [ ] **T2** `tests/goal.test.ts` 보강',
+    ].join('\n')
+    const { root, gdir, sdir } = setup(
+      { '12-plan.md': goalCard(12, 'NOT_STARTED', body) },
+      {},
+      { 'src/commands/goal.ts': 'export {}\n', 'tests/goal.test.ts': 'export {}\n' },
+    )
+    expect(findStatusDriftCandidates(gdir, sdir, root)).toEqual([])
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('체크박스가 전부 완료여도 status 가 DONE 이면 통과', () => {
+    const body = '## 티켓\n- [x] **T1** 하나\n'
+    const { root, gdir, sdir } = setup({ '13-ok.md': goalCard(13, 'DONE', body) }, {})
+    expect(findStatusDriftCandidates(gdir, sdir, root)).toEqual([])
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  // 112-T7(b): goals/ 가 비추적이라 CI 에는 없다 → 빈 배열끼리 비교하며 무조건 통과하던 가드.
+  // 판정력이 로컬에만 있다는 사실이 보이도록 조건부 실행으로 분리한다.
+  it.skipIf(!repoGoalsPresent())(
+    `실제 repo goals/ ↔ scripts/ 드리프트 0 (회귀 가드 — ${REPO_GOALS_SKIP_NOTE})`,
+    () => {
+      expect(findStatusDriftCandidates('goals', 'scripts')).toEqual([])
+    },
+  )
+})
+
+describe('tallyCheckboxes', () => {
+  it('체크·미체크를 세고 체크박스가 아닌 줄은 무시', () => {
+    const body = ['- [x] 완료', '- [ ] 미완', '* [X] 대문자도 완료', '- 그냥 항목', '텍스트'].join('\n')
+    expect(tallyCheckboxes(body)).toEqual({ total: 3, checked: 2 })
+  })
+
+  it('체크박스가 없으면 0/0', () => {
+    expect(tallyCheckboxes('# 제목\n본문\n')).toEqual({ total: 0, checked: 0 })
   })
 })

--- a/tests/init-core-rules-warn.test.ts
+++ b/tests/init-core-rules-warn.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { useIsolatedHome, type IsolatedHome } from '../src/lib/test-support/isolated-home.js'
 
 vi.mock('inquirer', () => ({
   default: {
@@ -13,14 +14,15 @@ vi.mock('inquirer', () => ({
 
 describe('vhk init — 범용 규칙 소스 가시화', () => {
   let originalCwd: string
-  let originalRulesFile: string | undefined
+  let home: IsolatedHome
   let dir: string
   let logs: string[]
 
   beforeEach(() => {
     originalCwd = process.cwd()
-    originalRulesFile = process.env.VHK_RULES_FILE
-    delete process.env.VHK_RULES_FILE
+    // init 은 loadCoreRuleset() 을 인자 없이 부르므로 홈 설정이 있는 머신에서는
+    // 번들 폴백 대신 live 규칙이 실린다. 홈을 격리해 판정을 머신 독립으로 만든다 (작업 단위 79).
+    home = useIsolatedHome('vhk-init-core-warn-home-')
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-init-core-warn-'))
     process.chdir(dir)
     logs = []
@@ -31,8 +33,7 @@ describe('vhk init — 범용 규칙 소스 가시화', () => {
   afterEach(() => {
     process.chdir(originalCwd)
     fs.rmSync(dir, { recursive: true, force: true })
-    if (originalRulesFile === undefined) delete process.env.VHK_RULES_FILE
-    else process.env.VHK_RULES_FILE = originalRulesFile
+    home.restore()
     vi.restoreAllMocks()
   })
 

--- a/tests/meta-gate.test.ts
+++ b/tests/meta-gate.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path'
 // tsconfig include=src/** 라 tsc --noEmit(M.1)는 tests/ 미검사 → .mjs 직접 import 가 게이트를 깨지 않음.
 // @ts-expect-error — _lib.mjs 는 순수 JS(타입 선언 없음). vitest(esbuild)는 transpile-only 라 런타임 OK.
 import { isStubGate, parseGoalMeta, findCompletedStubGates } from '../scripts/_lib.mjs'
+import { repoGoalsPresent, REPO_GOALS_SKIP_NOTE } from '../src/lib/test-support/repo-goals.js'
 
 // `vhk goal sync` 가 백필하는 실제 스캐폴드의 핵심(generateGateScript, src/commands/goal.ts:444).
 // 마커 `고유 검증 (직접 추가)` + 주석 예시 + 닫는 블록만 = 고유 검증 0.
@@ -138,7 +139,11 @@ describe('findCompletedStubGates', () => {
     fs.rmSync(root, { recursive: true, force: true })
   })
 
-  it('실제 repo goals/ ↔ scripts/ : 완료-스텁 0 (회귀 가드)', () => {
-    expect(findCompletedStubGates('goals', 'scripts')).toEqual([])
-  })
+  // 112-T7(b): goals/ 비추적 → CI 체크아웃에 없어 빈 배열끼리 비교하며 무조건 통과하던 가드.
+  it.skipIf(!repoGoalsPresent())(
+    `실제 repo goals/ ↔ scripts/ : 완료-스텁 0 (회귀 가드 — ${REPO_GOALS_SKIP_NOTE})`,
+    () => {
+      expect(findCompletedStubGates('goals', 'scripts')).toEqual([])
+    },
+  )
 })


### PR DESCRIPTION
로컬 `pnpm test:run` 이 4건 red 라 `vhk verify` 가 red 가 되고, 그 결과 `vhk receipt` 가 BLOCK 을 내 작업 단위를 하나도 닫을 수 없는 상태였다. 이 PR 이 그 선결 조건을 푼다.

## 무엇을 고쳤나

### A. core-rules 3건 — 판정이 머신마다 갈렸다 (작업 단위 79)

`loadCoreRuleset()` 은 인자 없이 불리면 `os.homedir()` 아래 `~/.vhk/config.json` 의 `rulesFile` 을 읽는다. 개발 머신에는 그 설정이 있어 **live 규칙**이 실리고, CI 체크아웃에는 없어 **번들 스냅샷**으로 폴백한다. 그래서 번들 스냅샷 내용을 단언하는 테스트가 CI 는 green 인데 로컬만 red 였다.

`os.homedir()` 가 POSIX 에서 `HOME`, Windows 에서 `USERPROFILE` 을 우선 참조하는 것을 실측으로 확인하고, 임시 홈으로 덮는 테스트 헬퍼(`src/lib/test-support/isolated-home.ts`)를 추가해 두 테스트가 번들 경로를 강제하게 했다. **프로덕션 시그니처 변경 0.**

### B. goal-drift 1건 = 작업 단위 112-T7 (a)

`findStatusDriftCandidates` 가 "본문에 실재하는 파일 경로가 인용됨 + status NOT_STARTED" 를 구현 증거로 판정했다. 그런데 계획 카드는 원래 앞으로 고칠 파일의 경로를 인용하고 그 경로는 당연히 이미 존재한다 — 즉 잘 쓴 계획 카드일수록 확실히 걸린다. **실측에서 신규 계획 카드 14장이 100% 오탐이었다.**

| 신호 | 조건 | 상태 |
|---|---|---|
| A | `check-goal-<id>.mjs` 에 고유 `must()` 호출 + NOT_STARTED | 변경 없음 |
| B | 카드 체크박스가 **전부** 완료 + NOT_STARTED | **신설** |
| C | 본문 경로 증거 ≥2 + NOT_STARTED | **체크박스 없는 카드 전용 폴백으로 강등** |

C 를 삭제하지 않고 폴백으로 남긴 이유: 체크박스를 안 쓰는 소비자 레포에서 A·B 가 항상 0건이 되는 미탐을 막기 위해서다. 진행 중(일부만 체크)은 정상이므로 B 는 전부 완료일 때만 발동한다.

실측: **오탐 14건 → 0건.**

### C. 죽은 회귀 가드 3건 = 112-T7 (b) 전수 확인

`goals/` 가 `.gitignore` 에 있어 CI 체크아웃에는 없다. 실물 `goals/` 를 읽는 회귀 가드는 빈 결과끼리 비교하거나 "비적용 통과"(exit 0)로 빠져 **CI 에서 무조건 통과**하고 있었다. 판정력이 로컬에만 있는데 초록으로 보이는 것이 더 위험하다.

| 파일 | 죽은 이유 | 조치 |
|---|---|---|
| `tests/goal-drift.test.ts` | 빈 배열끼리 비교 | `it.skipIf(!repoGoalsPresent())` |
| `tests/meta-gate.test.ts` | 빈 배열끼리 비교 | 〃 |
| `tests/check-goal-frontmatter.test.ts` | 스크립트가 "비적용 통과" | 〃 |
| `tests/gen-goals-index.test.ts` | — | 이미 픽스처 기반, 해당 없음 |

"CI 에서도 판정력을 갖게 픽스처화" 대신 "로컬 전용임을 명시"를 택했다. 로직 자체의 판정력은 같은 파일의 픽스처 케이스가 이미 CI 에서 유지하고 있고, 실물 카드 가드까지 픽스처로 옮기면 *실제 카드가 규칙을 지키는가* 라는 원래 질문이 사라진다.

## 검증 결과

| 검사 | 결과 |
|---|---|
| `pnpm typecheck` | 통과 |
| `pnpm lint` | 통과 |
| `pnpm test:run` | 통과 — 225 파일 / 2551건 (수정 전 4건 red) |
| `pnpm boundary:check` | 통과 — npm 10개 · Git 593개 |
| 드리프트 실측 | 14건 → 0건 |

## 짚어둘 것

**충족 불가능한 기록 게이트.** `scripts/check-records.mjs` 는 코드 커밋 시 `docs/log/<날짜>-*.md` 스테이지를 요구하는데 `docs/log/` 는 `.gitignore:41` 에 등록돼 있어 **스테이지 자체가 불가능**하다. 즉 현재 모든 코드 커밋이 `[skip-record]` 우회를 강제당한다. 이 PR 의 커밋도 그 사유를 메시지에 명기하고 우회했다. C 항의 "죽은 검사"와 같은 부류라 작업 단위 신설 후보로 남긴다.

머지 시 squash 대신 merge 커밋 사용 (squash가 작성자 이메일을 교체한 전례 있음)
