### PR TITLE
feat: 권한 단계 판정 (124-T1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ### Internal
 
+- 권한 단계 판정을 순수 함수로 신설 (작업 단위 124-T1 · RFC 0066 §4). 자율 실행이 어디까지 갈 수
+  있는지(`L0` 관찰 ~ `L3` 제출)를 3중 판정 집계에서 매번 재계산한다. 단계를 저장하지 않으므로
+  원장이 사라지면 시작값으로 돌아간다 — fail-closed 다. **아직 어디에도 배선되지 않았다**(계산만).
 - 자율 런 3중 판정 집계를 `commands/stats.ts` 에서 `lib/autonomy-stats.ts` 로 이관 (RFC 0066 §2.1).
   권한 단계 판정(작업 단위 124)이 이 계산을 유일한 입력으로 쓰는데, lib 이 commands 를 import 하면
   역방향 의존이 생긴다. 공개 표면과 출력은 불변 — `commands/stats.ts` 는 re-export 만 남긴다.

--- a/src/lib/permission-level.ts
+++ b/src/lib/permission-level.ts
@@ -1,0 +1,146 @@
+/*
+ * permission-level.ts — 자율 실행의 권한 단계 판정 (작업 단위 124-T1 · RFC 0066 §4).
+ *
+ * 이 모듈은 **계산만** 한다. 원장에 쓰지 않고(그건 policy-log.ts / T3), 단계를 저장하지도
+ * 않는다(§4.7). 현재 단계는 원장의 마지막 level 라인에서 매번 다시 계산되는 파생값이다.
+ * 파생 스냅샷이 원본 행세를 하는 것을 막기 위해서다.
+ *
+ * 원장이 통째로 사라지면 단계는 시작값으로 돌아간다. 이것은 결함이 아니라 fail-closed 다 —
+ * "과거 로컬 진행 상태는 복구된 것으로 추측하지 않고 unknown 으로 돌아간다"는 규율과 같다.
+ */
+import type { AutonomyStats } from './autonomy-stats.js'
+
+/** 무엇을 허용하는가의 상한. 낮은 단계가 높은 단계의 부분집합이다. */
+export const LEVELS = ['L0', 'L1', 'L2', 'L3'] as const
+export type PermissionLevel = (typeof LEVELS)[number]
+
+/**
+ * `L3` 가 절대 상한인 근거는 ADR-009 ② 다. `L4` 는 정의하지 않는다 —
+ * "자동 머지 활성화" 는 로드맵 §8 에서 이번 계열 밖으로 명시 제외돼 있다.
+ */
+export const MAX_LEVEL: PermissionLevel = 'L3'
+
+/**
+ * 승급을 허용하는 최근 창의 실패 상한. **이 계열의 유일한 새 상수다**(§4.6).
+ *
+ * 값이 1인 근거는 진동(flapping) 방지다. 관찰 게이트의 통과선은 "실패 2회 이하", 축소선은
+ * "3회 이상" 이다. 승급선을 통과선과 같은 2로 두면 실패 2건과 3건 사이를 오갈 때 매 런마다
+ * 승급·축소가 번갈아 난다. 승급 ≤1 / 유지 =2 / 축소 ≥3 으로 한 칸을 비워 히스테리시스를 만든다.
+ */
+export const PROMOTION_FAILURE_MAX = 1
+
+export type TransitionKind = 'init' | 'promote' | 'demote' | 'hold'
+
+export type LevelReasonCode =
+  | 'LEDGER_EMPTY'
+  | 'NO_NEW_JUDGED_RUN'
+  | 'INSUFFICIENT_SAMPLE'
+  | 'DEMOTE_ROLLING_FAILURES'
+  | 'INFRA_ABUSE_SUSPECTED'
+  | 'SELF_REPORT_GAP'
+  | 'PROMOTE_ROLLING_CLEAN'
+  | 'HOLD_HYSTERESIS'
+
+/** 원장의 마지막 `kind: 'level'` 라인에서 판정에 필요한 부분만(§3.3). */
+export interface LevelLine {
+  to: PermissionLevel
+  /** 전이 근거 표본 수. 다음 판정의 트리거 비교 기준이다(§4.3). */
+  judgedRuns: number
+  ts: string
+}
+
+/** 사람이 설정하는 것 — 상한을 **낮출 때만** 쓴다(§4.7). */
+export interface PermissionConfig {
+  maxLevel?: PermissionLevel
+}
+
+export interface LevelDecision {
+  level: PermissionLevel
+  transition: TransitionKind
+  reasonCode: LevelReasonCode
+}
+
+function indexOf(level: PermissionLevel): number {
+  return LEVELS.indexOf(level)
+}
+
+/** 하한 `L0` 과 상한 `L3` 을 둘 다 고정한다. 이 범위 밖으로 나가는 경로는 코드에 없어야 한다. */
+export function clampLevel(index: number): PermissionLevel {
+  return LEVELS[Math.max(0, Math.min(LEVELS.length - 1, index))]
+}
+
+/** 계산 결과와 사람이 정한 상한 중 낮은 쪽. 사람은 낮출 수만 있다. */
+function capped(index: number, config: PermissionConfig): PermissionLevel {
+  const ceiling = config.maxLevel ? indexOf(config.maxLevel) : indexOf(MAX_LEVEL)
+  return clampLevel(Math.min(index, ceiling))
+}
+
+/**
+ * 권한 단계 판정 (§4.4 의사코드).
+ *
+ * 분기 순서가 곧 계약이다. 특히 축소(3)가 승급(5)보다 **먼저**여야 한다 —
+ * 순서를 바꾸면 실패가 쌓이는 중에도 승급이 난다.
+ *
+ * @param stats 3중 판정 집계 — 권한 판정의 유일한 입력(§2)
+ * @param config 사람이 설정한 상한
+ * @param last 원장의 마지막 level 라인. 없으면 null
+ */
+export function decidePermissionLevel(
+  stats: AutonomyStats,
+  config: PermissionConfig,
+  last: LevelLine | null,
+): LevelDecision {
+  // 0) 신규 진입 — 원장에 level 라인이 없다.
+  //    §11 Q1 확정: L1(제안)에서 시작한다. L0 완전 차단은 원장이 비는 게 흔한 상태(새 클론·
+  //    유실)라 자율 레인이 매번 멈추고, 그러면 표본이 안 쌓여 승급도 영원히 못 한다.
+  if (last === null) {
+    return { level: capped(indexOf('L1'), config), transition: 'init', reasonCode: 'LEDGER_EMPTY' }
+  }
+
+  const previous = indexOf(last.to)
+
+  // 1) 전이 트리거 — 판정 대상 런이 늘지 않았으면 아무 일도 없다(§4.3 치명 3).
+  //    이게 없으면 vhk policy level 을 세 번 불러 L1 → L3 로 올라가는 경로가 열린다.
+  if (stats.judgedRuns <= last.judgedRuns) {
+    return { level: capped(previous, config), transition: 'hold', reasonCode: 'NO_NEW_JUDGED_RUN' }
+  }
+
+  // 2) 표본 부족 — 유지한다. 하강시키지 않는다(중대 15).
+  //    표본이 없다는 것은 나쁜 소식이 아니라 무소식이다.
+  if (stats.rollingFailures === null) {
+    return { level: capped(previous, config), transition: 'hold', reasonCode: 'INSUFFICIENT_SAMPLE' }
+  }
+
+  // 3) 축소가 승급보다 먼저다.
+  if (stats.demotionTriggered === true) {
+    return {
+      level: capped(previous - 1, config),
+      transition: 'demote',
+      reasonCode: 'DEMOTE_ROLLING_FAILURES',
+    }
+  }
+
+  // 4) 승급 차단 신호 — 하나라도 켜지면 유지. 첫 신호만 기록한다.
+  if (stats.infraAbuseSuspected) {
+    return {
+      level: capped(previous, config),
+      transition: 'hold',
+      reasonCode: 'INFRA_ABUSE_SUSPECTED',
+    }
+  }
+  if ((stats.rollingSelfReportedOnly ?? 0) > 0) {
+    return { level: capped(previous, config), transition: 'hold', reasonCode: 'SELF_REPORT_GAP' }
+  }
+
+  // 5) 승급 — 창이 충분히 깨끗할 때만 한 칸.
+  if (stats.rollingFailures <= PROMOTION_FAILURE_MAX) {
+    return {
+      level: capped(previous + 1, config),
+      transition: 'promote',
+      reasonCode: 'PROMOTE_ROLLING_CLEAN',
+    }
+  }
+
+  // 6) 그 사이 — 히스테리시스 구간.
+  return { level: capped(previous, config), transition: 'hold', reasonCode: 'HOLD_HYSTERESIS' }
+}

--- a/tests/permission-level.test.ts
+++ b/tests/permission-level.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest'
+import {
+  decidePermissionLevel,
+  clampLevel,
+  LEVELS,
+  PROMOTION_FAILURE_MAX,
+  type LevelLine,
+  type PermissionLevel,
+} from '../src/lib/permission-level.js'
+import type { AutonomyStats } from '../src/lib/autonomy-stats.js'
+
+/*
+ * RFC 0066 §4 — 권한 단계 판정 (124-T1).
+ *
+ * 이 판정은 순수 계산이다. 원장에 쓰지 않고, 단계를 저장하지도 않는다(§4.7).
+ * 현재 단계는 원장의 마지막 level 라인에서 매번 다시 계산되는 파생값이다.
+ *
+ * §4.4 의사코드의 분기 순서가 곧 계약이다. 특히 축소가 승급보다 **먼저**여야 한다 —
+ * 순서를 바꾸면 실패가 쌓이는 중에도 승급이 난다.
+ */
+
+/** 판정에 쓰는 필드만 채운 stats. 나머지는 판정이 보지 않는다(§2). */
+function stats(over: Partial<AutonomyStats> = {}): AutonomyStats {
+  return {
+    judgedRuns: 20,
+    rollingFailures: 0,
+    demotionTriggered: false,
+    infraAbuseSuspected: false,
+    rollingSelfReportedOnly: 0,
+    ...over,
+  } as AutonomyStats
+}
+
+function last(over: Partial<LevelLine> = {}): LevelLine {
+  return { to: 'L1', judgedRuns: 10, ts: '2026-08-20T00:00:00.000Z', ...over }
+}
+
+describe('권한 단계 판정 (RFC 0066 §4)', () => {
+  it('단계는 L0~L3 네 개뿐 — L4 는 없다 (ADR-009 ②)', () => {
+    expect(LEVELS).toEqual(['L0', 'L1', 'L2', 'L3'])
+  })
+
+  it('clamp 는 하한 L0 과 상한 L3 을 둘 다 고정한다', () => {
+    expect(clampLevel(-1)).toBe('L0')
+    expect(clampLevel(0)).toBe('L0')
+    expect(clampLevel(3)).toBe('L3')
+    expect(clampLevel(9)).toBe('L3')
+  })
+
+  // 케이스 0 — 원장에 level 라인이 없다 (§11 Q1 확정: L1)
+  it('원장이 비면 L1 에서 시작한다', () => {
+    const r = decidePermissionLevel(stats(), {}, null)
+    expect(r.level).toBe('L1')
+    expect(r.transition).toBe('init')
+    expect(r.reasonCode).toBe('LEDGER_EMPTY')
+  })
+
+  // 케이스 1 — 조회로는 승급하지 않는다 (§4.3 치명 3)
+  it('판정 대상 런이 늘지 않았으면 아무 일도 없다', () => {
+    const r = decidePermissionLevel(stats({ judgedRuns: 10 }), {}, last({ judgedRuns: 10 }))
+    expect(r.level).toBe('L1')
+    expect(r.transition).toBe('hold')
+    expect(r.reasonCode).toBe('NO_NEW_JUDGED_RUN')
+  })
+
+  // 케이스 2 — 표본 부족은 나쁜 소식이 아니라 무소식이다 (중대 15)
+  it('표본이 부족하면 유지한다 — 하강시키지 않는다', () => {
+    const r = decidePermissionLevel(stats({ rollingFailures: null }), {}, last({ to: 'L3' }))
+    expect(r.level).toBe('L3')
+    expect(r.transition).toBe('hold')
+    expect(r.reasonCode).toBe('INSUFFICIENT_SAMPLE')
+  })
+
+  // 케이스 3 — 축소가 승급보다 먼저다
+  it('축소 트리거가 켜지면 한 칸 내린다', () => {
+    const r = decidePermissionLevel(
+      stats({ rollingFailures: 4, demotionTriggered: true }),
+      {},
+      last({ to: 'L3' }),
+    )
+    expect(r.level).toBe('L2')
+    expect(r.transition).toBe('demote')
+    expect(r.reasonCode).toBe('DEMOTE_ROLLING_FAILURES')
+  })
+
+  it('축소는 L0 아래로 내려가지 않는다', () => {
+    const r = decidePermissionLevel(
+      stats({ rollingFailures: 5, demotionTriggered: true }),
+      {},
+      last({ to: 'L0' }),
+    )
+    expect(r.level).toBe('L0')
+  })
+
+  // 케이스 4 — 승급 차단 신호
+  it('인프라 남용 의심이면 승급하지 않는다', () => {
+    const r = decidePermissionLevel(stats({ infraAbuseSuspected: true }), {}, last())
+    expect(r.transition).toBe('hold')
+    expect(r.reasonCode).toBe('INFRA_ABUSE_SUSPECTED')
+  })
+
+  it('자기 보고 격차가 있으면 승급하지 않는다', () => {
+    const r = decidePermissionLevel(stats({ rollingSelfReportedOnly: 2 }), {}, last())
+    expect(r.transition).toBe('hold')
+    expect(r.reasonCode).toBe('SELF_REPORT_GAP')
+  })
+
+  // 케이스 5 — 승급
+  it('창이 깨끗하면 한 칸 올린다', () => {
+    const r = decidePermissionLevel(stats({ rollingFailures: PROMOTION_FAILURE_MAX }), {}, last())
+    expect(r.level).toBe('L2')
+    expect(r.transition).toBe('promote')
+    expect(r.reasonCode).toBe('PROMOTE_ROLLING_CLEAN')
+  })
+
+  it('한 번에 한 칸만 움직인다 — 두 칸 경로는 없다', () => {
+    const r = decidePermissionLevel(stats({ rollingFailures: 0 }), {}, last({ to: 'L0' }))
+    expect(r.level).toBe('L1')
+  })
+
+  it('승급은 L3 위로 올라가지 않는다 — 머지 경로는 만들지 않는다', () => {
+    const r = decidePermissionLevel(stats({ rollingFailures: 0 }), {}, last({ to: 'L3' }))
+    expect(r.level).toBe('L3')
+  })
+
+  // 케이스 6 — 히스테리시스 (승급 ≤1 / 유지 =2 / 축소 ≥3)
+  it('승급선과 축소선 사이는 유지 구간이다', () => {
+    const r = decidePermissionLevel(
+      stats({ rollingFailures: 2, demotionTriggered: false }),
+      {},
+      last(),
+    )
+    expect(r.transition).toBe('hold')
+    expect(r.reasonCode).toBe('HOLD_HYSTERESIS')
+  })
+
+  // §4.7 — 사람은 낮출 수만 있다
+  it('maxLevel 은 상한이다 — 그 위로는 승급하지 않는다', () => {
+    const r = decidePermissionLevel(
+      stats({ rollingFailures: 0 }),
+      { maxLevel: 'L1' as PermissionLevel },
+      last(),
+    )
+    expect(r.level).toBe('L1')
+  })
+
+  it('maxLevel 이 현재보다 낮으면 즉시 그 아래로 내린다', () => {
+    const r = decidePermissionLevel(
+      stats({ rollingFailures: null }),
+      { maxLevel: 'L1' as PermissionLevel },
+      last({ to: 'L3' }),
+    )
+    expect(r.level).toBe('L1')
+  })
+
+  // 판정은 순수해야 한다 — 원장 쓰기는 T3(policy-log) 소관이다
+  it('입력을 변형하지 않는다', () => {
+    const s = stats()
+    const l = last()
+    const snapshot = JSON.stringify({ s, l })
+    decidePermissionLevel(s, {}, l)
+    expect(JSON.stringify({ s, l })).toBe(snapshot)
+  })
+})


### PR DESCRIPTION
작업 단위 124 의 T1. 자율 실행이 어디까지 갈 수 있는지(`L0` 관찰 · `L1` 제안 · `L2` 커밋 · `L3` 제출)를 3중 판정 집계에서 계산한다. **아직 어디에도 배선하지 않았다** — 순수 함수만 추가한다.

`L3` 가 절대 상한이고 `L4` 는 정의하지 않는다(ADR-009 ②). 머지 경로는 코드에 만들지 않는다.

## 설계 요점

**단계를 저장하지 않는다(§4.7).** 원장의 마지막 전이 라인에서 매번 다시 계산하는 파생값이다. 파생 스냅샷이 원본 행세를 하는 것을 막는다. 원장이 사라지면 시작값(`L1`)으로 돌아가는데, 이건 결함이 아니라 fail-closed 다 — "과거 로컬 진행 상태는 복구된 것으로 추측하지 않는다"는 규율과 같다.

**분기 순서가 곧 계약이다(§4.4).**

| # | 조건 | 결과 |
|---|---|---|
| 0 | 원장에 전이 라인 없음 | `L1` init (§11 Q1 확정) |
| 1 | 판정 대상 런이 안 늘었음 | hold — **조회로는 승급하지 않는다**(§4.3) |
| 2 | 표본 부족 | hold — 하강시키지 않는다. 무소식은 나쁜 소식이 아니다 |
| 3 | 축소 트리거 | 한 칸 demote |
| 4 | 승급 차단 신호 | hold |
| 5 | 창이 깨끗함 | 한 칸 promote |
| 6 | 그 사이 | hold (히스테리시스) |

## 리뷰 포인트

- **축소(3)가 승급(5)보다 먼저인지.** 순서를 바꾸면 실패가 쌓이는 중에도 승급이 난다.
- **케이스 1이 조회 승급을 막는지.** 이게 없으면 `vhk policy level` 을 세 번 불러 `L1 → L3` 로 올라간다(적대 검증 치명 3).
- **`PROMOTION_FAILURE_MAX = 1`** 이 이 계열의 유일한 새 상수다. 승급 ≤1 / 유지 =2 / 축소 ≥3 으로 한 칸을 비워 진동을 막는다. 승급선을 관찰 게이트 통과선(2)과 같게 두면 실패 2건과 3건 사이에서 매 런마다 승급·축소가 번갈아 난다.
- **한 번에 한 칸만** 움직인다. 두 칸 경로가 코드에 없는지 — `clampLevel` 이 하한·상한을 둘 다 고정한다.

## 확인 방법

```
pnpm exec vitest run tests/permission-level.test.ts   # 16건
```

테스트가 §4.4 의 7개 분기를 각각 고정하고, 경계(`L0` 아래·`L3` 위·`maxLevel` 상한)와 입력 불변성도 단언한다.

실측: typecheck·lint 0, 16건 통과.
