### PR TITLE
fix: 릴리스 워크플로를 막던 이력 위반을 선언된 예외로 처리

### DIFF
--- a/scripts/check-public-boundary.mjs
+++ b/scripts/check-public-boundary.mjs
@@ -62,6 +62,59 @@ const PRIVATE_TEXT_PATTERNS = [
   { name: '외부 워크플로 식별자', pattern: /\bwf_[a-z0-9-]{6,}\b/iu },
 ]
 
+/**
+ * 알려진 이력 예외 — **커밋 메타데이터 검사에서만** 제외하는 이미 공개된 커밋.
+ *
+ * why 이런 게 필요한가: 공개 저장소에 이미 올라간 커밋의 작성자 정보는 되돌리려면
+ * main 이력 재작성 + force push 가 필요하다. 그런데 이 저장소는 fork 가 존재해
+ * 재작성해도 GitHub fork 네트워크에 옛 객체가 남는다(2026-07-28 실측) — 즉 비용은 큰데
+ * 노출은 안 끝난다. 그렇다고 방치하면 릴리스 워크플로가 **영구 red** 가 되고,
+ * 늘 빨간 게이트는 사람이 꺼버린다(이 저장소가 이미 두 번 겪은 실패 형태 — 이슈 #515).
+ *
+ * 그래서 조용히 우회하는 대신 **선언한다.** 작업 단위 117("검사 의도 선언")과 같은 규율이다.
+ *   - 예외는 SHA 단위다. 패턴을 끄지 않으므로 **다른 모든 커밋에는 검사가 그대로 작동**한다.
+ *   - 적용 범위는 커밋 메타데이터뿐이다. 파일 내용(blob)·추적 경로 검사에는 예외가 없다.
+ *   - `main()` 이 예외 건수를 **통과·실패와 무관하게 항상 출력**한다. 조용해지면 안 된다.
+ *
+ * ⚠️ 이 목록은 늘어나면 안 된다. 새 위반은 예외가 아니라 수정 대상이다.
+ */
+export const KNOWN_HISTORY_EXCEPTIONS = [
+  {
+    sha: 'db6976592570d1b1143e329410d536e809d790de',
+    label: '커밋 작성자 이메일이 개인 Gmail',
+    // committer 는 noreply@github.com 인데 author 만 개인 Gmail 이다 = GitHub 웹에서
+    // squash 머지될 때 작성자가 계정 기본 이메일로 교체된 것(#537). 2026-07-27 이력
+    // 재작성 **이후**에 유입됐다.
+    reason: 'GitHub squash 머지가 작성자를 계정 기본 이메일로 교체 (#537, 재작성 이후 유입)',
+    pending: '정정하려면 main 이력 재작성 + force push 필요 — 사람 판단 대기',
+  },
+]
+
+const RECORD_SEP = '\u001E'
+const FIELD_SEP = '\u001F'
+
+/**
+ * `<sha>\x1f<메타데이터>\x1e` 레코드 스트림에서 예외 SHA 레코드를 걷어낸다.
+ * 구분자를 SHA 앞에 붙여 뽑는 이유: 메타데이터를 통짜 문자열로 스캔하면 어느 커밋이
+ * 걸렸는지 알 수 없어 커밋 단위 예외가 불가능하다.
+ */
+export function stripKnownExceptions(raw, exceptions = KNOWN_HISTORY_EXCEPTIONS) {
+  const skip = new Set(exceptions.map((e) => e.sha))
+  const kept = []
+  for (const record of String(raw).split(RECORD_SEP)) {
+    if (!record.trim()) continue
+    const cut = record.indexOf(FIELD_SEP)
+    // 구분자가 없으면 SHA 를 특정할 수 없다 → 예외 판정 불가이므로 그대로 검사 대상에 남긴다.
+    if (cut < 0) {
+      kept.push(record)
+      continue
+    }
+    if (skip.has(record.slice(0, cut).trim())) continue
+    kept.push(record.slice(cut + 1))
+  }
+  return kept.join('\n')
+}
+
 const UUID_PATTERN = /\b[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}\b/giu
 const ZERO_UUID = /^0{32}$/u
 const NON_ZERO_UUID_HISTORY_PATTERN = String.raw`\b(?!0{8}-?0{4}-?0{4}-?0{4}-?0{12}\b)[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}\b`
