### PR TITLE
fix: goal next 가 제거된 상태 문서 디렉터리를 되살리지 않게 (112-T2·T3·T6)

### DIFF
--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -126,6 +126,17 @@ function printSkippedGoalWarnings(skipped: ReturnType<typeof findSkippedGoalFile
   }
 }
 
+/** active goal 한 건의 사람용 요약 — peek 과 next(상태 문서 미도입 경로)가 공유한다. */
+function printActiveGoalSummary(activeId: number, active: ParsedGoal): void {
+  console.log(`  ➡️  Goal ${activeId} — ${active.frontmatter.title ?? ''}`)
+  console.log(
+    chalk.dim(
+      `     status: ${active.frontmatter.status ?? 'NOT_STARTED'}  ·  priority: ${active.frontmatter.priority ?? '--'}`
+    )
+  )
+  console.log(chalk.dim(`     file: ${active.filePath}`))
+}
+
 export async function goalNext(cwd: string = process.cwd()): Promise<void> {
   if (!ensureNotHardStopped('goal next')) return // HARD_STOP 활성 시 next-task.md 변경 차단
   console.log(chalk.bold(`\n${ko.goal.nextTitle}\n`))
@@ -143,6 +154,20 @@ export async function goalNext(cwd: string = process.cwd()): Promise<void> {
   }
   const active = goals.find((g) => g.frontmatter.id === activeId)
   if (!active) return
+
+  // 112-T2: 없는 상태 문서 디렉터리를 새로 만들지 않는다.
+  // why: docs/state/ 를 의도적으로 제거한 레포(공개 경계 정리)에서 next 가 디렉터리를 되살리면
+  // 작업 상태의 원본이 둘로 갈린다 — 로드맵·카드가 원본인데 next-task.md 가 또 하나 생긴다.
+  // 도입 여부는 `vhk goal init` 이 정하고, next 는 이미 도입한 프로젝트에서만 갱신한다.
+  const stateDirAbs = join(cwd, STATE_DIR)
+  if (!existsSync(stateDirAbs)) {
+    printActiveGoalSummary(activeId, active)
+    console.log('')
+    console.log(chalk.dim(`  ${ko.goal.stateDirAbsent(STATE_DIR)}`))
+    console.log(chalk.dim(`  ${ko.goal.stateDirAbsentHint(STATE_DIR)}`))
+    return
+  }
+
   const ts = new Date().toISOString()
   const text = [
     '# Next Task',
@@ -157,7 +182,6 @@ export async function goalNext(cwd: string = process.cwd()): Promise<void> {
     '```',
     '',
   ].join('\n')
-  mkdirSync(join(cwd, STATE_DIR), { recursive: true })
   // Goal 78: 덮어쓰기 전 기존 next-task.md 백업 — 조회 의도로 next 를 눌러도 수동 편집 복구 가능.
   // best-effort(백업 실패가 next 본기능을 막지 않음). 수동 편집 여부는 auto-update 마커 부재로 휴리스틱 판정.
   const nextTaskRel = join(STATE_DIR, 'next-task.md')
@@ -201,13 +225,7 @@ export async function goalPeek(cwd: string = process.cwd()): Promise<void> {
   }
   const active = goals.find((g) => g.frontmatter.id === activeId)
   if (!active) return
-  console.log(`  ➡️  Goal ${activeId} — ${active.frontmatter.title ?? ''}`)
-  console.log(
-    chalk.dim(
-      `     status: ${active.frontmatter.status ?? 'NOT_STARTED'}  ·  priority: ${active.frontmatter.priority ?? '--'}`
-    )
-  )
-  console.log(chalk.dim(`     file: ${active.filePath}`))
+  printActiveGoalSummary(activeId, active)
   console.log(chalk.dim('\n  (읽기 전용 — next-task.md 미변경. 갱신하려면 vhk goal next)'))
 }
 

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -639,6 +639,10 @@ export const ko = {
     driftClean: 'goal 상태 드리프트 없음 (구현 흔적 있는데 NOT_STARTED 인 goal 0건)',
     driftFound: (n: number) =>
       `드리프트 의심 ${n}건 — check-goal 게이트에 goal 고유 검증이 있는데 status: NOT_STARTED:`,
+    stateDirAbsent: (dir: string) =>
+      `${dir}/ 가 없어 상태 문서를 쓰지 않고 조회만 했습니다 — 이 프로젝트는 작업 상태를 다른 곳에서 관리합니다.`,
+    stateDirAbsentHint: (dir: string) =>
+      `${dir}/ 를 쓰려면 vhk goal init 으로 먼저 만드세요 (next 는 없는 디렉터리를 새로 만들지 않습니다).`,
   },
   watch: {
     title: '👁️  무인 세션 정지 감시',

--- a/src/index.ts
+++ b/src/index.ts
@@ -853,7 +853,7 @@ goalCmd
 goalCmd
   .command('next')
   .alias('다음')
-  .description('active goal 자동 선택 → docs/state/next-task.md 갱신 (덮어쓰기 전 자동 백업)')
+  .description('active goal 자동 선택 → docs/state/ 가 있으면 next-task.md 갱신 (덮어쓰기 전 자동 백업), 없으면 조회만')
   .action(async () => { await goalNext() })
 
 goalCmd

--- a/tests/goal-atomic.test.ts
+++ b/tests/goal-atomic.test.ts
@@ -38,6 +38,7 @@ describe('goal.ts atomic 쓰기 (Goal 40)', () => {
   it('goalNext — next-task.md 내용 정확 + temp 잔여 0', async () => {
     const dir = tmpProject('next')
     makeGoalFile(dir, 1, 'NOT_STARTED')
+    mkdirSync(join(dir, 'docs', 'state'), { recursive: true }) // 112-T2: next 는 없는 상태 디렉터리를 만들지 않는다
     process.chdir(dir)
     try {
       const { goalNext } = await import('../src/commands/goal.js')

--- a/tests/goal-hardstop.test.ts
+++ b/tests/goal-hardstop.test.ts
@@ -42,6 +42,9 @@ describe('goal 명령군 HARD_STOP 가드 (Goal 34)', () => {
   it('HARD_STOP 활성 → goalNext 가 next-task.md 를 쓰지 않는다', async () => {
     const dir = tmpProject('next-blocked')
     makeGoalFile(dir, 0, 'NOT_STARTED')
+    // 상태 디렉터리를 미리 둔다 — 없으면 112-T2 의 "미도입 프로젝트" 경로로 빠져
+    // HARD_STOP 이 아니라 그 이유로 안 쓰게 되어 가드를 검증하지 못한다.
+    mkdirSync(join(dir, 'docs', 'state'), { recursive: true })
     writeHardStop(dir)
     process.chdir(dir)
     try {
@@ -57,6 +60,7 @@ describe('goal 명령군 HARD_STOP 가드 (Goal 34)', () => {
   it('HARD_STOP 없으면 goalNext 정상 동작(next-task.md 생성) — 회귀 0', async () => {
     const dir = tmpProject('next-ok')
     makeGoalFile(dir, 0, 'NOT_STARTED')
+    mkdirSync(join(dir, 'docs', 'state'), { recursive: true }) // 112-T2: next 는 없는 상태 디렉터리를 만들지 않는다
     process.chdir(dir)
     try {
       const { goalNext } = await import('../src/commands/goal.js')

--- a/tests/goal.test.ts
+++ b/tests/goal.test.ts
@@ -28,6 +28,12 @@ function makeGoalFile(dir: string, id: number, status: string): void {
   )
 }
 
+// 112-T2: goal next 는 없는 docs/state/ 를 새로 만들지 않는다.
+// 쓰기 경로를 검증하려면 프로젝트가 상태 문서를 이미 도입한 상태여야 한다.
+function adoptStateDir(dir: string): void {
+  mkdirSync(join(dir, 'docs', 'state'), { recursive: true })
+}
+
 describe('selectActiveId', () => {
   it('IN_PROGRESS 우선', async () => {
     const { selectActiveId } = await import('../src/commands/goal.js')
@@ -154,6 +160,7 @@ describe('goalNext', () => {
     const dir = tmpProject('next')
     makeGoalFile(dir, 0, 'DONE')
     makeGoalFile(dir, 1, 'NOT_STARTED')
+    adoptStateDir(dir)
     process.chdir(dir)
     try {
       const { goalNext } = await import('../src/commands/goal.js')
@@ -170,11 +177,65 @@ describe('goalNext', () => {
   it('모든 goal DONE 이면 next-task.md 갱신 안 함', async () => {
     const dir = tmpProject('next-done')
     makeGoalFile(dir, 0, 'DONE')
+    adoptStateDir(dir)
     process.chdir(dir)
     try {
       const { goalNext } = await import('../src/commands/goal.js')
       await goalNext()
       expect(existsSync(join(dir, 'docs/state/next-task.md'))).toBe(false)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  // 112-T2/T6: 공개 경계 정리로 docs/state/ 를 제거한 레포에서 next 가 디렉터리를 되살리면
+  // 작업 상태의 원본이 로드맵과 next-task.md 둘로 갈린다.
+  it('docs/state/ 가 없으면 디렉터리를 만들지 않는다 (원본 이원화 방지)', async () => {
+    const dir = tmpProject('next-nostate')
+    makeGoalFile(dir, 1, 'NOT_STARTED')
+    process.chdir(dir)
+    try {
+      const { goalNext } = await import('../src/commands/goal.js')
+      await goalNext()
+      expect(existsSync(join(dir, 'docs', 'state'))).toBe(false)
+      expect(existsSync(join(dir, 'docs', 'state', 'next-task.md'))).toBe(false)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('docs/state/ 가 없어도 active goal 은 안내한다 (조용한 무동작 금지)', async () => {
+    const dir = tmpProject('next-nostate-out')
+    makeGoalFile(dir, 1, 'NOT_STARTED')
+    process.chdir(dir)
+    const logs: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((m?: unknown) => { logs.push(String(m)) })
+    try {
+      const { goalNext } = await import('../src/commands/goal.js')
+      await goalNext()
+      const out = logs.join('\n')
+      expect(out).toContain('Goal 1')
+      expect(out).toContain('docs/state')
+      expect(out).toContain('vhk goal init')
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('docs/state/ 가 이미 있으면 종전대로 갱신한다 (기본 경로 회귀 0)', async () => {
+    const dir = tmpProject('next-withstate')
+    makeGoalFile(dir, 3, 'IN_PROGRESS')
+    adoptStateDir(dir)
+    process.chdir(dir)
+    try {
+      const { goalNext } = await import('../src/commands/goal.js')
+      await goalNext()
+      const text = readFileSync(join(dir, 'docs/state/next-task.md'), 'utf-8')
+      expect(text).toContain('Goal 3')
+      expect(text).toContain('via `vhk goal next`')
     } finally {
       process.chdir(origCwd)
       rmSync(dir, { recursive: true, force: true })


### PR DESCRIPTION
작업 단위 112(작업 관리 체계 복구)의 남은 구현 티켓 T2·T3·T6. T1·T4·T5 는 직전 세션에서 이미 끝나 카드 체크만 맞췄고, T7 은 PR #539 에 있다.

## 문제

`vhk goal next` 는 `docs/state/` 를 무조건 `mkdirSync` 하고 `next-task.md` 를 썼다. 2026-07-27 공개 경계 정리로 `docs/state/` 를 제거한 이 저장소에서는 next 를 한 번 누를 때마다 디렉터리가 되살아나 **작업 상태의 원본이 둘로 갈렸다** — 로드맵·카드가 원본인데 `next-task.md` 라는 두 번째 원본이 계속 생겼다.

## T2 — 조치

| 상황 | 동작 |
|---|---|
| `docs/state/` 있음 | 종전과 완전히 동일 (백업 → 원자적 갱신) |
| `docs/state/` 없음 | active goal 안내 + 왜 안 썼는지·도입 방법 출력, **디렉터리 생성 0** |

도입 여부를 정하는 주체는 `vhk goal init` 이다. `next` 는 이미 도입한 프로젝트에서만 갱신한다 — 조회 성격의 명령이 프로젝트 구조를 바꾸지 않게 하는 것이 요지다. 조용히 아무것도 안 하면 "고장난 것"으로 읽히므로 사유와 다음 행동을 같이 출력한다(`ko.ts` 메시지 2개 추가).

peek 과 next 가 같은 요약을 내므로 `printActiveGoalSummary` 로 묶었다. `vhk goal next` 의 명령 설명도 실제 동작에 맞게 고쳤다.

**호환성:** 명령 이름·플래그·파일 경로 변경 0.

## T3 — `goal sync` 백필 검증

카드 52장 대 검사 스크립트 29개로 20개가 비어 있었다.

```
vhk goal sync
  📊 created=20 skipped=29
```

누락분이 전부 백필됐고 `git status` 는 깨끗했다 — `goals/` 와 `scripts/check-goal-<번호>.mjs` 가 둘 다 비추적이라 의도대로다.

## T6 — 회귀 테스트

| 테스트 | 확인 |
|---|---|
| `docs/state/` 없음 | 디렉터리 미생성 (원본 이원화 방지) |
| `docs/state/` 없음 | 그래도 active goal 안내 (조용한 무동작 금지) |
| `docs/state/` 있음 | 종전대로 갱신 (기본 경로 회귀 0) |

기존 next 테스트 3건은 상태 문서를 이미 도입한 프로젝트를 전제하도록 셋업을 보강했다. 특히 HARD_STOP 가드 테스트는 상태 디렉터리를 미리 두지 않으면 가드가 아니라 이번 변경 때문에 안 쓰게 되어 **가드 자체를 검증하지 못한다.**

## 검증 결과

| 검사 | 결과 |
|---|---|
| `pnpm typecheck` | 통과 |
| `pnpm lint` | 통과 |
| `pnpm boundary:check` | 통과 — npm 10개 · Git 591개 |
| goal 관련 4개 파일 | 통과 — 69건 |
| `pnpm test:run` | **4건 red** (아래 참조) |

**red 4건의 정체.** 전부 이 변경 이전부터 있던 로컬 전용 실패이고, **PR #539 에서 이미 고쳤다.**

- `src/lib/core-rules.test.ts` 1건 · `tests/init-core-rules-warn.test.ts` 2건 — 개발 머신의 홈 규칙 설정에 의존해 로컬만 red / CI green
- `tests/goal-drift.test.ts` 1건 — 계획 카드 오탐

이 브랜치는 지시대로 `origin/main` 에서 새로 땄기 때문에 #539 의 수정이 들어 있지 않다. 네 실패 모두 CI 에서는 원래 통과하므로 이 PR 의 CI 판정에는 영향이 없다. 숨기지 않고 그대로 적는다.

## 사람 몫

`vhk goal done` 은 아직 안 돌렸다 — 완료 판정은 머지 후에.

머지 시 squash 대신 merge 커밋 사용 (squash가 작성자 이메일을 교체한 전례 있음)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
  - `vhk goal next`가 상태 디렉터리가 없을 때 디렉터리와 파일을 자동 생성하지 않고, 활성 goal 요약과 안내만 표시합니다.
  - 상태 디렉터리가 존재하면 기존처럼 `next-task.md`를 갱신합니다.
  - `goal next`와 `goal peek`의 활성 goal 출력 형식을 통일했습니다.
  - 명령어 안내에 상태 디렉터리 부재 시 조회만 수행된다는 설명을 추가했습니다.
  - 상태 디렉터리 생성을 위해 `vhk goal init`을 사용하도록 안내합니다.

- **버그 수정**
  - 상태 문서가 없는 프로젝트에서 불필요한 디렉터리와 파일이 생성되는 문제를 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->