### PR TITLE
docs: 진입점 배선 + 죽은 포인터 정리 (113-T3·T4·T6)

### DIFF
--- a/.agents/rules/vhk-rules.md
+++ b/.agents/rules/vhk-rules.md
@@ -6,6 +6,14 @@
 ## 필수 참조
 - docs/PRD.md · docs/ARCHITECTURE.md · CLAUDE.md · RULES.md
 
+## 세션 시작 필독
+> 이 절은 진입점이다. 어떤 도구로 세션을 열든 여기부터 읽는다 (ADR-010 §3).
+
+- **현 사이클 원본:** [docs/roadmap/2.x-roadmap.md](docs/roadmap/2.x-roadmap.md) — 작업 단위·순서·릴리스 종료 조건 전량. 작업 시작 전 여기부터 읽는다.
+- **수용 기준:** [docs/PRD-2.x.md](docs/PRD-2.x.md)
+- 실행 단위인 `goals/*.md` 카드와 `scripts/check-goal-<번호>.mjs` 는 위 원본에서 파생된 **비추적** 산출물이다. 소실되면 원본에서 재생성하고 `vhk goal sync` 로 검사 스크립트를 백필한다.
+- 로컬 작업 상태는 추적되지 않는 `.vhk/context.md` 가 SoT다. 원본 문서와 혼동하지 않는다.
+
 ## 기술 스택
 > 변경 시 ADR(docs/adr/) 필수.
 

--- a/.clinerules/vhk-rules.md
+++ b/.clinerules/vhk-rules.md
@@ -6,6 +6,14 @@
 ## 필수 참조
 - docs/PRD.md · docs/ARCHITECTURE.md · CLAUDE.md · RULES.md
 
+## 세션 시작 필독
+> 이 절은 진입점이다. 어떤 도구로 세션을 열든 여기부터 읽는다 (ADR-010 §3).
+
+- **현 사이클 원본:** [docs/roadmap/2.x-roadmap.md](docs/roadmap/2.x-roadmap.md) — 작업 단위·순서·릴리스 종료 조건 전량. 작업 시작 전 여기부터 읽는다.
+- **수용 기준:** [docs/PRD-2.x.md](docs/PRD-2.x.md)
+- 실행 단위인 `goals/*.md` 카드와 `scripts/check-goal-<번호>.mjs` 는 위 원본에서 파생된 **비추적** 산출물이다. 소실되면 원본에서 재생성하고 `vhk goal sync` 로 검사 스크립트를 백필한다.
+- 로컬 작업 상태는 추적되지 않는 `.vhk/context.md` 가 SoT다. 원본 문서와 혼동하지 않는다.
+
 ## 기술 스택
 > 변경 시 ADR(docs/adr/) 필수.
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -6,6 +6,14 @@
 ## 필수 참조
 - docs/PRD.md · docs/ARCHITECTURE.md · CLAUDE.md · RULES.md
 
+## 세션 시작 필독
+> 이 절은 진입점이다. 어떤 도구로 세션을 열든 여기부터 읽는다 (ADR-010 §3).
+
+- **현 사이클 원본:** [docs/roadmap/2.x-roadmap.md](docs/roadmap/2.x-roadmap.md) — 작업 단위·순서·릴리스 종료 조건 전량. 작업 시작 전 여기부터 읽는다.
+- **수용 기준:** [docs/PRD-2.x.md](docs/PRD-2.x.md)
+- 실행 단위인 `goals/*.md` 카드와 `scripts/check-goal-<번호>.mjs` 는 위 원본에서 파생된 **비추적** 산출물이다. 소실되면 원본에서 재생성하고 `vhk goal sync` 로 검사 스크립트를 백필한다.
+- 로컬 작업 상태는 추적되지 않는 `.vhk/context.md` 가 SoT다. 원본 문서와 혼동하지 않는다.
+
 ## 기술 스택
 > 변경 시 ADR(docs/adr/) 필수.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,14 @@
 ## 필수 참조
 - docs/PRD.md · docs/ARCHITECTURE.md · CLAUDE.md · RULES.md
 
+## 세션 시작 필독
+> 이 절은 진입점이다. 어떤 도구로 세션을 열든 여기부터 읽는다 (ADR-010 §3).
+
+- **현 사이클 원본:** [docs/roadmap/2.x-roadmap.md](docs/roadmap/2.x-roadmap.md) — 작업 단위·순서·릴리스 종료 조건 전량. 작업 시작 전 여기부터 읽는다.
+- **수용 기준:** [docs/PRD-2.x.md](docs/PRD-2.x.md)
+- 실행 단위인 `goals/*.md` 카드와 `scripts/check-goal-<번호>.mjs` 는 위 원본에서 파생된 **비추적** 산출물이다. 소실되면 원본에서 재생성하고 `vhk goal sync` 로 검사 스크립트를 백필한다.
+- 로컬 작업 상태는 추적되지 않는 `.vhk/context.md` 가 SoT다. 원본 문서와 혼동하지 않는다.
+
 ## 기술 스택
 > 변경 시 ADR(docs/adr/) 필수.
 

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -6,6 +6,14 @@
 ## 필수 참조
 - docs/PRD.md · docs/ARCHITECTURE.md · CLAUDE.md · RULES.md
 
