### PR TITLE
fix: goal done 미완 Task advisory 경고 (#612)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ## [Unreleased]
 
+### Fixed
+
+- `vhk goal done`이 134 문법(`### Phase N` · `- [ ] **Task N**`) 미완 Task를 침묵하고 DONE 하던 구멍을 막는다.
+  게이트는 통과시키고 경고 한 줄만 낸다. `vhk goal drift`는 같은 어긋남을 역방향으로 표시한다.
+  일반 `- [ ]` 체크박스와 review 신뢰도는 보지 않는다 (#612).
+
 ## [2.15.1] - 2026-08-30
 
 ### Security

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -70,6 +70,8 @@ Cursor에게 한국어로 말해도 됩니다.
 | 게이트 검증 | `vhk goal check --id 0` 또는 `vhk check --goal 0` | "목표 점검" |
 | 완료 처리 | `vhk goal done --id 0` | "목표 완료" |
 
+`goal done`은 게이트를 통과하면 DONE으로 옮깁니다. Goal 본문에 134 문법(`### Phase N` · `- [ ] **Task N**`) 미완 Task가 있으면 경고 한 줄을 내고 전이는 막지 않습니다. `goal drift`는 같은 어긋남을 역방향으로도 표시합니다.
+
 Goal frontmatter에 `depends_on: 1,2`를 선택적으로 쓰면 선행 Goal이 모두 `DONE`일 때만 `next/peek/done` 대상이 됩니다. 잘못된 ID·자기 참조·순환 참조는 설정 오류로 표시됩니다.
 
 `goal next`는 선택 가능한 Goal 없이 BLOCKED·DEFERRED·OBSERVING만 남으면 “모두 완료”로 쓰지 않고 사람이 쓴 `next-task.md`를 보존합니다. VHK가 만든 과거 완료 스냅샷이 거짓 상태가 되면 완료 표시와 시각을 함께 무효화합니다. 미해결 Goal 없이 DONE/CANCELED만 남으면 기존 `next-task.md`가 있을 때만 백업 후 완료 스냅샷으로 갱신하고, 파일이 없으면 만들지 않습니다. 이미 완료 스냅샷이면 시각·백업을 다시 만들지 않습니다.

--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from 'node:fs'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import chalk from 'chalk'
 import { ko } from '../i18n/ko.js'
 import { localDate } from '../lib/date.js'
@@ -20,6 +20,7 @@ import {
   type ParsedGoal,
 } from '../lib/goal-frontmatter.js'
 import { findStatusDriftCandidates } from '../lib/goal-drift.js'
+import { listPendingProjectedTaskNumbers } from '../lib/goal-task-projection.js'
 import {
   analyzeGoalDependencies,
   dependencyIssuesForGoal,
@@ -637,11 +638,11 @@ export async function goalDrift(): Promise<void> {
     console.log(chalk.dim(`      ${c.reason}`))
     console.log(chalk.dim(`      ${c.goalFile} · ${c.scriptFile}`))
   }
-  console.log(
-    chalk.dim(
-      '\n  → 구현됐다면 `vhk goal done --id <n>` 로 DONE 전환, 아니라면 게이트의 goal 고유 검증을 제거하세요.'
-    )
-  )
+  const hasForward = candidates.some((c) => c.kind !== 'done-pending-tasks')
+  const hasReverse = candidates.some((c) => c.kind === 'done-pending-tasks')
+  console.log('')
+  if (hasForward) console.log(chalk.dim(`  → ${ko.goal.driftForwardHint}`))
+  if (hasReverse) console.log(chalk.dim(`  → ${ko.goal.driftReverseHint}`))
   process.exitCode = 1
 }
 
@@ -731,6 +732,17 @@ export async function goalDone(opts: { id?: string }): Promise<void> {
   atomicWriteFile(target.filePath, updated) // Goal 40: frontmatter 갱신 중 kill 시 goal 파일 손상 방지
   showGateOutput()
   console.log(chalk.green(`\n  ✅ Goal ${id} → DONE (completed: ${today})`))
+  // #612: 차단이 아니라 advisory. 게이트 통과 후에도 134 문법 미완 Task 가 있으면 한 줄만 남긴다.
+  const pendingTasks = listPendingProjectedTaskNumbers({
+    goalId: id,
+    goalTitle: target.frontmatter.title ?? null,
+    goalStatus: 'DONE',
+    sourceRef: basename(target.filePath),
+    markdown: target.body,
+  })
+  if (pendingTasks && pendingTasks.length > 0) {
+    console.log(chalk.yellow(`  ⚠ ${ko.goal.donePendingTasks(pendingTasks.length, pendingTasks.join(', '))}`))
+  }
   printNextStep({
     message: `Goal ${id} 완료! 다음 goal 로:`,
     command: 'vhk goal next',

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -837,11 +837,15 @@ export const ko = {
       `Goal ${id}가 시작됐지만 선행 작업 ${waiting}이 완료되지 않았습니다. 상태와 로드맵을 먼저 맞추세요.`,
     dependencyDoneBlocked: (id: number, waiting: string) =>
       `Goal ${id} 완료 처리 거부 — 먼저 끝내야 할 Goal: ${waiting}`,
+    donePendingTasks: (count: number, ids: string) =>
+      `미완 Task ${count}개(${ids}) 남음 — 그래도 DONE 처리했습니다`,
     // 여기의 "불일치(drift)"는 설정이 아니라 goal 상태 ↔ 코드 현실의 어긋남이다 (ADR-011 대응표 적용 시 의미 보존).
     driftTitle: '🔍 Goal 상태↔코드 불일치(drift) 점검',
-    driftClean: 'goal 상태 불일치(drift) 없음 (구현 흔적 있는데 NOT_STARTED 인 goal 0건)',
-    driftFound: (n: number) =>
-      `상태 불일치(drift) 의심 ${n}건 — check-goal 게이트에 goal 고유 검증이 있는데 status: NOT_STARTED:`,
+    driftClean: 'goal 상태 불일치(drift) 없음',
+    driftFound: (n: number) => `상태 불일치(drift) 의심 ${n}건:`,
+    driftForwardHint:
+      '구현됐다면 `vhk goal done --id <n>` 로 DONE 전환, 아니라면 게이트의 goal 고유 검증을 제거하세요.',
+    driftReverseHint: 'DONE인데 미완 Task가 있으면 카드를 고치거나, 완료가 아니면 status를 되돌리세요.',
     stateDirAbsent: (dir: string) =>
       `${dir}/ 가 없어 상태 문서를 쓰지 않고 조회만 했습니다 — 이 프로젝트는 작업 상태를 다른 곳에서 관리합니다.`,
     stateDirAbsentHint: (dir: string) =>

--- a/src/lib/goal-drift.ts
+++ b/src/lib/goal-drift.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { basename, dirname, join, relative, sep } from 'node:path'
 import { listGoals, type GoalStatus } from './goal-frontmatter.js'
+import { listPendingProjectedTaskNumbers } from './goal-task-projection.js'
 
 // Goal 43: goal 상태 ↔ 코드 현실 드리프트 게이트.
 //
@@ -87,6 +88,8 @@ export function countMustAssertions(content: string): number {
   return count
 }
 
+export type DriftKind = 'not-started-implemented' | 'done-pending-tasks'
+
 export interface DriftCandidate {
   id: number
   title: string
@@ -94,6 +97,7 @@ export interface DriftCandidate {
   goalFile: string
   scriptFile: string
   reason: string
+  kind?: DriftKind
 }
 
 /** 카드 본문의 마크다운 체크박스 집계. */
@@ -356,6 +360,32 @@ export function findStatusDriftCandidates(
         reason: `status: NOT_STARTED 인데 goals 본문 경로 증거 ${pathHits.length}건 존재(${pathHits.slice(0, 3).join(', ')}${pathHits.length > 3 ? '…' : ''}) — 구현됐는데 status 만 안 바뀐 드리프트 의심`,
       })
     }
+  }
+
+  // #612: DONE 인데 134 문법 미완 Task 가 남은 역방향. 일반 `- [ ]` 체크박스는 안 본다
+  // (112-T7 계획 카드 오탐과 같은 함정). 파싱 실패는 건너뛴다.
+  for (const g of listGoals(goalsDir)) {
+    const status = g.frontmatter.status ?? 'NOT_STARTED'
+    if (status !== 'DONE') continue
+    const id = g.frontmatter.id
+    if (typeof id !== 'number') continue
+    const pending = listPendingProjectedTaskNumbers({
+      goalId: id,
+      goalTitle: g.frontmatter.title ?? null,
+      goalStatus: status,
+      sourceRef: basename(g.filePath),
+      markdown: g.body,
+    })
+    if (pending === null || pending.length === 0) continue
+    out.push({
+      id,
+      title: g.frontmatter.title ?? '',
+      status,
+      goalFile: g.filePath,
+      scriptFile: '(projected tasks)',
+      kind: 'done-pending-tasks',
+      reason: `status: DONE 인데 미완 Task ${pending.length}개(${pending.join(', ')}) — 완료 표시와 작업 목록이 어긋남`,
+    })
   }
   return out
 }

--- a/src/lib/goal-task-projection.ts
+++ b/src/lib/goal-task-projection.ts
@@ -414,3 +414,20 @@ export function parseGoalPhaseTasks(input: GoalTaskProjectionInput): WorkContext
     errors: [],
   }
 }
+
+// toActiveGoal 이 쓰는 `goal:<id>/task:<n>` 과 같아야 한다. 접두를 빼면 미완 목록이 전부 null 이 된다.
+const PROJECTED_TASK_ID = /^goal:(\d+)\/task:([1-9][0-9]*)$/u
+
+/** 파싱 실패는 null(호출측은 경고를 생략). Phase 없는 카드는 빈 배열. */
+export function listPendingProjectedTaskNumbers(input: GoalTaskProjectionInput): number[] | null {
+  const parsed = parseGoalPhaseTasks(input)
+  if (!parsed.valid || parsed.activeGoal === null) return null
+  const pending: number[] = []
+  for (const task of parsed.activeGoal.tasks) {
+    if (task.sourceStatus !== 'pending') continue
+    const match = PROJECTED_TASK_ID.exec(task.id)
+    if (!match) return null
+    pending.push(Number(match[2]))
+  }
+  return pending
+}

--- a/tests/goal-drift.test.ts
+++ b/tests/goal-drift.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { removeDirSync } from '../src/lib/fs-remove.js'
 import {
   hasCustomGateAssertions,
   findStatusDriftCandidates,
@@ -240,14 +241,14 @@ describe('findStatusDriftCandidates', () => {
     expect(hits.map((x) => x.id)).toEqual([14])
     expect(hits[0].kind).toBe('done-pending-tasks')
     expect(hits[0].reason).toContain('110')
-    fs.rmSync(root, { recursive: true, force: true })
+    removeDirSync(root)
   })
 
   it('#612 DONE + 일반 미완 체크박스(T1) → 통과(134 문법만 본다)', () => {
     const body = '## 티켓\n- [ ] **T1** 하나\n'
     const { root, gdir, sdir } = setup({ '15-legacy.md': goalCard(15, 'DONE', body) }, {})
     expect(findStatusDriftCandidates(gdir, sdir, root)).toEqual([])
-    fs.rmSync(root, { recursive: true, force: true })
+    removeDirSync(root)
   })
 
   // 112-T7(b): goals/ 가 비추적이라 CI 에는 없다 → 빈 배열끼리 비교하며 무조건 통과하던 가드.

--- a/tests/goal-drift.test.ts
+++ b/tests/goal-drift.test.ts
@@ -233,6 +233,23 @@ describe('findStatusDriftCandidates', () => {
     fs.rmSync(root, { recursive: true, force: true })
   })
 
+  it('#612 DONE + 134 문법 미완 Task → 역방향 드리프트', () => {
+    const body = '### Phase 10\n- [x] **Task 100** 끝\n- [ ] **Task 110** 남음\n'
+    const { root, gdir, sdir } = setup({ '14-pending.md': goalCard(14, 'DONE', body) }, {})
+    const hits = findStatusDriftCandidates(gdir, sdir, root)
+    expect(hits.map((x) => x.id)).toEqual([14])
+    expect(hits[0].kind).toBe('done-pending-tasks')
+    expect(hits[0].reason).toContain('110')
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('#612 DONE + 일반 미완 체크박스(T1) → 통과(134 문법만 본다)', () => {
+    const body = '## 티켓\n- [ ] **T1** 하나\n'
+    const { root, gdir, sdir } = setup({ '15-legacy.md': goalCard(15, 'DONE', body) }, {})
+    expect(findStatusDriftCandidates(gdir, sdir, root)).toEqual([])
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
   // 112-T7(b): goals/ 가 비추적이라 CI 에는 없다 → 빈 배열끼리 비교하며 무조건 통과하던 가드.
   // 판정력이 로컬에만 있다는 사실이 보이도록 조건부 실행으로 분리한다.
   it.skipIf(!repoGoalsPresent())(

--- a/tests/goal-task-projection.test.ts
+++ b/tests/goal-task-projection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  listPendingProjectedTaskNumbers,
   parseGoalPhaseTasks,
   type GoalTaskProjectionInput,
   type WorkContextV1,
@@ -776,5 +777,33 @@ describe('Goal projection 공개 경계', () => {
     expect(result.valid).toBe(false)
     expect(result.activeGoal).toBeNull()
     expect(result.errors).toEqual([{ code: 'PUBLIC_BOUNDARY_VIOLATION' }])
+  })
+})
+
+describe('listPendingProjectedTaskNumbers', () => {
+  const phaseTasks = [
+    '### Phase 10',
+    '- [x] **Task 100** 끝난 일',
+    '- [ ] **Task 110** 남은 일',
+  ].join('\n')
+
+  it('미완 Task 번호만 반환한다', () => {
+    expect(
+      listPendingProjectedTaskNumbers({ ...DEFAULT_INPUT, markdown: phaseTasks }),
+    ).toEqual([110])
+  })
+
+  it('Phase가 없으면 빈 배열이다', () => {
+    expect(listPendingProjectedTaskNumbers({ ...DEFAULT_INPUT, markdown: '본문만' })).toEqual([])
+  })
+
+  it('파싱 실패는 null이다', () => {
+    expect(
+      listPendingProjectedTaskNumbers({
+        ...DEFAULT_INPUT,
+        sourceRef: 'goals/sample-goal.md',
+        markdown: phaseTasks,
+      }),
+    ).toBeNull()
   })
 })

--- a/tests/goal.test.ts
+++ b/tests/goal.test.ts
@@ -20,11 +20,11 @@ function tmpProject(label: string): string {
   return dir
 }
 
-function makeGoalFile(dir: string, id: number, status: string, dependsOn?: string): void {
+function makeGoalFile(dir: string, id: number, status: string, dependsOn?: string, body = 'body'): void {
   mkdirSync(join(dir, 'goals'), { recursive: true })
   writeFileSync(
     join(dir, 'goals', `${id}-test.md`),
-    `---\nvhk_format: 1\ntype: goal\nid: ${id}\ntitle: Goal ${id}\nstatus: ${status}\npriority: P0\nversion: v0.${id}\n${dependsOn === undefined ? '' : `depends_on: ${dependsOn}\n`}---\nbody\n`,
+    `---\nvhk_format: 1\ntype: goal\nid: ${id}\ntitle: Goal ${id}\nstatus: ${status}\npriority: P0\nversion: v0.${id}\n${dependsOn === undefined ? '' : `depends_on: ${dependsOn}\n`}---\n${body}\n`,
     'utf-8'
   )
 }
@@ -578,6 +578,31 @@ describe('goalDone — Forbidden: 게이트 실패 시 frontmatter 변경 금지
       expect(after).toContain('status: DONE')
       expect(after).not.toContain('status: IN_PROGRESS')
       expect(after).toMatch(/completed: \d{4}-\d{2}-\d{2}/)
+    } finally {
+      process.chdir(origCwd)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('#612 미완 Task가 있어도 DONE 전이하고 advisory 경고만 낸다', async () => {
+    const dir = tmpProject('done-pending-task')
+    const body = ['### Phase 10', '- [x] **Task 100** 끝', '- [ ] **Task 110** 남음'].join('\n')
+    makeGoalFile(dir, 5, 'IN_PROGRESS', undefined, body)
+    mkdirSync(join(dir, 'scripts'), { recursive: true })
+    writeFileSync(join(dir, 'scripts/check-goal-5.sh'), '#!/usr/bin/env bash\nexit 0\n', 'utf-8')
+    mockSafeExecFile.mockReturnValue({ ok: true, out: 'all good', err: '' })
+    process.chdir(dir)
+    process.exitCode = 0
+    try {
+      const { goalDone } = await import('../src/commands/goal.js')
+      const logSpy = vi.spyOn(console, 'log')
+      await goalDone({ id: '5' })
+      const after = readFileSync(join(dir, 'goals/5-test.md'), 'utf-8')
+      expect(after).toContain('status: DONE')
+      expect(process.exitCode === 1).toBe(false)
+      const logs = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(logs).toMatch(/미완 Task 1개\(110\)/)
+      expect(logs).toMatch(/그래도 DONE 처리했습니다/)
     } finally {
       process.chdir(origCwd)
       rmSync(dir, { recursive: true, force: true })

--- a/tests/goal.test.ts
+++ b/tests/goal.test.ts
@@ -605,7 +605,7 @@ describe('goalDone — Forbidden: 게이트 실패 시 frontmatter 변경 금지
       expect(logs).toMatch(/그래도 DONE 처리했습니다/)
     } finally {
       process.chdir(origCwd)
-      rmSync(dir, { recursive: true, force: true })
+      removeDirSync(dir)
     }
   })
 })


### PR DESCRIPTION
## 요약
- `vhk goal done`이 게이트만 보고 침묵 DONE 하던 구멍을 막는다. 134 문법(`### Phase N` · `- [ ] **Task N**`) 미완 Task가 있으면 **경고 한 줄**만 내고 전이는 막지 않는다.
- `vhk goal drift`에 같은 어긋남을 역방향으로 추가한다. 일반 `- [ ]` 체크박스는 보지 않는다(112-T7 계획 카드 오탐).
- review 「신뢰도: 낮음」은 소비하지 않는다. 그 신호는 `.vhk/reports/latest.json`에 합쳐지고 이후 verify/gate가 덮어써서 done 시점에 durable하지 않다.

## 테스트
- [x] `tests/goal-task-projection.test.ts` — 미완 번호 / Phase 없음 / 파싱 실패
- [x] `tests/goal-drift.test.ts` — DONE+미완 Task 검출, 레거시 T1 체크박스는 통과
- [x] `tests/goal.test.ts` — DONE 전이 + advisory 문구, exit 0

Closes 없음 — 머지 후 #612 닫을 것.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - `goal done` 실행 시 미완료 Task가 있으면 경고를 표시하면서도 DONE 상태로 전환됩니다.
  - `goal drift`가 완료 상태와 미완료 투영 Task 간의 역방향 불일치를 감지하고 안내합니다.

- **버그 수정**
  - 투영된 Task의 상태를 기반으로 목표 상태 불일치를 보다 정확하게 확인합니다.

- **테스트**
  - 미완료 투영 Task 감지, 경고 표시, 드리프트 판정 동작을 검증하는 테스트를 추가했습니다.

- **문서**
  - 관련 명령어의 동작 및 경고 안내를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->