### PR TITLE
feat: 야간 지휘 스킬을 저장소 SoT 로 승격 (113-T8, B안)

### DIFF
--- a/.claude/skills/overnight-vhk-auto/SKILL.md
+++ b/.claude/skills/overnight-vhk-auto/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: overnight-vhk-auto
+description: VHK 야간 지휘 — 작업 단위 카드 1장을 골라 vhk-auto 계약대로 돌리고, push + PR 까지만 한다(머지 0). 트리거 - "밤새 vhk-auto", "overnight vhk", "자율 overnight", "큐부터 한 장".
+---
+
+# Overnight vhk-auto conductor
+
+호출 1회 = 작업 단위 카드 **1장**. `overnight-autoloop` 과는 별개 트랙이다(섞지 마라).
+
+> 이 파일이 SoT다. 글로벌(`~/.claude/skills/overnight-vhk-auto/`)에 사본이 있으면
+> 그쪽이 복제본이며, 어긋나면 **이 파일이 이긴다.**
+> 안쪽 구현 루프의 SoT 는 `.claude/skills/vhk-auto/SKILL.md`.
+
+## 환경 (설치 시 1회)
+
+이 스킬은 저장소 밖 스크립트 하나에 의존한다. 경로는 사람마다 다르므로 **환경변수로 주입**한다.
+
+| 변수 | 용도 | 없으면 |
+|---|---|---|
+| `VHK_AUTO_PR_SCRIPT` | push + PR 래퍼(PowerShell) 절대경로 | INV-B 를 건너뛰고 commit 까지만. 사람에게 "PR 은 수동" 이라고 보고 |
+
+절대경로를 이 파일에 적지 마라 — 공개 저장소이고 `pnpm boundary:check` 가 막는다.
+
+## 불변조건
+
+- **INV-A** 구현 루프는 `.claude/skills/vhk-auto/SKILL.md` 의 INV-1..INV-9 를 따른다.
+  commit 은 그 루프 안에서만. (vhk-auto INV-7)
+- **INV-B** verify green + commit 이후에만 `VHK_AUTO_PR_SCRIPT` 를 호출해 push + PR 할 수 있다.
+  **머지 = 0.** 래퍼는 *깨끗한 작업트리 + 미푸시 커밋* 상태를 지원한다(vhk-auto 가 이미 커밋한
+  뒤의 push-only 경로) — dirty porcelain 을 기대하지 마라.
+- **INV-C** autonomy-log 의 시작 또는 종결 이벤트가 없으면 `.vhk/HARD_STOP` 을 쓰고 멈춘다.
+- **INV-D** 사람에게 A/B/C 를 묻지 않는다 — `docs/roadmap/autonomy-evolution.md` 의 기본값을 쓴다.
+- **INV-E** 중단 조건: HARD_STOP · verify 2회 연속 red · PR 을 열어 보고 완료.
+
+## 루프
+
+0. `.vhk/HARD_STOP` 이 있으면 사유를 보고하고 즉시 종료.
+1. **다음 카드 선택** — `vhk goal next` 가 고르는 active 카드를 그대로 쓴다.
+   무엇을 먼저 할지의 근거는 **로드맵 원본**이다: `docs/roadmap/2.x-roadmap.md` §5(티켓 전량) ·
+   §8(이번 계열에서 안 하는 것). 카드 번호를 이 파일에 하드코딩하지 마라 — 계열이 바뀌면 낡는다.
+   고른 카드의 frontmatter 를 `IN_PROGRESS` 로 바꾼다.
+2. 그 카드에 대해 **vhk-auto** 루프를 돈다(autonomy-log 포함 — vhk-auto INV-9).
+3. 성공 시(커밋 완료, 작업트리는 깨끗할 수 있음):
+   `VHK_AUTO_PR_SCRIPT` 가 설정돼 있으면 저장소 루트를 대상으로 호출해 push + PR.
+   기준 브랜치는 `main`. PR 본문에 아침 확인 3문항을 넣는다.
+   설정돼 있지 않으면 이 단계를 건너뛰고 "PR 은 사람이" 로 보고한다.
+4. (선택) 아침 보고 생성 — `node scripts/gen-autonomy-morning-report.mjs --date YYYY-MM-DD`.
+5. PR URL(또는 HARD_STOP 사유)을 보고한다. **머지하지 않는다.**
+
+## 관련 문서
+
+- RFC: `docs/rfc/0063-overnight-vhk-auto.md`
+- 안쪽 루프 SoT: `.claude/skills/vhk-auto/SKILL.md`
+- 작업 항목 원본: `docs/roadmap/2.x-roadmap.md` · 수용 기준 `docs/PRD-2.x.md`
+- 운영 런북은 **로컬 전용(비추적)** 이다. 없으면 없는 대로 진행하고, 링크를 이 파일에 다시
+  적지 마라 — 저장소에서 죽은 링크가 된다.

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,8 @@ goals/
 scripts/check-goal-[0-9]*.mjs
 .claude/agents/memtest.md
 .claude/skills/auto-merge/
