### PR TITLE
feat: 위험도 분류 (124-T2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ### Internal
 
+- 위험도 분류를 신설 (작업 단위 124-T2 · RFC 0066 §5). 기존 `TaskKind` 7종을 `auto`/`human`
+  두 갈래로 접는 순수 매핑이다. **변경 경로 중 미분류가 하나라도 있으면 `human`** — 최댓값만 보면
+  `['docs/a.md', 'Dockerfile']` 이 통째로 `docs` 로 통과하던 구멍을 막는다. 권한 단계는 `human`
+  위험도를 완화하지 않는다. 이를 위해 `deriveTaskKindDetailed` 를 additive 로 추가하고
+  `.vhk/policy.json` 을 `security` 경로로 등재했다. **아직 배선되지 않았다**(계산만).
 - 권한 단계 판정을 순수 함수로 신설 (작업 단위 124-T1 · RFC 0066 §4). 자율 실행이 어디까지 갈 수
   있는지(`L0` 관찰 ~ `L3` 제출)를 3중 판정 집계에서 매번 재계산한다. 단계를 저장하지 않으므로
   원장이 사라지면 시작값으로 돌아간다 — fail-closed 다. **아직 어디에도 배선되지 않았다**(계산만).

--- a/src/lib/risk-class.ts
+++ b/src/lib/risk-class.ts
@@ -1,0 +1,57 @@
+/*
+ * risk-class.ts — 위험도 분류와 단계×위험도 매트릭스 (작업 단위 124-T2 · RFC 0066 §5).
+ *
+ * 새 분류 체계를 만들지 않는다. `task-kind.ts` 가 이미 7종 닫힌집합을 갖고 있고,
+ * 유형은 변경된 파일 경로에서 유도하므로 에이전트가 "이건 잡무입니다" 라고 신고해도
+ * 승인 경계를 우회할 수 없다. 여기서 하는 일은 그 7종을 두 갈래로 접는 순수 매핑뿐이다.
+ */
+import type { TaskKindBreakdown, TaskKind } from './task-kind.js'
+import type { PermissionLevel } from './permission-level.js'
+
+/**
+ * `auto` 는 "사람 없이 진행 가능" 이 아니다. **"이 단계에서 상한을 낮추는 추가 사유가 없다"** 는 뜻이다.
+ * `human` 은 권한 단계가 무엇이든 사람 확인 없이 넘어가지 않는다는 뜻이다.
+ */
+export type RiskClass = 'auto' | 'human'
+
+/**
+ * ADR-009 ③ 이 자동 허용으로 지정한 셋만 `auto` 다.
+ * 지정하지 않은 것은 전부 `human` — 목록에 없다는 이유로 낙관 추정하지 않는다.
+ */
+export const RISK_MAP: Record<TaskKind, RiskClass> = {
+  chore: 'auto',
+  docs: 'auto',
+  deps: 'auto', // §11 Q2 재검토 대상 — 관찰 게이트 종료 시 판정
+  source: 'human', // ADR-009 ③ 이 자동 허용으로 지정하지 않음 → fail-closed
+  schema: 'human',
+  security: 'human',
+  unknown: 'human', // 유도 실패. 낙관 추정 금지
+}
+
+/**
+ * 변경 내역 → 위험도 (§5.3).
+ *
+ * 미분류가 하나라도 섞이면 최댓값 유형이 무엇이든 `human` 이다. `deriveTaskKind` 의 최댓값만
+ * 보면 `['docs/a.md', 'Dockerfile']` 이 통째로 `docs` = `auto` 로 통과하는데, 컨테이너 정의·
+ * CI 보조 파일·확장자 없는 스크립트가 문서 파일 하나에 묻어 낮은 위험도로 새는 구멍이다.
+ *
+ * 경로가 0개인 것도 `human` 이다 — 범위를 못 구한 상태를 "바꾼 게 없으니 안전" 으로 읽지 않는다.
+ */
+export function riskClassOf(breakdown: TaskKindBreakdown): RiskClass {
+  if (breakdown.total === 0) return 'human'
+  if (breakdown.unclassified > 0) return 'human'
+  return RISK_MAP[breakdown.kind]
+}
+
+/**
+ * 단계 × 위험도 매트릭스 (§5.2) — 이 조합에서 실제로 허용되는 상한.
+ *
+ * 표의 전부는 `human` 열이 단계와 무관하게 같다는 것이다.
+ * **권한 단계는 `human` 위험도를 절대 완화하지 않는다.** 단계가 올라가면 `auto` 열만 넓어진다.
+ *
+ * 적용 지점은 커밋·push 같은 **런 종결 행위**다. 개별 명령 실행 전 검사(RFC 0067 §4)에는
+ * 적용하지 않는다 — 근거는 그쪽 문서에 있다.
+ */
+export function effectiveCeiling(level: PermissionLevel, risk: RiskClass): PermissionLevel {
+  return risk === 'human' ? 'L0' : level
+}

--- a/src/lib/task-kind.ts
+++ b/src/lib/task-kind.ts
@@ -34,6 +34,8 @@ const PATH_RULES: ReadonlyArray<{ kind: TaskKind; test: (p: string) => boolean }
     kind: 'security',
     test: (p) =>
       p.startsWith('.github/workflows/') ||
+      // RFC 0066 §7.3 조치3 — 권한 정책 설정. 이 파일이 바뀌면 자율 실행의 상한 자체가 바뀐다.
+      /(^|\/)\.vhk\/policy\.json$/.test(p) ||
       /(^|\/)(\.gitignore|\.npmrc|\.npmignore)$/.test(p) ||
       /(^|\/)[^/]*(secur|boundary|auth|secret|credential)[^/]*\.[a-z]+$/i.test(p) ||
       /(^|\/)exec\.[a-z]+$/i.test(p) ||
@@ -97,6 +99,35 @@ export function deriveTaskKind(paths: readonly string[]): TaskKind {
     if (rank > best) best = rank
   }
   return best < 0 ? 'unknown' : RISK_ORDER[best]
+}
+
+/**
+ * 변경 파일 목록의 분류 내역 (RFC 0066 §5.3 — additive).
+ *
+ * why 별도 함수인가: `deriveTaskKind` 는 위험도 최댓값만 돌려주는데, `RISK_ORDER` 에 `unknown`
+ * 이 없어서 미분류 경로는 `indexOf` 가 -1 을 주고 **어떤 분류된 유형에도 진다.** 그래서
+ * `['docs/a.md', 'Dockerfile']` 이 통째로 `docs` 가 된다 — 컨테이너 정의·CI 보조 파일·확장자
+ * 없는 스크립트가 문서 파일 하나에 묻어 낮은 위험도로 통과하는 구멍이다(적대 검증 치명 1).
+ *
+ * 기존 함수의 동작을 고치지 않는 이유는 원장에 이미 쓰인 `taskKind` 값의 의미가 달라지면
+ * 과거 라인과 비교가 깨지기 때문이다. 대신 미분류 수를 같이 돌려주고, 위험도 판정은
+ * 이 함수만 쓴다 — 미분류가 하나라도 있으면 `human` 이다.
+ */
+export interface TaskKindBreakdown {
+  /** `deriveTaskKind` 와 동일한 값 */
+  kind: TaskKind
+  /** 검사한 경로 수 */
+  total: number
+  /** `classifyPath` 가 `unknown` 을 준 경로 수 */
+  unclassified: number
+}
+
+export function deriveTaskKindDetailed(paths: readonly string[]): TaskKindBreakdown {
+  let unclassified = 0
+  for (const path of paths) {
+    if (classifyPath(path) === 'unknown') unclassified++
+  }
+  return { kind: deriveTaskKind(paths), total: paths.length, unclassified }
 }
 
 /** 외부(에이전트 플래그·과거 로그 라인)에서 들어온 값을 닫힌집합에 대조. 미매칭은 unknown. */

