### PR TITLE
feat: 패턴 사전 규약을 기계가 검사하게 (#527)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,7 @@
   - 범용 패턴(타 프로젝트 재사용 가능) → docs/patterns/ `PAT-NNN-영문명.md`
 - 세션 종료 시 미기록 ADR·트러블슈팅 후보를 확인하고 해당하면 공개 문서에는 일반화된 기술 사실만 기록
 - 개인 세션 기록·현재 작업 큐·외부 서비스 식별자는 커밋하지 않음
+- 패턴 사전은 `PAT-NNN-영문명.md` 형식과 frontmatter 필수 필드를 지키고, 문서가 참조하는 `PAT-NNN` 은 실존해야 한다 (깨진 참조가 sync 로 파생본에 복제됨) <!-- vhk:check=patterns -->
 - 코드 변경이 동작/사용법을 바꾸면 README를 같이 갱신
 - 교훈·결정·실패·성공의 운영 원본 = `vhk memory`(4버킷) / `vhk learn`. `docs/til.md`는 검증된 범용 배움만 공개 요약으로 승격하는 파생 문서다. learnings.md 는 v2 흡수·동결 → 신규 기록 금지.
 - 제품 작업 정의·순서의 원본 = 추적되는 `docs/roadmap/2.x-roadmap.md`, 수용 기준의 원본 = `docs/PRD-2.x.md` (ADR-010 §2).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ### Added
 
+- 패턴 사전 규약 검사 (#527) — `PAT-NNN` 명명·frontmatter 필수 필드·번호 중복·**참조 무결성**을
+  `vhk check` 가 검사한다. 규약이 문서로만 있던 탓에 결번을 가리키는 참조가 `vhk sync` 로 파생본 8개에
+  복제된 적이 있어, 없는 번호를 참조하면 차단한다.
 - 원격 에이전트·CI 가 기록 집행 사각지대이던 문제를 메우는 PR 게이트 (#526) — 코드가 바뀐 PR 은
   `CHANGELOG.md`·`README.md`·`RULES.md`·`docs/` 중 하나를 함께 갱신해야 한다. 로컬 훅이 요구하는
   세션 기록은 비추적이라 클론만 받는 CI 가 볼 수 없어, 추적되는 공개 기록물로 검증 축을 바꿨다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@
   - 범용 패턴(타 프로젝트 재사용 가능) → docs/patterns/ `PAT-NNN-영문명.md`
 - 세션 종료 시 미기록 ADR·트러블슈팅 후보를 확인하고 해당하면 공개 문서에는 일반화된 기술 사실만 기록
 - 개인 세션 기록·현재 작업 큐·외부 서비스 식별자는 커밋하지 않음
+- 패턴 사전은 `PAT-NNN-영문명.md` 형식과 frontmatter 필수 필드를 지키고, 문서가 참조하는 `PAT-NNN` 은 실존해야 한다 (깨진 참조가 sync 로 파생본에 복제됨) <!-- vhk:check=patterns -->
 - 코드 변경이 동작/사용법을 바꾸면 README를 같이 갱신
 - 교훈·결정·실패·성공의 운영 원본 = `vhk memory`(4버킷) / `vhk learn`. `docs/til.md`는 검증된 범용 배움만 공개 요약으로 승격하는 파생 문서다. learnings.md 는 v2 흡수·동결 → 신규 기록 금지.
 - 제품 작업 정의·순서의 원본 = 추적되는 `docs/roadmap/2.x-roadmap.md`, 수용 기준의 원본 = `docs/PRD-2.x.md` (ADR-010 §2).

--- a/RULES.md
+++ b/RULES.md
@@ -100,6 +100,7 @@
   - 범용 패턴(타 프로젝트 재사용 가능) → docs/patterns/ `PAT-NNN-영문명.md`
 - 세션 종료 시 미기록 ADR·트러블슈팅 후보를 확인하고 해당하면 공개 문서에는 일반화된 기술 사실만 기록
 - 개인 세션 기록·현재 작업 큐·외부 서비스 식별자는 커밋하지 않음
+- 패턴 사전은 `PAT-NNN-영문명.md` 형식과 frontmatter 필수 필드를 지키고, 문서가 참조하는 `PAT-NNN` 은 실존해야 한다 (깨진 참조가 sync 로 파생본에 복제됨) <!-- vhk:check=patterns -->
 - 코드 변경이 동작/사용법을 바꾸면 README를 같이 갱신
 - 교훈·결정·실패·성공의 운영 원본 = `vhk memory`(4버킷) / `vhk learn`. `docs/til.md`는 검증된 범용 배움만 공개 요약으로 승격하는 파생 문서다. learnings.md 는 v2 흡수·동결 → 신규 기록 금지.
 - 제품 작업 정의·순서의 원본 = 추적되는 `docs/roadmap/2.x-roadmap.md`, 수용 기준의 원본 = `docs/PRD-2.x.md` (ADR-010 §2).

--- a/scripts/check-rule-patterns.d.mts
+++ b/scripts/check-rule-patterns.d.mts
@@ -1,0 +1,13 @@
+/** check-rule-patterns.mjs 의 타입 — 게이트 스크립트는 .mjs 로 두고 선언만 붙인다. */
+
+export declare const LEGACY_FILES: Set<string>
+export declare const REQUIRED_FIELDS: string[]
+export declare const LEGACY_REQUIRED_FIELDS: string[]
+export declare const PATTERN_FILE_RE: RegExp
+
+export declare function frontmatterKeys(content: string): string[] | null
+export declare function frontmatterValue(content: string, key: string): string | null
+export declare function judge(
+  files: { name: string; content: string }[],
+  references: string[],
+): string[]

--- a/scripts/check-rule-patterns.mjs
+++ b/scripts/check-rule-patterns.mjs
@@ -1,0 +1,152 @@
+/*
+ * 패턴 사전 규약 검사 (#527).
+ *
+ * 왜 필요한가: 규약이 문서로만 있으면 붕괴한다. 실제로 2일 만에 무너져 PAT-003 이 결번인 채
+ * RULES.md 가 그 번호를 참조했고, 그 깨진 링크가 `vhk sync` 로 파생본 8개에 그대로 복제됐다.
+ * 참조 무결성이 이 검사에서 가장 값이 큰 이유다 — 틀린 참조는 증폭된다.
+ *
+ * 검사 4종:
+ *   ① PAT-NNN 파일의 frontmatter 필수 필드 + id 와 파일명 번호 일치
+ *   ② 번호 중복 금지
+ *   ③ 신규 파일은 PAT-NNN 형식 (기존 슬러그 파일은 개명 금지라 baseline 으로 허용)
+ *   ④ 추적 문서가 참조하는 PAT-NNN 이 실존하는가
+ *
+ * 결번 자체는 막지 않는다 — 파일을 지우면 자연히 생기고, 참조가 없으면 해롭지 않다.
+ * 해로운 건 "없는 번호를 가리키는 참조" 라서 ④가 그걸 직접 잡는다.
+ */
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { join, basename } from 'node:path'
+
+const ROOT = process.cwd()
+const PATTERN_DIR = join(ROOT, 'docs', 'patterns')
+
+/** PAT-NNN 도입 이전 파일들 — README 가 개명 금지(append-only)로 명시. 신규 추가는 이 목록 밖이라 차단된다. */
+export const LEGACY_FILES = new Set([
+  'auth-npm-scoped-publish-404.md',
+  'build-cli-coldstart-lazy-heavy-dep.md',
+  'build-exec-timeout-etimedout.md',
+  'build-json-parse-bom-strip.md',
+  'build-release-tool-forced-version-bump.md',
+  'build-version-runtime-read.md',
+  'env-bash-tool-vs-powershell-heredoc.md',
+  'env-windows-cmd-shim-node20.md',
+  'env-windows-filename-sanitize.md',
+  'git-crlf-normalize-before-compare.md',
+  'git-diff-since-no-op.md',
+  'state-single-chokepoint-guard.md',
+  'test-gate-derive-not-hardcode.md',
+  'ux-local-date-vs-utc-timestamp.md',
+  'ux-nontty-interactive-guard.md',
+  'ux-publish-stdio-inherit.md',
+])
+
+/** PAT-NNN 파일에 요구하는 frontmatter 필드 (docs/patterns/README.md 규약). */
+export const REQUIRED_FIELDS = [
+  'id', '패턴명', '카테고리', '증상', '원인', '해결',
+  '적용조건', '출처프로젝트', '태그', '발견일', '출처DevLog',
+]
+
+/** 레거시 파일에는 PAT-NNN 도입 때 생긴 필드를 소급 요구하지 않는다. */
+export const LEGACY_REQUIRED_FIELDS = ['패턴명', '카테고리', '출처프로젝트', '태그', '발견일']
+
+export const PATTERN_FILE_RE = /^PAT-(\d{3})-[a-z0-9-]+\.md$/
+
+/** frontmatter 의 최상위 키만 뽑는다(값은 여러 줄일 수 있어 키 존재만 본다). */
+export function frontmatterKeys(content) {
+  if (!content.startsWith('---')) return null
+  const end = content.indexOf('\n---', 3)
+  if (end === -1) return null
+  const block = content.slice(3, end)
+  const keys = []
+  for (const line of block.split('\n')) {
+    const m = line.match(/^([^\s:][^:]*):/)
+    if (m) keys.push(m[1].trim())
+  }
+  return keys
+}
+
+export function frontmatterValue(content, key) {
+  const end = content.indexOf('\n---', 3)
+  const block = content.slice(3, end === -1 ? undefined : end)
+  const m = block.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'))
+  return m ? m[1].trim() : null
+}
+
+/**
+ * @param {{name: string, content: string}[]} files 패턴 디렉터리의 .md (README 제외)
+ * @param {string[]} references 추적 문서에서 발견한 PAT-NNN 참조
+ * @returns {string[]} 위반 목록(빈 배열이면 통과)
+ */
+export function judge(files, references) {
+  const violations = []
+  const numbers = new Map()
+
+  for (const { name, content } of files) {
+    const keys = frontmatterKeys(content)
+    if (keys === null) {
+      violations.push(`${name} — frontmatter 가 없습니다`)
+      continue
+    }
+    const match = name.match(PATTERN_FILE_RE)
+    if (!match) {
+      if (!LEGACY_FILES.has(name)) {
+        violations.push(`${name} — 신규 패턴은 PAT-NNN-영문명.md 형식이어야 합니다 (docs/patterns/README.md)`)
+      }
+      for (const field of LEGACY_REQUIRED_FIELDS) {
+        if (!keys.includes(field)) violations.push(`${name} — frontmatter 필드 누락: ${field}`)
+      }
+      continue
+    }
+    const num = match[1]
+    if (numbers.has(num)) violations.push(`PAT-${num} 번호 중복: ${numbers.get(num)} · ${name}`)
+    else numbers.set(num, name)
+
+    for (const field of REQUIRED_FIELDS) {
+      if (!keys.includes(field)) violations.push(`${name} — frontmatter 필드 누락: ${field}`)
+    }
+    const id = frontmatterValue(content, 'id')
+    if (id !== null && id !== `PAT-${num}`) {
+      violations.push(`${name} — frontmatter id(${id})가 파일명 번호(PAT-${num})와 다릅니다`)
+    }
+  }
+
+  // ④ 참조 무결성 — 틀린 참조는 sync 로 파생본에 복제되므로 여기서 끊는다.
+  const existing = new Set([...numbers.keys()].map((n) => `PAT-${n}`))
+  for (const ref of new Set(references)) {
+    if (!existing.has(ref)) violations.push(`${ref} 를 참조하지만 docs/patterns/ 에 그 번호가 없습니다`)
+  }
+  return violations
+}
+
+function trackedMarkdown() {
+  const out = execFileSync('git', ['ls-files', '-z', '--', '*.md'], { encoding: 'utf-8', cwd: ROOT })
+  return out.split('\0').filter(Boolean)
+}
+
+if (existsSync(PATTERN_DIR)) {
+  const files = readdirSync(PATTERN_DIR)
+    .filter((f) => f.endsWith('.md') && f !== 'README.md')
+    .map((name) => ({ name, content: readFileSync(join(PATTERN_DIR, name), 'utf-8') }))
+
+  let references = []
+  try {
+    for (const rel of trackedMarkdown()) {
+      // 패턴 문서 자신의 제목·id 는 참조가 아니다.
+      if (rel.startsWith('docs/patterns/') && basename(rel) !== 'README.md') continue
+      const text = readFileSync(join(ROOT, rel), 'utf-8')
+      references.push(...(text.match(/PAT-\d{3}/g) ?? []))
+    }
+  } catch (error) {
+    // fail-open: git 이 없거나 얕은 클론이면 참조 검사만 건너뛴다(나머지는 계속).
+    const message = error instanceof Error ? error.message : String(error)
+    process.stdout.write(`참조 무결성 검사 생략(git 조회 실패): ${message}\n`)
+    references = []
+  }
+
+  const violations = judge(files, references)
+  if (violations.length > 0) {
+    process.stderr.write(`패턴 사전 규약 위반 (#527):\n${violations.join('\n')}\n`)
+    process.exitCode = 1
+  }
+}

--- a/tests/check-rule-patterns.test.ts
+++ b/tests/check-rule-patterns.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { judge, frontmatterKeys, REQUIRED_FIELDS } from '../scripts/check-rule-patterns.mjs'
+
+/*
+ * #527 — 패턴 사전 규약이 문서로만 있어 2일 만에 붕괴했다.
+ * PAT-003 이 결번인 채 RULES.md 가 그 번호를 참조했고, 깨진 링크가 vhk sync 로 파생본 8개에 복제됐다.
+ * 참조 무결성이 이 검사에서 가장 값이 큰 이유 — 틀린 참조는 증폭된다.
+ */
+
+/** 규약을 만족하는 PAT 문서 본문. */
+function validPattern(num: string): string {
+  const fields = REQUIRED_FIELDS.map((f: string) => (f === 'id' ? `id: PAT-${num}` : `${f}: 값`))
+  return ['---', ...fields, '---', '', `# PAT-${num}`, ''].join('\n')
+}
+
+describe('check-rule-patterns (#527)', () => {
+  it('규약을 지킨 문서는 통과', () => {
+    expect(judge([{ name: 'PAT-001-foo.md', content: validPattern('001') }], [])).toEqual([])
+  })
+
+  // 이 검사의 존재 이유 — 틀린 참조는 sync 로 파생본에 복제된다.
+  it('실존하지 않는 번호를 참조하면 잡는다', () => {
+    const v = judge([{ name: 'PAT-001-foo.md', content: validPattern('001') }], ['PAT-003'])
+    expect(v).toHaveLength(1)
+    expect(v[0]).toContain('PAT-003')
+  })
+
+  it('실존하는 번호 참조는 통과', () => {
+    expect(judge([{ name: 'PAT-001-foo.md', content: validPattern('001') }], ['PAT-001'])).toEqual([])
+  })
+
+  it('frontmatter 필수 필드 누락을 잡는다', () => {
+    const broken = ['---', 'id: PAT-002', '패턴명: x', '---', ''].join('\n')
+    const v = judge([{ name: 'PAT-002-bar.md', content: broken }], [])
+    expect(v.some((m: string) => m.includes('카테고리'))).toBe(true)
+  })
+
+  it('frontmatter 자체가 없으면 잡는다', () => {
+    const v = judge([{ name: 'PAT-004-x.md', content: '# 제목만 있는 문서\n' }], [])
+    expect(v).toEqual(['PAT-004-x.md — frontmatter 가 없습니다'])
+  })
+
+  it('id 가 파일명 번호와 다르면 잡는다', () => {
+    const v = judge([{ name: 'PAT-007-x.md', content: validPattern('009') }], [])
+    expect(v.some((m: string) => m.includes('파일명 번호'))).toBe(true)
+  })
+
+  it('번호 중복을 잡는다', () => {
+    const v = judge(
+      [
+        { name: 'PAT-001-a.md', content: validPattern('001') },
+        { name: 'PAT-001-b.md', content: validPattern('001') },
+      ],
+      [],
+    )
+    expect(v.some((m: string) => m.includes('번호 중복'))).toBe(true)
+  })
+
+  // README 가 기존 슬러그 파일은 개명 금지(append-only)로 두되 신규는 새 형식을 쓰라고 정했다.
+  it('baseline 밖의 새 슬러그 파일은 잡는다', () => {
+    const legacyShape = ['---', '패턴명: x', '카테고리: git', '출처프로젝트: vhk', '태그: [a]', '발견일: 2026-01-01', '---', ''].join('\n')
+    const v = judge([{ name: 'git-new-thing.md', content: legacyShape }], [])
+    expect(v.some((m: string) => m.includes('PAT-NNN-영문명.md 형식'))).toBe(true)
+  })
+
+  it('baseline 안의 기존 슬러그 파일은 통과', () => {
+    const legacyShape = ['---', '패턴명: x', '카테고리: git', '출처프로젝트: vhk', '태그: [a]', '발견일: 2026-01-01', '---', ''].join('\n')
+    expect(judge([{ name: 'git-diff-since-no-op.md', content: legacyShape }], [])).toEqual([])
+  })
+
+  it('frontmatterKeys — 없으면 null, 있으면 최상위 키', () => {
+    expect(frontmatterKeys('# 제목\n')).toBeNull()
+    expect(frontmatterKeys('---\na: 1\nb: 2\n---\n')).toEqual(['a', 'b'])
+  })
+})


### PR DESCRIPTION
#527 의 세 제안 중 (b)·(c)를 처리했다. 이슈 본인이 "(b)-3 이 제일 값큼"이라 짚은 **참조 무결성**이 핵심이다 — 결번을 가리키는 참조가 `vhk sync` 로 파생본 8개에 복제된 실피해가 있었다. 틀린 참조는 증폭된다.

`vhk check` 에 `check-patterns` 를 연결했다(자동 검사 5개 → 6개). CI 는 이미 「연결된 규칙 검사」 잡에서 `vhk check` 를 돌리므로 별도 잡 없이 걸린다.

검사 4종:

1. `PAT-NNN` 파일의 frontmatter 필수 필드 11개 + `id` 와 파일명 번호 일치
2. 번호 중복
3. 신규 파일 명명 — 기존 슬러그 파일 16건은 README 가 개명 금지(append-only)로 정해둬서 baseline 으로 허용하고, 그 밖의 새 슬러그 파일만 막는다
4. 추적 문서가 참조하는 `PAT-NNN` 실존 여부

**리뷰 포인트**

- **결번 자체는 막지 않는다.** 파일을 지우면 자연히 생기고, 참조가 없으면 해롭지 않다. 해로운 건 "없는 번호를 가리키는 참조"라 4번이 그걸 직접 잡는다. 이슈의 "번호 결번/중복" 요구를 이렇게 해석했다.
- 마커를 최상위 글머리표에 달아야 한다 — `parseRuleDeclarations` 가 `/^[-*]\s+/` 로 들여쓰지 않은 줄만 선언으로 읽는다. 처음에 판단표 하위 항목에 달았다가 인식이 안 돼 옮겼다.
- 참조 스캔은 추적되는 `.md` 전체가 대상이고, 패턴 문서 자신의 제목·`id` 는 참조로 세지 않는다.

**확인 방법**

```
node scripts/check-rule-patterns.mjs   # exit 0
node dist/index.js check               # check-patterns 포함 6개 통과
```

실물 검증: `RULES.md` 에 없는 번호(`PAT-099`) 참조를 넣으면 exit 1 로 잡히는 것을 확인하고 되돌렸다.

**남긴 것**: (a) 재발 자동 감지는 범위가 크고 애매해서 손대지 않았다. 이슈에도 "감지가 어렵다면 최소한 (b)만으로도 값이 크다"고 적혀 있다.

실측: 256파일 3099건 통과(4 skip), typecheck·lint·build·boundary·sync --check 전부 0.
