### PR TITLE
feat: worktree 대상 미리보기와 --path (#604)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ## [Unreleased]
 
+### Added
+
+- `vhk worktree add`가 생성 전에 source·branch·target·copy·install을 보여준다. `--path`와
+  `.vhk/config.json`의 `worktreeRoot`로 대상을 고를 수 있고, `--dry-run`은 Git·복사·install을
+  하지 않는다. 비-TTY는 `--yes` 없이 만들지 않는다. source는 git 루트다 (#604).
+
 ## [2.15.1] - 2026-08-30
 
 ### Security

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -181,10 +181,12 @@ Phase/Task는 선택 사항이며, Phase가 없는 legacy Goal도 호환됩니�
 | 하고 싶은 것 | 터미널 명령 | Cursor에게 말하기 |
 |-------------|-----------|------------------|
 | 새 worktree 생성 + env 복사 | `vhk worktree add feat/login` | "worktree 만들어줘" |
+| 경로 지정 | `vhk worktree add feat/login --path .worktrees/feat-login` | "worktree 여기 만들어줘" |
+| 생성 전 미리보기 | `vhk worktree add feat/login --dry-run` | "worktree 경로만 보여줘" |
 | 생성 + pnpm install까지 | `vhk worktree add feat/login --install` | "worktree 만들고 설치까지" |
 | 현재 worktree env 점검 | `vhk worktree check` | "worktree env 점검해" |
 
-> `worktree add` 는 `git worktree add` 로 새 worktree를 만들고 필수 env/설정(`.env*` + `.vhk/config.json`의 `worktreeCopy`)을 **파일 복사**(심볼릭 링크 X — Windows 안정)로 채웁니다. 비밀값은 **절대 출력 안 함**(env는 키 개수만). 대상 경로가 이미 있으면 덮어쓰지 않고 중단. git 훅은 건드리지 않습니다. `worktree check` 는 현재 worktree의 필수 env 누락을 개수로 점검(Goal 29 `worktree-env` 모듈 재사용).
+> `worktree add` 는 만들기 전에 source·branch·target·copy·install 을 보여줍니다. 기본 target은 **형제 디렉터리**(`../<repo>-<branch>`)입니다. `--path`가 있으면 그걸 쓰고, 없으면 `.vhk/config.json`의 `worktreeRoot`, 그것도 없으면 형제 기본값입니다. 상대 `--path`와 `worktreeRoot`는 git 루트 기준입니다. 비-TTY는 `--yes` 없이 만들지 않습니다. `--dry-run`은 Git·복사·install을 하지 않습니다. 필수 env/설정(`.env*` + `worktreeCopy`)은 **파일 복사**(심볼릭 링크 X). 비밀값은 **절대 출력 안 함**. 대상이 이미 있으면 덮어쓰지 않고 중단. `worktree check` 는 필수 env 누락을 개수로 점검합니다.
 
 ## 패턴 → 진화 (pattern / evolve)
 

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ VHK 프로젝트에서 **active goal 1개를 혼자 한 바퀴 돌리고 멈춰 
 | Trust | `vhk verify`, `vhk review`, `vhk receipt`, `vhk preflight`, `vhk testmap`, `vhk mission set/show/check/clear` | 증거 생성, 완료 보고 검증, 검증 리포트, 출고 전 점검, 테스트 매핑, 작업 범위 계약 |
 | 안전 | `vhk blocker`, `vhk resume --confirm`, `vhk mode`, `vhk secure scan`, `vhk policy level/risk/show/check/baseline` | HARD_STOP, safety mode, 시크릿 스캔, 기본-off 실행 정책 조회·판정·기준선 |
 | Git | `vhk status`, `vhk diff`, `vhk save`, `vhk 저장`, `vhk undo`, `vhk restore`, `vhk recap` | 상태/변경 확인, 커밋/푸시(save는 high-risk — 비-TTY Commander는 `--yes`로 commit+push하거나 그 대신 `--no-push`로 로컬 commit만 수행), 되돌리기, 세션 로그 |
-| 환경/품질 | `vhk doctor`, `vhk check`, `vhk env`, `vhk env-check`, `vhk harness`, `vhk audit`, `vhk worktree check/add` | 개발환경, RULES 린트, env, 통합 품질, 보안 감사, worktree 가드 |
+| 환경/품질 | `vhk doctor`, `vhk check`, `vhk env`, `vhk env-check`, `vhk harness`, `vhk audit`, `vhk worktree check/add` | 개발환경, RULES 린트, env, 통합 품질, 보안 감사, worktree 가드(`add`는 `--path`/`--dry-run`/`--yes`) |
 | 배포/패키지 | `vhk ship`, `vhk deploy`, `vhk publish`, `vhk update`, `vhk migrate` | 배포 체크, 배포 실행, npm 릴리스 자동화, 셀프 업데이트, 패키지 매니저 전환 |
 | MCP/클라우드 | `vhk mcp`, `vhk mcp-init`, `vhk cloud push/pull` | MCP stdio 서버, 클라이언트 설정, `.vhk/` secret gist 백업/복원 |
 | 기억/학습 | `vhk memory`, `vhk learn`, `vhk pattern`, `vhk evolve`, `vhk stats`, `vhk loop` | 결정/실패/성공 기억, 교훈, 반복 패턴, 룰 후보, 통계, 자가진화 조율 |

--- a/src/commands/worktree.ts
+++ b/src/commands/worktree.ts
@@ -1,16 +1,18 @@
 import chalk from 'chalk'
 import { existsSync } from 'node:fs'
-import { basename, dirname, join } from 'node:path'
+import { basename } from 'node:path'
 import { ko } from '../i18n/ko.js'
 import { printNextStep } from '../lib/next-step.js'
 import { ensureNotHardStopped } from '../lib/hard-stop-guard.js'
 import { safeExecFile } from '../lib/exec.js'
 import type { Runner } from '../lib/preflight.js'
 import { runWorktreeCheck } from '../worktree/check.js'
-import { collectCopyItems } from '../worktree/configList.js'
+import { collectCopyItems, readWorktreeRoot } from '../worktree/configList.js'
 import { copyAll, realCopyDeps } from '../worktree/copy.js'
-import { addWorktree, sanitizeBranchToDir } from '../worktree/add.js'
+import { addWorktree } from '../worktree/add.js'
+import { copyPreviewNames, decideWorktreeMutation, resolveWorktreeTarget } from '../worktree/plan.js'
 import { detectPM, installCommandFor } from '../worktree/pm.js'
+import { getGitRoot } from '../lib/git-repo.js'
 import type { CopyResult, WorktreeOptions } from '../worktree/types.js'
 
 // safeExecFile → Runner 어댑터(외부 명령 단일 경로 — execSync 금지).
@@ -50,6 +52,20 @@ export async function worktreeCheck(): Promise<void> {
   }
 }
 
+function printAddPreview(plan: {
+  source: string
+  branch: string
+  target: string
+  copy: string
+  install: boolean
+}): void {
+  console.log(chalk.dim(`  source: ${plan.source}`))
+  console.log(chalk.dim(`  branch: ${plan.branch}`))
+  console.log(chalk.dim(`  target: ${plan.target}`))
+  console.log(chalk.dim(`  copy: ${plan.copy}`))
+  console.log(chalk.dim(`  install: ${plan.install ? 'yes' : 'no'}`))
+}
+
 // vhk worktree add <branch> — worktree 생성 + 필수 env/설정 자동 복사(+ --install).
 export async function worktreeAdd(branch: string | undefined, opts: WorktreeOptions = {}): Promise<void> {
   if (!ensureNotHardStopped('worktree add')) return // VHK-020
@@ -60,19 +76,66 @@ export async function worktreeAdd(branch: string | undefined, opts: WorktreeOpti
   }
   console.log(chalk.bold(`\n${ko.worktree.addTitle(branch)}\n`))
 
-  const cwd = process.cwd()
+  let repoRoot: string
+  try {
+    repoRoot = getGitRoot(process.cwd())
+  } catch {
+    console.log(chalk.red(`  ${ko.worktree.noGitRoot}`))
+    process.exitCode = 1
+    return
+  }
+
+  const targetPath = resolveWorktreeTarget({
+    repoRoot,
+    branch,
+    pathOpt: opts.path,
+    worktreeRoot: readWorktreeRoot(repoRoot),
+  })
+  const previewItems = collectCopyItems(repoRoot, targetPath)
+  printAddPreview({
+    source: repoRoot,
+    branch,
+    target: targetPath,
+    copy: copyPreviewNames(previewItems.map((item) => basename(item.target))),
+    install: opts.install === true,
+  })
+
+  const gate = decideWorktreeMutation({
+    dryRun: opts.dryRun,
+    yes: opts.yes,
+    stdinTty: opts.stdinTty ?? !!process.stdin.isTTY,
+  })
+  if (gate === 'dry-run') {
+    console.log(chalk.green(`  ${ko.worktree.dryRunDone}`))
+    printNextStep({
+      message: '미리보기만 했습니다. 생성하려면:',
+      command: `vhk worktree add ${branch}${opts.path ? ` --path ${opts.path}` : ''}${opts.install ? ' --install' : ''}`,
+      cursorHint: 'worktree 만들어줘',
+    })
+    return
+  }
+  if (gate === 'need-yes') {
+    console.log(chalk.yellow(`  ${ko.worktree.needYes}`))
+    process.exitCode = 1
+    printNextStep({
+      message: '비-TTY에서는 --yes 또는 --dry-run 을 주세요.',
+      command: `vhk worktree add ${branch} --yes`,
+      cursorHint: 'worktree 만들어줘',
+    })
+    return
+  }
+
   const copyDeps = realCopyDeps()
   const run = realRunner()
-  const pm = detectPM(cwd) // 범용: pnpm 고정 X — lockfile 로 yarn/npm 자동 감지
+  const pm = detectPM(repoRoot)
   const result = addWorktree(
     branch,
     { install: opts.install },
     {
-      sourceDir: cwd,
+      sourceDir: repoRoot,
       run,
       exists: (p) => existsSync(p),
-      // 형제 디렉터리: ../<repoName>-<branch>
-      resolveTargetPath: (b) => join(dirname(cwd), sanitizeBranchToDir(basename(cwd), b)),
+      resolveTargetPath: () => targetPath,
       collectItems: (s, t) => collectCopyItems(s, t),
       copyAll: (items) => copyAll(items, copyDeps),
       installRun: (tp) => {

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -429,6 +429,9 @@ export const ko = {
     abortedExists: (p: string) => `🛑 이미 존재 — 중단(덮어쓰기 안 함): ${p}`,
     gitFailed: (d: string) => `❌ git worktree add 실패: ${d}`,
     installSkipped: 'node_modules 없음 → pnpm install (또는 --install 로 자동)',
+    noGitRoot: 'git 저장소가 아닙니다 — worktree 는 저장소 루트에서 만듭니다',
+    dryRunDone: '미리보기만 했습니다 — Git·복사·install 없음',
+    needYes: '비-TTY에서는 --yes 없이 worktree 를 만들지 않습니다. 먼저 --dry-run 으로 경로를 확인하세요',
   },
   nlp: {
     matched: '이게 맞나요?',

--- a/src/index.ts
+++ b/src/index.ts
@@ -667,8 +667,13 @@ worktreeCmd
   .command('add <branch>')
   .alias('추가')
   .option('--install', 'worktree 생성 후 pnpm install 자동 실행')
+  .option('--path <target>', '생성 경로 (상대면 git 루트 기준). 없으면 worktreeRoot 설정, 아니면 형제 디렉터리')
+  .option('--dry-run', '생성·복사·install 없이 대상만 출력')
+  .option('--yes', '비-TTY에서 미리보기 후 생성 승인')
   .description('worktree 생성 + 필수 env/설정 자동 복사 (파일 복사·심볼릭 X, 비밀값 미노출)')
-  .action(async (branch: string, opts: { install?: boolean }) => { await worktreeAdd(branch, opts) })
+  .action(async (branch: string, opts: { install?: boolean; path?: string; dryRun?: boolean; yes?: boolean }) => {
+    await worktreeAdd(branch, opts)
+  })
 
 program
   .command('standup')

--- a/src/worktree/configList.ts
+++ b/src/worktree/configList.ts
@@ -50,6 +50,19 @@ export function readExtraConfigs(sourceDir: string): string[] {
   return []
 }
 
+export function readWorktreeRoot(sourceDir: string): string | null {
+  const p = join(sourceDir, '.vhk', 'config.json')
+  if (!existsSync(p)) return null
+  try {
+    const cfg = readJsonFile<{ worktreeRoot?: unknown }>(p)
+    return typeof cfg.worktreeRoot === 'string' && cfg.worktreeRoot.trim() !== ''
+      ? cfg.worktreeRoot.trim()
+      : null
+  } catch {
+    return null
+  }
+}
+
 // IO 수집: sourceDir 스캔(.env*) + .vhk/config.json 추가 설정 → CopyItem[].
 export function collectCopyItems(sourceDir: string, targetDir: string): CopyItem[] {
   let names: string[] = []

--- a/src/worktree/plan.ts
+++ b/src/worktree/plan.ts
@@ -1,0 +1,39 @@
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
+import { sanitizeBranchToDir } from './add.js'
+
+export type WorktreeMutation = 'dry-run' | 'need-yes' | 'mutate'
+
+export function resolveWorktreeTarget(input: {
+  repoRoot: string
+  branch: string
+  pathOpt?: string
+  worktreeRoot?: string | null
+}): string {
+  const repoRoot = resolve(input.repoRoot)
+  const pathOpt = input.pathOpt?.trim()
+  if (pathOpt) {
+    return isAbsolute(pathOpt) ? resolve(pathOpt) : resolve(repoRoot, pathOpt)
+  }
+  const worktreeRoot = input.worktreeRoot?.trim()
+  if (worktreeRoot) {
+    const base = isAbsolute(worktreeRoot) ? resolve(worktreeRoot) : resolve(repoRoot, worktreeRoot)
+    return join(base, sanitizeBranchToDir(basename(repoRoot), input.branch))
+  }
+  return join(dirname(repoRoot), sanitizeBranchToDir(basename(repoRoot), input.branch))
+}
+
+/** 가드 confirm 축과 같게 stdin TTY 만 본다. VHK_FORCE_INTERACTIVE 는 승인을 대신하지 못한다. */
+export function decideWorktreeMutation(opts: {
+  dryRun?: boolean
+  yes?: boolean
+  stdinTty: boolean
+}): WorktreeMutation {
+  if (opts.dryRun) return 'dry-run'
+  if (opts.yes) return 'mutate'
+  if (opts.stdinTty) return 'mutate'
+  return 'need-yes'
+}
+
+export function copyPreviewNames(names: string[]): string {
+  return names.length === 0 ? '(none)' : names.join(', ')
+}

--- a/src/worktree/types.ts
+++ b/src/worktree/types.ts
@@ -2,6 +2,11 @@
 
 export interface WorktreeOptions {
   install?: boolean // --install: worktree 생성 후 pnpm install 실행
+  path?: string
+  dryRun?: boolean
+  yes?: boolean
+  /** 테스트 주입. 없으면 process.stdin.isTTY */
+  stdinTty?: boolean
 }
 
 export type CopyKind = 'env' | 'config'

--- a/tests/worktree/add-command.test.ts
+++ b/tests/worktree/add-command.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { removeDirSync } from '../../src/lib/fs-remove.js'
+
+const gitRoot = { value: '' }
+const addSpy = vi.fn()
+
+vi.mock('../../src/lib/hard-stop-guard.js', () => ({ ensureNotHardStopped: () => true }))
+vi.mock('../../src/lib/git-repo.js', () => ({ getGitRoot: () => gitRoot.value }))
+vi.mock('../../src/worktree/add.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/worktree/add.js')>()
+  return { ...actual, addWorktree: (...args: unknown[]) => addSpy(...args) }
+})
+
+describe('worktreeAdd preview gate', () => {
+  let origCwd: string
+  let origExit: number | string | undefined
+  let dir: string
+
+  beforeEach(() => {
+    origCwd = process.cwd()
+    origExit = process.exitCode
+    process.exitCode = 0
+    addSpy.mockReset()
+    dir = join(tmpdir(), `vhk-wt-add-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+    mkdirSync(dir, { recursive: true })
+    gitRoot.value = dir
+    process.chdir(dir)
+  })
+
+  afterEach(() => {
+    process.chdir(origCwd)
+    process.exitCode = origExit
+    removeDirSync(dir)
+  })
+
+  it('--dry-run 은 미리보기만 하고 addWorktree 를 호출하지 않는다', async () => {
+    const { worktreeAdd } = await import('../../src/commands/worktree.js')
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    await worktreeAdd('feat/login', { dryRun: true, stdinTty: false })
+    const logs = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+    expect(logs).toContain('source:')
+    expect(logs).toContain('target:')
+    expect(logs).toContain('feat/login')
+    expect(logs).toMatch(/Git·복사·install 없음/)
+    expect(addSpy).not.toHaveBeenCalled()
+    expect(process.exitCode === 1).toBe(false)
+    logSpy.mockRestore()
+  })
+
+  it('비-TTY 는 --yes 없이 거부하고 addWorktree 를 호출하지 않는다', async () => {
+    const { worktreeAdd } = await import('../../src/commands/worktree.js')
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    await worktreeAdd('feat/login', { stdinTty: false })
+    const logs = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+    expect(logs).toContain('target:')
+    expect(logs).toMatch(/--yes 없이/)
+    expect(addSpy).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(1)
+    logSpy.mockRestore()
+  })
+})

--- a/tests/worktree/configList.test.ts
+++ b/tests/worktree/configList.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest'
-import { isCopyableEnvFile, listEnvFiles, buildCopyList } from '../../src/worktree/configList.js'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { removeDirSync } from '../../src/lib/fs-remove.js'
+import {
+  isCopyableEnvFile,
+  listEnvFiles,
+  buildCopyList,
+  readWorktreeRoot,
+} from '../../src/worktree/configList.js'
 
 describe('isCopyableEnvFile', () => {
   it('.env / .env.local / .env.production 은 복사 대상', () => {
@@ -42,5 +51,21 @@ describe('buildCopyList', () => {
   })
   it('빈 목록이면 빈 배열', () => {
     expect(buildCopyList({ sourceDir: '/s', targetDir: '/t', envFiles: [], extraConfigs: [] })).toEqual([])
+  })
+})
+
+describe('readWorktreeRoot', () => {
+  it('문자열 worktreeRoot 만 읽고 손상 파일은 null', () => {
+    const dir = join(tmpdir(), `vhk-wt-root-${Date.now()}`)
+    mkdirSync(join(dir, '.vhk'), { recursive: true })
+    try {
+      expect(readWorktreeRoot(dir)).toBeNull()
+      writeFileSync(join(dir, '.vhk', 'config.json'), '{"worktreeRoot":".worktrees"}', 'utf-8')
+      expect(readWorktreeRoot(dir)).toBe('.worktrees')
+      writeFileSync(join(dir, '.vhk', 'config.json'), '{', 'utf-8')
+      expect(readWorktreeRoot(dir)).toBeNull()
+    } finally {
+      removeDirSync(dir)
+    }
   })
 })

--- a/tests/worktree/plan.test.ts
+++ b/tests/worktree/plan.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { basename, dirname, join, resolve } from 'node:path'
+import { copyPreviewNames, decideWorktreeMutation, resolveWorktreeTarget } from '../../src/worktree/plan.js'
+
+const repoRoot = resolve('/repo/sample-app')
+
+describe('resolveWorktreeTarget', () => {
+  it('기본은 형제 디렉터리', () => {
+    expect(resolveWorktreeTarget({ repoRoot, branch: 'feat/login' })).toBe(
+      join(dirname(repoRoot), 'sample-app-feat-login'),
+    )
+  })
+
+  it('상대 --path 는 git 루트 기준', () => {
+    expect(resolveWorktreeTarget({ repoRoot, branch: 'feat/login', pathOpt: '.worktrees/feat-login' })).toBe(
+      resolve(repoRoot, '.worktrees/feat-login'),
+    )
+  })
+
+  it('절대 --path 를 canonicalize 한다', () => {
+    const abs = resolve('/approved/feat-login')
+    expect(resolveWorktreeTarget({ repoRoot, branch: 'feat/login', pathOpt: abs })).toBe(abs)
+  })
+
+  it('--path 가 worktreeRoot 보다 우선', () => {
+    expect(
+      resolveWorktreeTarget({
+        repoRoot,
+        branch: 'feat/login',
+        pathOpt: '.worktrees/custom',
+        worktreeRoot: '.worktrees',
+      }),
+    ).toBe(resolve(repoRoot, '.worktrees/custom'))
+  })
+
+  it('worktreeRoot 아래 형제식 이름을 만든다', () => {
+    expect(resolveWorktreeTarget({ repoRoot, branch: 'feat/login', worktreeRoot: '.worktrees' })).toBe(
+      join(resolve(repoRoot, '.worktrees'), `${basename(repoRoot)}-feat-login`),
+    )
+  })
+})
+
+describe('decideWorktreeMutation', () => {
+  it('--dry-run 은 TTY·--yes 보다 앞선다', () => {
+    expect(decideWorktreeMutation({ dryRun: true, yes: true, stdinTty: true })).toBe('dry-run')
+  })
+
+  it('비-TTY 는 --yes 없이 거부', () => {
+    expect(decideWorktreeMutation({ stdinTty: false })).toBe('need-yes')
+  })
+
+  it('--yes 는 비-TTY 에서 생성한다', () => {
+    expect(decideWorktreeMutation({ yes: true, stdinTty: false })).toBe('mutate')
+  })
+
+  it('stdin TTY 는 미리보기 후 생성', () => {
+    expect(decideWorktreeMutation({ stdinTty: true })).toBe('mutate')
+  })
+})
+
+describe('copyPreviewNames', () => {
+  it('빈 목록은 (none)', () => {
+    expect(copyPreviewNames([])).toBe('(none)')
+  })
+
+  it('파일명만 이어 붙인다', () => {
+    expect(copyPreviewNames(['.env', 'settings.json'])).toBe('.env, settings.json')
+  })
+})


### PR DESCRIPTION
## 요약
- `vhk worktree add`가 Git·복사·install **전에** source/branch/target/copy/install을 보여준다.
- 대상 우선순위: `--path` > `.vhk/config.json` `worktreeRoot` > 형제 디렉터리 기본값.
- source는 `git rev-parse --show-toplevel`. 상대 경로는 그 루트 기준.
- `--dry-run`은 mutation 0회. 비-TTY는 `--yes` 없이 만들지 않는다(stdin TTY 축, `VHK_FORCE_INTERACTIVE`로 승인 대체 안 함).

## 이번 범위에 없는 것
- `worktree-add`를 HIGH_RISK/`runGuarded`에 넣지 않았다. TTY에서는 미리보기 후 바로 생성한다. 확인 프롬프트가 더 필요하면 후속.

## 테스트
- [x] `tests/worktree/plan.test.ts` — 경로 우선순위, dry-run/need-yes
- [x] `tests/worktree/add-command.test.ts` — dry-run·비-TTY가 addWorktree 미호출
- [x] `tests/worktree/configList.test.ts` — worktreeRoot 읽기

Closes 없음 — 머지 후 #604 닫을 것.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * `vhk worktree add`에 `--path`, `--dry-run`, `--yes` 옵션이 추가되었습니다.
  * 대상 경로를 지정하거나 설정 파일을 통해 관리할 수 있습니다.
  * 실행 전 브랜치, 대상 경로, 복사·설치 항목을 미리 확인할 수 있습니다.
  * `--dry-run`은 실제 생성 없이 실행 계획만 표시합니다.
* **개선 사항**
  * 비대화형 환경에서는 `--yes` 없이 작업 트리 생성을 방지합니다.
  * Git 저장소 루트를 기준으로 경로를 안정적으로 처리합니다.
  * 관련 명령어 문서와 한국어 안내 메시지가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->