--- a/tests/risk-class.test.ts
+++ b/tests/risk-class.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import {
+  riskClassOf,
+  effectiveCeiling,
+  RISK_MAP,
+  type RiskClass,
+} from '../src/lib/risk-class.js'
+import { deriveTaskKindDetailed, type TaskKind } from '../src/lib/task-kind.js'
+import { LEVELS, type PermissionLevel } from '../src/lib/permission-level.js'
+
+/*
+ * RFC 0066 §5 — 위험도 분류 (124-T2).
+ *
+ * 새 분류 체계를 만들지 않는다. 기존 TaskKind 7종을 두 갈래(auto/human)로 접는 순수 매핑이다.
+ * `auto` 는 "사람 없이 진행 가능" 이 아니라 "이 단계에서 상한을 낮추는 추가 사유가 없다" 는 뜻이고,
+ * `human` 은 권한 단계가 무엇이든 사람 확인 없이 넘어가지 않는다는 뜻이다.
+ */
+
+describe('위험도 매핑 (RFC 0066 §5.1)', () => {
+  it('ADR-009 ③ 의 자동 허용 셋만 auto 다', () => {
+    const expected: Record<TaskKind, RiskClass> = {
+      chore: 'auto',
+      docs: 'auto',
+      deps: 'auto',
+      source: 'human',
+      schema: 'human',
+      security: 'human',
+      unknown: 'human',
+    }
+    expect(RISK_MAP).toEqual(expected)
+  })
+
+  it('TaskKind 7종이 모두 매핑돼 있다 — 빠지면 판정이 undefined 가 된다', () => {
+    const kinds: TaskKind[] = ['chore', 'docs', 'deps', 'source', 'schema', 'security', 'unknown']
+    for (const k of kinds) expect(RISK_MAP[k]).toMatch(/^(auto|human)$/)
+  })
+})
+
+describe('riskClassOf — 미분류가 섞이면 human (§5.3 치명 1)', () => {
+  it('전부 분류된 자동 허용 유형은 auto', () => {
+    expect(riskClassOf(deriveTaskKindDetailed(['docs/a.md']))).toBe('auto')
+  })
+
+  // 이 케이스가 치명 1 그 자체다. kind 는 docs 지만 Dockerfile 이 미분류로 섞여 있다.
+  it('미분류가 하나라도 섞이면 kind 가 auto 라도 human', () => {
+    const b = deriveTaskKindDetailed(['docs/a.md', 'Dockerfile'])
+    expect(b.kind).toBe('docs')
+    expect(riskClassOf(b)).toBe('human')
+  })
+
+  it('범위를 못 구했으면(경로 0개) human', () => {
+    expect(riskClassOf(deriveTaskKindDetailed([]))).toBe('human')
+  })
+
+  it('사람 필수 유형은 미분류가 없어도 human', () => {
+    expect(riskClassOf(deriveTaskKindDetailed(['.github/workflows/ci.yml']))).toBe('human')
+  })
+})
+
+describe('단계 × 위험도 매트릭스 (§5.2)', () => {
+  // 이 표의 전부는 human 열이 단계와 무관하게 같다는 것이다.
+  it('human 위험도는 어느 단계에서도 완화되지 않는다', () => {
+    for (const level of LEVELS) {
+      expect(effectiveCeiling(level, 'human')).toBe('L0')
+    }
+  })
+
+  it('auto 위험도는 단계를 그대로 쓴다', () => {
+    for (const level of LEVELS) {
+      expect(effectiveCeiling(level, 'auto')).toBe(level)
+    }
+  })
+
+  it('L0 은 위험도와 무관하게 읽기만', () => {
+    expect(effectiveCeiling('L0' as PermissionLevel, 'auto')).toBe('L0')
+    expect(effectiveCeiling('L0' as PermissionLevel, 'human')).toBe('L0')
+  })
+})