+## 세션 시작 필독
+> 이 절은 진입점이다. 어떤 도구로 세션을 열든 여기부터 읽는다 (ADR-010 §3).
+
+- **현 사이클 원본:** [docs/roadmap/2.x-roadmap.md](docs/roadmap/2.x-roadmap.md) — 작업 단위·순서·릴리스 종료 조건 전량. 작업 시작 전 여기부터 읽는다.
+- **수용 기준:** [docs/PRD-2.x.md](docs/PRD-2.x.md)
+- 실행 단위인 `goals/*.md` 카드와 `scripts/check-goal-<번호>.mjs` 는 위 원본에서 파생된 **비추적** 산출물이다. 소실되면 원본에서 재생성하고 `vhk goal sync` 로 검사 스크립트를 백필한다.
+- 로컬 작업 상태는 추적되지 않는 `.vhk/context.md` 가 SoT다. 원본 문서와 혼동하지 않는다.
+
 ## 기술 스택
 > 변경 시 ADR(docs/adr/) 필수.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,14 @@
 - **Optional rules:** `VHK_RULES_FILE` or `vhk config set-rules-file <yaml>`
 - **금지:** AGENTS.md 손수 편집 → `RULES.md` + `vhk sync`
 
+## 세션 시작 필독
+> 이 절은 진입점이다. 어떤 도구로 세션을 열든 여기부터 읽는다 (ADR-010 §3).
+
+- **현 사이클 원본:** [docs/roadmap/2.x-roadmap.md](docs/roadmap/2.x-roadmap.md) — 작업 단위·순서·릴리스 종료 조건 전량. 작업 시작 전 여기부터 읽는다.
+- **수용 기준:** [docs/PRD-2.x.md](docs/PRD-2.x.md)
+- 실행 단위인 `goals/*.md` 카드와 `scripts/check-goal-<번호>.mjs` 는 위 원본에서 파생된 **비추적** 산출물이다. 소실되면 원본에서 재생성하고 `vhk goal sync` 로 검사 스크립트를 백필한다.
+- 로컬 작업 상태는 추적되지 않는 `.vhk/context.md` 가 SoT다. 원본 문서와 혼동하지 않는다.
+
 ## 기술 스택
 > 변경 시 ADR(docs/adr/) 필수.
 
@@ -58,7 +66,7 @@
 - 1 iteration = 작은 commit 하나 + 게이트 통과(or 정직한 블로커)
 
 ## VHK 운영 — Forbidden (전역 금지)
-> 단일 Forbidden 목록(통합 SoT — goals/_meta.md 는 이 섹션을 포인터로 참조).
+> 단일 Forbidden 목록(통합 SoT — 파생 산출물은 이 섹션을 포인터로 참조한다).
 > CLAUDE.md 헌법 영구구역의 Forbidden 은 불가침이라 그대로 둠 — 의례 수준 금지는 그쪽, 코드/운영 수준 금지는 여기.
 
 - `node_modules/` 직접 수정 금지
