### PR TITLE
chore: 패키지 매니저 감지 테스트 추가

### DIFF
--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -28,24 +28,6 @@ vi.mock('ora', () => ({
 }))
 
 describe('audit', () => {
-  describe('detectCurrentPM', () => {
-    it('pnpm과 yarn 잠금 파일이 모두 있으면 pnpm을 선택한다', async () => {
-      mockExistsSync.mockImplementation(
-        (file: unknown) => file === 'pnpm-lock.yaml' || file === 'yarn.lock'
-      )
-      const { detectCurrentPM } = await import('../src/commands/audit.js')
-
-      expect(detectCurrentPM()).toBe('pnpm')
-    })
-
-    it('yarn 잠금 파일만 있으면 yarn을 선택한다', async () => {
-      mockExistsSync.mockImplementation((file: unknown) => file === 'yarn.lock')
-      const { detectCurrentPM } = await import('../src/commands/audit.js')
-
-      expect(detectCurrentPM()).toBe('yarn')
-    })
-  })
-
   beforeEach(() => {
     vi.resetAllMocks()
     vi.spyOn(console, 'log').mockImplementation(() => {})
@@ -195,6 +177,24 @@ describe('audit', () => {
       const printed = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
       expect(printed).toContain('취약점이 발견되지 않았습니다')
       expect(process.exitCode).not.toBe(1)
+    })
+  })
+
+  describe('detectCurrentPM', () => {
+    it('pnpm과 yarn 잠금 파일이 모두 있으면 pnpm을 선택한다', async () => {
+      mockExistsSync.mockImplementation(
+        (file: unknown) => file === 'pnpm-lock.yaml' || file === 'yarn.lock'
+      )
+      const { detectCurrentPM } = await import('../src/commands/audit.js')
+
+      expect(detectCurrentPM()).toBe('pnpm')
+    })
+
+    it('yarn 잠금 파일만 있으면 yarn을 선택한다', async () => {
+      mockExistsSync.mockImplementation((file: unknown) => file === 'yarn.lock')
+      const { detectCurrentPM } = await import('../src/commands/audit.js')
+
+      expect(detectCurrentPM()).toBe('yarn')
     })
   })
 })

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -28,6 +28,24 @@ vi.mock('ora', () => ({
 }))
 
 describe('audit', () => {
+  describe('detectCurrentPM', () => {
+    it('pnpm과 yarn 잠금 파일이 모두 있으면 pnpm을 선택한다', async () => {
+      mockExistsSync.mockImplementation(
+        (file: unknown) => file === 'pnpm-lock.yaml' || file === 'yarn.lock'
+      )
+      const { detectCurrentPM } = await import('../src/commands/audit.js')
+
+      expect(detectCurrentPM()).toBe('pnpm')
+    })
+
+    it('yarn 잠금 파일만 있으면 yarn을 선택한다', async () => {
+      mockExistsSync.mockImplementation((file: unknown) => file === 'yarn.lock')
+      const { detectCurrentPM } = await import('../src/commands/audit.js')
+
+      expect(detectCurrentPM()).toBe('yarn')
+    })
+  })
+
   beforeEach(() => {
     vi.resetAllMocks()
     vi.spyOn(console, 'log').mockImplementation(() => {})


### PR DESCRIPTION
`detectCurrentPM()`의 잠금 파일 우선순위가 직접 검증되지 않아 pnpm·yarn 선택 계약을 유닛 테스트로 고정했다.
pnpm과 yarn 잠금 파일이 함께 있을 때 pnpm을 선택하고, yarn 잠금 파일만 있을 때 yarn을 선택하는지 확인한다.

**리뷰 포인트**

`existsSync` 입력 조합과 패키지 매니저 우선순위 기대값 위주로 봐줘.

확인: `pnpm.cmd exec vitest run tests/audit.test.ts --coverage --coverage.include=src/commands/audit.ts --coverage.reporter=text` (13/13), `pnpm.cmd run typecheck`, `pnpm.cmd run lint`, `pnpm.cmd run build`, `pnpm.cmd run boundary:check`

전체 `pnpm.cmd run test:run`은 assertion 실패 없이 진행됐지만 로컬 Windows 환경에서 Vitest fork worker가 비정상 종료해 exit 1이었다. 단일 워커 실행은 오류 없이 진행되다가 5분 실행 제한에 걸렸다.