### PR TITLE
fix: 자율 런이 완주해도 게이트 표본에 안 들어가던 배선 누락

### DIFF
--- a/.agents/skills/overnight-vhk-auto/SKILL.md
+++ b/.agents/skills/overnight-vhk-auto/SKILL.md
@@ -23,6 +23,8 @@ Prepare a temporary PR body file that follows `AGENTS.md` and includes the morni
 - **INV-B** After green verify + commit, call `scripts/auto_pr_goal.ps1`. **Merge = 0.** Never push `main`, force-push, publish, or change branch protection.
 - **INV-B2** The `autonomous` label is attached idempotently by that script on both create and reuse paths (Goal 111 cohort secondary signal). Never add or remove it by hand — the primary signal is the terminal-SHA join, and signal mismatch is quarantined as `unknown`.
 - **INV-C** If autonomy-log start or terminal event is missing → write `.vhk/HARD_STOP` and stop.
+  Same when a successful terminal event has no receipt for the same SHA — that run is recorded
+  but never counts as verified completion, so it never enters the observation gate sample (vhk-auto INV-10).
 - **INV-D** Use the release order in `docs/roadmap/2.x-roadmap.md` and acceptance criteria in `docs/PRD-2.x.md`. Do not invent a queue from old Goal numbers.
 - **INV-E** Stop on HARD_STOP, verify 2× red, or open PR reported.
 

--- a/.agents/skills/vhk-auto/SKILL.md
+++ b/.agents/skills/vhk-auto/SKILL.md
@@ -28,6 +28,10 @@ VHK로 개발 중인 프로젝트에서 **active goal 카드 1개**를 사람 �
 - **INV-9** 루프 시작 시 `vhk autonomy-log --event start`로 runId를 발급받아 루프 내내
   유지하고, 종결 분기에서 결과에 맞는 이벤트로 반드시 종결 기록한다(이슈 #373 자율성완주율
   계측 — 시작만 있고 종결이 없으면 완주율 분모/분자가 둘 다 부정확해진다).
+- **INV-10** 합격 종결 전에 `vhk receipt` 를 반드시 실행한다. 완주 판정은 **같은 커밋 SHA 의
+  receipt** 를 요구하는데(`isVerifiedComplete`), `vhk verify` 는 그 원장을 쓰지 않는다.
+  빠지면 런이 기록돼도 `verified=false` 로 떨어져 관찰 게이트의 유효 실행에 들어가지 않고,
+  자기 보고 격차로 잡혀 권한 승급까지 영구 차단된다. 커밋 직후에 불러야 SHA 가 일치한다.
 
 ## 루프 (1회 호출 = active goal 카드 1개)
 0. **안전 확인**: `.vhk/HARD_STOP` 존재? → 있으면 즉시 중단, 사유 보고하고 종료. (INV-6)
@@ -49,8 +53,9 @@ VHK로 개발 중인 프로젝트에서 **active goal 카드 1개**를 사람 �
    - **합격**(verify green AND 적대 치명 0):
      1) `docs/devlog/<오늘날짜>-autopilot.md` 에 "무엇을 했고 검증 결과" 1줄 append. (INV-5)
      2) 작은 commit 1개. **commit 만** — push/PR 금지. (INV-7)
-     3) `vhk autonomy-log --event complete --run-id <runId> [--goal <n>] [--ticks <n>] [--interventions <n>]`. (INV-9)
-     4) goal 완주 → 정지 + 핵심 보고 → 종료.
+     3) `vhk receipt` 실행 — **커밋 직후, 종결 기록 직전**. (INV-10)
+     4) `vhk autonomy-log --event complete --run-id <runId> [--goal <n>] [--ticks <n>] [--interventions <n>]`. (INV-9)
+     5) goal 완주 → 정지 + 핵심 보고 → 종료.
    - **critical 발견 또는 verify 연속 2회 red**:
      1) `.vhk/HARD_STOP` 파일을 사유와 함께 생성. (INV-6)
      2) `vhk autonomy-log --event hardstop --run-id <runId> [...] [--review-rejected]`