--- a/tests/task-kind-breakdown.test.ts
+++ b/tests/task-kind-breakdown.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifyPath,
+  deriveTaskKind,
+  deriveTaskKindDetailed,
+  type TaskKind,
+} from '../src/lib/task-kind.js'
+
+/*
+ * RFC 0066 §5.3 — 혼합 커밋에서 미분류가 섞이면 위험도는 human 이다 (적대 검증 치명 1).
+ *
+ * 초안은 "deriveTaskKind 가 이미 위험도 최댓값을 주므로 fail-closed" 라고 적었는데 코드와 반대였다.
+ * RISK_ORDER 에 unknown 이 없어서 `indexOf` 가 -1 을 주고, 미분류는 **어떤 분류된 유형에도 진다.**
+ * 그래서 `['docs/a.md', 'Dockerfile']` 이 통째로 docs = auto 로 통과했다.
+ *
+ * 기존 deriveTaskKind 의 시그니처·동작은 바꾸지 않는다 — 원장에 이미 쓰인 taskKind 값의 의미가
+ * 달라지면 과거 라인과 비교가 깨진다. 대신 additive 함수를 하나 더 둔다.
+ */
+
+describe('deriveTaskKindDetailed (RFC 0066 §5.3)', () => {
+  it('kind 는 기존 deriveTaskKind 와 항상 같다 — 원장 값의 의미 불변', () => {
+    const cases: string[][] = [
+      ['docs/a.md'],
+      ['docs/a.md', 'Dockerfile'],
+      ['Dockerfile'],
+      ['src/lib/a.ts', 'docs/b.md'],
+      ['.github/workflows/ci.yml'],
+      [],
+    ]
+    for (const paths of cases) {
+      expect(deriveTaskKindDetailed(paths).kind).toBe(deriveTaskKind(paths))
+    }
+  })
+
+  it('미분류 경로 수를 센다 — 이게 치명 1 을 막는 신호다', () => {
+    const r = deriveTaskKindDetailed(['docs/a.md', 'Dockerfile'])
+    expect(r.kind).toBe('docs') // 기존 동작 그대로
+    expect(r.total).toBe(2)
+    expect(r.unclassified).toBe(1) // 그러나 미분류가 섞였다는 사실이 남는다
+  })
+
+  it('전부 분류되면 unclassified 는 0', () => {
+    const r = deriveTaskKindDetailed(['docs/a.md', 'src/lib/x.ts'])
+    expect(r.unclassified).toBe(0)
+    expect(r.total).toBe(2)
+  })
+
+  it('빈 목록은 total 0 — 범위를 못 구한 상태', () => {
+    const r = deriveTaskKindDetailed([])
+    expect(r.total).toBe(0)
+    expect(r.unclassified).toBe(0)
+    expect(r.kind).toBe('unknown')
+  })
+
+  it('전부 미분류면 unclassified 가 total 과 같다', () => {
+    const r = deriveTaskKindDetailed(['Dockerfile', 'Makefile'])
+    expect(r.total).toBe(2)
+    expect(r.unclassified).toBe(2)
+    expect(r.kind).toBe('unknown')
+  })
+})
+
+describe('PATH_RULES 확장 — .vhk/policy.json (RFC 0066 §7.3 조치3)', () => {
+  // 설정 파일이 security 로 분류돼야 그 변경이 사람 승인 축에 걸린다.
+  it('.vhk/policy.json 은 security 다', () => {
+    expect(classifyPath('.vhk/policy.json')).toBe('security')
+  })
+
+  // additive 예외는 이 한 경로뿐이다. 다른 경로의 분류 결과는 하나도 바뀌지 않아야 한다.
+  it('기존 경로 집합의 분류 결과는 불변', () => {
+    const fixed: Array<[string, TaskKind]> = [
+      ['.github/workflows/ci.yml', 'security'],
+      ['.gitignore', 'security'],
+      ['src/lib/exec.ts', 'security'],
+      ['docs/adr/ADR-001.md', 'docs'],
+      ['src/lib/foo.ts', 'source'],
+      ['Dockerfile', 'unknown'],
+      ['.vhk/memory.json', 'unknown'],
+      ['.vhk/config.json', 'unknown'],
+    ]
+    for (const [path, kind] of fixed) {
+      expect([path, classifyPath(path)]).toEqual([path, kind])
+    }
+  })
+})