@@ -69,7 +77,8 @@
 - 게이트 실패 상태에서 done 처리 금지 / `vhk resume` 자동 호출 금지
 - AGENTS.md·.cursorrules 등 sync 산출물 직접 편집 금지 → RULES.md + `vhk sync`
 - publish 는 main 에서만 + 사람 승인 (가드 #119)
-- 공개 추적 금지: 개인 운영 로그·상태·goal, 로컬 절대경로, 개인 이메일, 실명, 개인 저장소명, 실제 외부 서비스 객체 ID
+- 공개 추적 금지 (ADR-010 §1 개정): **개인 운영 기록**(세션 로그·개인 일정·가용시간·개인 사정), 로컬 절대경로, 개인 이메일, 실명, 개인 저장소명, 실제 외부 서비스 객체 ID
+- 공개 추적 허용 (ADR-010 §1): **제품 작업 항목**(로드맵·릴리스 계획·작업 단위와 그 완료 조건) — 위 금지 항목을 하나도 포함하지 않을 때만
 - 예제는 `sample-*`, `<HOME>`, 명백한 가짜 ID만 사용하고 `boundary:check` 우회 금지
 - Git 작성자 이메일은 GitHub noreply, npm 공개 연락처는 `opensource@yohanstudio.co` 사용
 
@@ -87,3 +96,4 @@
 - 코드 변경이 동작/사용법을 바꾸면 README를 같이 갱신
 - 교훈·결정·실패·성공 = `vhk memory`(4버킷) / `vhk learn`. learnings.md 는 v2 흡수·동결 → 신규 기록 금지.
 - 로컬 작업 상태 SoT = 추적되지 않는 `.vhk/context.md`
+- 제품 작업 항목의 원본 = 추적되는 `docs/roadmap/2.x-roadmap.md` (ADR-010 §2). `goals/*.md` 는 그 파생물이므로 원본을 먼저 고친다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,21 @@
 
 ## 현재 상태
 - **버전:** v2.12.0
-- **Phase:** **FILL**
+- **Phase:** 2.x 계열 선행 — 복구·위생·용어 (작업 단위 112 · 113 · 114)
 - **블로커:** 없음
-- **다음 액션:** **FILL**
-- **마지막 업데이트:** 2026-07-27
+- **다음 액션:** [docs/roadmap/2.x-roadmap.md](docs/roadmap/2.x-roadmap.md) §5 선행 — 이 문서가 현 사이클의 원본이다
+- **마지막 업데이트:** 2026-07-28
 
 <!-- vhk:rules:start -->
 > ⚡ 아래 규칙 섹션은 RULES.md에서 자동 생성됨 (vhk sync). 직접 수정 금지.
+
+## 세션 시작 필독
+> 이 절은 진입점이다. 어떤 도구로 세션을 열든 여기부터 읽는다 (ADR-010 §3).
+
+- **현 사이클 원본:** [docs/roadmap/2.x-roadmap.md](docs/roadmap/2.x-roadmap.md) — 작업 단위·순서·릴리스 종료 조건 전량. 작업 시작 전 여기부터 읽는다.
+- **수용 기준:** [docs/PRD-2.x.md](docs/PRD-2.x.md)
+- 실행 단위인 `goals/*.md` 카드와 `scripts/check-goal-<번호>.mjs` 는 위 원본에서 파생된 **비추적** 산출물이다. 소실되면 원본에서 재생성하고 `vhk goal sync` 로 검사 스크립트를 백필한다.
+- 로컬 작업 상태는 추적되지 않는 `.vhk/context.md` 가 SoT다. 원본 문서와 혼동하지 않는다.
 
 ## 기술 스택
 > 변경 시 ADR(docs/adr/) 필수.
@@ -50,7 +58,7 @@
 - 1 iteration = 작은 commit 하나 + 게이트 통과(or 정직한 블로커)
 
 ## VHK 운영 — Forbidden (전역 금지)
-> 단일 Forbidden 목록(통합 SoT — goals/_meta.md 는 이 섹션을 포인터로 참조).
+> 단일 Forbidden 목록(통합 SoT — 파생 산출물은 이 섹션을 포인터로 참조한다).
 > CLAUDE.md 헌법 영구구역의 Forbidden 은 불가침이라 그대로 둠 — 의례 수준 금지는 그쪽, 코드/운영 수준 금지는 여기.
 
 - `node_modules/` 직접 수정 금지
@@ -61,7 +69,8 @@
 - 게이트 실패 상태에서 done 처리 금지 / `vhk resume` 자동 호출 금지
 - AGENTS.md·.cursorrules 등 sync 산출물 직접 편집 금지 → RULES.md + `vhk sync`
 - publish 는 main 에서만 + 사람 승인 (가드 #119)
-- 공개 추적 금지: 개인 운영 로그·상태·goal, 로컬 절대경로, 개인 이메일, 실명, 개인 저장소명, 실제 외부 서비스 객체 ID
+- 공개 추적 금지 (ADR-010 §1 개정): **개인 운영 기록**(세션 로그·개인 일정·가용시간·개인 사정), 로컬 절대경로, 개인 이메일, 실명, 개인 저장소명, 실제 외부 서비스 객체 ID
+- 공개 추적 허용 (ADR-010 §1): **제품 작업 항목**(로드맵·릴리스 계획·작업 단위와 그 완료 조건) — 위 금지 항목을 하나도 포함하지 않을 때만
 - 예제는 `sample-*`, `<HOME>`, 명백한 가짜 ID만 사용하고 `boundary:check` 우회 금지
 - Git 작성자 이메일은 GitHub noreply, npm 공개 연락처는 `opensource@yohanstudio.co` 사용
 
@@ -79,5 +88,6 @@
 - 코드 변경이 동작/사용법을 바꾸면 README를 같이 갱신
 - 교훈·결정·실패·성공 = `vhk memory`(4버킷) / `vhk learn`. learnings.md 는 v2 흡수·동결 → 신규 기록 금지.
 - 로컬 작업 상태 SoT = 추적되지 않는 `.vhk/context.md`
+- 제품 작업 항목의 원본 = 추적되는 `docs/roadmap/2.x-roadmap.md` (ADR-010 §2). `goals/*.md` 는 그 파생물이므로 원본을 먼저 고친다.
 
 <!-- vhk:rules:end -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -6,6 +6,14 @@
 ## 필수 참조
 - docs/PRD.md · docs/ARCHITECTURE.md · CLAUDE.md · RULES.md
 
+## 세션 시작 필독
+> 이 절은 진입점이다. 어떤 도구로 세션을 열든 여기부터 읽는다 (ADR-010 §3).
+
+- **현 사이클 원본:** [docs/roadmap/2.x-roadmap.md](docs/roadmap/2.x-roadmap.md) — 작업 단위·순서·릴리스 종료 조건 전량. 작업 시작 전 여기부터 읽는다.
+- **수용 기준:** [docs/PRD-2.x.md](docs/PRD-2.x.md)
+- 실행 단위인 `goals/*.md` 카드와 `scripts/check-goal-<번호>.mjs` 는 위 원본에서 파생된 **비추적** 산출물이다. 소실되면 원본에서 재생성하고 `vhk goal sync` 로 검사 스크립트를 백필한다.
+- 로컬 작업 상태는 추적되지 않는 `.vhk/context.md` 가 SoT다. 원본 문서와 혼동하지 않는다.
+
 ## 기술 스택
 > 변경 시 ADR(docs/adr/) 필수.
 

--- a/RULES.md
+++ b/RULES.md
@@ -4,6 +4,15 @@
 > 전파 대상: .cursorrules · .windsurfrules · .github/copilot-instructions.md · .agents/rules/vhk-rules.md · AGENTS.md · GEMINI.md · .clinerules/vhk-rules.md · CLAUDE.md(기록 규칙 영역)
 > 명령 사용법은 COMMANDS.md, 공개 기여 절차는 CONTRIBUTING.md가 담당.
 
+## 세션 시작 필독
+
+> 이 절은 진입점이다. 어떤 도구로 세션을 열든 여기부터 읽는다 (ADR-010 §3).
+
+- **현 사이클 원본:** [docs/roadmap/2.x-roadmap.md](docs/roadmap/2.x-roadmap.md) — 작업 단위·순서·릴리스 종료 조건 전량. 작업 시작 전 여기부터 읽는다.
+- **수용 기준:** [docs/PRD-2.x.md](docs/PRD-2.x.md)
+- 실행 단위인 `goals/*.md` 카드와 `scripts/check-goal-<번호>.mjs` 는 위 원본에서 파생된 **비추적** 산출물이다. 소실되면 원본에서 재생성하고 `vhk goal sync` 로 검사 스크립트를 백필한다.
+- 로컬 작업 상태는 추적되지 않는 `.vhk/context.md` 가 SoT다. 원본 문서와 혼동하지 않는다.
+
 ## 서문
 
 - 한 줄 설명: 바이브코딩 풀사이클 CLI
@@ -56,7 +65,7 @@
 
 ## VHK 운영 — Forbidden (전역 금지)
 
-> 단일 Forbidden 목록(통합 SoT — goals/_meta.md 는 이 섹션을 포인터로 참조).
+> 단일 Forbidden 목록(통합 SoT — 파생 산출물은 이 섹션을 포인터로 참조한다).
 > CLAUDE.md 헌법 영구구역의 Forbidden 은 불가침이라 그대로 둠 — 의례 수준 금지는 그쪽, 코드/운영 수준 금지는 여기.
 
 - `node_modules/` 직접 수정 금지
@@ -67,7 +76,8 @@
 - 게이트 실패 상태에서 done 처리 금지 / `vhk resume` 자동 호출 금지
 - AGENTS.md·.cursorrules 등 sync 산출물 직접 편집 금지 → RULES.md + `vhk sync`
 - publish 는 main 에서만 + 사람 승인 (가드 #119)
-- 공개 추적 금지: 개인 운영 로그·상태·goal, 로컬 절대경로, 개인 이메일, 실명, 개인 저장소명, 실제 외부 서비스 객체 ID
+- 공개 추적 금지 (ADR-010 §1 개정): **개인 운영 기록**(세션 로그·개인 일정·가용시간·개인 사정), 로컬 절대경로, 개인 이메일, 실명, 개인 저장소명, 실제 외부 서비스 객체 ID
+- 공개 추적 허용 (ADR-010 §1): **제품 작업 항목**(로드맵·릴리스 계획·작업 단위와 그 완료 조건) — 위 금지 항목을 하나도 포함하지 않을 때만
 - 예제는 `sample-*`, `<HOME>`, 명백한 가짜 ID만 사용하고 `boundary:check` 우회 금지
 - Git 작성자 이메일은 GitHub noreply, npm 공개 연락처는 `opensource@yohanstudio.co` 사용
 
@@ -86,3 +96,4 @@
 - 코드 변경이 동작/사용법을 바꾸면 README를 같이 갱신
 - 교훈·결정·실패·성공 = `vhk memory`(4버킷) / `vhk learn`. learnings.md 는 v2 흡수·동결 → 신규 기록 금지.
 - 로컬 작업 상태 SoT = 추적되지 않는 `.vhk/context.md`
+- 제품 작업 항목의 원본 = 추적되는 `docs/roadmap/2.x-roadmap.md` (ADR-010 §2). `goals/*.md` 는 그 파생물이므로 원본을 먼저 고친다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,36 +5,53 @@
 
 ## 읽는 순서 (처음 온 사람)
 
-1. [../CLAUDE.md](../CLAUDE.md) — 헌법(의례·금지) + 현재 상태(LIVE)
-2. [spec.md](spec.md) — `.vhk/` 데이터 규격
-3. [ARCHITECTURE.md](ARCHITECTURE.md) — 코드 구조
-4. [state/next-task.md](state/next-task.md) — 지금 할 일 (상태 SoT)
-5. [../goals/README.md](../goals/README.md) — 62개 goal 인덱스(자동 생성)
+1. [../CLAUDE.md](../CLAUDE.md) — 헌법(의례·금지) + 현재 상태
+2. [roadmap/2.x-roadmap.md](roadmap/2.x-roadmap.md) — **현 사이클의 원본** (작업 단위·순서·릴리스 종료 조건)
+3. [PRD-2.x.md](PRD-2.x.md) — 현 사이클 수용 기준
+4. [spec.md](spec.md) — `.vhk/` 데이터 규격
+5. [ARCHITECTURE.md](ARCHITECTURE.md) — 코드 구조
 
-## 카테고리 맵 (9)
+## 카테고리 맵 (11)
 
 | 폴더 | 목적 | 네이밍 |
 |------|------|--------|
 | [adr/](adr/) | 의사결정 기록 (패키지·아키텍처·정책) | `ADR-NNN-슬러그.md` |
 | [rfc/](rfc/) | 설계·제안 (구현 전 검토) | `NNNN-슬러그.md` |
-| [log/](log/) | 세션 dev log (append-only) | `YYYY-MM-DD-작업명.md` |
+| [roadmap/](roadmap/) | 계열별 로드맵 — 작업 항목의 원본 | `<계열>-roadmap.md` |
 | [troubleshooting/](troubleshooting/) | 에러·해결 과정 | `TS-NNN-슬러그.md` |
 | [patterns/](patterns/) | 프로젝트 무관 범용 패턴 | `PAT-NNN-영문명.md` (구: `{카테고리}-{이름}.md`) |
-| [state/](state/) | 상태 SoT (next-task·blockers) | 고정 파일명 |
+| [audits/](audits/) | 도그푸딩·감사 결과 | 날짜 기반 |
+| [evals/](evals/) | 평가·측정 산출물 | 자유 |
+| [reference/](reference/) | 외부 참고 자료 정리 | 자유 |
 | [superpowers/](superpowers/) | 구현 전 설계 spec | `specs/YYYY-MM-DD-주제-design.md` |
 | [context/](context/) | 세션 컨텍스트 스냅샷 | 날짜 기반 |
 | [blog/](blog/) | 외부 공개용 글 초안 | 자유 |
+
+### 추적하지 않는 경로
+
+공개 경계 정리(ADR-008 · ADR-010)로 저장소에서 제외됐다. 로컬에만 존재하므로 이 대시보드에서 링크하지 않는다.
+
+| 경로 | 무엇 | 대체 |
+|---|---|---|
+| `docs/devlog/` | 세션 작업 내역 | Notion Dev Log 또는 로컬 파일 |
+| `docs/log/` | 구 세션 dev log | 위와 같음 |
+| `goals/` | 작업 단위 카드 (실행 단위) | 원본 = [roadmap/](roadmap/) · 재생성 후 `vhk goal sync` |
+| `.vhk/context.md` | 로컬 작업 상태 SoT | — |
 
 ## 루트 문서
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) — 모듈 구조·데이터 흐름
 - [spec.md](spec.md) — `.vhk/` 파일 규격 (버전 명시·변경 시 범프)
 - [PRD.md](PRD.md) — 제품 요구사항
+- [PRD-2.x.md](PRD-2.x.md) — 2.x 계열 요구사항·수용 기준
 - [til.md](til.md) — 배움 메모 (가벼운 한 줄들)
-- [mcp-evolution.md](mcp-evolution.md) — MCP 0→29 tools 진화 카탈로그 (T5 백필)
+- [mcp-evolution.md](mcp-evolution.md) — MCP 0→29 tools 진화 카탈로그
+- [vhk-feature-guide.md](vhk-feature-guide.md) — 기능 안내 (쉬운 말)
+- [seo-key-setup.md](seo-key-setup.md) — 검색 노출 설정 절차
 
 ## 집행 (governance-v2)
 
-- 실질 코드변경 커밋 시 오늘자 dev log 필수 — `scripts/check-records.mjs`가 차단 (탈출구 `[skip-record]`)
 - 세션 종료 시 미기록 ADR/TS 후보 자동 보고 — `vhk work handoff` (RFC 0051)
-- goal 인덱스 재생성 — `node scripts/gen-goals-index.mjs`
+- 작업 단위 검사 스크립트 백필 — `vhk goal sync`
+
+> **알려진 결함:** `scripts/check-records.mjs` 는 실질 코드변경 커밋에 `docs/log/<날짜>-*.md` 스테이지를 요구하는데, 그 경로가 `.gitignore` 에 있어 **충족이 구조적으로 불가능**하다. 현재 모든 코드 커밋이 `[skip-record]` 우회를 강제당한다. 작업 단위 신설 후보(작업 단위 112-T7 부수 발견).

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -63,9 +63,21 @@ interface RulesSection {
   content: string
 }
 
+// 113-T6 / ADR-010 §3: 진입점 절('## 세션 시작 필독')은 도구를 가리지 않고 규칙 파일 8종
+// 전부에 실려야 한다 — 어떤 도구로 세션을 열든 자기 규칙 파일에서 원본 문서 경로를 읽게 하는 것이
+// 목적이라, 한 곳이라도 빠지면 그 도구로 연 세션은 원본을 모른 채 시작한다.
+// 코딩 타깃(.cursorrules·.windsurfrules·copilot·antigravity·GEMINI·cline)은 CURSORRULES_KEYS 만
+// 보므로 여기 넣어야 8종 전부에 도달한다(CLAUDE.md·AGENTS.md 는 이 키셋을 합집합으로 포함).
+// 실측: 넣기 전엔 8종 중 2종(AGENTS.md 는 '기타 규칙' 버킷 경유)에만 전파됐다.
+//
+// 키를 '세션 시작'이 아니라 '세션 시작 필독'으로 좁힌 이유는 'VHK 운영' 선례와 같다.
+// CURSORRULES_KEYS 확장은 VHK_MANAGED_KEYS 로 자동 전파되고, 그 집합은 마커 없는 레거시
+// CLAUDE.md 의 1회 마이그레이션에서 "옛 자동생성 → 삭제" 판정에도 쓰인다. '세션 시작'만 쓰면
+// 사용자가 손으로 쓴 `## 세션 시작` 류 제목이 오삭제 대상으로 분류될 수 있다.
+const ENTRYPOINT_KEYS = ['세션 시작 필독']
 // #90: '도메인' — init 커스터마이징 인터뷰가 쓰는 `## 도메인 규칙` 섹션을 코딩 타깃(.cursorrules 등)으로
 // 전파. CLAUDE.md는 toClaudeMd가 CURSORRULES_KEYS를 합집합하므로 자동 도달(CLAUDE_MD_KEYS 추가 불필요).
-const CURSORRULES_KEYS = ['코딩 규칙', '기술 스택', '아키텍처', '디자인', 'Anti-patterns', '커밋', '도메인']
+const CURSORRULES_KEYS = [...ENTRYPOINT_KEYS, '코딩 규칙', '기술 스택', '아키텍처', '디자인', 'Anti-patterns', '커밋', '도메인']
 // #149: 'VHK 운영'(이슈 정책 등 운영 규약)을 매핑 — CLAUDE.md/AGENTS.md record 그룹으로 전파.
 // (코딩 타깃에는 안 들어감 — 운영 규약은 코딩 규칙이 아니므로 의도된 분리.)
 // 키를 'VHK 운영'으로 한정 — '운영'만 쓰면 '## 자동 운영 스크립트' 등 무관 섹션까지 substring 오탐.

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -300,6 +300,52 @@ describe('vhk init → sync 연결 (VHK-002 / #61 회귀)', () => {
   })
 })
 
