### PR TITLE
feat: 원격 에이전트가 만든 PR 도 기록 집행을 받게 (#526)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,15 +162,35 @@ jobs:
   # Goal 47: 매트릭스화로 잡 컨텍스트가 'test (os, node)'·'dogfood (os)'로 바뀌어 브랜치 보호의
   #   고정 필수체크 이름이 깨진다. 집계 잡 'gate' 하나를 두고 보호 규칙은 이것만 require —
   #   매트릭스 조합이 바뀌어도 필수체크 이름(gate)은 불변(미래안전).
+  # #526 — 원격 에이전트·CI 기록 집행 사각지대.
+  # 로컬 훅이 요구하는 세션 기록은 docs/devlog/ 와 .vhk/events/ 로 전부 비추적이라 클론만 받는
+  # CI 는 존재를 볼 수 없다(훅을 CI 로 옮겨도 같다). 그래서 추적되는 공개 기록물로 축을 바꿨다.
+  record:
+    name: 기록 동반 확인
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: 코드 변경에 기록물이 동반됐는지
+        run: node scripts/check-pr-record.mjs "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"
+
   gate:
     name: gate
-    needs: [test, dogfood]
+    needs: [test, dogfood, record]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: 매트릭스 전조합 성공 확인
         run: |
-          echo "test=${{ needs.test.result }} · dogfood=${{ needs.dogfood.result }}"
+          echo "test=${{ needs.test.result }} · dogfood=${{ needs.dogfood.result }} · record=${{ needs.record.result }}"
+          # record 는 PR 에서만 도므로 main 푸시에서는 skipped 가 정상이다.
+          if [ "${{ needs.record.result }}" != "success" ] && [ "${{ needs.record.result }}" != "skipped" ]; then
+            echo "::error::기록 동반 확인 실패 — gate fail (머지 차단)"
+            exit 1
+          fi
           if [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.dogfood.result }}" != "success" ]; then
             echo "::error::매트릭스 일부 조합 실패 — gate fail (머지 차단)"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,13 +169,33 @@ jobs:
     name: 기록 동반 확인
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          # PR 코드를 실행하는 잡이라 체크아웃 토큰을 남기지 않는다.
+          persist-credentials: false
+
+      # 검사받는 쪽이 검사기를 고를 수 있으면 게이트가 아니다.
+      # PR 이 이 스크립트를 항상 통과하도록 바꿔 우회하는 걸 막으려고 base 판본을 꺼내 쓴다.
+      - name: 게이트 구현을 base 에서 추출
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if git cat-file -e "$BASE_SHA:scripts/check-pr-record.mjs" 2>/dev/null; then
+            git show "$BASE_SHA:scripts/check-pr-record.mjs" > "$RUNNER_TEMP/gate.mjs"
+          else
+            echo "::notice::base 에 게이트가 없습니다 — 도입 PR 로 보고 이 PR 판본을 씁니다"
+            cp scripts/check-pr-record.mjs "$RUNNER_TEMP/gate.mjs"
+          fi
 
       - name: 코드 변경에 기록물이 동반됐는지
-        run: node scripts/check-pr-record.mjs "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node "$RUNNER_TEMP/gate.mjs" "$BASE_SHA" "$HEAD_SHA"
 
   gate:
     name: gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ## [Unreleased]
 
