### PR TITLE
fix: memory add 한글 별칭 추가 (#613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ## [Unreleased]
 
+### Fixed
+
+- `vhk 기억 추가`가 `memory add`로 연결되지 않아 `--type`이 unknown option으로 나오던 문제를 고친다.
+  무효 서브커맨드에 옵션이 붙어도 영어 raw 에러 대신 유효 서브 목록을 안내한다 (#613).
+
 ## [2.15.1] - 2026-08-30
 
 ### Security

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -152,7 +152,7 @@ Phase/Task는 선택 사항이며, Phase가 없는 legacy Goal도 호환됩니�
 
 | 하고 싶은 것 | 터미널 명령 | Cursor에게 말하기 |
 |-------------|-----------|------------------|
-| 결정 기록 | `vhk memory add "tRPC 채택" --type decision` | "이거 기억해" |
+| 결정 기록 | `vhk memory add "tRPC 채택" --type decision` · `vhk 기억 추가 "tRPC 채택" --type decision` | "이거 기억해" |
 | 실패+교훈 기록 | `vhk memory add "테스트 미커버" --type failure --why "..." --lesson "회귀 가드 먼저"` | "이 실수 기억해" |
 | 성공 기록 | `vhk memory add "롤백 빨랐다" --type success --why "백업 먼저"` | "이 성공 기억해" |
 | 교훈만 빠르게 | `vhk learn "PowerShell 은 && 미지원"` | "교훈 남겨" |

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -382,8 +382,8 @@ export async function memoryList(opts: { type?: MemBucket; all?: boolean } = {})
 
   if (visible.length === 0) {
     console.log(chalk.yellow('\n📭 표시할 기억이 없습니다.'))
-    console.log(chalk.gray('   vhk memory add "내용" --type decision|failure|success'))
-    console.log(chalk.gray('   vhk 기억 추가 "내용" --type decision|failure|success'))
+    console.log(chalk.gray('   vhk memory add "내용" --type decision'))
+    console.log(chalk.gray('   vhk 기억 추가 "내용" --type decision'))
     return
   }
   console.log(chalk.cyan(`\n${visible.length}개${opts.all ? ' (보관 포함)' : ' (활성)'}:\n`))

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -327,6 +327,7 @@ export async function memoryAdd(
   if (!content || !content.trim()) {
     console.log(chalk.red('❌ 기억할 내용을 입력해주세요.'))
     console.log(chalk.gray('   예: vhk memory add "API는 tRPC 사용" --type decision'))
+    console.log(chalk.gray('       vhk 기억 추가 "API는 tRPC 사용" --type decision'))
     process.exitCode = 1
     return
   }
@@ -382,6 +383,7 @@ export async function memoryList(opts: { type?: MemBucket; all?: boolean } = {})
   if (visible.length === 0) {
     console.log(chalk.yellow('\n📭 표시할 기억이 없습니다.'))
     console.log(chalk.gray('   vhk memory add "내용" --type decision|failure|success'))
+    console.log(chalk.gray('   vhk 기억 추가 "내용" --type decision|failure|success'))
     return
   }
   console.log(chalk.cyan(`\n${visible.length}개${opts.all ? ' (보관 포함)' : ' (활성)'}:\n`))

--- a/src/index.ts
+++ b/src/index.ts
@@ -752,6 +752,7 @@ const memoryCmd = program
 
 memoryCmd
   .command('add [content]')
+  .alias('추가')
   // #148: 대시(--)로 시작하는 본문은 positional 로 못 넘긴다(commander 가 옵션으로 파싱) →
   //       `--content=<본문>` 폴백 제공. 예: vhk memory add --content=--on-accent ... --type decision
   .option('--content <text>', '본문 (대시 시작 등 positional 불가 시) — 예: --content=--on-accent ...')

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -255,6 +255,7 @@ export function detectNaturalLanguageInput(argv: string[]): string | null {
  * 잡는 케이스(드리프트 3종):
  *  - #344 leaf+추가인자: env check → "env-check 명령을 쓰세요" (정답 형제 명령 유도)
  *  - #314 컨테이너+무효서브: memory 왜안되나 → 유효 서브커맨드 목록 안내(엉뚱한 doctor 실행 금지)
+ *  - #613 컨테이너+무효서브+옵션: memory 없는서브 --type … → unknown option 오진 대신 같은 안내
  */
 export function detectInvalidCommandUsage(argv: string[]): string | null {
   const rest = argv.slice(2)
@@ -262,8 +263,9 @@ export function detectInvalidCommandUsage(argv: string[]): string | null {
 
   const first = rest[0]
   if (isOptionToken(first)) return null
-  // 옵션이 섞이면 commander 가 정상 파싱 — 손대지 않는다.
-  if (rest.some(isOptionToken)) return null
+  // 둘째 토큰이 옵션이면 서브커맨드 시도가 아님 — commander 파싱에 맡긴다.
+  // 예전엔 옵션이 하나라도 있으면 전부 건너뛰어, 무효 서브+옵션이 raw unknown option 으로 샜다(#613).
+  if (isOptionToken(rest[1])) return null
 
   // #344: leaf 명령 + 정답이 형제 top-level 명령인 경우 → 형제 명령으로 유도.
   const leaf = LEAF_ARG_SUGGEST[first]

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -46,6 +46,7 @@ export const CONTAINER_SUBCOMMAND_ALIASES: Record<string, Record<string, string>
   ref: { 목록: 'list', 열기: 'open' },
   worktree: { 점검: 'check', 추가: 'add' },
   memory: {
+    추가: 'add',
     목록: 'list',
     삭제: 'remove',
     보관: 'archive',

--- a/tests/cli-arg-dx.e2e.test.ts
+++ b/tests/cli-arg-dx.e2e.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import fs from 'node:fs'
 import os from 'node:os'
 import { readJsonFile } from '../src/lib/read-json.js'
+import { removeDirSync } from '../src/lib/fs-remove.js'
 
 // 실제 빌드된 CLI 를 spawn 해서 commander 인자 파싱을 검증한다(#148/#151 은 파싱 레이어 결함이라
 // 함수 단위 mock 으론 재현 불가 — dist 필요).
@@ -40,6 +41,47 @@ describe('ref add --title 별칭 (#151)', () => {
       expect(refs[0].memo).toBe('메모값')
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('memory add 한글 별칭 추가 (#613)', () => {
+  it('vhk 기억 추가 "본문" --type decision 이 저장되고 unknown option 이 없다', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mem-ko-add-'))
+    try {
+      const r = runCli(['기억', '추가', '한글별칭 결정', '--type', 'decision'], tmp)
+      expect(String(r.stderr ?? '')).not.toMatch(/unknown option/i)
+      expect(r.status).toBe(0)
+      expect(String(r.stdout ?? '')).toMatch(/기억 저장됨/)
+      const raw = fs.readFileSync(path.join(tmp, '.vhk', 'memory.json'), 'utf-8')
+      expect(raw).toContain('한글별칭 결정')
+    } finally {
+      removeDirSync(tmp)
+    }
+  })
+
+  it('vhk memory 추가 "본문" --type success 도 동일 (영문 컨테이너 + 한글 서브)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mem-ko-sub-'))
+    try {
+      const r = runCli(['memory', '추가', '한글서브 성공', '--type', 'success'], tmp)
+      expect(String(r.stderr ?? '')).not.toMatch(/unknown option/i)
+      expect(r.status).toBe(0)
+      expect(String(r.stdout ?? '')).toMatch(/기억 저장됨/)
+    } finally {
+      removeDirSync(tmp)
+    }
+  })
+
+  it('무효 서브 + 옵션은 unknown option 대신 친절 가드 (exit 1)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vhk-mem-bad-sub-'))
+    try {
+      const r = runCli(['memory', '없는서브', '--type', 'decision'], tmp)
+      const err = `${r.stdout ?? ''}\n${r.stderr ?? ''}`
+      expect(err).not.toMatch(/unknown option/i)
+      expect(err).toMatch(/서브커맨드가 아니에요/)
+      expect(r.status).not.toBe(0)
+    } finally {
+      removeDirSync(tmp)
     }
   })
 })

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -220,6 +220,12 @@ describe('detectNaturalLanguageInput — 한글 서브별칭 경로 가드 (R1 �
   it('vhk 기억 목록 → null (commander 가 memory list 실행)', () => {
     expect(detectNaturalLanguageInput(['node', 'vhk', '기억', '목록'])).toBeNull()
   })
+  it('vhk 기억 추가 <본문> --type decision → null (commander 가 memory add 실행, #613)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', '기억', '추가', '결정 내용', '--type', 'decision'])).toBeNull()
+  })
+  it('vhk memory 추가 <본문> --type success → null (영문 컨테이너 + 한글 서브, #613)', () => {
+    expect(detectNaturalLanguageInput(['node', 'vhk', 'memory', '추가', '성공 내용', '--type', 'success'])).toBeNull()
+  })
   it('vhk 진화 반영 <id> → null (인자 보존)', () => {
     expect(detectNaturalLanguageInput(['node', 'vhk', '진화', '반영', 'r1'])).toBeNull()
   })