-.claude/skills/overnight-vhk-auto/
+# `.claude/skills/overnight-vhk-auto/` 는 113-T8 로 추적 전환 — 저장소가 SoT 다.
+# 개인 절대경로는 VHK_AUTO_PR_SCRIPT 환경변수로 뺐고 boundary:check 가 재유입을 막는다.
 docs/runbooks/overnight-vhk-auto.md
 docs/runbooks/MORNING_AUTONOMY_MERGE.md
 docs/prompts/autonomy/

--- a/scripts/check-public-boundary.mjs
+++ b/scripts/check-public-boundary.mjs
@@ -16,9 +16,21 @@ const PRIVATE_TRACKED_PATHS = [
   '.vhk/ledger.jsonl',
   '.claude/agents/memtest.md',
   '.claude/skills/auto-merge/',
-  '.claude/skills/overnight-vhk-auto/',
+  // `.claude/skills/overnight-vhk-auto/` 는 113-T8 로 추적 전환됐다.
+  // 과거 이력에 남은 옛 버전(개인 절대경로 포함)은 아래 checkAllRefs 가 계속 잡는다 —
+  // 이 목록에서 뺄 수 없다. 현재 트리 검사만 면제하려고 PRIVATE_CURRENT_EXEMPT 로 분리한다.
   'docs/prompts/autonomy/',
 ]
+
+/**
+ * PRIVATE_TRACKED_PATHS 에 걸리지만 **현재 트리에서는 허용**하는 경로.
+ *
+ * why: 113-T8 로 야간 지휘 스킬을 저장소 SoT 로 승격했다(글로벌 전용은 동기화 사각지대라
+ * 낡은 카드 번호가 그대로 남았다). 새 버전은 개인 절대경로를 환경변수로 빼 공개 가능하지만,
+ * **과거 이력에 남은 옛 버전은 개인 경로를 포함**하므로 이력 검사(checkAllRefs)는 유지해야 한다.
+ * 그래서 목록에서 빼는 대신 현재 트리 검사만 면제한다.
+ */
+const PRIVATE_CURRENT_EXEMPT = ['.claude/skills/overnight-vhk-auto/']
 
 // 현재 추적·npm 패키지만 검사하고 **과거 이력은 면제**하는 경로.
 //
@@ -93,12 +105,17 @@ function historyContainsPrivateText() {
   return false
 }
 
