### PR TITLE
feat: 권한 판정 사유를 사람이 읽을 수 있게 (Phase 1·2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
   없었다. 기록은 남지만 `verified=false` 로 떨어져 유효 실행에 안 들어가고 권한 승급까지
   막힌다. 합격 종결 전 `vhk receipt` 를 불변식(INV-10)으로 못박았다.
 
+### Changed
+
+- `vhk policy` 출력이 판정 사유를 사람 문장으로 함께 보여준다 — `LEDGER_EMPTY` 같은 코드만
+  노출하면 무슨 상태인지 알 수 없다. 코드는 원장과 대조할 수 있게 그대로 남긴다.
+
 ### Added
 
 - `vhk policy` — 자율 실행 권한 정책 조회 (작업 단위 124-T4 · RFC 0066 §8). `policy level` 은 현재

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -434,8 +434,23 @@ export const ko = {
     levelTitle: '🔐 자율 실행 권한 단계',
     riskTitle: '⚖️  변경 위험도',
     showTitle: '🔐 권한 정책',
+    // 사유 코드를 그대로 노출하면 사람이 못 읽는다. 코드는 원장 계약이고 화면은 별개다 —
+    // 코드를 없애지 않고 한 줄 설명을 붙인다(추적성 유지 + 가독성).
+    levelReason: (reason: string): string => {
+      const table: Record<string, string> = {
+        LEDGER_EMPTY: '판정 이력이 없어 시작 단계로 계산',
+        NO_NEW_JUDGED_RUN: '판정 대상 런이 늘지 않아 단계 유지',
+        INSUFFICIENT_SAMPLE: '표본이 부족해 단계 유지 — 하강 아님',
+        DEMOTE_ROLLING_FAILURES: '최근 창의 실패가 기준을 넘어 한 칸 축소',
+        INFRA_ABUSE_SUSPECTED: '인프라 실패 제외 비율이 높아 승급 보류',
+        SELF_REPORT_GAP: '기계 증거가 뒷받침하지 못한 완료 신고가 있어 승급 보류',
+        PROMOTE_ROLLING_CLEAN: '최근 창이 깨끗해 한 칸 승급',
+        HOLD_HYSTERESIS: '승급선과 축소선 사이라 단계 유지',
+      }
+      return table[reason] ?? '사유 미상'
+    },
     currentLevel: (level: string, reason: string): string =>
-      `현재 단계: ${level}  (사유: ${reason})`,
+      `현재 단계: ${level} — ${ko.policy.levelReason(reason)} (${reason})`,
     previousLine: (to: string | null, judged: number | null): string =>
       to === null
         ? '직전 전이: 없음 — 원장이 비어 시작 단계로 계산했습니다'

--- a/tests/policy-message.test.ts
+++ b/tests/policy-message.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { ko } from '../src/i18n/ko.js'
+
+/*
+ * RFC 0066 은 원장 라인에 사람 문장·원문을 넣지 말라고 한다 — 공개 경계가 라인마다 새로 생기기
+ * 때문이다. 그건 **기록**의 규칙이고 **화면 출력**은 별개다.
+ *
+ * 코드만 노출하면 `LEDGER_EMPTY` 를 보고 사람이 무슨 상태인지 알 수 없다.
+ * 코드를 없애지 않고(추적성) 한 줄 설명을 붙인다(가독성).
+ */
+
+const REASON_CODES = [
+  'LEDGER_EMPTY',
+  'NO_NEW_JUDGED_RUN',
+  'INSUFFICIENT_SAMPLE',
+  'DEMOTE_ROLLING_FAILURES',
+  'INFRA_ABUSE_SUSPECTED',
+  'SELF_REPORT_GAP',
+  'PROMOTE_ROLLING_CLEAN',
+  'HOLD_HYSTERESIS',
+]
+
+describe('policy 출력 가독성', () => {
+  it('판정 사유 코드 전부에 사람이 읽을 설명이 있다', () => {
+    for (const code of REASON_CODES) {
+      const text = ko.policy.levelReason(code)
+      expect(text).not.toBe('사유 미상')
+      expect(text.length).toBeGreaterThan(5)
+    }
+  })
+
+  it('모르는 코드는 조용히 빈 문자열이 아니라 미상으로 표시한다', () => {
+    expect(ko.policy.levelReason('WHAT_IS_THIS')).toBe('사유 미상')
+  })
+
+  // 코드를 지우면 원장 라인과 화면을 대조할 수 없다 — 추적성이 끊긴다.
+  it('설명을 붙이되 코드 자체는 출력에 남는다', () => {
+    const line = ko.policy.currentLevel('L1', 'LEDGER_EMPTY')
+    expect(line).toContain('LEDGER_EMPTY')
+    expect(line).toContain('판정 이력이 없어')
+  })
+})


### PR DESCRIPTION
Phase 1(게이트를 채울 수 있게)의 **실측 검증**과 Phase 2 T2-1(출력 가독성)을 함께 담는다. 이 PR 의 커밋 자체가 실측 런의 작업물이다.

## Phase 1 실측 — C1 충족

자율 런 전체를 돌리지 않고 스킬(INV-9·INV-10)이 하는 순서를 그대로 재현했다.

```
start → 작업 커밋 → receipt(커밋 직후) → complete → stats
```

**결과:**

```
🤖 자율 완주율: 100.0% (검증된 완주 1/1 · hardstop 0 · blocked 0)
   롤링 판정: 표본 부족 (1/10회)
```

`selfReportedOnly` 가 아니라 **`verifiedComplete` 로 잡혔다.** 원장 대조:

| 라인 | sha |
|---|---|
| `start` | `e54f63a` (런 시작 시점 HEAD) |
| `complete` | `d67944a` (작업 커밋 후 HEAD) |
| `receipt` | **`d67944a`** ← complete 와 일치. 이게 조인 키다 |

권한 판정도 표본을 반영한다 — *"판정 대상 런이 더 필요"* → *"표본 부족 (현재 1회)"*.

**#596 의 INV-10(커밋 직후 receipt)이 없었으면** receipt 가 없거나 SHA 가 어긋나 `verified=false` 였다. 배선 수정이 실제로 효과가 있었다는 증거다.

## Phase 2 T2-1 — 출력 가독성

RFC 0066 이 원장에 사람 문장을 넣지 말라고 한 건 **기록 계약**이고 화면 출력은 별개다. 코드만 보여주면 사람이 무슨 상태인지 모른다.

```
before:  현재 단계: L1  (사유: LEDGER_EMPTY)
after:   현재 단계: L1 — 판정 이력이 없어 시작 단계로 계산 (LEDGER_EMPTY)
```

**코드를 지우지 않았다.** 지우면 원장 라인과 화면을 대조할 수 없어 추적성이 끊긴다.

## 리뷰 포인트

- **모르는 코드를 빈 문자열이 아니라 `사유 미상`으로** 표시한다. 조용히 사라지면 사유가 없는 것처럼 보인다. 테스트로 고정했다.
- 사유 코드 8종 전부에 설명이 있는지 테스트가 단언한다 — 코드를 추가하고 설명을 빠뜨리면 실패한다.

## 확인 방법

```
node dist/index.js policy level
node dist/index.js stats            # 자율 완주율 섹션
pnpm exec vitest run tests/policy-message.test.ts
```

실측: CI 게이트 6종 로컬 0.

## 남은 것

게이트는 4주 AND 10회다. 지금 **1/10**, 기간 9일차. 남은 표본은 실제 자율 런으로 쌓아야 한다 — 수동 재현은 배선 검증용이지 표본 생산용이 아니다.
