### PR TITLE
feat: 판정 원장 변형과 vhk policy check (125a-T6·T7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ### Added
 
+- `vhk policy check -- <명령>` — 실행 전 결정론 검사 (작업 단위 125a-T6·T7 · RFC 0067 §4·§6).
+  판정만 하고 **명령을 실행하지 않는다**. 종료 코드로 결과를 준다 — `allow` 0 · `require-human` 2 ·
+  `deny` 1. 설정이 없으면 형식을 안내한다(파일은 만들지 않는다 — 무엇을 허용할지는 사람이 정한다).
+  한글 별칭 `정책 검사`.
 - `vhk policy` — 자율 실행 권한 정책 조회 (작업 단위 124-T4 · RFC 0066 §8). `policy level` 은 현재
   단계와 다음 승급 조건을, `policy risk` 는 스테이징된 변경의 위험도를, `policy show` 는 설정까지
   함께 보여준다. 한글 별칭 `정책 단계`·`정책 위험도`·`정책 보기`. **세 서브커맨드 전부 읽기 전용이고

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -230,7 +230,7 @@ vhk doctor
 | `vhk recap` | 오늘 한 일 정리 + ADR 분리 (비-TTY/헤드리스: `--summary/--next/--decisions/--blockers/--yes`) |
 | `vhk sync` | RULES.md → 규칙 파일 동기화. `<!-- vhk:sync=all -->` 절은 8개 타겟 필수. `--check`는 재생성 결과 불일치와 필수 섹션 누락을 별도 집계하고, 문서-실측 drift는 경고로 표시 |
 | `vhk check` | RULES.md 규칙 점검. 규칙 줄의 `<!-- vhk:check=no-exec-sync -->`를 `scripts/check-rule-no-exec-sync.mjs`에 연결하며 검사 비율 출력 (`--json` = 선언·검사·미검사 수와 비율 포함) |
-| `vhk policy` | 자율 실행 권한 정책 조회 (읽기 전용 — 원장에 기록하지 않음). `policy level` = 현재 단계·다음 승급 조건, `policy risk` = 스테이징 변경의 위험도, `policy show` = 설정+단계+위험도. 한글: `정책 단계`·`정책 위험도`·`정책 보기` |
+| `vhk policy` | 자율 실행 권한 정책 조회 (읽기 전용 — 원장에 기록하지 않음). `policy level` = 현재 단계·다음 승급 조건, `policy risk` = 스테이징 변경의 위험도, `policy show` = 설정+단계+위험도, `policy check -- <명령>` = 실행 전 결정론 검사(판정만 — 실행 안 함, allow 0·require-human 2·deny 1). 한글: `정책 단계`·`정책 위험도`·`정책 보기`·`정책 검사` |
 | `vhk secure` | 보안 스캔 (시크릿 유출 검사). `secure scan <파일...>` = 발행물 초안 등 특정 파일만(.md 포함) — 게시 전 게이트(#457), CRITICAL/HIGH 시 exit 1 |
 | `vhk cloud` | .vhk 클라우드 백업·복원 (push/pull) |
 | `vhk ship` | 배포 체크리스트 + 회고 |

--- a/src/commands/policy.ts
+++ b/src/commands/policy.ts
@@ -8,6 +8,8 @@
  * 전이는 자율 런 종결 이벤트에서만 일어난다. 여기서는 계산 결과를 보여주기만 한다.
  */
 import chalk from 'chalk'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
 import { log } from '../utils/logger.js'
 import { ko } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
@@ -19,6 +21,9 @@ import { loadPolicyConfig } from '../lib/policy-config.js'
 import { checkPolicyBaseline } from '../lib/policy-baseline.js'
 import { lastLevelLine } from '../lib/policy-log.js'
 import { deriveTaskKindDetailed, stagedPaths } from '../lib/task-kind.js'
+import { preflight, exitCodeOf } from '../lib/execution-preflight.js'
+import { readRunState } from '../lib/run-state.js'
+import { HARD_STOP_PATH } from '../lib/state-files.js'
 import { riskClassOf } from '../lib/risk-class.js'
 
 /** 설정이 신뢰할 수 없으면 그 사실을 먼저 알린다 — 자율 레인은 이 상태에서 전부 거부다. */
@@ -88,4 +93,67 @@ export function policyShow(cwd: string = process.cwd()): void {
 
   policyLevel(cwd)
   policyRisk(cwd)
+}
+
+/**
+ * `vhk policy check -- <bin> [args...]` — 실행 전 결정론 검사를 사람이 미리 돌려본다.
+ *
+ * **읽기 전용이다.** 판정만 하고 원장에 쓰지 않으며 명령을 실행하지도 않는다.
+ * 집행은 125b(작업 단위 126 과 함께)이고 여기서는 "돌리면 어떻게 판정되나" 만 보여준다.
+ *
+ * 종료 코드로 결과를 전달한다 — allow 0 · require-human 2 · deny 1.
+ * `require-human` 을 0 으로 두지 않는 이유는 §4.3 이다.
+ */
+export function policyCheck(argv: string[], cwd: string = process.cwd()): void {
+  console.log(chalk.bold(`
+${ko.policy.checkTitle}`))
+  printConfigHealth(cwd)
+
+  const [bin, ...args] = argv
+  if (!bin) {
+    log.warn(ko.policy.checkUsage)
+    process.exitCode = 1
+    return
+  }
+
+  const config = loadPolicyConfig(cwd)
+  if (!config.sectionsUsable || !config.limits) {
+    // 허용목록·한도가 없으면 자율 레인은 아무것도 못 돌린다. 그 사실을 그대로 알린다.
+    log.warn(ko.policy.checkNoSections)
+    console.log(chalk.dim(`  ${ko.policy.configExample}`))
+    process.exitCode = exitCodeOf('deny')
+    return
+  }
+
+  const stats = calcAutonomyStats(readAutonomyLog(cwd), readReceiptLog(cwd))
+  const last = lastLevelLine(cwd)
+  const previous =
+    last?.to !== undefined ? { to: last.to, judgedRuns: last.judgedRuns ?? 0, ts: last.ts } : null
+  const level = decidePermissionLevel(stats, { maxLevel: config.maxLevel }, previous).level
+
+  // 런 밖 판정이면 상태 파일이 없다 — 카운터 0, 경과 0 으로 본다(§6.3).
+  const nowUtc = new Date().toISOString()
+  const runs = Object.values(readRunState(cwd))
+  const run = runs.length === 1 ? runs[0] : undefined
+
+  const result = preflight(
+    { bin, args },
+    {
+      // 판정용 존재 확인만 한다 — 기존 가드는 출력·차단까지 해서 조회 명령에 맞지 않는다.
+      hardStopActive: existsSync(join(cwd, HARD_STOP_PATH)),
+      allowlist: config.allow,
+      limits: config.limits,
+      level,
+      runCommandCount: run?.commandCount ?? 0,
+      startedAtUtc: run?.startedAtUtc ?? nowUtc,
+      lastSeenUtc: run?.lastSeenUtc ?? nowUtc,
+      nowUtc,
+      clockAnomaly: run?.clockAnomaly,
+    },
+  )
+
+  console.log(`  ${ko.policy.checkVerdict(result.verdict, result.reasonCode)}`)
+  if (result.matchedId) console.log(chalk.dim(`  ${ko.policy.checkMatched(result.matchedId)}`))
+  if (run === undefined) console.log(chalk.dim(`  ${ko.policy.checkOutsideRun}`))
+  process.exitCode = exitCodeOf(result.verdict)
 }

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -483,6 +483,30 @@ export const ko = {
       `정책 설정을 신뢰할 수 없습니다 (${reason}) — 자율 레인은 전부 거부됩니다. 사람이 실행하는 명령은 영향 없습니다.`,
     baselineMutated:
       '정책 설정이 고정해둔 내용과 다릅니다 — 자율 레인은 전부 거부됩니다. 의도한 변경이면 베이스라인을 다시 고정하세요.',
+    checkTitle: '🚦 실행 전 검사',
+    checkUsage: '검사할 명령을 주세요 — vhk policy check -- pnpm typecheck',
+    checkNoSections:
+      '허용목록·한도 설정이 없어 자율 레인은 아무 명령도 돌릴 수 없습니다 (사람이 실행하는 명령은 영향 없음).',
+    // 설정 파일을 만들어주지 않는다 — 무엇을 허용할지는 사람이 정한다. 형식만 보여준다.
+    configExample:
+      '.vhk/policy.json 형식: { "schemaVersion": 1, "allow": [{ "id": "lint", "bin": "pnpm", "args": ["lint"], "minLevel": "L1" }], "limits": { "perRunSec": 3600, "perCommandSec": 900, "perRunCommandCount": 40 } }',
+    checkVerdict: (verdict: string, reason: string): string => {
+      const label =
+        verdict === 'allow' ? '실행 가능' : verdict === 'require-human' ? '사람 확인 필요' : '거부'
+      const why: Record<string, string> = {
+        HARD_STOP_ACTIVE: '중단 신호가 켜져 있습니다 — vhk resume --confirm 으로만 풀립니다',
+        NOT_IN_ALLOWLIST: '허용목록에 없는 명령입니다',
+        CALL_BUDGET_EXCEEDED: '이 런의 명령 호출 수가 상한에 도달했습니다',
+        TIME_LIMIT_EXCEEDED: '이 런의 시간 상한을 넘었습니다',
+        TIME_LIMIT_WOULD_EXCEED: '남은 시간 안에 끝날 수 없는 명령입니다',
+        CLOCK_ANOMALY: '시계가 흔들려 이 런의 시간 한도를 믿을 수 없습니다',
+        LEVEL_TOO_LOW: '이 명령이 요구하는 권한 단계에 못 미칩니다',
+        PREFLIGHT_PASSED: '모든 검사를 통과했습니다',
+      }
+      return `판정: ${label} — ${why[reason] ?? '사유 미상'} (${reason})`
+    },
+    checkMatched: (id: string): string => `매칭된 허용목록 항목: ${id}`,
+    checkOutsideRun: '런 밖 판정입니다 — 호출 수 0, 경과 0 으로 계산했습니다',
     nextStepLevel: '설정과 위험도까지 한 번에 보려면:',
     nextStepRisk: '권한 단계와 설정까지 한 번에 보려면:',
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { recap } from './commands/recap.js'
 import { sync } from './commands/sync.js'
 import { check } from './commands/check.js'
 import { secure } from './commands/secure.js'
-import { policyLevel, policyRisk, policyShow } from './commands/policy.js'
+import { policyLevel, policyRisk, policyShow, policyCheck } from './commands/policy.js'
 import { doctor } from './commands/doctor.js'
 import { ship } from './commands/ship.js'
 import { save } from './commands/save.js'
@@ -270,6 +270,13 @@ policyCmd
   .alias('위험도')
   .description('스테이징된 변경의 작업 유형과 위험도')
   .action(() => { policyRisk() })
+
+policyCmd
+  .command('check')
+  .alias('검사')
+  .argument('[argv...]', '검사할 명령 — vhk policy check -- pnpm typecheck')
+  .description('실행 전 결정론 검사 (판정만 — 실행하지 않는다)')
+  .action((argv: string[]) => { policyCheck(argv) })
 
 policyCmd
   .command('show')

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -12,7 +12,7 @@ export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
   ref: ['add', 'list', 'open'],
   memory: ['add', 'list', 'remove', 'archive', 'resolve', 'unarchive', 'migrate', 'eval'],
   cloud: ['push', 'pull'],
-  policy: ['level', 'risk', 'show'],
+  policy: ['level', 'risk', 'show', 'check'],
   secure: ['scan'],
   // #344: env·design 은 서브커맨드 없는 leaf 다(env-check·design-palette 는 별도 top-level 명령).
   // 여기 env:['check']·design:['palette'] 를 두면 R1 가드가 'env check' 를 "실제 서브 경로"로 오판 →
@@ -40,7 +40,7 @@ export const CONTAINER_SUBCOMMANDS: Record<string, readonly string[]> = {
  * 별칭 없는 컨테이너(mission/seo/bootstrap 등)는 등재하지 않는다(발명 금지).
  */
 export const CONTAINER_SUBCOMMAND_ALIASES: Record<string, Record<string, string>> = {
-  policy: { 단계: 'level', 위험도: 'risk', 보기: 'show' },
+  policy: { 단계: 'level', 위험도: 'risk', 보기: 'show', 검사: 'check' },
   secure: { 스캔: 'scan' },
   cloud: { 올리기: 'push', 내리기: 'pull' },
   ref: { 목록: 'list', 열기: 'open' },

--- a/src/lib/policy-log.ts
+++ b/src/lib/policy-log.ts
@@ -45,7 +45,40 @@ export interface PolicyDecisionV1 {
   judgedRuns?: number
   rollingFailures?: number | null
   window?: number
+
+  // ── RFC 0067 §6.1 — 봉투는 그대로 두고 변형별 필드만 얹는다 ──
+
+  /**
+   * kind: 'allowlist' 전용.
+   *
+   * `bin` 은 **`normalizeBin()` 을 거친 값만** 넣는다. 호출부가 절대경로를 넘기면 원장에
+   * 로컬 절대경로가 그대로 남아 이 저장소의 공개 경계 규칙을 원장이 스스로 위반한다.
+   * 같은 이유로 **인자 원문은 남기지 않고 개수만** 센다 — 인자에는 파일 경로·토큰·URL 이
+   * 들어올 수 있다. `.vhk/events/` 가 추적 금지 경로이긴 하지만 원장 내용이 출력·요약으로
+   * 새는 경로가 그동안 여러 번 있었다.
+   */
+  bin?: string
+  argCount?: number
+  matchedId?: string | null
+
+  /**
+   * kind: 'budget' 전용.
+   *
+   * `dimension` 에 `usd` 가 없는 것이 설계다(§5.5) — 자기 보고 비용은 판정에 안 쓰므로
+   * 그 축으로 막힌 기록도 존재할 수 없다.
+   * `usedRatio` 만 남기고 절대 초·횟수를 안 남기는 것도 같은 규율이다.
+   */
+  dimension?: BudgetDimension
+  usedRatio?: number
+  /** 어느 지점이 막았나. 실측에서 exec 만 계속 나오면 호출 측 집행이 안 걸리고 있다는 뜻이다 */
+  site?: EnforcementSite
 }
+
+/** 한도 축. **`usd` 는 없다** — 자기 보고 비용은 판정에 쓰지 않는다(§5.5). */
+export type BudgetDimension = 'runSec' | 'commandSec' | 'callCount'
+
+/** 이중 집행의 관측 지점 — 어느 쪽이 막았는지 남겨야 두 지점이 실제로 도는지 알 수 있다. */
+export type EnforcementSite = 'call' | 'exec'
 
 /** 기록 여부를 정하는 두 플래그(ADR-019). */
 export interface RecordGate {

--- a/tests/policy-cli.test.ts
+++ b/tests/policy-cli.test.ts
@@ -23,8 +23,8 @@ describe('vhk policy 등록 지점 (RFC 0066 §8.3)', () => {
     expect(TOP_LEVEL_COMMANDS.map((c) => c.name)).toContain('policy')
   })
 
-  it('서브커맨드 세 개가 등록돼 있다', () => {
-    expect(CONTAINER_SUBCOMMANDS.policy).toEqual(['level', 'risk', 'show'])
+  it('서브커맨드 네 개가 등록돼 있다', () => {
+    expect(CONTAINER_SUBCOMMANDS.policy).toEqual(['level', 'risk', 'show', 'check'])
   })
 
   it('컨테이너 한글 별칭이 있다', () => {
@@ -36,6 +36,7 @@ describe('vhk policy 등록 지점 (RFC 0066 §8.3)', () => {
       단계: 'level',
       위험도: 'risk',
       보기: 'show',
+      검사: 'check',
     })
   })
 
@@ -46,6 +47,7 @@ describe('vhk policy 등록 지점 (RFC 0066 §8.3)', () => {
   })
 
   it('한글 서브 별칭이 정규 이름으로 해석된다', () => {
+    expect(resolveSubcommandAlias('policy', '검사')).toBe('check')
     expect(resolveSubcommandAlias('policy', '단계')).toBe('level')
     expect(resolveSubcommandAlias('policy', '위험도')).toBe('risk')
     expect(resolveSubcommandAlias('policy', '보기')).toBe('show')

--- a/tests/policy-log.test.ts
+++ b/tests/policy-log.test.ts
@@ -138,3 +138,62 @@ describe('마지막 라인 CAS (§4.5)', () => {
     expect(appendPolicyDecision(dir, levelEntry(), opts).written).toBe(true)
   })
 })
+
+/*
+ * RFC 0067 §6.1 — allowlist·budget 변형.
+ *
+ * 봉투는 하나도 안 바꾼다. 변형별 필드만 얹는다.
+ * 핵심은 **원장이 공개 경계를 스스로 위반하지 않는 것**이다 — 절대경로·인자 원문·절대 수치를
+ * 남기지 않는다. .vhk/events/ 가 추적 금지 경로여도 원장 내용이 출력·요약으로 새는 경로가
+ * 그동안 여러 번 있었다.
+ */
+describe('판정 변형 (RFC 0067 §6.1)', () => {
+  const opts = { record: true, enforce: false }
+
+  it('allowlist 변형을 기록한다', () => {
+    const e: PolicyDecisionV1 = {
+      schemaVersion: POLICY_LOG_SCHEMA_VERSION,
+      ts: '2026-08-21T00:00:00.000Z',
+      kind: 'allowlist',
+      verdict: 'deny',
+      reasonCode: 'NOT_IN_ALLOWLIST',
+      bin: 'pnpm',
+      argCount: 2,
+      matchedId: null,
+    }
+    expect(appendPolicyDecision(dir, e, opts).written).toBe(true)
+    const read = readPolicyLog(dir)[0]
+    expect(read.kind).toBe('allowlist')
+    expect(read.matchedId).toBeNull()
+  })
+
+  it('budget 변형을 기록한다 — site 가 이중 집행의 관측 지점이다', () => {
+    const e: PolicyDecisionV1 = {
+      schemaVersion: POLICY_LOG_SCHEMA_VERSION,
+      ts: '2026-08-21T00:00:00.000Z',
+      kind: 'budget',
+      verdict: 'deny',
+      reasonCode: 'CALL_BUDGET_EXCEEDED',
+      dimension: 'callCount',
+      usedRatio: 1.0,
+      site: 'call',
+    }
+    expect(appendPolicyDecision(dir, e, opts).written).toBe(true)
+    expect(readPolicyLog(dir)[0].site).toBe('call')
+  })
+
+  // 관측 기록은 상태 갱신이 아니라 CAS 를 걸지 않는다 — level 만 상태다.
+  it('변형 기록은 lastLevelLine 에 잡히지 않는다', () => {
+    appendPolicyDecision(dir, {
+      schemaVersion: POLICY_LOG_SCHEMA_VERSION,
+      ts: '2026-08-21T00:00:00.000Z',
+      kind: 'allowlist',
+      verdict: 'deny',
+      reasonCode: 'NOT_IN_ALLOWLIST',
+      bin: 'rm',
+      argCount: 1,
+      matchedId: null,
+    }, opts)
+    expect(lastLevelLine(dir)).toBeNull()
+  })
+})


### PR DESCRIPTION
**125a 의 마지막 두 티켓.** 이걸로 판정기 + 기록이 완성된다. 집행(125b)은 126 과 함께다.

## 원장이 공개 경계를 스스로 위반하지 않게 (§6.1)

봉투는 하나도 안 바꾸고 변형별 필드만 얹었다. **무엇을 안 남기는지가 설계다.**

| 규칙 | 이유 |
|---|---|
| `bin` 은 `normalizeBin()` 거친 값만 | 호출부가 절대경로를 넘기면 **원장에 로컬 경로가 그대로 남아** 이 저장소의 공개 경계 규칙을 원장이 스스로 위반한다 |
| 인자는 원문 대신 **개수만** | 인자에는 파일 경로·토큰·URL 이 들어올 수 있다. 추적 금지 경로에 있어도 원장 내용이 출력·요약으로 새는 경로가 그동안 여러 번 있었다 |
| `budget` 은 `usedRatio` 만 | 절대 초·횟수를 안 남긴다 |
| `dimension` 에 **`usd` 가 없다** | 자기 보고 비용은 판정에 안 쓰므로 그 축으로 막힌 기록도 존재할 수 없다(§5.5) |
| `site` 는 남긴다 | 이중 집행의 관측 지점 — `exec` 만 계속 나오면 호출 측이 실제로는 안 걸리고 있다는 뜻이다 |

## `vhk policy check` — 판정만, 실행 안 함

영문·한글 **둘 다 인자를 붙여 실측**했다(§8.3 필수).

```
policy check -- pnpm typecheck  → 실행 가능 (PREFLIGHT_PASSED)     exit 0
policy check -- rm -rf          → 거부 (NOT_IN_ALLOWLIST)          exit 1
policy check -- pnpm deploy     → 사람 확인 필요 (LEVEL_TOO_LOW)    exit 2
정책 검사 -- pnpm typecheck      → 동일
```

`require-human` 이 **0 이 아닌 것**을 종료 코드로 확인했다. 0 이면 호출부가 코드만 보고 진행해 승인 절차가 생략된다.

## 리뷰 포인트

- **설정이 없을 때 형식을 안내하되 파일을 만들지 않는다**(T2-2 · §12 Q1). 무엇을 허용할지는 사람이 정하는 것이 이 기능의 목적이라, 기본값을 넣으면 검토 없이 켜는 경로가 열린다.
- **`HARD_STOP` 판정을 직접 했다** — 기존 `hard-stop-guard` 는 출력·차단까지 해서 조회 명령에 맞지 않는다. 존재 확인만 한다.
- **런 밖 판정** 처리 — 상태 파일이 없으면 호출 수 0·경과 0 으로 보고 그 사실을 출력에 표시한다(§6.3).
- 등록은 **6지점 전부** 채웠다(124 에서 `KNOWN_COMMAND_TOKENS` 누락으로 라우터에 먹힌 전례).

## 확인 방법

```
node dist/index.js policy check -- pnpm typecheck
node dist/index.js 정책 검사 -- pnpm typecheck
pnpm exec vitest run tests/policy-log.test.ts tests/policy-cli.test.ts
```

실측: **3246건 통과**(4 skip), CI 게이트 8종 로컬 0.
