### PR TITLE
feat: vhk policy 조회 명령 (124-T4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ## [Unreleased]
 
+### Added
+
+- `vhk policy` — 자율 실행 권한 정책 조회 (작업 단위 124-T4 · RFC 0066 §8). `policy level` 은 현재
+  단계와 다음 승급 조건을, `policy risk` 는 스테이징된 변경의 위험도를, `policy show` 는 설정까지
+  함께 보여준다. 한글 별칭 `정책 단계`·`정책 위험도`·`정책 보기`. **세 서브커맨드 전부 읽기 전용이고
+  원장에 기록하지 않는다** — 조회로 단계가 오르면 세 번 불러 권한을 올리는 경로가 열린다.
+
 ### Internal
 
 - 권한 판정 원장을 신설 (작업 단위 124-T3 · RFC 0066 §3·§4.5). `record` 또는 `enforce` 일 때만

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -230,6 +230,7 @@ vhk doctor
 | `vhk recap` | 오늘 한 일 정리 + ADR 분리 (비-TTY/헤드리스: `--summary/--next/--decisions/--blockers/--yes`) |
 | `vhk sync` | RULES.md → 규칙 파일 동기화. `<!-- vhk:sync=all -->` 절은 8개 타겟 필수. `--check`는 재생성 결과 불일치와 필수 섹션 누락을 별도 집계하고, 문서-실측 drift는 경고로 표시 |
 | `vhk check` | RULES.md 규칙 점검. 규칙 줄의 `<!-- vhk:check=no-exec-sync -->`를 `scripts/check-rule-no-exec-sync.mjs`에 연결하며 검사 비율 출력 (`--json` = 선언·검사·미검사 수와 비율 포함) |
+| `vhk policy` | 자율 실행 권한 정책 조회 (읽기 전용 — 원장에 기록하지 않음). `policy level` = 현재 단계·다음 승급 조건, `policy risk` = 스테이징 변경의 위험도, `policy show` = 설정+단계+위험도. 한글: `정책 단계`·`정책 위험도`·`정책 보기` |
 | `vhk secure` | 보안 스캔 (시크릿 유출 검사). `secure scan <파일...>` = 발행물 초안 등 특정 파일만(.md 포함) — 게시 전 게이트(#457), CRITICAL/HIGH 시 exit 1 |
 | `vhk cloud` | .vhk 클라우드 백업·복원 (push/pull) |
 | `vhk ship` | 배포 체크리스트 + 회고 |

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ VHK 프로젝트에서 **active goal 1개를 혼자 한 바퀴 돌리고 멈춰 
 | 그룹 | 도구 |
 | --- | --- |
 | Git/세션 | `save`, `undo`, `status`, `diff`, `ship`, `recap` |
-| 진단/품질 | `doctor`, `check`, `secure`, `audit`, `harness` |
+| 진단/품질 | `doctor`, `check`, `secure`, `audit`, `harness`, `policy` |
 | 환경/규칙 | `env`, `env-check`, `sync`, `mcp-init` |
 | 컨텍스트/기억 | `context`, `context-show`, `brief`, `loop-brief`, `remind`, `memory-list`, `learn` |
 | 풀사이클 뒷단 | `content`, `launch`, `ops`, `sell` |

--- a/src/commands/policy.ts
+++ b/src/commands/policy.ts
@@ -1,0 +1,91 @@
+/*
+ * policy.ts — `vhk policy` 컨테이너 (작업 단위 124-T4 · RFC 0066 §8).
+ *
+ * 세 서브커맨드 전부 **읽기 전용이고 원장에 기록하지 않는다.** 조회로 전이가 일어나면
+ * `vhk policy level` 을 세 번 불러 L1 → L3 로 올라가는 경로가 열린다(§4.3 적대 검증 치명 3).
+ * 그래서 이 파일은 `appendPolicyDecision` 을 import 하지 않는다 — 실수로도 못 쓰게 한다.
+ *
+ * 전이는 자율 런 종결 이벤트에서만 일어난다. 여기서는 계산 결과를 보여주기만 한다.
+ */
+import chalk from 'chalk'
+import { log } from '../utils/logger.js'
+import { ko } from '../i18n/ko.js'
+import { printNextStep } from '../lib/next-step.js'
+import { readAutonomyLog } from '../lib/autonomy-log.js'
+import { readReceiptLog } from '../lib/receipt-log.js'
+import { calcAutonomyStats } from '../lib/autonomy-stats.js'
+import { decidePermissionLevel, PROMOTION_FAILURE_MAX } from '../lib/permission-level.js'
+import { loadPolicyConfig } from '../lib/policy-config.js'
+import { checkPolicyBaseline } from '../lib/policy-baseline.js'
+import { lastLevelLine } from '../lib/policy-log.js'
+import { deriveTaskKindDetailed, stagedPaths } from '../lib/task-kind.js'
+import { riskClassOf } from '../lib/risk-class.js'
+
+/** 설정이 신뢰할 수 없으면 그 사실을 먼저 알린다 — 자율 레인은 이 상태에서 전부 거부다. */
+function printConfigHealth(cwd: string): void {
+  const config = loadPolicyConfig(cwd)
+  if (config.failClosed) {
+    log.warn(ko.policy.configFailClosed(config.reasonCode ?? 'UNKNOWN'))
+  }
+  const baseline = checkPolicyBaseline(cwd)
+  if (baseline.mutated) log.warn(ko.policy.baselineMutated)
+}
+
+export function policyLevel(cwd: string = process.cwd()): void {
+  console.log(chalk.bold(`\n${ko.policy.levelTitle}`))
+  printConfigHealth(cwd)
+
+  const config = loadPolicyConfig(cwd)
+  const stats = calcAutonomyStats(readAutonomyLog(cwd), readReceiptLog(cwd))
+  const last = lastLevelLine(cwd)
+  const previous =
+    last?.to !== undefined ? { to: last.to, judgedRuns: last.judgedRuns ?? 0, ts: last.ts } : null
+  const decision = decidePermissionLevel(stats, { maxLevel: config.maxLevel }, previous)
+
+  console.log(`  ${ko.policy.currentLevel(decision.level, decision.reasonCode)}`)
+  console.log(chalk.dim(`  ${ko.policy.previousLine(previous?.to ?? null, previous?.judgedRuns ?? null)}`))
+
+  // 조회로는 올라가지 않으므로 사람이 무엇을 기다려야 하는지 보이는 편이 낫다(§8.1).
+  console.log(
+    chalk.dim(
+      `  ${ko.policy.nextPromotion(stats.judgedRuns, previous?.judgedRuns ?? 0, stats.rollingFailures, PROMOTION_FAILURE_MAX)}`,
+    ),
+  )
+
+  printNextStep({
+    message: ko.policy.nextStepLevel,
+    command: 'vhk policy show',
+    cursorHint: '권한 정책 보여줘',
+  })
+}
+
+export function policyRisk(cwd: string = process.cwd()): void {
+  console.log(chalk.bold(`\n${ko.policy.riskTitle}`))
+  printConfigHealth(cwd)
+
+  // 조회 시점 판정 대상 = 스테이징 목록(§5.2). 작업 트리 전체를 세면 관련 없는 로컬 변경
+  // 하나가 모든 판정을 human 으로 만든다.
+  const paths = stagedPaths(cwd)
+  const breakdown = deriveTaskKindDetailed(paths)
+  const risk = riskClassOf(breakdown)
+
+  console.log(`  ${ko.policy.riskLine(risk, breakdown.kind)}`)
+  console.log(chalk.dim(`  ${ko.policy.riskBreakdown(breakdown.total, breakdown.unclassified)}`))
+  if (breakdown.unclassified > 0) console.log(chalk.yellow(`  ${ko.policy.unclassifiedHint}`))
+
+  printNextStep({
+    message: ko.policy.nextStepRisk,
+    command: 'vhk policy show',
+    cursorHint: '권한 정책 보여줘',
+  })
+}
+
+export function policyShow(cwd: string = process.cwd()): void {
+  const config = loadPolicyConfig(cwd)
+  console.log(chalk.bold(`\n${ko.policy.showTitle}`))
+  console.log(`  ${ko.policy.flags(config.record, config.enforce)}`)
+  console.log(chalk.dim(`  ${ko.policy.maxLevelLine(config.maxLevel ?? null)}`))
+
+  policyLevel(cwd)
+  policyRisk(cwd)
+}

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -429,6 +429,49 @@ export const ko = {
     menuHint: 'vhk를 입력하면 메뉴에서 선택할 수 있습니다.',
     evolveExplanation: '현재 진화 후보 확인 (vhk evolve list) — 반영·되돌리기는 직접 실행',
   },
+  // RFC 0066 §8 — vhk policy. 세 서브커맨드 전부 읽기 전용이고 원장에 기록하지 않는다.
+  policy: {
+    levelTitle: '🔐 자율 실행 권한 단계',
+    riskTitle: '⚖️  변경 위험도',
+    showTitle: '🔐 권한 정책',
+    currentLevel: (level: string, reason: string): string =>
+      `현재 단계: ${level}  (사유: ${reason})`,
+    previousLine: (to: string | null, judged: number | null): string =>
+      to === null
+        ? '직전 전이: 없음 — 원장이 비어 시작 단계로 계산했습니다'
+        : `직전 전이: ${to} (표본 ${judged ?? 0}회 시점)`,
+    // 조회로는 승급하지 않으므로 무엇을 기다려야 하는지 보여준다.
+    nextPromotion: (
+      judged: number,
+      lastJudged: number,
+      failures: number | null,
+      maxFailures: number,
+    ): string =>
+      judged <= lastJudged
+        ? `다음 승급 조건: 판정 대상 런이 더 필요합니다 (현재 ${judged}회 — 직전 전이와 같음)`
+        : failures === null
+          ? `다음 승급 조건: 표본 부족 (현재 ${judged}회). 창이 찰 때까지 단계는 유지됩니다`
+          : `다음 승급 조건: 최근 창 실패 ${failures}회 / 허용 ${maxFailures}회 이하`,
+    riskLine: (risk: string, kind: string): string =>
+      risk === 'human'
+        ? `판정: 사람 확인 필요 (유형 ${kind})`
+        : `판정: 자동 허용 범위 (유형 ${kind})`,
+    riskBreakdown: (total: number, unclassified: number): string =>
+      `검사 경로 ${total}개 · 미분류 ${unclassified}개`,
+    unclassifiedHint:
+      '⚠️  미분류 경로가 있어 사람 확인이 필요합니다 — 규칙을 넓히기 전에 왜 빠졌는지 먼저 보세요',
+    flags: (record: boolean, enforce: boolean): string =>
+      `기록: ${record ? '켜짐' : '꺼짐'} · 집행: ${enforce ? '켜짐' : '꺼짐'}`,
+    maxLevelLine: (maxLevel: string | null): string =>
+      maxLevel === null ? '사람이 지정한 상한: 없음' : `사람이 지정한 상한: ${maxLevel}`,
+    configFailClosed: (reason: string): string =>
+      `정책 설정을 신뢰할 수 없습니다 (${reason}) — 자율 레인은 전부 거부됩니다. 사람이 실행하는 명령은 영향 없습니다.`,
+    baselineMutated:
+      '정책 설정이 고정해둔 내용과 다릅니다 — 자율 레인은 전부 거부됩니다. 의도한 변경이면 베이스라인을 다시 고정하세요.',
+    nextStepLevel: '설정과 위험도까지 한 번에 보려면:',
+    nextStepRisk: '권한 단계와 설정까지 한 번에 보려면:',
+  },
+
   secure: {
     title: '🔒 비밀번호·키 유출 검사',
     noGitignore: '⚠️ .gitignore 파일이 없어요!',

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { recap } from './commands/recap.js'
 import { sync } from './commands/sync.js'
 import { check } from './commands/check.js'
 import { secure } from './commands/secure.js'
+import { policyLevel, policyRisk, policyShow } from './commands/policy.js'
 import { doctor } from './commands/doctor.js'
 import { ship } from './commands/ship.js'
 import { save } from './commands/save.js'
@@ -249,6 +250,32 @@ program
   .option('--json', 'JSON 요약 출력 (CI/MCP용, #374)')
   .description('RULES.md 규칙 점검 — 코드 위반 검사 (또는 --goal <id> 로 goal 게이트)')
   .action(async (target: string | undefined, opts: { goal?: string; json?: boolean }) => { await check(opts, target) })
+
+// RFC 0066 §8 — 권한 정책 조회. 세 서브커맨드 전부 읽기 전용이고 원장에 기록하지 않는다
+// (조회로 전이가 일어나면 세 번 불러 단계를 올리는 경로가 열린다 — §4.3).
+const policyCmd = program
+  .command('policy')
+  .alias('정책')
+  .description('자율 실행 권한 정책 조회 — level: 단계, risk: 위험도, show: 전체')
+  .action(() => { policyShow() })
+
+policyCmd
+  .command('level')
+  .alias('단계')
+  .description('현재 권한 단계와 다음 승급 조건')
+  .action(() => { policyLevel() })
+
+policyCmd
+  .command('risk')
+  .alias('위험도')
+  .description('스테이징된 변경의 작업 유형과 위험도')
+  .action(() => { policyRisk() })
+
+policyCmd
+  .command('show')
+  .alias('보기')
+  .description('설정 상태 + 권한 단계 + 위험도')
+  .action(() => { policyShow() })
 
 const secureCmd = program
   .command('secure')

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -13,6 +13,7 @@ export const KNOWN_COMMAND_TOKENS = new Set([
   // #345: 'scan'·'스캔' 은 secure 의 서브-별칭일 뿐 최상위 명령/별칭이 아니다 → 유령 KNOWN 토큰.
   // KNOWN 에 두면 단일토큰일 때 detect 가 null 반환 → commander raw 'too many arguments'(미지 단어보다 나쁨).
   // 빼면 NL 라우터로 흘러 친절 처리된다. (KNOWN ⊆ 실제 명령/별칭 — registry-drift-usage 테스트가 강제)
+  'policy', '정책',
   'secure', '보안',
   'ship',
   'doctor', '환경', '진단',

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -12,6 +12,7 @@ export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
   ref: ['add', 'list', 'open'],
   memory: ['add', 'list', 'remove', 'archive', 'resolve', 'unarchive', 'migrate', 'eval'],
   cloud: ['push', 'pull'],
+  policy: ['level', 'risk', 'show'],
   secure: ['scan'],
   // #344: env·design 은 서브커맨드 없는 leaf 다(env-check·design-palette 는 별도 top-level 명령).
   // 여기 env:['check']·design:['palette'] 를 두면 R1 가드가 'env check' 를 "실제 서브 경로"로 오판 →
@@ -39,6 +40,7 @@ export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
  * 별칭 없는 컨테이너(mission/seo/bootstrap 등)는 등재하지 않는다(발명 금지).
  */
 export const CONTAINER_SUBCOMMAND_ALIASES: Record<string, Record<string, string>> = {
+  policy: { 단계: 'level', 위험도: 'risk', 보기: 'show' },
   secure: { 스캔: 'scan' },
   cloud: { 올리기: 'push', 내리기: 'pull' },
   ref: { 목록: 'list', 열기: 'open' },
@@ -90,6 +92,7 @@ export const CONTAINER_ALIASES: Record<string, string> = {
   레퍼런스: 'ref',
   기억: 'memory',
   클라우드: 'cloud',
+  정책: 'policy',
   보안: 'secure',
   // #344: env·design 은 컨테이너가 아닌 leaf 라 CONTAINER_SUBCOMMANDS 에서 제거됨 →
   // 그 한글 별칭(환경변수·디자인)도 컨테이너 별칭에서 제거(별칭이 무효 컨테이너를 가리키지 않게).
@@ -120,6 +123,7 @@ export const TOP_LEVEL_COMMANDS: ReadonlyArray<{ name: string; desc: string }> =
   { name: 'recap', desc: '오늘 한 일 정리 + ADR 분리' },
   { name: 'sync', desc: 'RULES.md → 규칙 파일 동기화' },
   { name: 'check', desc: 'RULES.md 규칙 점검' },
+  { name: 'policy', desc: '자율 실행 권한 정책 조회 (읽기 전용)' },
   { name: 'secure', desc: '보안 스캔 (시크릿 유출 검사)' },
   { name: 'cloud', desc: '.vhk 클라우드 백업·복원 (push/pull)' },
   { name: 'ship', desc: '배포 체크리스트 + 회고' },

--- a/src/lib/nlp-router.ts
+++ b/src/lib/nlp-router.ts
@@ -8,6 +8,7 @@ export type NlpCommand =
   | 'sync'
   | 'check'
   | 'secure'
+  | 'policy'
   | 'ship'
   | 'doctor'
   | 'save'
@@ -218,6 +219,14 @@ const RULES: NlpRule[] = [
     test: t =>
       (/테마(?!\s*(파일|이름))|theme|다크\s*모드|라이트\s*모드|dark\s*mode|light\s*mode|색상\s*모드|모드\s*전환/.test(t)) &&
       !/보안|시크릿|비밀|키\s*유출|secure|scan|스캔|배포|deploy/.test(t),
+  },
+  {
+    command: 'policy',
+    explanation: '자율 실행 권한 정책 조회 (vhk policy show)',
+    confidence: 'high',
+    test: t =>
+      /권한\s*단계|권한\s*정책|자율\s*권한|위험도|policy|permission\s*level/.test(t) &&
+      !/보안|시크릿|secure|scan|스캔/.test(t),
   },
   {
     command: 'ref',

--- a/src/lib/nlp-run.ts
+++ b/src/lib/nlp-run.ts
@@ -8,6 +8,7 @@ import { recap } from '../commands/recap.js'
 import { sync } from '../commands/sync.js'
 import { check } from '../commands/check.js'
 import { secure } from '../commands/secure.js'
+import { policyShow } from '../commands/policy.js'
 import { doctor } from '../commands/doctor.js'
 import { ship } from '../commands/ship.js'
 import { save } from '../commands/save.js'
@@ -73,6 +74,8 @@ export async function dispatchNlpRoute(route: NlpRoute, input: string): Promise<
       return sync()
     case 'check':
       return check()
+    case 'policy':
+      return policyShow()
     case 'secure':
       return secure()
     case 'ship':

--- a/src/lib/task-kind.ts
+++ b/src/lib/task-kind.ts
@@ -141,6 +141,26 @@ export function normalizeTaskKind(raw: string | undefined | null): TaskKind {
  * 두 커밋 사이 변경 파일 목록. 기존 git 통로(gitOut)만 사용 — 새 execSync 도입 없음.
  * git 레포 아님·잘못된 SHA·범위 계산 실패는 빈 배열(추측 금지 → 호출부에서 unknown 이 된다).
  */
+/**
+ * 스테이징된 변경 경로 (RFC 0066 §5.2).
+ *
+ * 커밋 게이트와 조회 판정의 대상이다. 작업 트리 전체(`git diff --name-only`)를 쓰지 않는 이유는
+ * 실제로 커밋될 것만이 판정 대상이기 때문이다 — 스테이징하지 않은 파일까지 세면 관련 없는
+ * 로컬 변경 하나가 모든 판정을 `human` 으로 만든다.
+ */
+export function stagedPaths(cwd: string): string[] {
+  try {
+    // core.quotepath=false: 한글 등 비ASCII 경로가 octal 이스케이프되면 경로 매칭이 깨진다.
+    const out = gitOut(['-c', 'core.quotepath=false', 'diff', '--cached', '--name-only'], cwd)
+    return out
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0)
+  } catch {
+    return []
+  }
+}
+
 export function changedPathsBetween(cwd: string, fromSha: string, toSha: string): string[] {
   if (!fromSha || !toSha) return []
   try {

--- a/tests/policy-cli.test.ts
+++ b/tests/policy-cli.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CONTAINER_SUBCOMMANDS,
+  CONTAINER_ALIASES,
+  CONTAINER_SUBCOMMAND_ALIASES,
+  TOP_LEVEL_COMMANDS,
+  resolveSubcommandAlias,
+} from '../src/lib/command-registry.js'
+import { KNOWN_COMMAND_TOKENS } from '../src/lib/cli-args.js'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/*
+ * RFC 0066 §8.3 — 신규 명령 등록 지점.
+ *
+ * 하나라도 빠지면 자연어 라우터가 문장을 삼켜 인자가 조용히 사라진다.
+ * 이 저장소에서 2회 실증된 결함 클래스이고, 이번에도 KNOWN_COMMAND_TOKENS 누락으로 재현됐다 —
+ * `vhk policy level` 과 `vhk 정책 단계` 가 둘 다 라우터에 먹혔다. 그래서 지점별로 못박는다.
+ */
+
+describe('vhk policy 등록 지점 (RFC 0066 §8.3)', () => {
+  it('TOP_LEVEL_COMMANDS 에 있다', () => {
+    expect(TOP_LEVEL_COMMANDS.map((c) => c.name)).toContain('policy')
+  })
+
+  it('서브커맨드 세 개가 등록돼 있다', () => {
+    expect(CONTAINER_SUBCOMMANDS.policy).toEqual(['level', 'risk', 'show'])
+  })
+
+  it('컨테이너 한글 별칭이 있다', () => {
+    expect(CONTAINER_ALIASES['정책']).toBe('policy')
+  })
+
+  it('서브커맨드 한글 별칭이 전부 있다', () => {
+    expect(CONTAINER_SUBCOMMAND_ALIASES.policy).toEqual({
+      단계: 'level',
+      위험도: 'risk',
+      보기: 'show',
+    })
+  })
+
+  // 이번에 실측으로 잡은 누락 지점. 여기 없으면 firstIsKnown 이 false 라 NL 라우터가 가로챈다.
+  it('KNOWN_COMMAND_TOKENS 에 영문·한글 둘 다 있다', () => {
+    expect(KNOWN_COMMAND_TOKENS.has('policy')).toBe(true)
+    expect(KNOWN_COMMAND_TOKENS.has('정책')).toBe(true)
+  })
+
+  it('한글 서브 별칭이 정규 이름으로 해석된다', () => {
+    expect(resolveSubcommandAlias('policy', '단계')).toBe('level')
+    expect(resolveSubcommandAlias('policy', '위험도')).toBe('risk')
+    expect(resolveSubcommandAlias('policy', '보기')).toBe('show')
+  })
+})
+
+describe('조회는 원장에 쓰지 않는다 (§4.3)', () => {
+  // 조회로 전이가 일어나면 vhk policy level 을 세 번 불러 L1 → L3 로 올라간다.
+  // import 자체를 막아 실수로도 못 쓰게 한다.
+  it('policy 커맨드가 원장 append 를 import 하지 않는다', () => {
+    const source = readFileSync(join(process.cwd(), 'src', 'commands', 'policy.ts'), 'utf-8')
+    // 주석에서의 언급은 허용한다 — 왜 안 쓰는지 적어두는 편이 낫다. import 문만 본다.
+    const imports = source
+      .split(/\r?\n/)
+      .filter((l) => l.trimStart().startsWith('import'))
+      .join(' ')
+    expect(imports).not.toContain('appendPolicyDecision')
+  })
+})


### PR DESCRIPTION
작업 단위 124 의 마지막 티켓. 권한 단계와 위험도를 사람이 볼 수 있게 한다.

| 명령 | 한글 | 출력 |
|---|---|---|
| `vhk policy level` | `정책 단계` | 현재 단계 · 직전 전이 · **다음 승급까지 필요한 것** |
| `vhk policy risk` | `정책 위험도` | 스테이징 변경의 작업 유형 · 미분류 수 · 위험도 |
| `vhk policy show` | `정책 보기` | 설정 상태(기록·집행·상한) + 위 둘 |

**세 서브커맨드 전부 읽기 전용이고 원장에 기록하지 않는다.** 조회로 전이가 일어나면 같은 명령을 세 번 불러 `L1 → L3` 로 올리는 경로가 열린다(§4.3 적대 검증 치명 3). 그래서 커맨드 파일이 `appendPolicyDecision` 을 **import 하지 않고**, 테스트가 그걸 단언한다.

## 실측이 등록 누락을 잡았다

RFC §8.3 이 "하나라도 빠지면 자연어 라우터가 삼켜 인자가 조용히 사라진다(이 저장소에서 2회 실증된 결함 클래스)" 고 경고한 그대로 재현됐다. 체크리스트의 등록 지점을 다 채웠는데도 영문·한글 **둘 다** 라우터에 먹혔다.

```
$ vhk policy level
  💬 "policy level"
  → 자율 실행 권한 정책 조회 (vhk policy show)     ← commander 가 아니라 NL 라우터가 처리
```

원인은 `cli-args.ts` 의 `KNOWN_COMMAND_TOKENS` 가 **하드코딩 집합**이고 RFC 체크리스트에 없었다는 것이다. 이 값이 `false` 면 `isRealSubcommandPath` 가 **아예 호출되지 않아** 실경로 판정을 건너뛴다.

실제 등록 지점은 6곳이었다: `index.ts` · `command-registry`(4종) · `cli-args`의 `KNOWN_COMMAND_TOKENS` · `nlp-router` · `nlp-run` switch. 마지막 것은 lint 의 `switch-exhaustiveness` 가 잡아줬다.

## 리뷰 포인트

- **등록 지점 테스트**(`tests/policy-cli.test.ts`) — 지점별로 못박았다. RFC 체크리스트에 없던 `KNOWN_COMMAND_TOKENS` 포함이다.
- **판정 대상 경로가 스테이징 목록인지**(§5.2). 작업 트리 전체를 쓰면 관련 없는 로컬 변경 하나가 모든 판정을 `human` 으로 만든다.
- **설정이 신뢰할 수 없을 때 먼저 알리는지** — `failClosed`·베이스라인 변조를 세 명령 모두 앞머리에서 경고한다.

## 확인 방법

영문·한글 **둘 다 직접 실행**했다(§8.3 실측 필수).

```
node dist/index.js policy level      # 현재 단계: L1 (사유: LEDGER_EMPTY)
node dist/index.js 정책 단계          # 동일 출력
node dist/index.js policy risk       # 판정: 사람 확인 필요 (유형 unknown)
node dist/index.js policy show
```

실측: 264파일 3175건 통과(4 skip), CI 게이트 8종 전부 0.