### PR DESCRIPTION
작업 단위 124 의 T2. 기존 `TaskKind` 7종을 `auto`/`human` 두 갈래로 접는 순수 매핑이다. **아직 배선하지 않았다** — 계산만 추가한다.

새 분류 체계를 만들지 않는 이유는 유형을 **변경된 파일 경로에서 유도**해야 에이전트가 "이건 잡무입니다" 라고 신고해 승인 경계를 우회할 수 없기 때문이다(`task-kind.ts` 주석이 이 작업 단위를 명시 예고하고 있다).

## 적대 검증 치명 1 을 실제로 막는다

`deriveTaskKind` 는 `RISK_ORDER.indexOf()` 로 최댓값을 구하는데 그 목록에 `unknown` 이 없다. 미분류는 `-1` 이라 **어떤 분류된 유형에도 진다.**

| 입력 | `deriveTaskKind` | 실제 위험도 |
|---|---|---|
| `['docs/a.md']` | `docs` | `auto` — 맞음 |
| `['docs/a.md', 'Dockerfile']` | **`docs`** | **`human` 이어야 하는데 `auto` 로 샘** |
| `['Dockerfile']` | `unknown` | `human` — 맞음 |

두 번째 행이 구멍이다. 컨테이너 정의·CI 보조 파일·확장자 없는 스크립트가 문서 파일 하나에 묻어 통과한다.

`riskClassOf` 는 `unclassified > 0` 이면 최댓값 유형과 무관하게 `human` 을 준다. 경로가 0개인 것도 `human` 이다 — 범위를 못 구한 상태를 "바꾼 게 없으니 안전" 으로 읽지 않는다.

## 리뷰 포인트

- **기존 `deriveTaskKind` 무변경.** 원장에 이미 쓰인 `taskKind` 값의 의미가 달라지면 과거 라인과 비교가 깨진다. `deriveTaskKindDetailed` 를 additive 로 더했고, `kind` 는 기존 함수와 항상 같음을 테스트가 단언한다.
- **`human` 열이 단계와 무관하게 같은지**(§5.2). 이 표의 전부가 그것이다 — 권한 단계는 `human` 위험도를 절대 완화하지 않고, 단계가 오르면 `auto` 열만 넓어진다. `effectiveCeiling` 이 L0~L3 전부에서 `L0` 을 주는지 테스트로 고정했다.
- **`PATH_RULES` 에 `.vhk/policy.json` 등재**(§7.3 조치3) — 이게 유일한 additive 예외라 다른 경로 8개의 분류 결과 불변을 함께 못박았다. 설정 파일이 `security` 로 분류돼야 그 변경이 사람 승인 축에 걸린다.
- `deps` 가 `auto` 인 것은 ADR-009 ③ 을 따른 것이고 §11 Q2 로 재검토 대상이다(관찰 게이트 종료 시 판정).

## 확인 방법

```
pnpm exec vitest run tests/risk-class.test.ts tests/task-kind.test.ts tests/task-kind-breakdown.test.ts
```

실측: 32건 통과(기존 16 + 신규 16), typecheck·lint 0.
