### PR TITLE
chore: 2.14.1 릴리스 범위에 #526·#527 포함

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ## [Unreleased]
 
-### Added
+## [2.14.1] - 2026-08-18
+
+### Internal
+
+> 아래 두 항목은 저장소의 검사 체계 변경이라 npm 배포물(`dist`)은 바뀌지 않는다.
 
 - 패턴 사전 규약 검사 (#527) — `PAT-NNN` 명명·frontmatter 필수 필드·번호 중복·**참조 무결성**을
   `vhk check` 가 검사한다. 규약이 문서로만 있던 탓에 결번을 가리키는 참조가 `vhk sync` 로 파생본 8개에
@@ -13,8 +17,6 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
   `CHANGELOG.md`·`README.md`·`RULES.md`·`docs/` 중 하나를 함께 갱신해야 한다. 로컬 훅이 요구하는
   세션 기록은 비추적이라 클론만 받는 CI 가 볼 수 없어, 추적되는 공개 기록물로 검증 축을 바꿨다.
   `[skip-record]` 우회는 로컬 훅과 동일하게 인정한다.
-
-## [2.14.1] - 2026-08-18
 
 ### Fixed
 


### PR DESCRIPTION
`v2.14.1` 태그를 잡은 뒤 #526·#527 두 건이 더 머지됐다. npm 발행 전이라 태그를 다시 잡아 릴리스 노트와 실제 범위를 맞춘다.

**`Added` 가 아니라 `Internal` 로 적은 이유**

두 건 모두 `src/` 를 건드리지 않는다. 바뀐 건 `.github/workflows/`·`scripts/`·`tests/`·규칙 문서뿐이고, npm 패키지는 `files: ["dist","README.md","SECURITY.md","LICENSE"]` 라 **배포물이 완전히 동일하다**. 기능 추가로 읽히면 사용자가 없는 변화를 기대하게 된다.

같은 이유로 버전은 2.14.1 그대로다. 공개 API 표면이 그대로라 patch 판정이 유지되고, 2.15.0 에 걸린 관찰 게이트와도 무관하다.

**리뷰 포인트**

- CHANGELOG 의 `Internal` 섹션 표기 — 이 레포에 이미 쓰인 적 있는 섹션이라 새 관례를 만들지는 않았다.
- 머지 후 태그 재지정이 뒤따른다. 발행 전이라 안전하지만, 이미 push 된 태그를 옮기는 작업이라 이 PR 이 머지되면 바로 처리한다.

**확인 방법**

```
git diff --stat v2.14.1 <머지커밋> -- src/    # 비어 있어야 한다
```
