### PR TITLE
chore: worktree 생성 시 pnpm install 자동 실행 훅 추가

### DIFF
--- a/paseo.json
+++ b/paseo.json
@@ -1,0 +1,5 @@
+{
+  "worktree": {
+    "setup": "pnpm install --frozen-lockfile"
+  }
+}


### PR DESCRIPTION
Paseo 로 워크트리를 만들면 `node_modules` 가 없는 상태로 시작해서, 거기 붙는 에이전트가 매번 `pnpm install` 부터 실행했다. 이걸 `paseo.json` 의 worktree setup 훅으로 옮겨 자동화한다.

**리뷰 포인트**

`--frozen-lockfile` 이 맞는지. 워크트리는 항상 커밋된 lockfile 기준이라 붙였는데, lockfile 갱신 작업을 워크트리에서 할 일이 있으면 빼야 한다.

확인: 새 워크트리 생성 후 `node_modules` 가 자동으로 생기는지.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 작업 공간 설정에 고정된 잠금 파일을 기반으로 패키지를 설치하는 단계가 추가되었습니다.
  * 작업 환경을 보다 일관되게 구성할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->