### PR TITLE
fix: context.md 생성 시각만 바뀌면 다시 쓰지 않음 (#603)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ VHK 변경 이력. [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형�
 
 ### Fixed
 
+- `vhk context`가 세션마다 `_생성:` 시각만 바꿔 `.vhk/context.md`를 dirty로 만들던 문제를 고친다.
+  본문(git HEAD 마커 포함)이 같으면 다시 쓰지 않는다 (#603).
 - `vhk goal done`이 134 문법(`### Phase N` · `- [ ] **Task N**`) 미완 Task를 침묵하고 DONE 하던 구멍을 막는다.
   게이트는 통과시키고 경고 한 줄만 낸다. `vhk goal drift`는 같은 어긋남을 역방향으로 표시한다.
   일반 `- [ ]` 체크박스와 review 신뢰도는 보지 않는다 (#612).

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -269,7 +269,7 @@ vhk doctor
 | `vhk audit` | 보안 취약점 감사 (npm audit) |
 | `vhk migrate` | 패키지 매니저 전환 (npm/yarn/pnpm) |
 | `vhk update` | VHK CLI 셀프 업데이트 |
-| `vhk context` | 프로젝트 맥락 파일 생성 (.vhk/context.md) · `--json`은 Goal Phase/Task 읽기 전용 투영 |
+| `vhk context` | 프로젝트 맥락 파일 생성 (.vhk/context.md). 본문이 같으면 `_생성:` 시각만 바뀌어도 다시 쓰지 않음. `--json`은 Goal Phase/Task 읽기 전용 투영 |
 | `vhk mode` | Safety Mode 조회/변경 (lite\|standard\|strict) |
 | `vhk verify` | 검증 실행 + 확인이 필요한 항목의 경과 시간·숨긴 횟수 + 증거·행동 기록 (`--dismiss <id>`) |
 | `vhk cost` | 비용·예산 가드 — add/check/budget (자문형) |

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -29,6 +29,7 @@ import {
 import { getActiveBlockers, isHardStopActive } from '../lib/state-files.js'
 import { gitOut } from '../lib/git-repo.js'
 import { CONTEXT_GIT_MARKER } from '../lib/drift.js'
+import { shouldRewriteContext } from '../lib/context-stamp.js'
 import { TOP_LEVEL_COMMANDS } from '../lib/command-registry.js'
 import { loadCoreRuleset } from '../lib/core-rules.js'
 import {
@@ -461,8 +462,27 @@ export async function context(opts: { compact?: boolean } = {}): Promise<void> {
   }
   lines.push('')
 
+  const next = lines.join('\n')
+  let existing: string | null = null
+  if (existsSync(CONTEXT_PATH)) {
+    try {
+      existing = readFileSync(CONTEXT_PATH, 'utf-8')
+    } catch {
+      existing = null
+    }
+  }
+  if (!shouldRewriteContext(existing, next)) {
+    console.log(chalk.green(`\n✅ ${t('context.unchanged')}`))
+    printNextStep({
+      message: '컨텍스트 파일이 이미 최신입니다.',
+      command: 'vhk context-show',
+      cursorHint: '컨텍스트 보여줘',
+    })
+    return
+  }
+
   mkdirSync('.vhk', { recursive: true })
-  atomicWriteFile(CONTEXT_PATH, lines.join('\n'))
+  atomicWriteFile(CONTEXT_PATH, next)
 
   console.log(chalk.green(`\n✅ ${CONTEXT_PATH} 생성 완료!`))
   console.log(chalk.gray(`   기술 스택 ${Object.keys(detectedStack).length}개 감지`))

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -789,6 +789,7 @@ export const ko = {
     resumeMissing: '🧭 AI 세션 복원 컨텍스트 없음 → 생성: vhk context',
     resumeExists: '🧭 새 세션이면 AI 컨텍스트 복원: vhk context-show (갱신: vhk context)',
     resumeStale: '🧭 컨텍스트가 오래됨(코드 변경 이후) → 갱신: vhk context',
+    unchanged: '내용이 같아 다시 쓰지 않았습니다 (생성 시각만 달랐음)',
   },
   brief: {
     title: '프로젝트 브리핑',

--- a/src/lib/context-stamp.ts
+++ b/src/lib/context-stamp.ts
@@ -1,0 +1,15 @@
+const GENERATED_AT_LINE = /^_생성: .+_$/u
+
+/** `_생성:` 시각만 다른 context.md 는 같은 스냅샷으로 본다 (#603). */
+export function contextFingerprint(markdown: string): string {
+  return markdown
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .filter((line) => !GENERATED_AT_LINE.test(line))
+    .join('\n')
+}
+
+export function shouldRewriteContext(existing: string | null, next: string): boolean {
+  if (existing === null) return true
+  return contextFingerprint(existing) !== contextFingerprint(next)
+}

--- a/tests/context-stamp.test.ts
+++ b/tests/context-stamp.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { contextFingerprint, shouldRewriteContext } from '../src/lib/context-stamp.js'
+
+const body = ['# 프로젝트 컨텍스트', '', 'stack: next', '---', ''].join('\n')
+
+describe('contextFingerprint', () => {
+  it('_생성: 줄을 무시한다', () => {
+    const a = `${body}_생성: 2026. 8. 31. 오전 10:00:00_\n_git: abc_\n`
+    const b = `${body}_생성: 2026. 8. 31. 오전 11:00:00_\n_git: abc_\n`
+    expect(contextFingerprint(a)).toBe(contextFingerprint(b))
+  })
+
+  it('본문이 바뀌면 다르다', () => {
+    const a = `${body}_생성: 1_\n`
+    const b = `# 다른\n\n${body}_생성: 1_\n`
+    expect(contextFingerprint(a)).not.toBe(contextFingerprint(b))
+  })
+})
+
+describe('shouldRewriteContext', () => {
+  it('파일이 없으면 쓴다', () => {
+    expect(shouldRewriteContext(null, `${body}_생성: 1_\n`)).toBe(true)
+  })
+
+  it('시각만 다르면 안 쓴다', () => {
+    expect(
+      shouldRewriteContext(`${body}_생성: old_\n_git: abc_\n`, `${body}_생성: new_\n_git: abc_\n`),
+    ).toBe(false)
+  })
+
+  it('HEAD 마커가 바뀌면 쓴다', () => {
+    expect(
+      shouldRewriteContext(`${body}_생성: old_\n_git: aaa_\n`, `${body}_생성: new_\n_git: bbb_\n`),
+    ).toBe(true)
+  })
+})

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -181,4 +181,33 @@ describe('context — 헌법(core-rules) 소스 표기 (goal 91)', () => {
     const md = String(call![1])
     expect(md).toContain('VHK 기본 규칙 스냅샷')
   })
+
+  it('#603 본문이 같으면 _생성: 만 달라도 context.md를 다시 쓰지 않는다', async () => {
+    const pkg = JSON.stringify({
+      name: 'test-pkg',
+      version: '1.2.3',
+      dependencies: { next: '15.0.0', typescript: '5.5.0' },
+      devDependencies: { vitest: '2.0.0' },
+    })
+    let stored = ''
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const s = String(p)
+      if (s.includes('context.md')) return stored !== ''
+      return s.includes('package.json')
+    })
+    mockReadFileSync.mockImplementation((p: unknown) => {
+      if (String(p).includes('context.md')) return stored.replace(/_생성: .+_/, '_생성: 어제_')
+      return pkg
+    })
+    mockReaddirSync.mockReturnValue([])
+    mockStatSync.mockReturnValue({ isDirectory: () => false })
+
+    const { context } = await import('../src/commands/context.js')
+    await context()
+    expect(mockWriteFileSync.mock.calls.some((c) => String(c[0]).includes('context.md'))).toBe(true)
+    stored = String(mockWriteFileSync.mock.calls.find((c) => String(c[0]).includes('context.md'))![1])
+    mockWriteFileSync.mockClear()
+    await context()
+    expect(mockWriteFileSync.mock.calls.some((c) => String(c[0]).includes('context.md'))).toBe(false)
+  })
 })


### PR DESCRIPTION
## 요약
- `vhk context`가 매번 `_생성:` 시각을 바꿔 추적 중인 `.vhk/context.md`를 dirty로 만들던 구멍을 막는다.
- 본문과 git HEAD 마커가 같으면 파일을 다시 쓰지 않는다.
- 이 VHK 레포는 `context.md`를 gitignore 하지만, 추적하는 소비자 레포가 대상이다.

## 테스트
- [x] `tests/context-stamp.test.ts`
- [x] `tests/context.test.ts` skip-write

Closes 없음 — 머지 후 #603 닫을 것.