--- a/.claude/skills/overnight-vhk-auto/SKILL.md
+++ b/.claude/skills/overnight-vhk-auto/SKILL.md
@@ -31,6 +31,8 @@ powershell -NoProfile -ExecutionPolicy Bypass -File scripts/auto_pr_goal.ps1 `
   **머지 = 0.** 래퍼는 *깨끗한 작업트리 + 미푸시 커밋* 상태를 지원한다(vhk-auto 가 이미 커밋한
   뒤의 push-only 경로) — dirty porcelain 을 기대하지 마라.
 - **INV-C** autonomy-log 의 시작 또는 종결 이벤트가 없으면 `.vhk/HARD_STOP` 을 쓰고 멈춘다.
+  합격 종결인데 **같은 SHA 의 receipt 가 없을 때도** 같다 — 그 런은 기록돼도 완주로 판정되지
+  않아 관찰 게이트 표본에 들어가지 않는다(vhk-auto INV-10).
 - **INV-D** 사람에게 A/B/C 를 묻지 않는다 — `docs/roadmap/autonomy-evolution.md` 의 기본값을 쓴다.
 - **INV-E** 중단 조건: HARD_STOP · verify 2회 연속 red · PR 을 열어 보고 완료.
 

--- a/.claude/skills/vhk-auto/SKILL.md
+++ b/.claude/skills/vhk-auto/SKILL.md
@@ -28,6 +28,10 @@ VHK로 개발 중인 프로젝트에서 **active goal 카드 1개**를 사람 �
 - **INV-9** 루프 시작 시 `vhk autonomy-log --event start`로 runId를 발급받아 루프 내내
   유지하고, 종결 분기에서 결과에 맞는 이벤트로 반드시 종결 기록한다(이슈 #373 자율성완주율
   계측 — 시작만 있고 종결이 없으면 완주율 분모/분자가 둘 다 부정확해진다).
+- **INV-10** 합격 종결 전에 `vhk receipt` 를 반드시 실행한다. 완주 판정은 **같은 커밋 SHA 의
+  receipt** 를 요구하는데(`isVerifiedComplete`), `vhk verify` 는 그 원장을 쓰지 않는다.
+  빠지면 런이 기록돼도 `verified=false` 로 떨어져 관찰 게이트의 유효 실행에 들어가지 않고,
+  자기 보고 격차로 잡혀 권한 승급까지 영구 차단된다. 커밋 직후에 불러야 SHA 가 일치한다.
 
 ## 루프 (1회 호출 = active goal 카드 1개)
 0. **안전 확인**: `.vhk/HARD_STOP` 존재? → 있으면 즉시 중단, 사유 보고하고 종료. (INV-6)
@@ -46,8 +50,9 @@ VHK로 개발 중인 프로젝트에서 **active goal 카드 1개**를 사람 �
    - **합격**(verify green AND 적대 치명 0):
      1) `docs/devlog/<오늘날짜>-autopilot.md` 에 "무엇을 했고 검증 결과" 1줄 append. (INV-5)
      2) 작은 commit 1개. **commit 만** — push/PR 금지. (INV-7)
-     3) `vhk autonomy-log --event complete --run-id <runId> [--goal <n>] [--ticks <n>] [--interventions <n>]`. (INV-9)
-     4) goal 완주 → 정지 + 핵심 보고 → 종료.
+     3) `vhk receipt` 실행 — **커밋 직후, 종결 기록 직전**. (INV-10)
+     4) `vhk autonomy-log --event complete --run-id <runId> [--goal <n>] [--ticks <n>] [--interventions <n>]`. (INV-9)
+     5) goal 완주 → 정지 + 핵심 보고 → 종료.
    - **critical 발견 또는 verify 연속 2회 red**:
      1) `.vhk/HARD_STOP` 파일을 사유와 함께 생성. (INV-6)
      2) `vhk autonomy-log --event hardstop --run-id <runId> [...] [--review-rejected]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ## [Unreleased]
 