-function isPrivatePath(file) {
-  const normalized = normalizePath(file).toLowerCase()
-  return [...PRIVATE_TRACKED_PATHS, ...PRIVATE_CURRENT_PATHS].some((part) => {
+function matchesPath(normalized, parts) {
+  return parts.some((part) => {
     const target = part.toLowerCase()
     return target.endsWith('/') ? normalized.startsWith(target) : normalized === target
   })
+}
+
+function isPrivatePath(file) {
+  const normalized = normalizePath(file).toLowerCase()
+  if (matchesPath(normalized, PRIVATE_CURRENT_EXEMPT)) return false
+  return matchesPath(normalized, [...PRIVATE_TRACKED_PATHS, ...PRIVATE_CURRENT_PATHS])
 }
 
 export function scanPublicText(label, content) {


### PR DESCRIPTION
작업 단위 113-T8. 카드가 "결정 필요(공개 경계 판단)"로 남겨둔 항목이며, 제시한 A/B/C 중 **B(저장소 SoT 사본)** 로 진행 승인을 받았다.

## 문제

`overnight-vhk-auto` 스킬은 글로벌(`~/.claude/skills/`)에만 있었다. `vhk-auto` 는 저장소에 추적 사본이 있는데 이것만 없어 **동기화 사각지대**였고, 실제로 낡아 있었다.

| 항목 | 실측 |
|---|---|
| 낡은 하드코딩 | `Wave B: 105→107` — 105~107 은 이번 계열 밖으로 이연됨(로드맵 §8) |
| 죽은 링크 | `docs/runbooks/overnight-vhk-auto.md` · `docs/runbooks/MORNING_AUTONOMY_MERGE.md` — 둘 다 저장소에 없음(`.gitignore`) |
| 추적 | 없음 → INV-9(글로벌↔저장소 동기화)가 이 스킬을 덮지 못함 |

A(글로벌만 고침)를 택하지 않은 이유는 같은 문제를 다음 계열로 그대로 넘기기 때문이다. 카드 자신이 이미 "동기화 사각지대"라고 진단했다.

## 선결 조건 — 경로 추상화

스킬 본문에 Windows 절대경로와 개인 작업공간명이 있어 그대로는 `pnpm boundary:check` 위반이었다. 저장소 밖 스크립트 의존을 **환경변수로 뺐다.**

| 종전 | 이후 |
|---|---|
| `C:\...\auto_pr_goal.ps1` (2곳) | `VHK_AUTO_PR_SCRIPT` 환경변수. 미설정이면 그 단계를 건너뛰고 "PR 은 사람이" 로 보고 |
| `-RepoPath "<절대경로>"` | "저장소 루트" 로 서술 |
| `Wave B: 105→107` | **로드맵 원본 참조**(`docs/roadmap/2.x-roadmap.md` §5·§8). 카드 번호를 하드코딩하면 계열이 바뀔 때 낡는다는 이유를 본문에 명시 |
| 죽은 런북 링크 2개 | 제거 + "운영 런북은 로컬 전용(비추적)이며 링크를 다시 적지 마라" |

"절대경로를 이 파일에 적지 마라 — 공개 저장소이고 `boundary:check` 가 막는다" 를 스킬 본문 **환경 절 첫머리**에 넣었다. 다음 편집자가 같은 실수를 하지 않게.

## 경계 검사 처리 — 목록에서 빼지 않았다

`.claude/skills/overnight-vhk-auto/` 를 `PRIVATE_TRACKED_PATHS` 에서 제거하면 손쉽게 통과하지만, 그 목록은 **과거 이력**까지 검사한다. 이력에 남은 옛 버전은 개인 절대경로를 포함하므로 이력 검사는 유지해야 한다.

대신 `PRIVATE_CURRENT_EXEMPT` 를 신설해 **현재 트리 검사만** 면제한다. 같은 파일의 `PRIVATE_CURRENT_PATHS`(현재만 금지)와 대칭 구조다.

## 검증 결과

| 검사 | 결과 |
|---|---|
| `pnpm boundary:check` | 통과 — 새 스킬 파일에 개인 경로·개인 작업공간명 0 |
| `pnpm typecheck` | 통과 |
| `pnpm lint` | 통과 |
| `pnpm test:run` | 통과 — 226 파일 / 2577건 |

글로벌 사본을 저장소 SoT 내용으로 갱신해 둘을 일치시켰다. 앞으로 어긋나면 저장소가 이긴다(본문에 명시).

머지 시 squash 대신 merge 커밋 사용 (squash가 작성자 이메일을 교체한 전례 있음)