+### Added
+
+- 원격 에이전트·CI 가 기록 집행 사각지대이던 문제를 메우는 PR 게이트 (#526) — 코드가 바뀐 PR 은
+  `CHANGELOG.md`·`README.md`·`RULES.md`·`docs/` 중 하나를 함께 갱신해야 한다. 로컬 훅이 요구하는
+  세션 기록은 비추적이라 클론만 받는 CI 가 볼 수 없어, 추적되는 공개 기록물로 검증 축을 바꿨다.
+  `[skip-record]` 우회는 로컬 훅과 동일하게 인정한다.
+
 ## [2.14.1] - 2026-08-18
 
 ### Fixed

--- a/scripts/check-pr-record.d.mts
+++ b/scripts/check-pr-record.d.mts
@@ -1,0 +1,12 @@
+/** check-pr-record.mjs 의 타입 — 게이트 스크립트는 런타임 의존이 없어 .mjs 로 두고 선언만 붙인다. */
+
+export declare const CODE_PATTERNS: RegExp[]
+export declare const RECORD_PATTERNS: RegExp[]
+export declare const BYPASS_TOKEN: string
+
+export declare function classify(files: string[]): { code: string[]; records: string[] }
+
+export declare function judge(
+  files: string[],
+  commitMessages: string[],
+): { ok: boolean; reason: string }

--- a/scripts/check-pr-record.mjs
+++ b/scripts/check-pr-record.mjs
@@ -1,0 +1,89 @@
+/*
+ * 원격 기록 집행 게이트 (#526).
+ *
+ * 로컬 커밋은 .githooks 의 check-records 가 세션 기록을 강제한다. 그런데 그 기록은
+ * docs/devlog/ 와 .vhk/events/*.jsonl 로 전부 비추적이다(공개 경계 정책 — 개인 세션 기록은
+ * 커밋하지 않는다). 클론만 받는 CI 와 원격 에이전트는 그 파일을 원리적으로 볼 수 없어서,
+ * "기록했는가" 를 원격에서 검증하는 건 불가능하다. 훅을 CI 로 옮겨도 해결되지 않는다.
+ *
+ * 그래서 검증 축을 바꾼다. 비공개 세션 기록 대신 **추적되는 공개 기록물**을 요구한다 —
+ * 코드가 바뀌었으면 CHANGELOG·docs·README·RULES 중 하나는 같이 움직여야 한다는 규칙이고,
+ * 이건 클론에 그대로 들어오므로 원격 에이전트가 만든 PR 도 동일하게 걸린다.
+ *
+ * 커밋이 아니라 PR 전체 diff 를 본다: 이 레포는 논리 단위로 커밋을 쪼개서
+ * 코드 커밋과 CHANGELOG 커밋이 분리되는 게 정상이다.
+ *
+ * 사용: node scripts/check-pr-record.mjs <baseSha> <headSha>
+ */
+import { execFileSync } from 'node:child_process'
+
+/** 기록을 동반해야 하는 실질 변경. */
+export const CODE_PATTERNS = [/^src\//, /^scripts\//]
+
+/** 기록으로 인정하는 추적 산출물. */
+export const RECORD_PATTERNS = [
+  /^CHANGELOG\.md$/,
+  /^README\.md$/,
+  /^RULES\.md$/,
+  /^docs\//,
+]
+
+/** 커밋 메시지에 이게 있으면 의도된 우회로 인정한다(로컬 훅과 같은 토큰). */
+export const BYPASS_TOKEN = '[skip-record]'
+
+export function classify(files) {
+  const code = files.filter((f) => CODE_PATTERNS.some((p) => p.test(f)))
+  const records = files.filter((f) => RECORD_PATTERNS.some((p) => p.test(f)))
+  return { code, records }
+}
+
+/**
+ * @returns {{ok: boolean, reason: string}}
+ */
+export function judge(files, commitMessages) {
+  const { code, records } = classify(files)
+  if (code.length === 0) return { ok: true, reason: '실질 코드변경 없음 — 검사 대상 아님' }
+  if (records.length > 0) {
+    return { ok: true, reason: `기록 동반 확인(${records.length}건): ${records.slice(0, 3).join(', ')}` }
+  }
+  if (commitMessages.some((m) => m.includes(BYPASS_TOKEN))) {
+    return { ok: true, reason: `${BYPASS_TOKEN} — 의도된 우회` }
+  }
+  return {
+    ok: false,
+    reason:
+      `실질 코드변경 ${code.length}건에 기록물 변경이 없습니다: ${code.slice(0, 5).join(', ')}\n`
+      + 'CHANGELOG.md · README.md · RULES.md · docs/ 중 해당하는 곳을 함께 갱신하거나, '
+      + `사소한 변경이면 커밋 메시지에 ${BYPASS_TOKEN} 을 넣으세요.\n`
+      + '(로컬 훅의 세션 기록은 비추적이라 원격에서 확인할 수 없습니다 — #526)',
+  }
+}
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf-8' })
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].split(/[\\/]/).pop())) {
+  const [base, head] = process.argv.slice(2)
+  if (!base || !head) {
+    process.stderr.write('사용법: node scripts/check-pr-record.mjs <baseSha> <headSha>\n')
+    process.exit(1)
+  }
+  let files
+  let messages
+  try {
+    files = git(['diff', '--name-only', `${base}...${head}`]).split('\n').filter(Boolean)
+    messages = git(['log', '--format=%B', `${base}..${head}`]).split('\n')
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    // fail-open: 게이트 자체가 못 도는 상황(얕은 클론 등)으로 작업을 막지 않는다.
+    process.stdout.write(`기록 게이트 실행 불가 — 통과 처리: ${message}\n`)
+    process.exit(0)
+  }
+  const verdict = judge(files, messages)
+  if (!verdict.ok) {
+    process.stderr.write(`::error::${verdict.reason}\n`)
+    process.exit(1)
+  }
+  process.stdout.write(`✅ ${verdict.reason}\n`)
+}