+### Fixed
+
+- 자율 런이 완주해도 관찰 게이트 표본에 들어가지 않던 문제 — 완주 판정은 같은 커밋 SHA 의
+  `vhk receipt` 를 요구하는데 `vhk verify` 는 그 원장을 쓰지 않고, 자율 루프 스킬에도 호출이
+  없었다. 기록은 남지만 `verified=false` 로 떨어져 유효 실행에 안 들어가고 권한 승급까지
+  막힌다. 합격 종결 전 `vhk receipt` 를 불변식(INV-10)으로 못박았다.
+
 ### Added
 
 - `vhk policy` — 자율 실행 권한 정책 조회 (작업 단위 124-T4 · RFC 0066 §8). `policy level` 은 현재


### PR DESCRIPTION
관찰 게이트 표본이 `0/10` 인 원인을 "스킬을 안 돌려서" 로만 봤는데, **돌려도 안 찬다**는 것을 실측으로 확인했다.

## 조용한 실패였다

게이트의 유효 실행 정의는 이렇다(로드맵 §관찰 게이트).

> 유효 실행은 작업 유형·최종 결과·**현재 HEAD와 일치하는 verify 결과**·사람 개입 여부가 기록되고 인프라 실패가 아닌 실행이다.

그 "verify 결과 기록" 은 `receipt-log.jsonl` 이고 **`vhk receipt` 만 쓴다**. `vhk verify` 는 쓰지 않는다. 그런데 자율 루프 스킬에 그 호출이 없었다.

```
autonomy-log start/complete  →  런은 기록됨, judgedRuns +1
같은 SHA 의 receipt 없음      →  verified = false
                             →  selfReportedOnly +1
                             →  게이트 유효 실행 미충족
                             →  RFC 0066 §4.4 케이스 4 SELF_REPORT_GAP → 권한 승급 영구 차단
```

**표본이 쌓이는 것처럼 보이는데 하나도 안 찬다.** 그리고 방금 만든 124 의 권한 단계도 같은 이유로 `L1` 에서 못 올라간다.

## 실측 근거

| 확인 | 결과 |
|---|---|
| `receipt-log` 를 쓰는 코드 | `src/commands/receipt.ts` **한 곳** |
| `vhk verify` 가 쓰는가 | 아니오 — 이 세션에서 여러 번 돌렸는데 파일 자체가 없었다 |
| `vhk receipt` 실행 | 없던 `receipt-log.jsonl` 이 **생성됨** |
| 그 라인 | `sha`=HEAD 일치 · `red=false` · `dirty=false` · `stale≠true` → `isVerifiedComplete` 통과 가능 |
| 스킬의 호출 | **0건** |

## 조치

`vhk-auto` 에 **INV-10** 을 신설했다 — 합격 종결 전 `vhk receipt` 필수. **커밋 직후**에 불러야 SHA 가 맞으므로 커밋과 종결 기록 사이에 넣었다.

`overnight-vhk-auto` 의 INV-C 도 receipt 부재를 중단 사유에 포함시켰다. 표본이 조용히 비는 대신 멈추게 하는 쪽이 낫다.

## 리뷰 포인트

- **호출 위치가 커밋 직후인지.** 커밋 전에 부르면 SHA 가 달라져 조인이 깨지고, 종결 기록 후면 순서상 의미가 없다.
- **`.claude/` 와 `.agents/` 두 판 모두 반영.** 두 파일은 의도적으로 다르다(Claude용은 `/code-review`, agents용은 `codex review`) — 동기화 산출물이 아니라 각각 고쳐야 한다.
- hardstop·blocked 분기에는 넣지 않았다. 커밋이 없을 수 있고 `complete` 가 아니라 완주 판정 대상이 아니다.

## 확인 방법

```
node dist/index.js receipt --json     # receipt-log.jsonl 생성
node dist/index.js stats              # 자율 완주율 섹션
```

실측: typecheck·lint·boundary·raw-json-parse·stray 게이트 전부 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 검증 완료 절차에 커밋 후 동일 커밋을 확인하는 영수증 생성 단계를 추가했습니다.
  * 영수증이 없거나 커밋과 일치하지 않는 실행은 완료 및 관찰 대상에서 제외되도록 기준을 명확히 했습니다.
  * 필요한 검증 기록이 누락된 경우 실행을 중단하도록 운영 지침을 보완했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->