--- a/tests/command-registry.test.ts
+++ b/tests/command-registry.test.ts
@@ -40,6 +40,15 @@ describe('R1 드리프트 가드 — command-registry 단일 소스', () => {
 
   // #327: `vhk mission show` 가 commander 서브커맨드로 등록돼야 함.
   // 미등록이면 'show' 가 mission(0-arity) 위치인자로 처리돼 'too many arguments' cryptic 에러.
+  it('#613 memory add 에 한글 별칭 추가가 등록됨', () => {
+    const memory = program.commands.find((c) => c.name() === 'memory')
+    expect(memory, 'memory 컨테이너 명령이 commander 에 없음').toBeDefined()
+    const add = memory!.commands.find((c) => c.name() === 'add')
+    expect(add, 'memory add 가 commander 에 없음').toBeDefined()
+    expect(add!.aliases()).toContain('추가')
+    expect(resolveSubcommandAlias('memory', '추가')).toBe('add')
+  })
+
   it('#327 mission 에 show 서브커맨드가 등록돼 있음 (set/check/clear 와 대칭)', () => {
     const mission = program.commands.find((c) => c.name() === 'mission')
     expect(mission, 'mission 컨테이너 명령이 commander 에 없음').toBeDefined()

--- a/tests/registry-drift-usage.test.ts
+++ b/tests/registry-drift-usage.test.ts
@@ -111,6 +111,18 @@ describe('#314 컨테이너 무효 서브 + 트리거 단어 → cross-misroute 
     expect(msg).toMatch(/list/)
   })
 
+  it('#613 무효 서브 + 옵션도 unknown option 이 아니라 같은 친절 안내', () => {
+    const msg = detectInvalidCommandUsage(['node', 'vhk', 'memory', '없는서브', '--type', 'decision'])
+    expect(msg).not.toBeNull()
+    expect(msg).toMatch(/서브커맨드가 아니에요/)
+    expect(msg).toMatch(/add/)
+  })
+
+  it('#613 회귀: 유효 서브 + 옵션은 친절안내 대상 아님(commander 파싱)', () => {
+    expect(detectInvalidCommandUsage(['node', 'vhk', 'memory', 'add', '내용', '--type', 'decision'])).toBeNull()
+    expect(detectInvalidCommandUsage(['node', 'vhk', '기억', '추가', '내용', '--type', 'decision'])).toBeNull()
+  })
+
   it('회귀: 보안 확인 → 여전히 자연어 (secure 자기 명령으로의 라우팅은 허용)', () => {
     // 보안(secure) 컨테이너 + 확인 → NL 이 secure(=같은 명령)로 라우팅 → 가로채기 허용 유지.
     expect(detectNaturalLanguageInput(['node', 'vhk', '보안', '확인'])).toBe('보안 확인')


### PR DESCRIPTION
## Summary
- `memory add`에 한글 별칭 `추가`를 등록하고 레지스트리를 맞춘다.
- 무효 서브커맨드에 옵션이 붙어도 raw `unknown option` 대신 기존 친절 가드로 안내한다.
- 빈 목록 힌트와 COMMANDS.md에 한글 예시를 넣는다.

## Test plan
- [x] `vitest run tests/cli-args.test.ts tests/command-registry.test.ts tests/registry-drift-usage.test.ts`
- [x] `vitest run tests/cli-arg-dx.e2e.test.ts` (빌드 후)
- [ ] `vhk 기억 추가 "내용" --type decision` 이 저장되고 unknown option 이 없는지
- [ ] `vhk memory 없는서브 --type decision` 이 친절 가드 + exit 1 인지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 기억 추가 명령에 한글 별칭 `추가`를 지원합니다.
  * `기억 추가` 및 `memory 추가` 형식으로 기억을 저장할 수 있습니다.
  * 명령어 안내 문구에 한글 사용 예시를 추가했습니다.

* **버그 수정**
  * 잘못된 서브커맨드와 옵션을 함께 입력해도 알맞은 안내 메시지를 표시합니다.
  * 유효한 한글 명령어가 옵션과 함께 정상 처리됩니다.

* **테스트**
  * 한글 별칭, 옵션 조합, 잘못된 명령어 안내를 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->