--- a/tests/check-pr-record.test.ts
+++ b/tests/check-pr-record.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+// @ts-expect-error — 게이트 스크립트는 .mjs 라 타입 선언이 없다(빌드 산출물 아님).
+import { judge, classify, BYPASS_TOKEN } from '../scripts/check-pr-record.mjs'
+
+/*
+ * #526 — 원격 에이전트·CI 가 기록 집행 사각지대인 문제.
+ *
+ * 로컬 훅이 요구하는 세션 기록은 docs/devlog/ 와 .vhk/events/*.jsonl 로 전부 비추적이라
+ * 클론만 받는 CI 는 존재 자체를 볼 수 없다. 그래서 추적되는 공개 기록물로 축을 바꿨고,
+ * 그 판정 규칙을 여기서 고정한다.
+ */
+
+describe('check-pr-record (#526)', () => {
+  it('코드 변경이 없으면 검사 대상이 아니다', () => {
+    const r = judge(['docs/adr/ADR-001.md'], ['docs: ADR 추가'])
+    expect(r.ok).toBe(true)
+    expect(r.reason).toContain('검사 대상 아님')
+  })
+
+  it('코드 변경에 기록물이 동반되면 통과', () => {
+    const r = judge(['src/commands/foo.ts', 'CHANGELOG.md'], ['fix: foo'])
+    expect(r.ok).toBe(true)
+  })
+
+  it('코드만 바뀌고 기록물이 없으면 차단', () => {
+    const r = judge(['src/commands/foo.ts', 'tests/foo.test.ts'], ['fix: foo'])
+    expect(r.ok).toBe(false)
+    expect(r.reason).toContain('기록물 변경이 없습니다')
+  })
+
+  it('우회 토큰이 있으면 통과 — 로컬 훅과 같은 탈출구', () => {
+    const r = judge(['src/commands/foo.ts'], ['fix: 오타\n\n[skip-record]'])
+    expect(r.ok).toBe(true)
+    expect(r.reason).toContain(BYPASS_TOKEN)
+  })
+
+  // 테스트만 있는 PR 은 기록 요구 대상이 아니다 — 과안정화 경계(로컬 훅의 CODE_GLOBS 와 같은 판단).
+  it('tests 만 바뀌면 검사 대상이 아니다', () => {
+    expect(judge(['tests/a.test.ts'], ['test: 추가']).ok).toBe(true)
+  })
+
+  it('scripts 변경도 코드로 센다 — 게이트 자체가 바뀌는 경우', () => {
+    const { code } = classify(['scripts/check-foo.mjs'])
+    expect(code).toEqual(['scripts/check-foo.mjs'])
+    expect(judge(['scripts/check-foo.mjs'], ['chore: 게이트 수정']).ok).toBe(false)
+  })
+
+  it('docs 하위는 어느 경로든 기록으로 인정', () => {
+    for (const rec of ['docs/rfc/0001-x.md', 'docs/troubleshooting/TS-001.md', 'docs/patterns/PAT-001.md']) {
+      expect(judge(['src/a.ts', rec], ['fix: a']).ok).toBe(true)
+    }
+  })
+})