+// 113-T6 / ADR-010 §3: 진입점 절이 규칙 파일 8종 **전부**에 실려야 한다.
+// 한 곳이라도 빠지면 그 도구로 연 세션은 원본 문서를 모른 채 시작한다.
+// 실측(2026-07-28): 이 키 매핑 전에는 8종 중 2종에만 전파됐다.
+describe('vhk sync — 113-T6 진입점 절 전 규칙 파일 전파', () => {
+  const entrypointRules =
+    '# vhk — Rules\n\n' +
+    '## 세션 시작 필독\n' +
+    '- 현 사이클 원본: docs/roadmap/2.x-roadmap.md SENTINEL_ENTRYPOINT\n' +
+    '\n## 코딩 규칙\n- a\n'
+
+  it('코딩 타깃 6종 전부에 진입점 본문이 실린다', () => {
+    const s = parseRulesMd(entrypointRules)
+    expect(toCursorrules(s, 'vhk')).toContain('SENTINEL_ENTRYPOINT')
+    expect(toWindsurfrules(s, 'vhk')).toContain('SENTINEL_ENTRYPOINT')
+    expect(toCopilotInstructions(s, 'vhk')).toContain('SENTINEL_ENTRYPOINT')
+    expect(toGeminiMd(s, 'vhk')).toContain('SENTINEL_ENTRYPOINT')
+    expect(toClineRules(s, 'vhk')).toContain('SENTINEL_ENTRYPOINT')
+    expect(toAntigravityRules(s, 'vhk')).toContain('SENTINEL_ENTRYPOINT')
+  })
+
+  it('AGENTS.md 에는 매핑 섹션으로 실린다 (기타 규칙 버킷 폴백 아님)', () => {
+    const out = toAgentsMd(parseRulesMd(entrypointRules), 'vhk', null)
+    expect(out).toContain('SENTINEL_ENTRYPOINT')
+    expect(out).not.toContain('## 기타 규칙')
+  })
+
+  it('CLAUDE.md 마커 블록 안에 실린다', () => {
+    const out = toClaudeMd(parseRulesMd(entrypointRules), '# 기록 규칙 (vhk)\n\n## 현재 상태\n- P1\n')
+    const start = out.indexOf('<!-- vhk:rules:start -->')
+    const end = out.indexOf('<!-- vhk:rules:end -->')
+    expect(out.indexOf('SENTINEL_ENTRYPOINT')).toBeGreaterThan(start)
+    expect(out.indexOf('SENTINEL_ENTRYPOINT')).toBeLessThan(end)
+  })
+
+  it('진입점 절은 미매칭 경고 대상이 아니다 (조용한 누락 아님이 아니라 아예 매핑됨)', () => {
+    expect(findUnmappedSections(parseRulesMd(entrypointRules))).not.toContain('세션 시작 필독')
+  })
+
+  // 'VHK 운영' 선례와 같은 이유로 키를 '세션 시작'이 아닌 '세션 시작 필독'으로 좁혔다 —
+  // 넓은 키는 레거시 CLAUDE.md 마이그레이션에서 사용자 작성 섹션을 오삭제 대상으로 만든다.
+  it('키가 좁아 사용자 작성 "세션 시작" 류 제목은 매핑하지 않는다', () => {
+    const looseRules = '# P — Rules\n\n## 세션 시작 메모\n- 사용자가 손으로 쓴 내용\n\n## 코딩 규칙\n- a\n'
+    expect(findUnmappedSections(parseRulesMd(looseRules))).toContain('세션 시작 메모')
+  })
+})
+
 describe('vhk sync — goal 90: 도메인 규칙 섹션이 .cursorrules + CLAUDE.md 양쪽 도달 (회귀)', () => {
   // init 커스터마이징 인터뷰가 쓸 법한 합성 RULES.md — 도메인 불변식 + ### 절대 금지.
   const domainRules =


### PR DESCRIPTION
작업 단위 113(릴리스 위생 + 진입점 배선)의 T3·T4·T6. T2(태그 push)는 사람 몫이라 손대지 않았고, T5·T7·T8 은 코드 변경이 없어 카드와 `docs/devlog/` 에만 기록했다(아래 "이 PR 밖" 참조).

## T6 — 진입점 배선 (ADR-010 §3)

원본 문서를 만들어두는 것만으로는 아무도 안 읽는다. `RULES.md` 에 `## 세션 시작 필독` 절을 신설해 현 사이클 원본과 수용 기준 경로를 명시했다.

**전파해보니 8종 중 2종에만 도달했다.**

| 시점 | `.cursorrules` | `.windsurfrules` | copilot | antigravity | AGENTS.md | GEMINI.md | cline | CLAUDE.md |
|---|---|---|---|---|---|---|---|---|
| 키 매핑 전 | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ |
| 키 매핑 후 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |

원인: 코딩 타깃 6종은 `CURSORRULES_KEYS` 에 매핑된 섹션만 싣는데 새 절이 어느 키에도 안 걸려 조용히 빠졌다. AGENTS.md 만 '기타 규칙' 버킷 폴백으로 받고 있었다.

조치: `ENTRYPOINT_KEYS` 를 `CURSORRULES_KEYS` 앞에 합쳤다. 진입점은 도구를 가리지 않아야 한다 — 한 곳이라도 빠지면 그 도구로 연 세션은 원본을 모른 채 시작한다.

**키를 '세션 시작'이 아니라 '세션 시작 필독'으로 좁힌 이유**는 `'VHK 운영'` 선례와 같다. `CURSORRULES_KEYS` 확장은 `VHK_MANAGED_KEYS` 로 전파되고, 그 집합은 마커 없는 레거시 `CLAUDE.md` 마이그레이션의 "옛 자동생성 → 삭제" 판정에도 쓰인다. 넓은 키는 사용자가 손으로 쓴 `## 세션 시작` 류 제목을 오삭제 대상으로 만든다. 이 트레이드오프를 테스트로 고정했다.

## T3 — 미기입·낡은 참조

| 대상 | 조치 |
|---|---|
| `CLAUDE.md` 현재 상태 | `**FILL**` 두 칸 기입 (Phase · 다음 액션) |
| `RULES.md` `goals/_meta.md` 참조 | 일반화 — 그 파일은 비추적이라 공개 저장소에 없다 |
| `RULES.md` Forbidden 공개 추적 금지 | ADR-010 §1 개정판으로 교체 + 허용 조항 추가 |
| `RULES.md` 기록 규칙 | "제품 작업 항목의 원본 = 로드맵" 한 줄 추가 |

종전 Forbidden 문구는 "goal" 을 통째로 금지해 **로드맵을 원본으로 삼는 현 구조와 정면으로 어긋나 있었다.** ADR-010 이 이미 개정을 결정했는데 규칙 파일이 낡은 채였다.

## T4 — `docs/README.md` 죽은 포인터

읽는 순서 5개 중 2개, 카테고리 맵 9개 중 2개가 제거된 경로를 가리켰다 — `state/next-task.md` · `goals/README.md` · `log/` · `state/`.

- 읽는 순서를 로드맵·PRD 중심으로 재배치
- 카테고리 맵 9 → 11 (누락돼 있던 `roadmap` · `audits` · `evals` · `reference` 추가)
- **"추적하지 않는 경로" 표 신설** — 왜 없는지와 대체 경로를 같이 적어 다음 사람이 죽은 링크를 다시 만들지 않게 했다
- 루트 문서 목록에 `PRD-2.x.md` · `vhk-feature-guide.md` · `seo-key-setup.md` 추가
- 집행 절에 `check-records.mjs` 의 충족 불가 결함 명시

## 커밋에서 의도적으로 뺀 것

`vhk sync` 가 **추적 파일** `.agents/CORE-RULES.md` 를 홈 설정의 live 규칙으로 재생성했다.

| 관측 | 값 |
|---|---|
| 저장소 커밋본 | 번들 스냅샷 `v0.1.0` |
| 홈에 규칙 파일이 설정된 머신에서 sync 후 | `v0.1.5 (generated from configured rules file)` |
| 그대로 `sync --check` | exit 1 (드리프트) |
| `HOME`·`USERPROFILE` 격리 후 `sync --check` | **exit 0** — 커밋본이 옳다 |

그대로 커밋하면 개인 규칙 원문이 공개 저장소에 실리고 RULES.md Forbidden 위반이라 되돌렸다. 홈에 규칙 파일을 설정한 개발자는 "개인 규칙을 커밋" 또는 "게이트 영구 red" 둘 중 하나를 강요당하는 구조다. 작업 단위 79 와 같은 뿌리이며 이 PR 범위 밖이라 카드에만 기록했다 — **작업 단위 신설 후보.**

## 검증 결과

| 검사 | 결과 |
|---|---|
| `pnpm typecheck` | 통과 |
| `pnpm lint` | 통과 |
| `pnpm boundary:check` | 통과 — npm 10개 · Git 591개 |
| `tests/sync.test.ts` | 통과 — 42건 (신규 5건 포함) |
| 8종 전파 실측 | 전량 도달 |
| `vhk sync --check` | 통과 (홈 격리 조건) |
| `vhk doctor` | 경고 0 |
| `pnpm test:run` | **4건 red** — 사전 존재, PR #539 에서 수정됨 |

red 4건은 `core-rules` 3건(홈 규칙 설정 의존) + `goal-drift` 1건(계획 카드 오탐). 이 브랜치는 지시대로 `origin/main` 에서 새로 따 #539 의 수정이 없다. 넷 다 CI 에서는 원래 통과한다.

## 이 PR 밖 (코드 변경 없음 — 카드·devlog 기록만)

- **T5 부분 수행** — 이슈 #515·#514 를 실측 검증하고 close 근거 코멘트 **초안까지만** 썼다. 실제 게시·close·브랜치 삭제는 사람 몫. #515 는 이슈 본문이 적은 수정 2개 중 1개(`sk_test_` 접두 스킵)가 main 에 없어 조건부 close 를 권고했다
- **T7 완료 — 문제 아님.** 기억 파일은 영속되고 새 프로세스에서 재조회된다. 추적 제외는 `.gitignore` 에 명시된 의도된 정책(개인 메모·개인 쿼리). 작업 단위 신설 불필요
- **T8 조사만.** 카드가 "결정 필요(공개 경계 판단)"라 명시한 항목이라 글로벌 스킬 파일 수정·추적 사본 생성·`.gitignore` 변경 전부 하지 않았다. 카드 기재를 재확인했고 죽은 런북 링크 2건을 추가로 찾았다. 선택지 3안과 권고를 카드에 남겼다

머지 시 squash 대신 merge 커밋 사용 (squash가 작성자 이메일을 교체한 전례 있음)