@@ -198,8 +251,13 @@ function checkAllRefs() {
     return ['Git 이력: shallow clone에서는 --all-refs 검사를 신뢰할 수 없음']
   }
 
+  // SHA 를 레코드 앞에 붙여 뽑아야 커밋 단위 예외(KNOWN_HISTORY_EXCEPTIONS)를 걸 수 있다.
+  // 통짜로 스캔하면 어느 커밋이 걸렸는지 알 수 없어 전부 아니면 전무가 된다.
+  const commitMetadata = stripKnownExceptions(
+    git(['log', '--all', '--format=%H%x1F%an%n%ae%n%cn%n%ce%n%B%x1E']),
+  )
   const metadata = [
-    git(['log', '--all', '--format=%an%n%ae%n%cn%n%ce%n%B']),
+    commitMetadata,
     git(['for-each-ref', 'refs/tags', '--format=%(taggername)%n%(taggeremail)%n%(subject)%n%(body)']),
   ].join('\n')
   problems.push(...scanPublicText('Git 전체 메타데이터', metadata))
@@ -243,6 +301,24 @@ export function checkPublicBoundary({ manifest, trackedEntries = [], metadata = 
   return { packageFiles, trackedFiles: trackedEntries.map((entry) => entry.path), problems: [...new Set(problems)] }
 }
 
+/**
+ * 알려진 예외를 사람에게 노출한다. 예외가 있다는 사실이 조용해지면 그때부터 영구 회피다.
+ * `--all-refs` 일 때만 실제로 적용되므로 그 사실도 같이 알린다.
+ */
+function reportKnownExceptions(allRefs) {
+  if (KNOWN_HISTORY_EXCEPTIONS.length === 0) {
+    console.log('알려진 이력 예외: 0건')
+    return
+  }
+  const scope = allRefs ? '적용됨' : '이번 실행에서는 미적용 — --all-refs 에서만 쓰인다'
+  console.log(`알려진 이력 예외 ${KNOWN_HISTORY_EXCEPTIONS.length}건 (${scope}):`)
+  for (const e of KNOWN_HISTORY_EXCEPTIONS) {
+    console.log(`  - ${e.sha.slice(0, 7)} ${e.label}`)
+    console.log(`      사유: ${e.reason}`)
+    console.log(`      남은 일: ${e.pending}`)
+  }
+}
+
 function main() {
   const argv = new Set(process.argv.slice(2))
   const staged = argv.has('--staged')
@@ -255,6 +331,9 @@ function main() {
     metadata: readPendingMetadata(commitMessageFile),
     allRefs: argv.has('--all-refs'),
   })
+
+  // 예외는 통과·실패와 무관하게 **항상** 보여준다. 조용해지는 순간 영구 회피가 된다.
+  reportKnownExceptions(argv.has('--all-refs'))
 
   if (result.problems.length > 0) {
     console.error('공개 경계 검사 실패:')

--- a/tests/check-public-boundary.test.ts
+++ b/tests/check-public-boundary.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from 'vitest'
-import { buildHistorySearchPattern, checkPublicBoundary, scanPublicText } from '../scripts/check-public-boundary.mjs'
+import {
+  buildHistorySearchPattern,
+  checkPublicBoundary,
+  scanPublicText,
+  stripKnownExceptions,
+  KNOWN_HISTORY_EXCEPTIONS,
+} from '../scripts/check-public-boundary.mjs'
+
+const RS = String.fromCharCode(0x1e)
+const US = String.fromCharCode(0x1f)
+/** `git log --format=%H%x1F...%x1E` 가 내는 레코드 스트림 모양. */
+const record = (sha: string, meta: string): string => `${sha}${US}${meta}${RS}`
 
 const manifest = (paths: string[]) => ({ files: paths.map((path) => ({ path })) })
 const requiredPackageFiles = [
@@ -59,5 +70,59 @@ describe('공개 경계 검사', () => {
     expect(pattern.test(privateRepository)).toBe(true)
     expect(pattern.test(objectId)).toBe(true)
     expect(pattern.test(zeroId)).toBe(false)
+  })
+})
+
+// 이미 공개된 커밋의 작성자 정보는 되돌리려면 이력 재작성 + force push 가 필요한데,
+// fork 가 있어 그래도 노출이 안 끝난다. 방치하면 릴리스 워크플로가 영구 red 가 되므로
+// **조용한 우회 대신 선언된 예외**로 처리한다. 검사 자체는 죽이지 않는다.
+describe('알려진 이력 예외 (커밋 메타데이터 한정)', () => {
+  const privateMail = ['byh3071', '@', 'gmail.com'].join('')
+  const EXEMPT = 'a'.repeat(40)
+  const OTHER = 'b'.repeat(40)
+  const exceptions = [{ sha: EXEMPT, label: 'x', reason: 'y', pending: 'z' }]
+
+  it('예외 SHA 의 레코드는 검사 대상에서 빠진다', () => {
+    const raw = record(EXEMPT, `이름\n${privateMail}\nGitHub\nnoreply@github.com\n제목`)
+    expect(stripKnownExceptions(raw, exceptions)).not.toContain(privateMail)
+  })
+
+  it('예외가 아닌 커밋은 그대로 남아 계속 잡힌다 (검사 무력화 아님)', () => {
+    const raw = record(OTHER, `이름\n${privateMail}\nGitHub\nnoreply@github.com\n제목`)
+    const kept = stripKnownExceptions(raw, exceptions)
+    expect(kept).toContain(privateMail)
+    expect(scanPublicText('메타', kept).length).toBeGreaterThan(0)
+  })
+
+  it('예외와 비예외가 섞이면 비예외만 남는다', () => {
+    const raw =
+      record(EXEMPT, `이름\n${privateMail}\n제목A`) + record(OTHER, '이름\nok@users.noreply.github.com\n제목B')
+    const kept = stripKnownExceptions(raw, exceptions)
+    expect(kept).not.toContain(privateMail)
+    expect(kept).toContain('제목B')
+  })
+
+  it('구분자가 없는 입력은 SHA 판정 불가라 그대로 남긴다 (fail-closed)', () => {
+    const raw = `이름\n${privateMail}\n제목`
+    expect(stripKnownExceptions(raw, exceptions)).toContain(privateMail)
+  })
+
+  it('예외 목록이 비면 아무것도 걸러내지 않는다', () => {
+    const raw = record(EXEMPT, `이름\n${privateMail}\n제목`)
+    expect(stripKnownExceptions(raw, [])).toContain(privateMail)
+  })
+
+  it('실제 예외 항목은 사유와 남은 일을 반드시 적는다 (영구 회피 방지)', () => {
+    expect(KNOWN_HISTORY_EXCEPTIONS.length).toBeGreaterThan(0)
+    for (const e of KNOWN_HISTORY_EXCEPTIONS) {
+      expect(e.sha).toMatch(/^[0-9a-f]{40}$/)
+      expect(e.reason.length).toBeGreaterThan(10)
+      expect(e.pending.length).toBeGreaterThan(10)
+    }
+  })
+
+  // 예외가 늘어나기 시작하면 "선언"이 아니라 "회피"가 된다.
+  it('예외는 1건을 넘지 않는다 — 새 위반은 예외가 아니라 수정 대상', () => {
+    expect(KNOWN_HISTORY_EXCEPTIONS.length).toBeLessThanOrEqual(1)
   })
 })


### PR DESCRIPTION
`v2.12.0` 태그 push 시 릴리스 워크플로가 1단계(`check-public-boundary --git-only --all-refs`)에서 실패했다. 그걸 푼다.

## 문제

```
공개 경계 검사 실패:
- Git 전체 메타데이터: 개인 Gmail 노출
```

| 항목 | 값 |
|---|---|
| 원인 커밋 | `db69765` (#537) |
| committer | `noreply@github.com` ✅ |
| **author** | **개인 Gmail** ❌ |
| 유입 시점 | 2026-07-27 이력 재작성 **이후** |

author 만 개인 이메일이고 committer 가 GitHub noreply 라는 조합은 **웹에서 squash 머지될 때 작성자가 계정 기본 이메일로 교체**된 흔적이다.

## 왜 이력 재작성으로 안 고치나

되돌리려면 main 이력 재작성 + force push 가 필요하다. 그런데 **이 저장소에는 fork 가 있다**(`kiminbean/vhk`, 재작성 이전 생성). GitHub fork 네트워크는 객체를 공유하므로 재작성해도 옛 커밋이 상위 저장소 URL 로 계속 조회된다 — 2026-07-28 에 직접 확인했다.

즉 **비용은 큰데(17커밋 재작성 + 브랜치 보호 해제 + fork divergence) 노출은 안 끝난다.**

그렇다고 방치하면 릴리스 워크플로가 영구 red 다. 늘 빨간 게이트는 사람이 꺼버린다 — 이 저장소가 이미 두 번 겪은 실패 형태이고, 이슈 #515 가 그 인과("항상 빨간 게이트 → 150커밋 동안 게이트 방치")를 기록해뒀다.

## 조치 — 조용한 우회 대신 **선언**

`KNOWN_HISTORY_EXCEPTIONS` 신설. 작업 단위 117("검사 의도 선언")과 같은 규율이다.

| 원칙 | 구현 |
|---|---|
| 검사를 죽이지 않는다 | **SHA 단위** 예외. 패턴은 그대로라 다른 모든 커밋에 작동 |
| 범위를 넓히지 않는다 | 커밋 **메타데이터 한정**. 파일 내용(blob)·추적 경로 검사엔 예외 없음 |
| 조용해지지 않는다 | 통과·실패와 무관하게 예외 건수·사유·**남은 일**을 항상 출력 |
| 늘어나지 않는다 | 테스트가 **1건 상한**으로 막는다 |

```
알려진 이력 예외 1건 (적용됨):
  - db69765 커밋 작성자 이메일이 개인 Gmail
      사유: GitHub squash 머지가 작성자를 계정 기본 이메일로 교체 (#537, 재작성 이후 유입)
      남은 일: 정정하려면 main 이력 재작성 + force push 필요 — 사람 판단 대기
```

### 구현상 필요했던 것

종전에는 `git log --all` 메타데이터를 **통짜 문자열**로 스캔해 어느 커밋이 걸렸는지 알 수 없었다 — 커밋 단위 예외가 구조적으로 불가능했다.

`--format=%H%x1F...%x1E` 로 SHA 를 레코드 앞에 붙여 뽑고 `stripKnownExceptions` 가 걸러낸다. **구분자가 없는 입력은 SHA 판정 불가이므로 그대로 검사 대상에 남긴다**(fail-closed).

## 검증 결과

| 검사 | 결과 |
|---|---|
| **CI 환경 재현** (fresh clone, ref 21개) | `--git-only --all-refs` **통과** — 예외 1건이 출력에 노출됨 |
| `tests/check-public-boundary.test.ts` | 통과 — 13건 (**신규 7건**) |
| `pnpm typecheck` | 통과 |
| `pnpm lint` | 통과 |
| `pnpm test:run` | 통과 — 226 파일 / **2584건** |

신규 테스트가 고정하는 것: 예외 필터링 · **비예외 커밋이 계속 잡히는지**(무력화 아님) · 혼합 입력 · 구분자 없는 입력 fail-closed · 예외 항목이 사유·남은 일을 반드시 적는지 · 예외 1건 상한.

## 남은 일 (사람)

이 예외는 **정정 대기** 상태다. 근본 해소는 fork 처리(GitHub Support 요청) + 이력 정정이며 둘 다 사람 판단이 필요하다. 예외 목록이 늘어나면 규율이 무너지는 신호다.

머지 시 squash 대신 merge 커밋 사용 (squash가 작성자 이메일을 교체한 전례 있음 — 이 PR이 다루는 문제가 정확히 그것이다)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 공개 경계 검사에서 알려진 이력 예외를 처리해, 커밋 메타데이터 검사 시 허용된 예외로 인한 오류를 줄였습니다.
  * 전체 참조 검사 결과에서 예외 커밋을 정확히 제외합니다.
  * 알려진 예외 내역을 사람이 읽기 쉬운 형태로 항상 표시합니다.

* **테스트**
  * 예외 커밋 필터링, 혼합 입력, 잘못된 형식 및 예외 목록 제한에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->