--- a/tests/check-pr-record.test.ts
+++ b/tests/check-pr-record.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'vitest'
-// @ts-expect-error — 게이트 스크립트는 .mjs 라 타입 선언이 없다(빌드 산출물 아님).
 import { judge, classify, BYPASS_TOKEN } from '../scripts/check-pr-record.mjs'
 
 /*


### PR DESCRIPTION
#526 을 처리하려고 "훅을 CI 로도 돌리자" 로 접근했는데, 그대로는 성립하지 않았다.

로컬 훅이 요구하는 세션 기록은 `docs/devlog/` 와 `.vhk/events/*.jsonl` 로 **전부 gitignore** 다. 공개 경계 정책상 개인 세션 기록은 커밋하지 않기로 돼 있어서다. 클론만 받는 CI 와 원격 에이전트는 그 파일의 존재를 원리적으로 확인할 수 없다 — 훅을 CI 로 옮겨도 같은 벽에 막힌다.

그래서 검증 축을 바꿨다. 비공개 세션 기록 대신 **추적되는 공개 기록물**을 요구한다. 코드가 바뀐 PR 은 `CHANGELOG.md` · `README.md` · `RULES.md` · `docs/` 중 하나를 같이 움직여야 한다. 이건 클론에 그대로 들어오므로 원격 에이전트가 만든 PR 도 동일하게 걸린다. 이미 CLAUDE.md 기록 규칙("코드 변경이 동작·사용법을 바꾸면 README를 같이 갱신", "의사결정 → docs/adr/")이 요구하던 것이기도 하다.

**리뷰 포인트**

- 커밋이 아니라 **PR 전체 diff** 를 본다. 이 레포는 논리 단위로 커밋을 쪼개서 코드 커밋과 CHANGELOG 커밋이 갈리는 게 정상이라, 커밋 단위로 걸면 정상 워크플로가 깨진다.
- 도입 영향 실측 — 최근 PR 5건(#577 #578 #580 #581 #582)에 적용해보니 전부 통과한다. 기존 관례를 깨지 않는다.
- 판정 범위: `src/` · `scripts/` 만 코드로 센다. `tests/` 만 바뀐 PR 은 대상이 아니다(로컬 훅의 `CODE_GLOBS` 와 같은 과안정화 경계). `[skip-record]` 우회도 로컬 훅과 동일하게 인정한다.
- 게이트 자체가 못 도는 상황(얕은 클론 등)은 fail-open 이다 — 게이트 버그로 작업을 막지 않는다.

**확인 방법**

```
pnpm exec vitest run tests/check-pr-record.test.ts
node scripts/check-pr-record.mjs <baseSha> <headSha>
```

이 PR 자신도 새 게이트를 통과해야 한다(`CHANGELOG.md` 를 동반한다).

실측: 255파일 3089건 통과(4 skip), typecheck·lint·rmSync 가드 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 풀 리퀘스트에서 코드 변경 시 관련 기록물 동반 여부를 자동으로 확인합니다.
  * 기록물 없이 코드만 변경된 경우 검사가 실패하며, 필요 시 `[skip-record]`로 예외 처리할 수 있습니다.
* **개선**
  * 기록 확인 결과가 풀 리퀘스트 품질 검증 과정에 반영됩니다.
  * 다양한 변경 유형에 대한 자동 검증 범위와 신뢰성이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->